### PR TITLE
Add container id to container info when store to cache

### DIFF
--- a/pkg/runtimeproxy/resexecutor/cri/container.go
+++ b/pkg/runtimeproxy/resexecutor/cri/container.go
@@ -125,6 +125,7 @@ func (c *ContainerResourceExecutor) ResourceCheckPoint(rsp interface{}) error {
 	// container level resource checkpoint would be triggered during post container create only
 	switch response := rsp.(type) {
 	case *runtimeapi.CreateContainerResponse:
+		c.ContainerMata.Id = response.GetContainerId()
 		err := store.WriteContainerInfo(response.GetContainerId(), &c.ContainerInfo)
 		if err != nil {
 			return err

--- a/pkg/runtimeproxy/resexecutor/cri/container_test.go
+++ b/pkg/runtimeproxy/resexecutor/cri/container_test.go
@@ -219,3 +219,51 @@ func TestContainerResourceExecutor_UpdateRequestForUpdateContainerResourcesReque
 		assert.Equal(t, tt.wantAnnotations, tt.args.req.(*runtimeapi.UpdateContainerResourcesRequest).GetAnnotations())
 	}
 }
+
+func TestContainerResourceExecutor_ResourceCheckPoint(t *testing.T) {
+	type fields struct {
+		ContainerInfo store.ContainerInfo
+	}
+	type args struct {
+		rsp interface{}
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		wantErr       bool
+		wantStoreInfo *store.ContainerInfo
+	}{
+		{
+			name: "normal case - CreateContainerResponse - Set Container id successfully",
+			args: args{
+				rsp: &runtimeapi.CreateContainerResponse{
+					ContainerId: "111111",
+				},
+			},
+			fields: fields{
+				ContainerInfo: store.ContainerInfo{
+					ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+						ContainerMata: &v1alpha1.ContainerMetadata{},
+					},
+				},
+			},
+			wantErr: false,
+			wantStoreInfo: &store.ContainerInfo{
+				ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+					ContainerMata: &v1alpha1.ContainerMetadata{
+						Id: "111111",
+					},
+				}},
+		},
+	}
+	for _, tt := range tests {
+		c := &ContainerResourceExecutor{
+			ContainerInfo: tt.fields.ContainerInfo,
+		}
+		err := c.ResourceCheckPoint(tt.args.rsp)
+		containerInfo := store.GetContainerInfo(c.ContainerInfo.ContainerMata.GetId())
+		assert.Equal(t, tt.wantErr, err != nil, err)
+		assert.Equal(t, tt.wantStoreInfo, containerInfo)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Cheimu <xerhoneyfc@gmail.com>


### Ⅰ. Describe what this PR does
Currently, when write to cache, there is no container id. This pr, for cri scenario will additionally add container id to cache.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

