### PR TITLE
api: remove deprecated field in NodeSLO

### DIFF
--- a/apis/slo/v1alpha1/nodeslo_types.go
+++ b/apis/slo/v1alpha1/nodeslo_types.go
@@ -178,11 +178,6 @@ type ResourceThresholdStrategy struct {
 	// +kubebuilder:validation:Minimum=0
 	MemoryEvictLowerPercent *int64 `json:"memoryEvictLowerPercent,omitempty"`
 
-	// cpu evict threshold percentage (0,100), default = 70
-	// +kubebuilder:default=70
-	// +kubebuilder:validation:Maximum=100
-	// +kubebuilder:validation:Minimum=0
-	CPUEvictThresholdPercent *int64 `json:"cpuEvictThresholdPercent,omitempty"`
 	// if be CPU RealLimit/allocatedLimit > CPUEvictBESatisfactionUpperPercent, then stop evict BE pods
 	CPUEvictBESatisfactionUpperPercent *int64 `json:"cpuEvictBESatisfactionUpperPercent,omitempty"`
 	// if be CPU (RealLimit/allocatedLimit < CPUEvictBESatisfactionLowerPercent and usage nearly 100%) continue CPUEvictTimeWindowSeconds,then start evict

--- a/apis/slo/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/slo/v1alpha1/zz_generated.deepcopy.go
@@ -656,11 +656,6 @@ func (in *ResourceThresholdStrategy) DeepCopyInto(out *ResourceThresholdStrategy
 		*out = new(int64)
 		**out = **in
 	}
-	if in.CPUEvictThresholdPercent != nil {
-		in, out := &in.CPUEvictThresholdPercent, &out.CPUEvictThresholdPercent
-		*out = new(int64)
-		**out = **in
-	}
 	if in.CPUEvictBESatisfactionUpperPercent != nil {
 		in, out := &in.CPUEvictBESatisfactionUpperPercent, &out.CPUEvictBESatisfactionUpperPercent
 		*out = new(int64)

--- a/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
@@ -820,14 +820,6 @@ spec:
                       then stop evict BE pods
                     format: int64
                     type: integer
-                  cpuEvictThresholdPercent:
-                    default: 70
-                    description: cpu evict threshold percentage (0,100), default =
-                      70
-                    format: int64
-                    maximum: 100
-                    minimum: 0
-                    type: integer
                   cpuEvictTimeWindowSeconds:
                     description: cpu evict start after continue avg(cpuusage) > CPUEvictThresholdPercent
                       in seconds


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>


### Ⅰ. Describe what this PR does
`CPUEvictThresholdPercent` is no longer in used. This PR would remove it from `NodeSLO.Spec`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #189

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

