### PR TITLE
chore: fix test tempdir generation

### DIFF
--- a/pkg/util/system/util_test_tool.go
+++ b/pkg/util/system/util_test_tool.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type FileTestUtil struct {
@@ -32,11 +34,15 @@ type FileTestUtil struct {
 
 // NewFileTestUtil creates a new test util for the specified subsystem
 func NewFileTestUtil(t *testing.T) *FileTestUtil {
+	// NOTE: When $TMPDIR is not set, `t.TempDir()` can use different base directory on Mac OS X and Linux, which may
+	// generates too long paths to test unix socket.
+	t.Setenv("TMPDIR", "/tmp")
 	tempDir := t.TempDir()
 	HostSystemInfo.IsAnolisOS = true
 
 	Conf.ProcRootDir = path.Join(tempDir, "proc")
-	os.MkdirAll(Conf.ProcRootDir, 0777)
+	err := os.MkdirAll(Conf.ProcRootDir, 0777)
+	assert.NoError(t, err)
 	Conf.CgroupRootDir = tempDir
 
 	return &FileTestUtil{TempDir: tempDir, t: t}


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>


### Ⅰ. Describe what this PR does

Fix a failure of unit tests on mac os (but not fails CI in GitHub Actions).

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

The issue exists after PR #151 merged.

```bash
$ go test ./pkg/runtime/...
E0519 18:25:43.411020   40030 runtime.go:57] failed to get docker endpoint, error: docker endpoint does not exist
E0519 18:25:43.412342   40030 runtime.go:88] failed to get containerd endpoint, error: containerd endpoint does not exist
E0519 18:25:43.413709   40030 runtime.go:57] failed to get docker endpoint, error: docker endpoint does not exist
E0519 18:25:43.415042   40030 runtime.go:63] failed to create docker runtime handler, error: Unix socket path "/var/folders/wf/0n_kt22d1ld90gfmbq0k8z5c0000gp/T/Test_GetRuntimeHandlertest_have_dockerRuntime_but_need_containerd758888209/001/var/run/docker.sock" is too long
--- FAIL: Test_GetRuntimeHandler (0.01s)
    --- FAIL: Test_GetRuntimeHandler/test_have_dockerRuntime_but_need_containerd (0.00s)
        runtime_test.go:136: 
                Error Trace:    runtime_test.go:136
                Error:          Not equal: 
                                expected: false
                                actual  : true
                Test:           Test_GetRuntimeHandler/test_have_dockerRuntime_but_need_containerd
                Messages:       Unix socket path "/var/folders/wf/0n_kt22d1ld90gfmbq0k8z5c0000gp/T/Test_GetRuntimeHandlertest_have_dockerRuntime_but_need_containerd758888209/001/var/run/docker.sock" is too long
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xf8 pc=0x1f25452]

goroutine 68 [running]:
testing.tRunner.func1.2({0x203dae0, 0x2f5f6b0})
        /Users/home/sdk/go1.17.9/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /Users/home/sdk/go1.17.9/src/testing/testing.go:1212 +0x218
panic({0x203dae0, 0x2f5f6b0})
        /Users/home/sdk/go1.17.9/src/runtime/panic.go:1038 +0x215
github.com/koordinator-sh/koordinator/pkg/runtime.Test_GetRuntimeHandler.func1(0xc000503380)
        /Users/home/go/src/github.com/koordinator-sh/koordinator/pkg/runtime/runtime_test.go:138 +0x4f2
testing.tRunner(0xc000503380, 0xc0002f1c20)
        /Users/home/sdk/go1.17.9/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
        /Users/home/sdk/go1.17.9/src/testing/testing.go:1306 +0x35a
FAIL    github.com/koordinator-sh/koordinator/pkg/runtime       1.527s
--- FAIL: Test_Docker_NewDockerRuntimeHandler (0.00s)
--- FAIL: Test_Docker_StopContainer (0.00s)
--- FAIL: Test_Docker_UpdateContainerResources (0.00s)
FAIL
FAIL    github.com/koordinator-sh/koordinator/pkg/runtime/handler       0.938s
?       github.com/koordinator-sh/koordinator/pkg/runtime/handler/mockclient    [no test files]
FAIL
```

### Ⅲ. Describe how to verify it

`make test` gets no error

### Ⅳ. Special notes for reviews

related issues:
- https://github.com/golang/go/issues/21318
- https://github.com/kata-containers/kata-containers/issues/497
- https://github.com/containerd/containerd/pull/3046

