### PR TITLE
Fix bug where runtime proxy cannot decode annotations within Docker c…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,29 @@
-flag_management:
-  default_rules:
-    carryforward: true
-    statuses:
-      - name_prefix: project-
-        type: project
+coverage:
+  status:
+    project:
+      # global coverage
+      default:
         target: auto
-        threshold: 5%
+        threshold: 2%
+        flags:
+          - unittests
+        paths:
+          - "pkg"
+        # advanced settings
+        if_ci_failed: error #success, failure, error, ignore
         if_no_uploads: error
         if_not_found: success # no commit found? still set a success
-      - name_prefix: patch-
-        type: patch
+    patch:
+      # diff coverage
+      default:
         target: 70%
+        flags:
+          - unittests
+        paths:
+          - "pkg"
+        if_ci_failed: error
         if_no_uploads: success
         if_not_found: success
+
 github_checks:
   annotations: true

--- a/pkg/runtimeproxy/server/docker/utils.go
+++ b/pkg/runtimeproxy/server/docker/utils.go
@@ -119,8 +119,8 @@ func splitLabelsAndAnnotations(configs map[string]string) (labels map[string]str
 	labels = make(map[string]string)
 	annos = make(map[string]string)
 	for k, v := range configs {
-		if strings.HasPrefix("annotation.", k) {
-			annos[strings.TrimPrefix("annotation.", k)] = v
+		if strings.HasPrefix(k, "annotation.") {
+			annos[strings.TrimPrefix(k, "annotation.")] = v
 		} else {
 			labels[k] = v
 		}

--- a/pkg/runtimeproxy/server/docker/utils_test.go
+++ b/pkg/runtimeproxy/server/docker/utils_test.go
@@ -78,3 +78,37 @@ func Test_getContainerID(t *testing.T) {
 		assert.Equal(t, tt.expectContainerID, cid)
 	}
 }
+
+func Test_splitLabelsAndAnnotations(t *testing.T) {
+	type args struct {
+		configs map[string]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantLabels map[string]string
+		wantAnnos  map[string]string
+	}{
+		{
+			name: "Docker - normal case",
+			args: args{
+				configs: map[string]string{
+					"annotation.dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
+					"io.kubernetes.docker.type": "podsandbox",
+				},
+			},
+			wantLabels: map[string]string{
+				"io.kubernetes.docker.type": "podsandbox",
+			},
+			wantAnnos: map[string]string{
+				"dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
+			},
+		},
+
+	}
+	for _, tt := range tests {
+		gotLabels, gotAnnos := splitLabelsAndAnnotations(tt.args.configs)
+		assert.Equal(t, tt.wantLabels, gotLabels)
+		assert.Equal(t, tt.wantAnnos, gotAnnos)
+	}
+}

--- a/pkg/util/meminfo_test.go
+++ b/pkg/util/meminfo_test.go
@@ -49,9 +49,26 @@ func Test_readMemInfo(t *testing.T) {
 		"HugePages_Rsvd:        0\nHugePages_Surp:        0\nHugepagesize:       2048 kB\n" +
 		"DirectMap4k:      414760 kB\nDirectMap2M:     8876032 kB\nDirectMap1G:    261095424 kB\n"
 	err := ioutil.WriteFile(tempMemInfoPath, []byte(memInfoContentStr), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
+	tempMemInfoPath1 := filepath.Join(tempDir, "meminfo1")
+	memInfoContentStr1 := "MemTotal:       263432804 kB\nMemFree:        254391744 kB\nMemAvailable:   256703236 kB\n" +
+		"Buffers:          958096 kB\nCached:          invalidField kB\nSwapCached:            0 kB\n" +
+		"Active:          2786012 kB\nInactive:        2223752 kB\nActive(anon):     289488 kB\n" +
+		"Inactive(anon):     1300 kB\nActive(file):    2496524 kB\nInactive(file):  2222452 kB\n" +
+		"Unevictable:           0 kB\nMlocked:               0 kB\nSwapTotal:             0 kB\n" +
+		"SwapFree:              0 kB\nDirty:               624 kB\nWriteback:             0 kB\n" +
+		"AnonPages:        281748 kB\nMapped:           495936 kB\nShmem:              2340 kB\n" +
+		"Slab:            1097040 kB\nSReclaimable:     445164 kB\nSUnreclaim:       651876 kB\n" +
+		"KernelStack:       20944 kB\nPageTables:         7896 kB\nNFS_Unstable:          0 kB\n" +
+		"Bounce:                0 kB\nWritebackTmp:          0 kB\nCommitLimit:    131716400 kB\n" +
+		"Committed_AS:    3825364 kB\nVmallocTotal:   34359738367 kB\nVmallocUsed:           0 kB\n" +
+		"VmallocChunk:          0 kB\nHardwareCorrupted:     0 kB\nAnonHugePages:     38912 kB\n" +
+		"ShmemHugePages:        0 kB\nShmemPmdMapped:        0 kB\nCmaTotal:              0 kB\n" +
+		"CmaFree:               0 kB\nHugePages_Total:       0\nHugePages_Free:        0\n" +
+		"HugePages_Rsvd:        0\nHugePages_Surp:        0\nHugepagesize:       2048 kB\n" +
+		"DirectMap4k:      414760 kB\nDirectMap2M:     8876032 kB\nDirectMap1G:    261095424 kB\n"
+	err = ioutil.WriteFile(tempMemInfoPath1, []byte(memInfoContentStr1), 0666)
+	assert.NoError(t, err)
 	type args struct {
 		path string
 	}
@@ -73,6 +90,50 @@ func Test_readMemInfo(t *testing.T) {
 			want: &MemInfo{
 				MemTotal: 263432804, MemFree: 254391744, MemAvailable: 256703236,
 				Buffers: 958096, Cached: 3763224, SwapCached: 0,
+				Active: 2786012, Inactive: 2223752, ActiveAnon: 289488,
+				InactiveAnon: 1300, ActiveFile: 2496524, InactiveFile: 2222452,
+				Unevictable: 0, Mlocked: 0, SwapTotal: 0,
+				SwapFree: 0, Dirty: 624, Writeback: 0,
+				AnonPages: 281748, Mapped: 495936, Shmem: 2340,
+				Slab: 1097040, SReclaimable: 445164, SUnreclaim: 651876,
+				KernelStack: 20944, PageTables: 7896, NFS_Unstable: 0,
+				Bounce: 0, WritebackTmp: 0, CommitLimit: 131716400,
+				Committed_AS: 3825364, VmallocTotal: 34359738367, VmallocUsed: 0,
+				VmallocChunk: 0, HardwareCorrupted: 0, AnonHugePages: 38912,
+				HugePages_Total: 0, HugePages_Free: 0, HugePages_Rsvd: 0,
+				HugePages_Surp: 0, Hugepagesize: 2048, DirectMap4k: 414760,
+				DirectMap2M: 8876032, DirectMap1G: 261095424,
+			},
+			wantErr: false,
+		},
+		{
+			name: "read test mem stat path",
+			args: args{path: tempMemInfoPath},
+			want: &MemInfo{
+				MemTotal: 263432804, MemFree: 254391744, MemAvailable: 256703236,
+				Buffers: 958096, Cached: 3763224, SwapCached: 0,
+				Active: 2786012, Inactive: 2223752, ActiveAnon: 289488,
+				InactiveAnon: 1300, ActiveFile: 2496524, InactiveFile: 2222452,
+				Unevictable: 0, Mlocked: 0, SwapTotal: 0,
+				SwapFree: 0, Dirty: 624, Writeback: 0,
+				AnonPages: 281748, Mapped: 495936, Shmem: 2340,
+				Slab: 1097040, SReclaimable: 445164, SUnreclaim: 651876,
+				KernelStack: 20944, PageTables: 7896, NFS_Unstable: 0,
+				Bounce: 0, WritebackTmp: 0, CommitLimit: 131716400,
+				Committed_AS: 3825364, VmallocTotal: 34359738367, VmallocUsed: 0,
+				VmallocChunk: 0, HardwareCorrupted: 0, AnonHugePages: 38912,
+				HugePages_Total: 0, HugePages_Free: 0, HugePages_Rsvd: 0,
+				HugePages_Surp: 0, Hugepagesize: 2048, DirectMap4k: 414760,
+				DirectMap2M: 8876032, DirectMap1G: 261095424,
+			},
+			wantErr: false,
+		},
+		{
+			name: "read test mem stat path",
+			args: args{path: tempMemInfoPath1},
+			want: &MemInfo{
+				MemTotal: 263432804, MemFree: 254391744, MemAvailable: 256703236,
+				Buffers: 958096, Cached: 0, SwapCached: 0,
 				Active: 2786012, Inactive: 2223752, ActiveAnon: 289488,
 				InactiveAnon: 1300, ActiveFile: 2496524, InactiveFile: 2222452,
 				Unevictable: 0, Mlocked: 0, SwapTotal: 0,


### PR DESCRIPTION
Signed-off-by: cheimu yimo@xiaohongshu.com


### Ⅰ. Describe what this PR does
In runtime proxy, for Docker backend, the splitLablesAndAnnotations cannot successfully decode annotations.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

