### PR TITLE
fix: incorrect coversion of an integer

### DIFF
--- a/pkg/util/cpuinfo.go
+++ b/pkg/util/cpuinfo.go
@@ -144,16 +144,16 @@ func getProcessorInfos(lsCPUStr string) ([]ProcessorInfo, error) {
 		if len(items) < 6 {
 			continue
 		}
-		cpu, err := strconv.Atoi(items[0])
+		cpu, err := strconv.ParseInt(items[0], 10, 32)
 		if err != nil {
 			continue
 		}
-		node, _ := strconv.Atoi(items[1])
-		socket, err := strconv.Atoi(items[2])
+		node, _ := strconv.ParseInt(items[1], 10, 32)
+		socket, err := strconv.ParseInt(items[2], 10, 32)
 		if err != nil {
 			continue
 		}
-		core, err := strconv.Atoi(items[3])
+		core, err := strconv.ParseInt(items[3], 10, 32)
 		if err != nil {
 			continue
 		}

--- a/pkg/util/system/lscpu.go
+++ b/pkg/util/system/lscpu.go
@@ -43,7 +43,7 @@ func GetCacheInfo(str string) (string, int32, error) {
 		return "", 0, fmt.Errorf("invalid cache info %s", str)
 	}
 	l1l2 := infos[0]
-	l3, err := strconv.Atoi(infos[3])
+	l3, err := strconv.ParseInt(infos[3], 10, 32)
 	if err != nil {
 		return "", 0, err
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -92,18 +92,18 @@ func ParseCPUSetStr(cpusetStr string) ([]int32, error) {
 		boundaries := strings.Split(r, "-")
 		if len(boundaries) == 1 {
 			// only one element case, eg. "46"
-			elem, err := strconv.Atoi(boundaries[0])
+			elem, err := strconv.ParseInt(boundaries[0], 10, 32)
 			if err != nil {
 				return nil, err
 			}
 			cpuset = append(cpuset, int32(elem))
 		} else if len(boundaries) == 2 {
 			// multi-element case, eg. "0-5"
-			start, err := strconv.Atoi(boundaries[0])
+			start, err := strconv.ParseInt(boundaries[0], 10, 32)
 			if err != nil {
 				return nil, err
 			}
-			end, err := strconv.Atoi(boundaries[1])
+			end, err := strconv.ParseInt(boundaries[1], 10, 32)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>


### Ⅰ. Describe what this PR does
If a string is parsed into an int using strconv.Atoi, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
ref #240 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

