### PR TITLE
Fix bug where runtime proxy cannot decode annotations in Docker config

### DIFF
--- a/pkg/runtimeproxy/server/docker/utils.go
+++ b/pkg/runtimeproxy/server/docker/utils.go
@@ -119,8 +119,8 @@ func splitLabelsAndAnnotations(configs map[string]string) (labels map[string]str
 	labels = make(map[string]string)
 	annos = make(map[string]string)
 	for k, v := range configs {
-		if strings.HasPrefix("annotation.", k) {
-			annos[strings.TrimPrefix("annotation.", k)] = v
+		if strings.HasPrefix(k, "annotation.") {
+			annos[strings.TrimPrefix(k, "annotation.")] = v
 		} else {
 			labels[k] = v
 		}

--- a/pkg/runtimeproxy/server/docker/utils_test.go
+++ b/pkg/runtimeproxy/server/docker/utils_test.go
@@ -78,3 +78,37 @@ func Test_getContainerID(t *testing.T) {
 		assert.Equal(t, tt.expectContainerID, cid)
 	}
 }
+
+func Test_splitLabelsAndAnnotations(t *testing.T) {
+	type args struct {
+		configs map[string]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantLabels map[string]string
+		wantAnnos  map[string]string
+	}{
+		{
+			name: "Docker - normal case",
+			args: args{
+				configs: map[string]string{
+					"annotation.dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
+					"io.kubernetes.docker.type": "podsandbox",
+				},
+			},
+			wantLabels: map[string]string{
+				"io.kubernetes.docker.type": "podsandbox",
+			},
+			wantAnnos: map[string]string{
+				"dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
+			},
+		},
+
+	}
+	for _, tt := range tests {
+		gotLabels, gotAnnos := splitLabelsAndAnnotations(tt.args.configs)
+		assert.Equal(t, tt.wantLabels, gotLabels)
+		assert.Equal(t, tt.wantAnnos, gotAnnos)
+	}
+}

--- a/pkg/runtimeproxy/server/docker/utils_test.go
+++ b/pkg/runtimeproxy/server/docker/utils_test.go
@@ -94,7 +94,7 @@ func Test_splitLabelsAndAnnotations(t *testing.T) {
 			args: args{
 				configs: map[string]string{
 					"annotation.dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
-					"io.kubernetes.docker.type": "podsandbox",
+					"io.kubernetes.docker.type":                                      "podsandbox",
 				},
 			},
 			wantLabels: map[string]string{
@@ -104,7 +104,6 @@ func Test_splitLabelsAndAnnotations(t *testing.T) {
 				"dummy.koordinator.sh/test_splitLabelsAndAnnotations": "true",
 			},
 		},
-
 	}
 	for _, tt := range tests {
 		gotLabels, gotAnnos := splitLabelsAndAnnotations(tt.args.configs)


### PR DESCRIPTION
Signed-off-by: cheimu yimo@xiaohongshu.com

### Ⅰ. Describe what this PR does
In runtime proxy, for Docker backend, the splitLablesAndAnnotations cannot successfully decode annotations.
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

