### PR TITLE
runtime-manager: refactor codes about store and resource-exectutor

### DIFF
--- a/pkg/runtime-manager/dispatcher/dispatcher.go
+++ b/pkg/runtime-manager/dispatcher/dispatcher.go
@@ -34,9 +34,11 @@ type RuntimeHookDispatcher struct {
 	hookManager *config.Manager
 }
 
-func NewRuntimeDispatcher(cm *HookServerClientManager, hookManager *config.Manager) *RuntimeHookDispatcher {
+func NewRuntimeDispatcher() *RuntimeHookDispatcher {
+	hookManager := config.NewConfigManager()
+	hookManager.Setup()
 	return &RuntimeHookDispatcher{
-		cm:          cm,
+		cm:          NewClientManager(),
 		hookManager: hookManager,
 	}
 }
@@ -69,7 +71,7 @@ func (rd *RuntimeHookDispatcher) Dispatch(ctx context.Context, runtimeRequestPat
 			if hookType.HookStage() != stage {
 				continue
 			}
-			client, err := rd.cm.RuntimeHookClient(HookServerPath{
+			client, err := rd.cm.RuntimeHookServerClient(HookServerPath{
 				Path: hookServer.RemoteEndpoint,
 			})
 			if err != nil {

--- a/pkg/runtime-manager/dispatcher/hookclient.go
+++ b/pkg/runtime-manager/dispatcher/hookclient.go
@@ -68,7 +68,7 @@ func newRuntimeHookClient(sockPath string) (*RuntimeHookClient, error) {
 	return client, nil
 }
 
-func (cm *HookServerClientManager) RuntimeHookClient(serverPath HookServerPath) (*RuntimeHookClient, error) {
+func (cm *HookServerClientManager) RuntimeHookServerClient(serverPath HookServerPath) (*RuntimeHookClient, error) {
 	cacheKey, err := json.Marshal(serverPath)
 	if err != nil {
 		return nil, err

--- a/pkg/runtime-manager/resource-executor/resource_executor.go
+++ b/pkg/runtime-manager/resource-executor/resource_executor.go
@@ -24,7 +24,6 @@ import (
 
 type RuntimeResourceExecutor interface {
 	GetMetaInfo() string
-	GenerateResourceCheckpoint() interface{}
 	GenerateHookRequest() interface{}
 	ParseRequest(request interface{}) error
 	UpdateResource(response interface{}) error
@@ -40,12 +39,12 @@ const (
 	RuntimeNoopResource      RuntimeResourceType = "RuntimeNoopResource"
 )
 
-func NewRuntimeResourceExecutor(runtimeResourceType RuntimeResourceType, store *store.MetaManager) RuntimeResourceExecutor {
+func NewRuntimeResourceExecutor(runtimeResourceType RuntimeResourceType) RuntimeResourceExecutor {
 	switch runtimeResourceType {
 	case RuntimePodResource:
-		return cri.NewPodResourceExecutor(store)
+		return cri.NewPodResourceExecutor()
 	case RuntimeContainerResource:
-		return cri.NewContainerResourceExecutor(store)
+		return cri.NewContainerResourceExecutor()
 	}
 	return &NoopResourceExecutor{}
 }

--- a/pkg/runtime-manager/server/utils/utils.go
+++ b/pkg/runtime-manager/server/utils/utils.go
@@ -17,7 +17,7 @@ limitations under the License.
 package utils
 
 const (
-	DefaultRuntimeManagerSocketPath = "/var/run/runtimemanger/runtimemanager.sock"
+	DefaultRuntimeManagerSocketPath = "/var/run/runtime-manager/runtimemanager.sock"
 	DefaultRuntimeServiceSocketPath = "/run/containerd/containerd.sock"
 	DefaultImageServiceSocketPath   = "/run/containerd/containerd.sock"
 


### PR DESCRIPTION
1. set metaManager as inner class inside store package. other package call store.WritePodSandboxInfo
   directly instead of getting a new Metamanager first.
2. resource-executor adapts for the new structed PodSandboxInfo/ContianerInfo

Signed-off-by: honpey <honpey@gmail.com>


### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

