### PR TITLE
Introduce framwork of RuntimeManager and cri-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/docker v20.10.2+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-logr/logr v0.4.0
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
 	github.com/jinzhu/copier v0.3.5
@@ -61,7 +62,6 @@ require (
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/pkg/runtime-manager/dispatcher/dispatcher.go
+++ b/pkg/runtime-manager/dispatcher/dispatcher.go
@@ -1,0 +1,86 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/runtime/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/runtime-manager/config"
+)
+
+// RuntimeHookDispatcher dispatches hook request to RuntimeHookServer(e.g. koordlet)
+type RuntimeHookDispatcher struct {
+	cm          *HookServerClientManager
+	hookManager *config.Manager
+}
+
+func NewRuntimeDispatcher(cm *HookServerClientManager, hookManager *config.Manager) *RuntimeHookDispatcher {
+	return &RuntimeHookDispatcher{
+		cm:          cm,
+		hookManager: hookManager,
+	}
+}
+
+func (rd *RuntimeHookDispatcher) dispatchInternal(ctx context.Context, hookType config.RuntimeHookType,
+	client *RuntimeHookClient, request interface{}) (response interface{}, err error) {
+	switch hookType {
+	case config.PreRunPodSandbox:
+		return client.PreRunPodSandboxHook(ctx, request.(*v1alpha1.RunPodSandboxHookRequest))
+	case config.PreStartContainer:
+		return client.PreStartContainerHook(ctx, request.(*v1alpha1.ContainerResourceHookRequest))
+	case config.PreUpdateContainerResources:
+		return client.PreUpdateContainerResourcesHook(ctx, request.(*v1alpha1.ContainerResourceHookRequest))
+	case config.PostStartContainer:
+		return client.PostStartContainerHook(ctx, request.(*v1alpha1.ContainerResourceHookRequest))
+	case config.PostStopContainer:
+		return client.PostStopContainerHook(ctx, request.(*v1alpha1.ContainerResourceHookRequest))
+	}
+	return nil, status.Errorf(codes.Unimplemented, fmt.Sprintf("method %v not implemented", string(hookType)))
+}
+
+func (rd *RuntimeHookDispatcher) Dispatch(ctx context.Context, runtimeRequestPath config.RuntimeRequestPath,
+	stage config.RuntimeHookStage, request interface{}) (interface{}, error) {
+	hookServers := rd.hookManager.GetAllHook()
+	for _, hookServer := range hookServers {
+		for _, hookType := range hookServer.RuntimeHooks {
+			if !hookType.OccursOn(runtimeRequestPath) {
+				continue
+			}
+			if hookType.HookStage() != stage {
+				continue
+			}
+			client, err := rd.cm.RuntimeHookClient(HookServerPath{
+				Path: hookServer.RemoteEndpoint,
+			})
+			if err != nil {
+				klog.Errorf("fail to get client %v", err)
+				continue
+			}
+			// currently, only one hook be called during one runtime
+			// TODO: multi hook server to merge response
+			return rd.dispatchInternal(ctx, hookType, client, request)
+		}
+	}
+	return nil, nil
+}

--- a/pkg/runtime-manager/dispatcher/hookclient.go
+++ b/pkg/runtime-manager/dispatcher/hookclient.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/groupcache/lru"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/runtime/v1alpha1"
+)
+
+type HookServerClientManager struct {
+	cache *lru.Cache
+}
+
+const (
+	defaultCacheSize = 10
+)
+
+// NewClientManager
+// TODO: garbage client gc
+func NewClientManager() *HookServerClientManager {
+	cache := lru.New(defaultCacheSize)
+	return &HookServerClientManager{
+		cache: cache,
+	}
+}
+
+type HookServerPath struct {
+	Path string
+	Port int64
+}
+
+type RuntimeHookClient struct {
+	SockPath string
+	v1alpha1.RuntimeHookServiceClient
+}
+
+func newRuntimeHookClient(sockPath string) (*RuntimeHookClient, error) {
+	client := &RuntimeHookClient{
+		SockPath: sockPath,
+	}
+	conn, err := grpc.Dial(fmt.Sprintf("unix://%v", sockPath),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	client.RuntimeHookServiceClient = v1alpha1.NewRuntimeHookServiceClient(conn)
+	return client, nil
+}
+
+func (cm *HookServerClientManager) RuntimeHookClient(serverPath HookServerPath) (*RuntimeHookClient, error) {
+	cacheKey, err := json.Marshal(serverPath)
+	if err != nil {
+		return nil, err
+	}
+	if client, ok := cm.cache.Get(string(cacheKey)); ok {
+		return client.(*RuntimeHookClient), nil
+	}
+
+	runtimeHookClient, err := newRuntimeHookClient(serverPath.Path)
+	if err != nil {
+		klog.Errorf("fail to create client %v", err)
+		return nil, err
+	}
+	cm.cache.Add(string(cacheKey), runtimeHookClient)
+	return runtimeHookClient, nil
+}

--- a/pkg/runtime-manager/resource-executor/resource_executor.go
+++ b/pkg/runtime-manager/resource-executor/resource_executor.go
@@ -1,0 +1,38 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_executor
+
+type RuntimeResourceExecutor interface {
+	GetMetaInfo() string
+	GenerateResourceCheckpoint() interface{}
+	GenerateHookRequest() interface{}
+	ParseRequest(request interface{}) error
+	ResourceCheckPoint(response interface{}) error
+}
+
+type RuntimeResourceType string
+
+const (
+	RuntimePodResource       RuntimeResourceType = "RuntimePodResource"
+	RuntimeContainerResource RuntimeResourceType = "RuntimeContainerResource"
+	RuntimeNoopResource      RuntimeResourceType = "RuntimeNoopResource"
+)
+
+func NewRuntimeResourceExecutor(runtimeResourceType RuntimeResourceType) RuntimeResourceExecutor {
+	return nil
+}

--- a/pkg/runtime-manager/server/cri/criserver.go
+++ b/pkg/runtime-manager/server/cri/criserver.go
@@ -1,0 +1,137 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/runtime-manager/config"
+	"github.com/koordinator-sh/koordinator/pkg/runtime-manager/dispatcher"
+	resource_executor "github.com/koordinator-sh/koordinator/pkg/runtime-manager/resource-executor"
+	"github.com/koordinator-sh/koordinator/pkg/runtime-manager/server/utils"
+)
+
+const (
+	defaultTimeout = 5 * time.Second
+)
+
+type RuntimeManagerCriServer struct {
+	hookDispatcher *dispatcher.RuntimeHookDispatcher
+	backendClient  runtimeapi.RuntimeServiceClient
+}
+
+func NewRuntimeManagerCriServer(dispatcher *dispatcher.RuntimeHookDispatcher) *RuntimeManagerCriServer {
+	criInterceptor := &RuntimeManagerCriServer{
+		hookDispatcher: dispatcher,
+	}
+	return criInterceptor
+}
+
+func (ci *RuntimeManagerCriServer) Name() string {
+	return "RuntimeManagerCriServer"
+}
+
+func (ci *RuntimeManagerCriServer) Run() error {
+	if err := ci.initBackendServer(utils.DefaultContainerdSocketPath); err != nil {
+		return err
+	}
+	lis, err := net.Listen("unix", utils.DefaultRuntimeManagerSocketPath)
+	if err != nil {
+		klog.Errorf("fail to create the lis %v", err)
+		return err
+	}
+	grpcServer := grpc.NewServer()
+	runtimeapi.RegisterRuntimeServiceServer(grpcServer, ci)
+	err = grpcServer.Serve(lis)
+	return err
+}
+
+func (ci *RuntimeManagerCriServer) getRuntimeHookInfo(serviceType RuntimeServiceType) (config.RuntimeRequestPath,
+	resource_executor.RuntimeResourceType) {
+	switch serviceType {
+	case RunPodSandbox:
+		return config.RunPodSandbox, resource_executor.RuntimePodResource
+	case CreateContainer:
+		// No Nook point in create container, but we need store the container info during container create
+		return config.NoneRuntimeHookPath, resource_executor.RuntimeContainerResource
+	case StartContainer:
+		return config.StartContainer, resource_executor.RuntimeContainerResource
+	case StopContainer:
+		return config.StopContainer, resource_executor.RuntimeContainerResource
+	case UpdateContainerResources:
+		return config.UpdateContainerResources, resource_executor.RuntimeContainerResource
+	}
+	return config.NoneRuntimeHookPath, resource_executor.RuntimeNoopResource
+}
+
+func (ci *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeServiceType,
+	ctx context.Context, request interface{}, handler grpc.UnaryHandler) (interface{}, error) {
+
+	runtimeHookPath, runtimeResourceType := ci.getRuntimeHookInfo(serviceType)
+	resourceExecutor := resource_executor.NewRuntimeResourceExecutor(runtimeResourceType)
+
+	if err := resourceExecutor.ParseRequest(request); err != nil {
+		klog.Errorf("fail to parse request %v %v", request, err)
+	}
+
+	// pre call hook server
+	// TODO deal with the Dispatch response
+	if _, err := ci.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil {
+		klog.Errorf("fail to call hook server %v", err)
+	}
+
+	// call the backend runtime engine
+	res, err := handler(ctx, request)
+	if err == nil {
+		klog.Infof("%v call on backend %v success", resourceExecutor.GetMetaInfo(), string(runtimeHookPath))
+		// store checkpoint info basing request
+		// checkpoint only when response success
+		if err := resourceExecutor.ResourceCheckPoint(res); err != nil {
+			klog.Errorf("fail to checkpoint %v %v", resourceExecutor.GetMetaInfo(), err)
+		}
+	} else {
+		klog.Errorf("%v call on backend %v fail %v", resourceExecutor.GetMetaInfo(), string(runtimeHookPath), err)
+	}
+
+	// post call hook server
+	// TODO the response
+	ci.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PostHook, resourceExecutor.GenerateHookRequest())
+	return res, err
+}
+
+func dialer(ctx context.Context, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, "unix", addr)
+}
+
+func (ci *RuntimeManagerCriServer) initBackendServer(sockPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, sockPath, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
+	if err != nil {
+		klog.Infof("err to create  %v\n", err)
+		return err
+	}
+	ci.backendClient = runtimeapi.NewRuntimeServiceClient(conn)
+	return nil
+}

--- a/pkg/runtime-manager/server/cri/runtime.go
+++ b/pkg/runtime-manager/server/cri/runtime.go
@@ -1,0 +1,152 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"context"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (ci *RuntimeManagerCriServer) Version(ctx context.Context, req *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	return ci.backendClient.Version(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) RunPodSandbox(ctx context.Context, req *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	rsp, err := ci.interceptRuntimeRequest(RunPodSandbox, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.RunPodSandbox(ctx, req.(*runtimeapi.RunPodSandboxRequest))
+		})
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.RunPodSandboxResponse), err
+}
+func (ci *RuntimeManagerCriServer) StopPodSandbox(ctx context.Context, req *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+
+	rsp, err := ci.interceptRuntimeRequest(StopPodSandbox, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.StopPodSandbox(ctx, req.(*runtimeapi.StopPodSandboxRequest))
+		})
+
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.StopPodSandboxResponse), err
+}
+
+func (ci *RuntimeManagerCriServer) RemovePodSandbox(ctx context.Context, req *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	return ci.backendClient.RemovePodSandbox(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) PodSandboxStatus(ctx context.Context, req *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	return ci.backendClient.PodSandboxStatus(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) ListPodSandbox(ctx context.Context, req *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	return ci.backendClient.ListPodSandbox(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) CreateContainer(ctx context.Context, req *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	rsp, err := ci.interceptRuntimeRequest(CreateContainer, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.CreateContainer(ctx, req.(*runtimeapi.CreateContainerRequest))
+		})
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.CreateContainerResponse), err
+}
+
+func (ci *RuntimeManagerCriServer) StartContainer(ctx context.Context, req *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	rsp, err := ci.interceptRuntimeRequest(StartContainer, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.StartContainer(ctx, req.(*runtimeapi.StartContainerRequest))
+		})
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.StartContainerResponse), err
+}
+
+func (ci *RuntimeManagerCriServer) StopContainer(ctx context.Context, req *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	rsp, err := ci.interceptRuntimeRequest(StopContainer, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.StopContainer(ctx, req.(*runtimeapi.StopContainerRequest))
+		})
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.StopContainerResponse), err
+}
+
+func (ci *RuntimeManagerCriServer) RemoveContainer(ctx context.Context, req *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	rsp, err := ci.interceptRuntimeRequest(RemoveContainer, ctx, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return ci.backendClient.RemoveContainer(ctx, req.(*runtimeapi.RemoveContainerRequest))
+		})
+	if err != nil {
+		return nil, err
+	}
+	return rsp.(*runtimeapi.RemoveContainerResponse), err
+}
+
+func (ci *RuntimeManagerCriServer) ContainerStatus(ctx context.Context, req *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	return ci.backendClient.ContainerStatus(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) ListContainers(ctx context.Context, req *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	return ci.backendClient.ListContainers(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) UpdateContainerResources(ctx context.Context, req *runtimeapi.UpdateContainerResourcesRequest) (*runtimeapi.UpdateContainerResourcesResponse, error) {
+	return ci.backendClient.UpdateContainerResources(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) ContainerStats(ctx context.Context, req *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
+	return ci.backendClient.ContainerStats(ctx, req)
+}
+func (ci *RuntimeManagerCriServer) ListContainerStats(ctx context.Context, req *runtimeapi.ListContainerStatsRequest) (*runtimeapi.ListContainerStatsResponse, error) {
+	return ci.backendClient.ListContainerStats(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) Status(ctx context.Context, req *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	return ci.backendClient.Status(ctx, req)
+}
+
+func (ci *RuntimeManagerCriServer) ReopenContainerLog(ctx context.Context, in *runtimeapi.ReopenContainerLogRequest) (*runtimeapi.ReopenContainerLogResponse, error) {
+	return ci.backendClient.ReopenContainerLog(ctx, in)
+}
+func (ci *RuntimeManagerCriServer) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	return ci.backendClient.ExecSync(ctx, in)
+}
+func (ci *RuntimeManagerCriServer) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	return ci.backendClient.Exec(ctx, in)
+}
+
+func (ci *RuntimeManagerCriServer) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	return ci.backendClient.Attach(ctx, in)
+}
+
+func (ci *RuntimeManagerCriServer) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	return ci.backendClient.PortForward(ctx, in)
+}
+
+func (ci *RuntimeManagerCriServer) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	return ci.backendClient.UpdateRuntimeConfig(ctx, in)
+}

--- a/pkg/runtime-manager/server/cri/utils.go
+++ b/pkg/runtime-manager/server/cri/utils.go
@@ -1,0 +1,37 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+type ServiceType int
+type RuntimeServiceType int
+type ImageServiceType int
+
+const (
+	RuntimeService ServiceType = iota
+	ImageService
+)
+
+const (
+	RunPodSandbox RuntimeServiceType = iota
+	StopPodSandbox
+	CreateContainer
+	StartContainer
+	StopContainer
+	RemoveContainer
+	UpdateContainerResources
+)

--- a/pkg/runtime-manager/server/server.go
+++ b/pkg/runtime-manager/server/server.go
@@ -1,0 +1,23 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+type RuntimeManagerServer interface {
+	Name() string
+	Run() error
+}

--- a/pkg/runtime-manager/server/utils/utils.go
+++ b/pkg/runtime-manager/server/utils/utils.go
@@ -1,0 +1,23 @@
+/*
+
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+const (
+	DefaultRuntimeManagerSocketPath = "/var/run/runtimemanger/runtimemanager.sock"
+	DefaultContainerdSocketPath     = "/run/containerd/containerd.sock"
+)

--- a/vendor/google.golang.org/grpc/credentials/insecure/insecure.go
+++ b/vendor/google.golang.org/grpc/credentials/insecure/insecure.go
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package insecure provides an implementation of the
+// credentials.TransportCredentials interface which disables transport security.
+//
+// Experimental
+//
+// Notice: This package is EXPERIMENTAL and may be changed or removed in a
+// later release.
+package insecure
+
+import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// NewCredentials returns a credentials which disables transport security.
+func NewCredentials() credentials.TransportCredentials {
+	return insecureTC{}
+}
+
+// insecureTC implements the insecure transport credentials. The handshake
+// methods simply return the passed in net.Conn and set the security level to
+// NoSecurity.
+type insecureTC struct{}
+
+func (insecureTC) ClientHandshake(ctx context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, info{credentials.CommonAuthInfo{SecurityLevel: credentials.NoSecurity}}, nil
+}
+
+func (insecureTC) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, info{credentials.CommonAuthInfo{SecurityLevel: credentials.NoSecurity}}, nil
+}
+
+func (insecureTC) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{SecurityProtocol: "insecure"}
+}
+
+func (insecureTC) Clone() credentials.TransportCredentials {
+	return insecureTC{}
+}
+
+func (insecureTC) OverrideServerName(string) error {
+	return nil
+}
+
+// info contains the auth information for an insecure connection.
+// It implements the AuthInfo interface.
+type info struct {
+	credentials.CommonAuthInfo
+}
+
+// AuthType returns the type of info as a string.
+func (info) AuthType() string {
+	return "insecure"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -535,6 +535,7 @@ google.golang.org/grpc/binarylog/grpc_binarylog_v1
 google.golang.org/grpc/codes
 google.golang.org/grpc/connectivity
 google.golang.org/grpc/credentials
+google.golang.org/grpc/credentials/insecure
 google.golang.org/grpc/encoding
 google.golang.org/grpc/encoding/gzip
 google.golang.org/grpc/encoding/proto


### PR DESCRIPTION
Signed-off-by: pengyang.hpy <honpey@gmail.com>


### Ⅰ. Describe what this PR does

Introduce framwork of RuntimeManager and cri-proxy

1. framework of runtimemanager, including:
   server: intercept request from kubelet, and forward request to backend containerd/dockerd
   resource-executor: parse intercepted request, genereate request to hook server and do checkpoint
   dispatcher: mange hook server client and dispatch hook request to hook server

2. cri-proxy
   part of 'server', intercept request from kubelet under containerd scenario


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

