### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/koordlet/audit/auditor_test.go
+++ b/pkg/koordlet/audit/auditor_test.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 )
@@ -64,11 +63,7 @@ func mustCreateHttpServer(t *testing.T, handler http.Handler) *TestServer {
 }
 
 func TestAuditorLogger(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	c := NewDefaultConfig()
 	c.LogDir = tempDir
@@ -155,11 +150,7 @@ func TestAuditorLogger(t *testing.T) {
 }
 
 func TestAuditorLoggerTxtOutput(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	c := NewDefaultConfig()
 	c.LogDir = tempDir
@@ -198,11 +189,7 @@ func TestAuditorLoggerTxtOutput(t *testing.T) {
 }
 
 func TestAuditorLoggerReaderInvalidPageToken(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	c := NewDefaultConfig()
 	c.LogDir = tempDir
@@ -269,11 +256,7 @@ func TestAuditorLoggerReaderInvalidPageToken(t *testing.T) {
 }
 
 func TestAuditorLoggerMaxActiveReaders(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	c := NewDefaultConfig()
 	c.LogDir = tempDir

--- a/pkg/koordlet/audit/event_logger_test.go
+++ b/pkg/koordlet/audit/event_logger_test.go
@@ -20,17 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestEventLogger(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	logger := NewEventLogger(tempDir, 10, 0)
 	logger.Log(0, &Event{Reason: "hello"})
@@ -48,11 +43,7 @@ func TestEventLogger(t *testing.T) {
 }
 
 func TestFluentEventLogger(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	logger := NewFluentEventLogger(tempDir, 10, 0)
 	defer logger.Close()
@@ -81,11 +72,7 @@ func makeBlock(n int, b byte) []byte {
 }
 
 func TestReverseEventReaderSingleFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	logger := NewFluentEventLogger(tempDir, 10, 0)
 
@@ -111,11 +98,7 @@ func TestReverseEventReaderSingleFile(t *testing.T) {
 }
 
 func TestReverseEventReaderMultiFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	logger := NewFluentEventLogger(tempDir, 10, 0)
 

--- a/pkg/koordlet/audit/logger_test.go
+++ b/pkg/koordlet/audit/logger_test.go
@@ -20,17 +20,12 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 )
 
 func TestLogWriter(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	name := tempDir + "/audit.log"
 	writer, err := OpenLogWriter(name)
@@ -56,11 +51,7 @@ func TestLogWriter(t *testing.T) {
 }
 
 func TestLogReader(t *testing.T) {
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	name := tempDir + "/audit.log"
 	writer, err := OpenLogWriter(name)

--- a/pkg/koordlet/pleg/watcher_linux_test.go
+++ b/pkg/koordlet/pleg/watcher_linux_test.go
@@ -20,7 +20,6 @@
 package pleg
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -34,11 +33,7 @@ func TestWatcher(t *testing.T) {
 	assert.NoError(t, err, "create watcher failed")
 	defer watcher.Close()
 
-	tempDir, err := ioutil.TempDir(".", "_test")
-	if err != nil {
-		t.Fatal("failed to create dir", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	err = watcher.AddWatch(tempDir)
 	assert.NoError(t, err, "watch path: %v failed", tempDir)

--- a/pkg/koordlet/resmanager/be_reconcile_test.go
+++ b/pkg/koordlet/resmanager/be_reconcile_test.go
@@ -18,7 +18,6 @@ package resmanager
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -231,7 +230,7 @@ func Test_reconcileBECPULimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		system.Conf = system.NewDsModeConfig()
-		system.Conf.CgroupRootDir, _ = ioutil.TempDir("/tmp", "koordlet-test")
+		system.Conf.CgroupRootDir = t.TempDir()
 		err := initTestPodCFS(tt.args.podMeta, tt.args.podCurCFS, tt.args.containerCurCFS)
 		if err != nil {
 			t.Errorf("init cfs quota failed, error: %v", err)
@@ -341,7 +340,7 @@ func Test_reconcileBECPUShare(t *testing.T) {
 	}
 	for _, tt := range tests {
 		system.Conf = system.NewDsModeConfig()
-		system.Conf.CgroupRootDir, _ = ioutil.TempDir("/tmp", "koordlet-test")
+		system.Conf.CgroupRootDir = t.TempDir()
 		err := initTestPodCPUShare(tt.args.podMeta, tt.args.podCurCPUShare, tt.args.containerCurCPUShare)
 		if err != nil {
 			t.Errorf("init cpu share failed, error: %v", err)
@@ -451,7 +450,7 @@ func Test_reconcileBEMemLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		system.Conf = system.NewDsModeConfig()
-		system.Conf.CgroupRootDir, _ = ioutil.TempDir("/tmp", "koordlet-test")
+		system.Conf.CgroupRootDir = t.TempDir()
 		err := initTestPodMemLimit(tt.args.podMeta, tt.args.podCurMemLimit, tt.args.containerCurMemLimit)
 		if err != nil {
 			t.Errorf("init cpu share failed, error: %v", err)

--- a/pkg/koordlet/resmanager/cgroup_reconcile_test.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile_test.go
@@ -804,7 +804,7 @@ func TestCgroupResourceReconcile_calculateResources(t *testing.T) {
 			assert.NoError(t, err)
 			defer func() { stop <- struct{}{} }()
 
-			_ = system.NewFileTestUtil(t)
+			system.NewFileTestUtil(t)
 
 			got, got1, got2 := m.calculateResources(tt.args.nodeCfg, tt.args.node, tt.args.podMetas)
 			assertCgroupResourceEqual(t, tt.want, got)

--- a/pkg/koordlet/resmanager/cgroup_reconcile_test.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile_test.go
@@ -425,7 +425,6 @@ func Test_calculateAndUpdateResources(t *testing.T) {
 			defer func() { stop <- struct{}{} }()
 
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 
 			initQoSStrategy := defaultQoSStrategy()
 			initQoSCgroupFile(initQoSStrategy, helper)
@@ -805,8 +804,7 @@ func TestCgroupResourceReconcile_calculateResources(t *testing.T) {
 			assert.NoError(t, err)
 			defer func() { stop <- struct{}{} }()
 
-			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
+			_ = system.NewFileTestUtil(t)
 
 			got, got1, got2 := m.calculateResources(tt.args.nodeCfg, tt.args.node, tt.args.podMetas)
 			assertCgroupResourceEqual(t, tt.want, got)

--- a/pkg/koordlet/resmanager/cpu_burst_test.go
+++ b/pkg/koordlet/resmanager/cpu_burst_test.go
@@ -689,7 +689,6 @@ func TestCPUBurst_applyCPUBurst(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testHelper := system.NewFileTestUtil(t)
-			defer testHelper.Cleanup()
 
 			b := &CPUBurst{
 				executor: NewResourceUpdateExecutor("CPUBurstTestExecutor", 60),
@@ -1187,7 +1186,6 @@ func TestCPUBurst_applyCFSQuotaBurst(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testHelper := system.NewFileTestUtil(t)
-			defer testHelper.Cleanup()
 
 			stop := make(chan struct{})
 			defer func() { stop <- struct{}{} }()
@@ -1566,7 +1564,6 @@ func TestCPUBurst_start(t *testing.T) {
 			}
 
 			testHelper := system.NewFileTestUtil(t)
-			defer testHelper.Cleanup()
 
 			b := NewCPUBurst(resmanager)
 			stop := make(chan struct{})

--- a/pkg/koordlet/resmanager/cpu_suppress_test.go
+++ b/pkg/koordlet/resmanager/cpu_suppress_test.go
@@ -590,7 +590,6 @@ func Test_cpuSuppress_suppressBECPU(t *testing.T) {
 
 			// prepare testing files
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 			helper.WriteCgroupFileContents(util.GetKubeQosRelativePath(corev1.PodQOSGuaranteed), system.CPUSet, tt.args.nodeCPUSet)
 			helper.WriteCgroupFileContents(util.GetKubeQosRelativePath(corev1.PodQOSBestEffort), system.CPUSet, tt.args.preBECPUSet)
 			helper.WriteCgroupFileContents(util.GetKubeQosRelativePath(corev1.PodQOSBestEffort), system.CPUCFSQuota, strconv.FormatInt(tt.args.preBECFSQuota, 10))
@@ -917,7 +916,6 @@ func Test_cpuSuppress_recoverCPUSetIfNeed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare testing files
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 			podDirs := []string{"pod1", "pod2", "pod3"}
 			testingPrepareBECgroupData(helper, podDirs, tt.args.oldCPUSets)
 			helper.WriteCgroupFileContents(util.GetKubeQosRelativePath(corev1.PodQOSGuaranteed), system.CPUSet, tt.args.rootCPUSets)
@@ -973,7 +971,6 @@ func Test_cpuSuppress_recoverCFSQuotaIfNeed(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 			beQosDir := util.GetKubeQosRelativePath(corev1.PodQOSBestEffort)
 			helper.CreateCgroupFile(beQosDir, system.CPUCFSQuota)
 
@@ -1195,7 +1192,6 @@ func Test_calculateBESuppressCPUSetPolicy(t *testing.T) {
 func Test_applyBESuppressCPUSetPolicy(t *testing.T) {
 	// prepare testing files
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	podDirs := []string{"pod1", "pod2", "pod3"}
 	testingPrepareBECgroupData(helper, podDirs, "1,2")
 
@@ -1218,7 +1214,6 @@ func Test_applyBESuppressCPUSetPolicy(t *testing.T) {
 func Test_getBECgroupCPUSetPathsRecursive(t *testing.T) {
 	// prepare testing files
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	podDirs := []string{"pod1", "pod2", "pod3"}
 	testingPrepareBECgroupData(helper, podDirs, "1,2")
 	var wantPaths []string
@@ -1288,7 +1283,6 @@ func Test_adjustByCPUSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare testing files
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 			podDirs := []string{"pod1", "pod2", "pod3"}
 			testingPrepareBECgroupData(helper, podDirs, tt.args.oldCPUSets)
 
@@ -1306,7 +1300,6 @@ func Test_adjustByCPUSet(t *testing.T) {
 
 func Test_adjustByCfsQuota(t *testing.T) {
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	beQosDir := util.GetKubeQosRelativePath(corev1.PodQOSBestEffort)
 	helper.CreateCgroupFile(beQosDir, system.CPUCFSQuota)
 	node := &corev1.Node{
@@ -1375,7 +1368,6 @@ func Test_adjustByCfsQuota(t *testing.T) {
 func Test_writeBECgroupsCPUSet(t *testing.T) {
 	// prepare testing files
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	podDirs := []string{"pod1", "pod2", "pod3"}
 	testingPrepareBECgroupData(helper, podDirs, "1,2")
 

--- a/pkg/koordlet/resmanager/resctrl_reconcile_test.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile_test.go
@@ -399,7 +399,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = system.NewFileTestUtil(t)
+			system.NewFileTestUtil(t)
 
 			testingPrepareContainerCgroupCPUTasks(t,
 				tt.fields.containerParentDir, tt.fields.containerTasksStr)

--- a/pkg/koordlet/resmanager/resctrl_reconcile_test.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile_test.go
@@ -223,7 +223,6 @@ func Test_calculateCatL3Schemata(t *testing.T) {
 func Test_initCatResctrl(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "initCatResctrl"
 		helper.MkDirAll(sysFSRootDirName)
@@ -400,9 +399,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
+			_ = system.NewFileTestUtil(t)
 
 			testingPrepareContainerCgroupCPUTasks(t,
 				tt.fields.containerParentDir, tt.fields.containerTasksStr)
@@ -611,7 +608,6 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 
 			sysFSRootDirName := "calculateAndApplyCatL3PolicyForGroup"
 			helper.MkDirAll(sysFSRootDirName)
@@ -762,7 +758,6 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 
 			sysFSRootDirName := "calculateAndApplyCatMbPolicyForGroup"
 			helper.MkDirAll(sysFSRootDirName)
@@ -857,7 +852,6 @@ func TestResctrlReconcile_calculateAndApplyCatL3GroupTasks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 
 			sysFSRootDirName := "writeCatL3GroupTasks"
 			helper.MkDirAll(sysFSRootDirName)
@@ -891,7 +885,6 @@ func TestResctrlReconcile_calculateAndApplyCatL3GroupTasks(t *testing.T) {
 func TestResctrlReconcile_reconcileCatResctrlPolicy(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "reconcileCatResctrlPolicy"
 		helper.MkDirAll(sysFSRootDirName)
@@ -1062,7 +1055,6 @@ func TestResctrlReconcile_reconcileResctrlGroups(t *testing.T) {
 		statesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{testingPodMeta}).MaxTimes(2)
 
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "reconcileResctrlGroups"
 		helper.MkDirAll(sysFSRootDirName)
@@ -1181,7 +1173,6 @@ func TestResctrlReconcile_reconcile(t *testing.T) {
 		}
 
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "ResctrlReconcile"
 		helper.MkDirAll(sysFSRootDirName)
@@ -1283,7 +1274,6 @@ func Test_calculateMbaPercentForGroup(t *testing.T) {
 func Test_calculateL3SchemataResource(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "reconcileCatResctrlPolicy"
 		helper.MkDirAll(sysFSRootDirName)
@@ -1299,7 +1289,6 @@ func Test_calculateL3SchemataResource(t *testing.T) {
 func Test_calculateMbSchemataResource(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
 		helper := system.NewFileTestUtil(t)
-		defer helper.Cleanup()
 
 		sysFSRootDirName := "reconcileCatResctrlPolicy"
 		helper.MkDirAll(sysFSRootDirName)

--- a/pkg/koordlet/resmanager/resource_update_executor_test.go
+++ b/pkg/koordlet/resmanager/resource_update_executor_test.go
@@ -40,7 +40,6 @@ type reconcileInfo struct {
 func Test_UpdateBatch(t *testing.T) {
 
 	helper := sysutil.NewFileTestUtil(t)
-	defer helper.Cleanup()
 
 	helper.CreateCgroupFile("/", sysutil.CPUShares)
 	helper.CreateFile(commonTestFile)
@@ -79,7 +78,6 @@ func Test_UpdateBatch(t *testing.T) {
 func Test_UpdateBatchByCache(t *testing.T) {
 
 	helper := sysutil.NewFileTestUtil(t)
-	defer helper.Cleanup()
 
 	absFile := path.Join(helper.TempDir, commonTestFile)
 

--- a/pkg/koordlet/runtimehooks/runtimehooks_test.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks_test.go
@@ -17,7 +17,6 @@
 package runtimehooks
 
 import (
-	"io/ioutil"
 	"path"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func Test_runtimeHook_Run(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "runtime-hook-test")
+	tmpDir := t.TempDir()
 	type fields struct {
 		config *Config
 	}

--- a/pkg/runtime/handler/containerd_runtime_test.go
+++ b/pkg/runtime/handler/containerd_runtime_test.go
@@ -38,7 +38,6 @@ func Test_NewContainerdRuntimeHandler(t *testing.T) {
 	defer stubs.Reset()
 
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	helper.MkDirAll("/var/run")
 	helper.WriteFileContents("/var/run/containerd.sock", "test")
 	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")

--- a/pkg/runtime/handler/docker_runtime_test.go
+++ b/pkg/runtime/handler/docker_runtime_test.go
@@ -48,7 +48,6 @@ func Test_Docker_NewDockerRuntimeHandler(t *testing.T) {
 	defer stubs.Reset()
 
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	helper.MkDirAll("/var/run")
 	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")
 	helper.WriteFileContents("/var/run/docker.sock", "test")
@@ -62,7 +61,6 @@ func Test_Docker_NewDockerRuntimeHandler(t *testing.T) {
 
 func Test_Docker_StopContainer(t *testing.T) {
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	helper.MkDirAll("/var/run")
 	helper.WriteFileContents("/var/run/docker.sock", "test")
 	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")
@@ -95,7 +93,6 @@ func Test_Docker_StopContainer(t *testing.T) {
 
 func Test_Docker_UpdateContainerResources(t *testing.T) {
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	helper.MkDirAll("/var/run")
 	helper.WriteFileContents("/var/run/docker.sock", "test")
 	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -108,7 +108,6 @@ func Test_GetRuntimeHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := system.NewFileTestUtil(t)
-			defer helper.Cleanup()
 			system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")
 			if tt.endPoint != "" {
 				helper.CreateFile(tt.endPoint)

--- a/pkg/util/container_test.go
+++ b/pkg/util/container_test.go
@@ -264,9 +264,7 @@ func Test_GetContainerCurTasks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cgroupRootDir string
-			cgroupRootDir, _ = ioutil.TempDir("", "GetContainerCurTasks")
-			defer os.RemoveAll(cgroupRootDir)
+			cgroupRootDir := t.TempDir()
 
 			dname := filepath.Join(cgroupRootDir, system.CgroupCPUDir, tt.field.containerParentDir)
 			err := os.MkdirAll(dname, 0700)

--- a/pkg/util/meminfo_test.go
+++ b/pkg/util/meminfo_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -30,11 +29,7 @@ import (
 )
 
 func Test_readMemInfo(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	tempInvalidMemInfoPath := filepath.Join(tempDir, "no_meminfo")
 	tempMemInfoPath := filepath.Join(tempDir, "meminfo")
 	memInfoContentStr := "MemTotal:       263432804 kB\nMemFree:        254391744 kB\nMemAvailable:   256703236 kB\n" +
@@ -53,7 +48,7 @@ func Test_readMemInfo(t *testing.T) {
 		"CmaFree:               0 kB\nHugePages_Total:       0\nHugePages_Free:        0\n" +
 		"HugePages_Rsvd:        0\nHugePages_Surp:        0\nHugepagesize:       2048 kB\n" +
 		"DirectMap4k:      414760 kB\nDirectMap2M:     8876032 kB\nDirectMap1G:    261095424 kB\n"
-	err = ioutil.WriteFile(tempMemInfoPath, []byte(memInfoContentStr), 0666)
+	err := ioutil.WriteFile(tempMemInfoPath, []byte(memInfoContentStr), 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,11 +116,7 @@ func Test_GetMemInfoUsageKB(t *testing.T) {
 }
 
 func Test_readPodMemStat(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	tempInvalidPodCgroupDir := filepath.Join(tempDir, "no_cgroup")
 	tempPodMemStatPath := filepath.Join(tempDir, system.MemStatFileName)
 	memStatContentStr := "...\ntotal_cache 4843945984\ntotal_rss 310595584\ntotal_rss_huge 60817408\n" +
@@ -137,7 +128,7 @@ func Test_readPodMemStat(t *testing.T) {
 		"total_pg_pgscan 0\ntotal_pgrefill 0\ntotal_inactive_anon 1331200\n" +
 		"total_active_anon 310775808\ntotal_inactive_file 2277351424\ntotal_active_file 2564194304\n" +
 		"total_unevictable 0"
-	err = ioutil.WriteFile(tempPodMemStatPath, []byte(memStatContentStr), 0666)
+	err := ioutil.WriteFile(tempPodMemStatPath, []byte(memStatContentStr), 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -177,27 +168,19 @@ func Test_readPodMemStat(t *testing.T) {
 }
 
 func Test_GetPodMemStatUsageBytes(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	system.Conf = system.NewDsModeConfig()
-	_, err = GetPodMemStatUsageBytes(tempDir)
+	_, err := GetPodMemStatUsageBytes(tempDir)
 	assert.NotNil(t, err)
 }
 
 func TestGetContainerMemStatUsageBytes(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	container := &corev1.ContainerStatus{
 		Name:        "test-container",
 		ContainerID: "test-container-id",
 	}
 	system.Conf = system.NewDsModeConfig()
-	_, err = GetContainerMemStatUsageBytes(tempDir, container)
+	_, err := GetContainerMemStatUsageBytes(tempDir, container)
 	assert.NotNil(t, err)
 }

--- a/pkg/util/pod_test.go
+++ b/pkg/util/pod_test.go
@@ -180,8 +180,7 @@ func Test_GetPodRequest(t *testing.T) {
 
 func Test_GetRootCgroupCurCPUSet(t *testing.T) {
 	// prepare testing tmp files
-	var cgroupRootDir string
-	cgroupRootDir, _ = ioutil.TempDir("", "GetRootCgroupCurCPUSet")
+	cgroupRootDir := t.TempDir()
 	dname := filepath.Join(cgroupRootDir, system.CgroupCPUSetDir)
 	err := os.MkdirAll(dname, 0700)
 	if err != nil {

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -30,11 +29,7 @@ import (
 )
 
 func Test_readTotalCPUStat(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	tempInvalidStatPath := filepath.Join(tempDir, "no_stat")
 	tempStatPath := filepath.Join(tempDir, "stat")
 	statContentStr := "cpu  514003 37519 593580 1706155242 5134 45033 38832 0 0 0\n" +
@@ -47,7 +42,7 @@ func Test_readTotalCPUStat(t *testing.T) {
 		"procs_running 53\n" +
 		"procs_blocked 0\n" +
 		"softirq 134422017 2 39835165 107003 28614585 2166152 0 2398085 30750729 0 30550296\n"
-	err = ioutil.WriteFile(tempStatPath, []byte(statContentStr), 0666)
+	err := ioutil.WriteFile(tempStatPath, []byte(statContentStr), 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -100,15 +95,11 @@ func Test_GetCPUStatUsageTicks(t *testing.T) {
 }
 
 func Test_readPodCPUStatUsageTicks(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	tempInvalidPodCgroupDir := filepath.Join(tempDir, "no_cgroup")
 	tempPodStatPath := filepath.Join(tempDir, system.CpuacctStatFileName)
 	statContentStr := getStatContents()
-	err = ioutil.WriteFile(tempPodStatPath, []byte(statContentStr), 0666)
+	err := ioutil.WriteFile(tempPodStatPath, []byte(statContentStr), 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -148,13 +139,9 @@ func Test_readPodCPUStatUsageTicks(t *testing.T) {
 }
 
 func Test_GetPodCPUStatUsageTicks(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tempDir := t.TempDir()
 	system.Conf = system.NewDsModeConfig()
-	_, err = GetPodCPUStatUsageTicks(tempDir)
+	_, err := GetPodCPUStatUsageTicks(tempDir)
 	assert.NotNil(t, err)
 }
 
@@ -166,7 +153,6 @@ func getStatContents() string {
 
 func TestGetContainerCPUStatUsageTicks(t *testing.T) {
 	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
 	podCgroupDir := "pod-cgroup-dir"
 	container := &corev1.ContainerStatus{
 		Name:        "test-container",

--- a/pkg/util/system/cgroup_driver_linux_test.go
+++ b/pkg/util/system/cgroup_driver_linux_test.go
@@ -20,7 +20,6 @@
 package system
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,9 +63,8 @@ func Test_GuessCgroupDriverFromCgroupName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpCgroupRoot, _ := ioutil.TempDir("", "cgroup")
+			tmpCgroupRoot := t.TempDir()
 			os.MkdirAll(tmpCgroupRoot, 0555)
-			defer os.RemoveAll(tmpCgroupRoot)
 
 			Conf = &Config{
 				CgroupRootDir: tmpCgroupRoot,

--- a/pkg/util/system/cgroup_test.go
+++ b/pkg/util/system/cgroup_test.go
@@ -69,7 +69,6 @@ func TestCgroupFileReadInt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := NewFileTestUtil(t)
-			defer helper.Cleanup()
 			helper.CreateCgroupFile(taskDir, tt.args.file)
 
 			err := CgroupFileWrite(taskDir, tt.args.file, tt.args.value)
@@ -92,7 +91,6 @@ func genCPUStatContent() string {
 
 func TestGetCPUStatRaw(t *testing.T) {
 	helper := NewFileTestUtil(t)
-	defer helper.Cleanup()
 	testCPUDir := "cpu"
 	filePath := GetCgroupFilePath(testCPUDir, CpuacctStat)
 

--- a/pkg/util/system/common_linux_test.go
+++ b/pkg/util/system/common_linux_test.go
@@ -20,7 +20,6 @@
 package system
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,11 +36,10 @@ func Test_ProcCmdLine(t *testing.T) {
 		assert.ElementsMatch(t, cmdline, os.Args)
 	})
 	t.Run("fake process should fail", func(t *testing.T) {
-		procRoot, _ := ioutil.TempDir("", "proc")
+		procRoot := t.TempDir()
 		fakePid := 42
 		fakeProcDir := filepath.Join(procRoot, strconv.Itoa((fakePid)))
 		os.MkdirAll(fakeProcDir, 0555)
-		defer os.RemoveAll(procRoot)
 
 		_, err := ProcCmdLine(procRoot, fakePid)
 		assert.NotEmpty(t, err)

--- a/pkg/util/system/resctrl_linux_test.go
+++ b/pkg/util/system/resctrl_linux_test.go
@@ -58,7 +58,6 @@ func Test_isResctrlAvailableByCpuInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := NewFileTestUtil(t)
-			defer helper.Cleanup()
 
 			helper.WriteProcSubFileContents("cpuinfo", tt.cpuInfoContents)
 			gotIsCatFlagSet, gotIsMbaFlagSet, err := isResctrlAvailableByCpuInfo(filepath.Join(Conf.ProcRootDir, "cpuinfo"))
@@ -115,7 +114,6 @@ func Test_isResctrlAvailableByKernelCmd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := NewFileTestUtil(t)
-			defer helper.Cleanup()
 			helper.WriteProcSubFileContents("cmdline", tt.args.content)
 			isCatFlagSet, isMbaFlagSet, _ := isResctrlAvailableByKernelCmd(filepath.Join(Conf.ProcRootDir, "cmdline"))
 			if isCatFlagSet != tt.wantCat {

--- a/pkg/util/system/resctrl_test.go
+++ b/pkg/util/system/resctrl_test.go
@@ -74,8 +74,7 @@ func Test_ReadResctrlTasksMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var sysFSRootDir string
-			sysFSRootDir, _ = ioutil.TempDir("", "ReadResctrlTasksMap")
+			sysFSRootDir := t.TempDir()
 			resctrlDir := filepath.Join(sysFSRootDir, ResctrlDir, tt.args.groupPath)
 			err := os.MkdirAll(resctrlDir, 0700)
 			assert.NoError(t, err)
@@ -83,8 +82,6 @@ func Test_ReadResctrlTasksMap(t *testing.T) {
 			tasksPath := filepath.Join(resctrlDir, ResctrlTaskFileName)
 			err = ioutil.WriteFile(tasksPath, []byte(tt.fields.tasksStr), 0666)
 			assert.NoError(t, err)
-
-			defer os.RemoveAll(sysFSRootDir)
 
 			Conf = &Config{
 				SysFSRootDir: sysFSRootDir,
@@ -125,9 +122,7 @@ func Test_CheckAndTryEnableResctrlCat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var sysFSRootDir string
-			sysFSRootDir, _ = ioutil.TempDir("", "CheckAndTryEnableResctrlCat")
-			defer os.RemoveAll(sysFSRootDir)
+			sysFSRootDir := t.TempDir()
 			resctrlDir := filepath.Join(sysFSRootDir, ResctrlDir)
 			l3CatDir := filepath.Join(resctrlDir, RdtInfoDir, L3CatDir)
 			err := os.MkdirAll(l3CatDir, 0700)
@@ -153,9 +148,7 @@ func Test_CheckAndTryEnableResctrlCat(t *testing.T) {
 
 func Test_MountResctrlSubsystem(t *testing.T) {
 	t.Run("test not panic", func(t *testing.T) {
-		var sysFSRootDir string
-		sysFSRootDir, _ = ioutil.TempDir("", "MountResctrlSubsystem")
-		defer os.RemoveAll(sysFSRootDir)
+		sysFSRootDir := t.TempDir()
 		resctrlDir := filepath.Join(sysFSRootDir, ResctrlDir)
 		err := os.MkdirAll(resctrlDir, 0700)
 		assert.NoError(t, err)

--- a/pkg/util/system/util_test_tool.go
+++ b/pkg/util/system/util_test_tool.go
@@ -42,10 +42,6 @@ func NewFileTestUtil(t *testing.T) *FileTestUtil {
 	return &FileTestUtil{TempDir: tempDir, t: t}
 }
 
-func (c *FileTestUtil) Cleanup() {
-	os.RemoveAll(c.TempDir)
-}
-
 func (c *FileTestUtil) MkDirAll(dirRelativePath string) {
 	dir := path.Join(c.TempDir, dirRelativePath)
 	if err := os.MkdirAll(dir, 0777); err != nil {

--- a/pkg/util/system/util_test_tool.go
+++ b/pkg/util/system/util_test_tool.go
@@ -30,14 +30,10 @@ type FileTestUtil struct {
 	t *testing.T
 }
 
-// Creates a new test util for the specified subsystem
+// NewFileTestUtil creates a new test util for the specified subsystem
 func NewFileTestUtil(t *testing.T) *FileTestUtil {
-	tempDir, err := ioutil.TempDir("/tmp", "koordlet_test")
+	tempDir := t.TempDir()
 	HostSystemInfo.IsAnolisOS = true
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	Conf.ProcRootDir = path.Join(tempDir, "proc")
 	os.MkdirAll(Conf.ProcRootDir, 0777)

--- a/pkg/util/system/util_test_tool_test.go
+++ b/pkg/util/system/util_test_tool_test.go
@@ -25,7 +25,6 @@ import (
 
 func Test_CommonFileFuncs(t *testing.T) {
 	helper := NewFileTestUtil(t)
-	defer helper.Cleanup()
 
 	testDir := "test"
 	helper.MkDirAll(testDir)
@@ -45,7 +44,6 @@ func Test_CommonFileFuncs(t *testing.T) {
 
 func Test_CgroupFileFuncs(t *testing.T) {
 	helper := NewFileTestUtil(t)
-	defer helper.Cleanup()
 
 	helper.CreateCgroupFile("", CPUCFSQuota)
 	exist := FileExists(GetCgroupFilePath("", CPUCFSQuota))
@@ -59,7 +57,6 @@ func Test_CgroupFileFuncs(t *testing.T) {
 
 func Test_ProcFileFuncs(t *testing.T) {
 	helper := NewFileTestUtil(t)
-	defer helper.Cleanup()
 
 	procFile := "testfile"
 	helper.CreateProcSubFile(procFile)

--- a/pkg/util/system/version_test.go
+++ b/pkg/util/system/version_test.go
@@ -59,7 +59,6 @@ func TestIsAnolisOS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := NewFileTestUtil(t)
-			defer helper.Cleanup()
 			helper.MkDirAll(tt.fs)
 			helper.CreateFile(tt.cgroupFile)
 			assert.Equal(t, tt.expect, isAnolisOS())

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -262,14 +261,12 @@ func Test_GenerateCPUSetStr(t *testing.T) {
 
 func Test_UtilCgroupCPUSet(t *testing.T) {
 	// prepare testing files
-	dname, err := ioutil.TempDir("", "cgroupCPUSet")
-	defer os.RemoveAll(dname)
-	assert.NoError(t, err)
+	dname := t.TempDir()
 
 	cpuset := []int32{5, 1, 0}
 	cpusetStr := GenerateCPUSetStr(cpuset)
 
-	err = WriteCgroupCPUSet(dname, cpusetStr)
+	err := WriteCgroupCPUSet(dname, cpusetStr)
 	assert.NoError(t, err)
 
 	rawContent, err := ioutil.ReadFile(filepath.Join(dname, system.CPUSFileName))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
All tests should continue to pass. No leftover temporary directories when the tests finish.

### Ⅳ. Special notes for reviews

