### PR TITLE
docker-proxy: update podInfo and containerInfo with hook resp cgroupParent

### DIFF
--- a/pkg/runtimeproxy/server/docker/handler.go
+++ b/pkg/runtimeproxy/server/docker/handler.go
@@ -122,6 +122,7 @@ func (d *RuntimeManagerDockerServer) HandleCreateContainer(ctx context.Context, 
 			podInfo.Resources = resp.Resources
 		}
 		cfgBody.HostConfig.CgroupParent = resp.CgroupParent
+		podInfo.CgroupParent = resp.CgroupParent
 	} else if hookResp != nil {
 		resp := hookResp.(*v1alpha1.ContainerResourceHookResponse)
 		if resp.ContainerResources != nil {
@@ -129,6 +130,7 @@ func (d *RuntimeManagerDockerServer) HandleCreateContainer(ctx context.Context, 
 			containerInfo.ContainerResources = resp.ContainerResources
 		}
 		cfgBody.HostConfig.CgroupParent = resp.PodCgroupParent
+		containerInfo.PodCgroupParent = resp.PodCgroupParent
 	}
 	// send req to docker
 	nBody, err := encodeBody(cfgBody)


### PR DESCRIPTION
Signed-off-by: cheimu <yimo@xiaohongshu.com>


### Ⅰ. Describe what this PR does
Current docker proxy forgot to update hook response's cgroup parent field, so there is no updated information within cache. This pr fix this issue.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

