### PR TITLE
improve koordlet log verbosity

### DIFF
--- a/pkg/koordlet/metricsadvisor/collector.go
+++ b/pkg/koordlet/metricsadvisor/collector.go
@@ -362,7 +362,7 @@ func (c *collector) collectPodThrottledInfo() {
 		if err != nil || currentCPUStat == nil {
 			if pod.Status.Phase == corev1.PodRunning {
 				// print running pod collection error
-				klog.Infof("collect pod %s/%s, uid %v cpu throttled failed, err %v, metric %v",
+				klog.V(4).Infof("collect pod %s/%s, uid %v cpu throttled failed, err %v, metric %v",
 					pod.Namespace, pod.Name, uid, err, currentCPUStat)
 			}
 			continue
@@ -402,7 +402,7 @@ func (c *collector) collectContainerThrottledInfo(podMeta *statesinformer.PodMet
 		collectTime := time.Now()
 		containerStat := &pod.Status.ContainerStatuses[i]
 		if len(containerStat.ContainerID) == 0 {
-			klog.Infof("container %s/%s/%s id is empty, maybe not ready, skip this round",
+			klog.V(4).Infof("container %s/%s/%s id is empty, maybe not ready, skip this round",
 				pod.Namespace, pod.Name, containerStat.Name)
 			continue
 		}
@@ -414,7 +414,7 @@ func (c *collector) collectContainerThrottledInfo(podMeta *statesinformer.PodMet
 		}
 		currentCPUStat, err := system.GetCPUStatRaw(containerCgroupPath)
 		if err != nil {
-			klog.Infof("collect container %s/%s/%s cpu throttled failed, err %v, metric %v",
+			klog.V(4).Infof("collect container %s/%s/%s cpu throttled failed, err %v, metric %v",
 				pod.Namespace, pod.Name, containerStat.Name, err, currentCPUStat)
 			continue
 		}

--- a/pkg/koordlet/reporter/reporter.go
+++ b/pkg/koordlet/reporter/reporter.go
@@ -211,7 +211,7 @@ func (r *reporter) sync() {
 	if retErr != nil {
 		klog.Warningf("update node metric status failed, status %v, err %v", util.DumpJSON(newStatus), retErr)
 	} else {
-		klog.Infof("update node metric status success, detail: %v", util.DumpJSON(newStatus))
+		klog.V(4).Infof("update node metric status success, detail: %v", util.DumpJSON(newStatus))
 	}
 }
 

--- a/pkg/koordlet/resmanager/cgroup_reconcile.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile.go
@@ -467,6 +467,8 @@ func makeCgroupResourcesForAnolis(owner *OwnerRef, parentDir string, summary *cg
 	var resources []MergeableResourceUpdater
 
 	if !system.HostSystemInfo.IsAnolisOS {
+		klog.V(5).Infof("ignored cgroup resources which required non Anolis OS, owner: %v, parentDir: %v",
+			owner, parentDir)
 		return nil
 	}
 

--- a/pkg/koordlet/resmanager/memory_evict.go
+++ b/pkg/koordlet/resmanager/memory_evict.go
@@ -51,11 +51,11 @@ func NewMemoryEvictor(mgr *resmanager) *MemoryEvictor {
 }
 
 func (m *MemoryEvictor) memoryEvict() {
-	klog.Infof("starting memory evict process")
-	defer klog.Infof("memory evict process completed")
+	klog.V(5).Infof("starting memory evict process")
+	defer klog.V(5).Infof("memory evict process completed")
 
 	if time.Now().Before(m.lastEvictTime.Add(time.Duration(m.resManager.config.MemoryEvictCoolTimeSeconds) * time.Second)) {
-		klog.Infof("skip memory evict process, still in evict cooling time")
+		klog.V(5).Infof("skip memory evict process, still in evict cooling time")
 		return
 	}
 
@@ -110,7 +110,7 @@ func (m *MemoryEvictor) memoryEvict() {
 
 	nodeMemoryUsage := nodeMetric.MemoryUsed.MemoryWithoutCache.Value() * 100 / memoryCapacity
 	if nodeMemoryUsage < *thresholdPercent {
-		klog.Infof("skip memory evict, node memory usage(%v) is below threshold(%v)", nodeMemoryUsage, thresholdConfig)
+		klog.V(5).Infof("skip memory evict, node memory usage(%v) is below threshold(%v)", nodeMemoryUsage, thresholdConfig)
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

improve the log verbosity of koordlet.

For example, when we use Centos 7, we don't expect an error-like log for the cgroup file `cpu.burst_us`, since this file may not exist on OSs other than Anolis OS.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

reduce misunderstandings when koordlet is deployed with the default log level

### Ⅳ. Special notes for reviews

some refactoring may conflict with #328 

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
