### PR TITLE
Introduce image service proxy under cri scenario

### DIFF
--- a/pkg/runtime-manager/server/cri/criserver.go
+++ b/pkg/runtime-manager/server/cri/criserver.go
@@ -38,9 +38,10 @@ const (
 )
 
 type RuntimeManagerCriServer struct {
-	hookDispatcher *dispatcher.RuntimeHookDispatcher
-	backendClient  runtimeapi.RuntimeServiceClient
-	store          *store.MetaManager
+	hookDispatcher              *dispatcher.RuntimeHookDispatcher
+	backendRuntimeServiceClient runtimeapi.RuntimeServiceClient
+	backendImageServiceClient   runtimeapi.ImageServiceClient
+	store                       *store.MetaManager
 }
 
 func NewRuntimeManagerCriServer(dispatcher *dispatcher.RuntimeHookDispatcher) *RuntimeManagerCriServer {
@@ -51,15 +52,15 @@ func NewRuntimeManagerCriServer(dispatcher *dispatcher.RuntimeHookDispatcher) *R
 	return criInterceptor
 }
 
-func (ci *RuntimeManagerCriServer) Name() string {
+func (c *RuntimeManagerCriServer) Name() string {
 	return "RuntimeManagerCriServer"
 }
 
-func (ci *RuntimeManagerCriServer) Run() error {
-	if err := ci.initBackendServer(utils.DefaultContainerdSocketPath); err != nil {
+func (c *RuntimeManagerCriServer) Run() error {
+	if err := c.initBackendServer(utils.DefaultRuntimeServiceSocketPath, utils.DefaultImageServiceSocketPath); err != nil {
 		return err
 	}
-	ci.failOver()
+	c.failOver()
 	klog.Infof("do failOver done")
 
 	lis, err := net.Listen("unix", utils.DefaultRuntimeManagerSocketPath)
@@ -68,12 +69,12 @@ func (ci *RuntimeManagerCriServer) Run() error {
 		return err
 	}
 	grpcServer := grpc.NewServer()
-	runtimeapi.RegisterRuntimeServiceServer(grpcServer, ci)
+	runtimeapi.RegisterRuntimeServiceServer(grpcServer, c)
 	err = grpcServer.Serve(lis)
 	return err
 }
 
-func (ci *RuntimeManagerCriServer) getRuntimeHookInfo(serviceType RuntimeServiceType) (config.RuntimeRequestPath,
+func (c *RuntimeManagerCriServer) getRuntimeHookInfo(serviceType RuntimeServiceType) (config.RuntimeRequestPath,
 	resource_executor.RuntimeResourceType) {
 	switch serviceType {
 	case RunPodSandbox:
@@ -91,11 +92,11 @@ func (ci *RuntimeManagerCriServer) getRuntimeHookInfo(serviceType RuntimeService
 	return config.NoneRuntimeHookPath, resource_executor.RuntimeNoopResource
 }
 
-func (ci *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeServiceType,
+func (c *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeServiceType,
 	ctx context.Context, request interface{}, handler grpc.UnaryHandler) (interface{}, error) {
 
-	runtimeHookPath, runtimeResourceType := ci.getRuntimeHookInfo(serviceType)
-	resourceExecutor := resource_executor.NewRuntimeResourceExecutor(runtimeResourceType, ci.store)
+	runtimeHookPath, runtimeResourceType := c.getRuntimeHookInfo(serviceType)
+	resourceExecutor := resource_executor.NewRuntimeResourceExecutor(runtimeResourceType, c.store)
 
 	if err := resourceExecutor.ParseRequest(request); err != nil {
 		klog.Errorf("fail to parse request %v %v", request, err)
@@ -104,7 +105,7 @@ func (ci *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeSe
 
 	// pre call hook server
 	// TODO deal with the Dispatch response
-	if response, err := ci.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil {
+	if response, err := c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil {
 		klog.Errorf("fail to call hook server %v", err)
 	} else {
 		resourceExecutor.UpdateResource(response)
@@ -125,7 +126,7 @@ func (ci *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeSe
 
 	// post call hook server
 	// TODO the response
-	ci.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PostHook, resourceExecutor.GenerateHookRequest())
+	c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PostHook, resourceExecutor.GenerateHookRequest())
 	return res, err
 }
 
@@ -133,29 +134,41 @@ func dialer(ctx context.Context, addr string) (net.Conn, error) {
 	return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 }
 
-func (ci *RuntimeManagerCriServer) initBackendServer(sockPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, sockPath, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
-	if err != nil {
-		klog.Infof("err to create  %v\n", err)
-		return err
+func (c *RuntimeManagerCriServer) initBackendServer(runtimeSockPath, imageSockPath string) error {
+	generateGrpcConn := func(sockPath string) (*grpc.ClientConn, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+		return grpc.DialContext(ctx, sockPath, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
 	}
-	ci.backendClient = runtimeapi.NewRuntimeServiceClient(conn)
+	if conn, err := generateGrpcConn(runtimeSockPath); err != nil {
+		klog.Errorf("fail to create runtime service client %v", err)
+		return err
+	} else {
+		c.backendRuntimeServiceClient = runtimeapi.NewRuntimeServiceClient(conn)
+		klog.Infof("success to create runtime client %v", runtimeSockPath)
+	}
+	if conn, err := generateGrpcConn(imageSockPath); err != nil {
+		klog.Errorf("fail to create image service client %v", err)
+		return err
+	} else {
+		c.backendImageServiceClient = runtimeapi.NewImageServiceClient(conn)
+		klog.Infof("success to create image client %v", imageSockPath)
+	}
+
 	return nil
 }
 
-func (ci *RuntimeManagerCriServer) failOver() error {
-	podResponse, podErr := ci.backendClient.ListPodSandbox(context.TODO(), &runtimeapi.ListPodSandboxRequest{})
+func (c *RuntimeManagerCriServer) failOver() error {
+	podResponse, podErr := c.backendRuntimeServiceClient.ListPodSandbox(context.TODO(), &runtimeapi.ListPodSandboxRequest{})
 	if podErr != nil {
 		return podErr
 	}
-	containerResponse, containerErr := ci.backendClient.ListContainers(context.TODO(), &runtimeapi.ListContainersRequest{})
+	containerResponse, containerErr := c.backendRuntimeServiceClient.ListContainers(context.TODO(), &runtimeapi.ListContainersRequest{})
 	if containerErr != nil {
 		return podErr
 	}
 	for _, pod := range podResponse.Items {
-		podResourceExecutor := cri_resource_executor.NewPodResourceExecutor(ci.store)
+		podResourceExecutor := cri_resource_executor.NewPodResourceExecutor(c.store)
 		podResourceExecutor.ParsePod(pod)
 		podResourceExecutor.ResourceCheckPoint(&runtimeapi.RunPodSandboxResponse{
 			PodSandboxId: pod.GetId(),
@@ -163,7 +176,7 @@ func (ci *RuntimeManagerCriServer) failOver() error {
 	}
 
 	for _, container := range containerResponse.Containers {
-		containerExecutor := cri_resource_executor.NewContainerResourceExecutor(ci.store)
+		containerExecutor := cri_resource_executor.NewContainerResourceExecutor(c.store)
 		containerExecutor.ParseContainer(container)
 		containerExecutor.ResourceCheckPoint(&runtimeapi.CreateContainerResponse{
 			ContainerId: container.GetId(),

--- a/pkg/runtime-manager/server/cri/image.go
+++ b/pkg/runtime-manager/server/cri/image.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"context"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *RuntimeManagerCriServer) PullImage(ctx context.Context, req *runtimeapi.PullImageRequest) (*runtimeapi.PullImageResponse, error) {
+	return c.backendImageServiceClient.PullImage(ctx, req)
+}
+
+func (c *RuntimeManagerCriServer) ImageStatus(ctx context.Context, req *runtimeapi.ImageStatusRequest) (*runtimeapi.ImageStatusResponse, error) {
+	return c.backendImageServiceClient.ImageStatus(ctx, req)
+}
+
+func (c *RuntimeManagerCriServer) RemoveImage(ctx context.Context, req *runtimeapi.RemoveImageRequest) (*runtimeapi.RemoveImageResponse, error) {
+	return c.backendImageServiceClient.RemoveImage(ctx, req)
+}
+
+func (c *RuntimeManagerCriServer) ListImages(ctx context.Context, req *runtimeapi.ListImagesRequest) (*runtimeapi.ListImagesResponse, error) {
+	return c.backendImageServiceClient.ListImages(ctx, req)
+}
+
+func (c *RuntimeManagerCriServer) ImageFsInfo(ctx context.Context, req *runtimeapi.ImageFsInfoRequest) (*runtimeapi.ImageFsInfoResponse, error) {
+	return c.backendImageServiceClient.ImageFsInfo(ctx, req)
+}

--- a/pkg/runtime-manager/server/cri/runtime.go
+++ b/pkg/runtime-manager/server/cri/runtime.go
@@ -22,25 +22,25 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-func (ci *RuntimeManagerCriServer) Version(ctx context.Context, req *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
-	return ci.backendClient.Version(ctx, req)
+func (c *RuntimeManagerCriServer) Version(ctx context.Context, req *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	return c.backendRuntimeServiceClient.Version(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) RunPodSandbox(ctx context.Context, req *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
-	rsp, err := ci.interceptRuntimeRequest(RunPodSandbox, ctx, req,
+func (c *RuntimeManagerCriServer) RunPodSandbox(ctx context.Context, req *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	rsp, err := c.interceptRuntimeRequest(RunPodSandbox, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.RunPodSandbox(ctx, req.(*runtimeapi.RunPodSandboxRequest))
+			return c.backendRuntimeServiceClient.RunPodSandbox(ctx, req.(*runtimeapi.RunPodSandboxRequest))
 		})
 	if err != nil {
 		return nil, err
 	}
 	return rsp.(*runtimeapi.RunPodSandboxResponse), err
 }
-func (ci *RuntimeManagerCriServer) StopPodSandbox(ctx context.Context, req *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+func (c *RuntimeManagerCriServer) StopPodSandbox(ctx context.Context, req *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
 
-	rsp, err := ci.interceptRuntimeRequest(StopPodSandbox, ctx, req,
+	rsp, err := c.interceptRuntimeRequest(StopPodSandbox, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.StopPodSandbox(ctx, req.(*runtimeapi.StopPodSandboxRequest))
+			return c.backendRuntimeServiceClient.StopPodSandbox(ctx, req.(*runtimeapi.StopPodSandboxRequest))
 		})
 
 	if err != nil {
@@ -49,22 +49,22 @@ func (ci *RuntimeManagerCriServer) StopPodSandbox(ctx context.Context, req *runt
 	return rsp.(*runtimeapi.StopPodSandboxResponse), err
 }
 
-func (ci *RuntimeManagerCriServer) RemovePodSandbox(ctx context.Context, req *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
-	return ci.backendClient.RemovePodSandbox(ctx, req)
+func (c *RuntimeManagerCriServer) RemovePodSandbox(ctx context.Context, req *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	return c.backendRuntimeServiceClient.RemovePodSandbox(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) PodSandboxStatus(ctx context.Context, req *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
-	return ci.backendClient.PodSandboxStatus(ctx, req)
+func (c *RuntimeManagerCriServer) PodSandboxStatus(ctx context.Context, req *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	return c.backendRuntimeServiceClient.PodSandboxStatus(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) ListPodSandbox(ctx context.Context, req *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
-	return ci.backendClient.ListPodSandbox(ctx, req)
+func (c *RuntimeManagerCriServer) ListPodSandbox(ctx context.Context, req *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	return c.backendRuntimeServiceClient.ListPodSandbox(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) CreateContainer(ctx context.Context, req *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
-	rsp, err := ci.interceptRuntimeRequest(CreateContainer, ctx, req,
+func (c *RuntimeManagerCriServer) CreateContainer(ctx context.Context, req *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	rsp, err := c.interceptRuntimeRequest(CreateContainer, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.CreateContainer(ctx, req.(*runtimeapi.CreateContainerRequest))
+			return c.backendRuntimeServiceClient.CreateContainer(ctx, req.(*runtimeapi.CreateContainerRequest))
 		})
 	if err != nil {
 		return nil, err
@@ -72,10 +72,10 @@ func (ci *RuntimeManagerCriServer) CreateContainer(ctx context.Context, req *run
 	return rsp.(*runtimeapi.CreateContainerResponse), err
 }
 
-func (ci *RuntimeManagerCriServer) StartContainer(ctx context.Context, req *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
-	rsp, err := ci.interceptRuntimeRequest(StartContainer, ctx, req,
+func (c *RuntimeManagerCriServer) StartContainer(ctx context.Context, req *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	rsp, err := c.interceptRuntimeRequest(StartContainer, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.StartContainer(ctx, req.(*runtimeapi.StartContainerRequest))
+			return c.backendRuntimeServiceClient.StartContainer(ctx, req.(*runtimeapi.StartContainerRequest))
 		})
 	if err != nil {
 		return nil, err
@@ -83,10 +83,10 @@ func (ci *RuntimeManagerCriServer) StartContainer(ctx context.Context, req *runt
 	return rsp.(*runtimeapi.StartContainerResponse), err
 }
 
-func (ci *RuntimeManagerCriServer) StopContainer(ctx context.Context, req *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
-	rsp, err := ci.interceptRuntimeRequest(StopContainer, ctx, req,
+func (c *RuntimeManagerCriServer) StopContainer(ctx context.Context, req *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	rsp, err := c.interceptRuntimeRequest(StopContainer, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.StopContainer(ctx, req.(*runtimeapi.StopContainerRequest))
+			return c.backendRuntimeServiceClient.StopContainer(ctx, req.(*runtimeapi.StopContainerRequest))
 		})
 	if err != nil {
 		return nil, err
@@ -94,10 +94,10 @@ func (ci *RuntimeManagerCriServer) StopContainer(ctx context.Context, req *runti
 	return rsp.(*runtimeapi.StopContainerResponse), err
 }
 
-func (ci *RuntimeManagerCriServer) RemoveContainer(ctx context.Context, req *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
-	rsp, err := ci.interceptRuntimeRequest(RemoveContainer, ctx, req,
+func (c *RuntimeManagerCriServer) RemoveContainer(ctx context.Context, req *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	rsp, err := c.interceptRuntimeRequest(RemoveContainer, ctx, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return ci.backendClient.RemoveContainer(ctx, req.(*runtimeapi.RemoveContainerRequest))
+			return c.backendRuntimeServiceClient.RemoveContainer(ctx, req.(*runtimeapi.RemoveContainerRequest))
 		})
 	if err != nil {
 		return nil, err
@@ -105,47 +105,47 @@ func (ci *RuntimeManagerCriServer) RemoveContainer(ctx context.Context, req *run
 	return rsp.(*runtimeapi.RemoveContainerResponse), err
 }
 
-func (ci *RuntimeManagerCriServer) ContainerStatus(ctx context.Context, req *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
-	return ci.backendClient.ContainerStatus(ctx, req)
+func (c *RuntimeManagerCriServer) ContainerStatus(ctx context.Context, req *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	return c.backendRuntimeServiceClient.ContainerStatus(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) ListContainers(ctx context.Context, req *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
-	return ci.backendClient.ListContainers(ctx, req)
+func (c *RuntimeManagerCriServer) ListContainers(ctx context.Context, req *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	return c.backendRuntimeServiceClient.ListContainers(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) UpdateContainerResources(ctx context.Context, req *runtimeapi.UpdateContainerResourcesRequest) (*runtimeapi.UpdateContainerResourcesResponse, error) {
-	return ci.backendClient.UpdateContainerResources(ctx, req)
+func (c *RuntimeManagerCriServer) UpdateContainerResources(ctx context.Context, req *runtimeapi.UpdateContainerResourcesRequest) (*runtimeapi.UpdateContainerResourcesResponse, error) {
+	return c.backendRuntimeServiceClient.UpdateContainerResources(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) ContainerStats(ctx context.Context, req *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
-	return ci.backendClient.ContainerStats(ctx, req)
+func (c *RuntimeManagerCriServer) ContainerStats(ctx context.Context, req *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
+	return c.backendRuntimeServiceClient.ContainerStats(ctx, req)
 }
-func (ci *RuntimeManagerCriServer) ListContainerStats(ctx context.Context, req *runtimeapi.ListContainerStatsRequest) (*runtimeapi.ListContainerStatsResponse, error) {
-	return ci.backendClient.ListContainerStats(ctx, req)
-}
-
-func (ci *RuntimeManagerCriServer) Status(ctx context.Context, req *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
-	return ci.backendClient.Status(ctx, req)
+func (c *RuntimeManagerCriServer) ListContainerStats(ctx context.Context, req *runtimeapi.ListContainerStatsRequest) (*runtimeapi.ListContainerStatsResponse, error) {
+	return c.backendRuntimeServiceClient.ListContainerStats(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) ReopenContainerLog(ctx context.Context, in *runtimeapi.ReopenContainerLogRequest) (*runtimeapi.ReopenContainerLogResponse, error) {
-	return ci.backendClient.ReopenContainerLog(ctx, in)
-}
-func (ci *RuntimeManagerCriServer) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
-	return ci.backendClient.ExecSync(ctx, in)
-}
-func (ci *RuntimeManagerCriServer) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
-	return ci.backendClient.Exec(ctx, in)
+func (c *RuntimeManagerCriServer) Status(ctx context.Context, req *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	return c.backendRuntimeServiceClient.Status(ctx, req)
 }
 
-func (ci *RuntimeManagerCriServer) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
-	return ci.backendClient.Attach(ctx, in)
+func (c *RuntimeManagerCriServer) ReopenContainerLog(ctx context.Context, in *runtimeapi.ReopenContainerLogRequest) (*runtimeapi.ReopenContainerLogResponse, error) {
+	return c.backendRuntimeServiceClient.ReopenContainerLog(ctx, in)
+}
+func (c *RuntimeManagerCriServer) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	return c.backendRuntimeServiceClient.ExecSync(ctx, in)
+}
+func (c *RuntimeManagerCriServer) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	return c.backendRuntimeServiceClient.Exec(ctx, in)
 }
 
-func (ci *RuntimeManagerCriServer) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
-	return ci.backendClient.PortForward(ctx, in)
+func (c *RuntimeManagerCriServer) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	return c.backendRuntimeServiceClient.Attach(ctx, in)
 }
 
-func (ci *RuntimeManagerCriServer) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
-	return ci.backendClient.UpdateRuntimeConfig(ctx, in)
+func (c *RuntimeManagerCriServer) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	return c.backendRuntimeServiceClient.PortForward(ctx, in)
+}
+
+func (c *RuntimeManagerCriServer) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	return c.backendRuntimeServiceClient.UpdateRuntimeConfig(ctx, in)
 }

--- a/pkg/runtime-manager/server/utils/utils.go
+++ b/pkg/runtime-manager/server/utils/utils.go
@@ -18,7 +18,8 @@ package utils
 
 const (
 	DefaultRuntimeManagerSocketPath = "/var/run/runtimemanger/runtimemanager.sock"
-	DefaultContainerdSocketPath     = "/run/containerd/containerd.sock"
+	DefaultRuntimeServiceSocketPath = "/run/containerd/containerd.sock"
+	DefaultImageServiceSocketPath   = "/run/containerd/containerd.sock"
 
 	UnKnownCgroupParent = "UnKnownCgroupParent"
 )


### PR DESCRIPTION
for kubelet, when --image-service-endpoint is not set, kubelet would use
the runtime socket as the image-service endpoint.

under kubelet using runtime-manager as remote runtime and image-service not configured scenario :
	kubelet xx --container-runtime-endpoint=/var/run/runtime-manager/runtimemanager.sock
runtime-manager should implement image service proxy, otherwise there would be image related errors
as no image-service exists.

runtime-manager just forwards image request to backend containerd tranparently.

Signed-off-by: honpey <honpey@gmail.com>


### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

