### PR TITLE
Add Defer os.Remove before starting runtime proxy server 

### DIFF
--- a/cmd/koord-runtime-proxy/main.go
+++ b/cmd/koord-runtime-proxy/main.go
@@ -48,6 +48,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to create socket dir, err: %v", err)
 	}
+	defer os.Remove(options.RuntimeProxyEndpoint)
 
 	switch options.BackendRuntimeMode {
 	case options.BackendRuntimeModeContainerd:
@@ -62,6 +63,5 @@ func main() {
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	<-stopCh
-	os.Remove(options.RuntimeProxyEndpoint)
 	klog.Info("RuntimeManager shutting down")
 }


### PR DESCRIPTION
Signed-off-by: Cheimu yimo@xiaohongshu.com


### Ⅰ. Describe what this PR does
Try to clean up runtime proxy endpoint socket file when runtime proxy got unexpected panic

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #246 
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

