### PR TITLE
remove macos tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,7 @@ jobs:
           install-go: false
 
   unit-tests:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -83,7 +80,6 @@ jobs:
         run: make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.os == 'ubuntu-latest'
         with:
           flags: unittests
           file: cover.out


### PR DESCRIPTION
Signed-off-by: Fansong Zeng <fanster.z@gmail.com>


The test of MacOS is too slow. It is recommended that you can test locally when developing:

- `./hack/run-test.sh` to run all unittests
- `./hack/run-test.sh TestXX` to run the specified test
- `./hack/run-test.sh xx.go` to run tests in the xx.go file 