### PR TITLE
🛠 bump go version to 1.17.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.17.8'
 
 jobs:
   golangci-lint:


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>


### Ⅰ. Describe what this PR does
Github updated Golang version from 1.17.8 to 1.17.9 in https://github.com/actions/virtual-environments/pull/5442 on April 28th. Since then, CI workflows have become extremely slow. 
So this PR will stick the Golang version to 1.17.8. Hope to fix the efficiency issue.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #114 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews
![image](https://user-images.githubusercontent.com/24452340/166087492-1dfbccc3-7de0-41fe-bad0-9faf270d6369.png)

