### PR TITLE
feat(nodeslo-ctrl): use DefaultCPUBurstStrategy when config map not exist

### DIFF
--- a/pkg/slo-controller/nodeslo/nodeslo_controller.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_controller.go
@@ -78,6 +78,7 @@ func (r *NodeSLOReconciler) getNodeSLOSpec(node *corev1.Node, oldSpec *slov1alph
 	nodeSLOSpec := &slov1alpha1.NodeSLOSpec{
 		ResourceUsedThresholdWithBE: util.DefaultResourceThresholdStrategy(),
 		ResourceQoSStrategy:         &slov1alpha1.ResourceQoSStrategy{},
+		CPUBurstStrategy:            util.DefaultCPUBurstStrategy(),
 	}
 
 	// TODO: record an event about the failure reason on configmap/crd when failed to load the config

--- a/pkg/slo-controller/nodeslo/nodeslo_controller_test.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_controller_test.go
@@ -86,6 +86,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 			want: &slov1alpha1.NodeSLOSpec{
 				ResourceUsedThresholdWithBE: util.DefaultResourceThresholdStrategy(),
 				ResourceQoSStrategy:         &slov1alpha1.ResourceQoSStrategy{},
+				CPUBurstStrategy:            util.DefaultCPUBurstStrategy(),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>


### Ⅰ. Describe what this PR does
User might not specify a value in config map. In that case, we use `DefaultCPUBurstStrategy` to create default value for CPU Burst Strategy.

