### PR TITLE
ci: enable CGO when GoReleaser compiles binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,9 +5,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos:
+  - goos:
       - linux
     goarch:
       - amd64
@@ -20,9 +18,7 @@ builds:
       - -X github.com/koordinator-sh/koordinator/pkg/version.buildDate={{ .Date }}
       - -X github.com/koordinator-sh/koordinator/pkg/version.gitCommit={{ .Commit }}
       - -X github.com/koordinator-sh/koordinator/pkg/version.gitTreeState=clean
-  - env:
-      - CGO_ENABLED=0
-    goos:
+  - goos:
       - linux
     goarch:
       - amd64
@@ -50,9 +46,7 @@ builds:
       - -X github.com/koordinator-sh/koordinator/pkg/version.buildDate={{ .Date }}
       - -X github.com/koordinator-sh/koordinator/pkg/version.gitCommit={{ .Commit }}
       - -X github.com/koordinator-sh/koordinator/pkg/version.gitTreeState=clean
-  - env:
-      - CGO_ENABLED=0
-    goos:
+  - goos:
       - linux
     goarch:
       - amd64


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>

### Ⅰ. Describe what this PR does
This PR would enable CGO when GoReleaser is compiling binaries.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
![image](https://user-images.githubusercontent.com/24452340/176862197-8d124d52-48c4-4993-85b6-d8c2d2d99e72.png)

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
