### PR TITLE
Add pod uid to pod meta when failover

### DIFF
--- a/pkg/runtimeproxy/resexecutor/cri/pod.go
+++ b/pkg/runtimeproxy/resexecutor/cri/pod.go
@@ -90,6 +90,7 @@ func (p *PodResourceExecutor) ParsePod(podsandbox *runtimeapi.PodSandbox) error 
 			PodMeta: &v1alpha1.PodSandboxMetadata{
 				Name:      podsandbox.GetMetadata().GetName(),
 				Namespace: podsandbox.GetMetadata().GetNamespace(),
+				Uid:       podsandbox.GetMetadata().GetUid(),
 			},
 			RuntimeHandler: podsandbox.GetRuntimeHandler(),
 			Annotations:    podsandbox.GetAnnotations(),

--- a/pkg/runtimeproxy/resexecutor/cri/pod.go
+++ b/pkg/runtimeproxy/resexecutor/cri/pod.go
@@ -67,6 +67,7 @@ func (p *PodResourceExecutor) ParseRequest(req interface{}) error {
 				PodMeta: &v1alpha1.PodSandboxMetadata{
 					Name:      request.GetConfig().GetMetadata().GetName(),
 					Namespace: request.GetConfig().GetMetadata().GetNamespace(),
+					Uid:       request.GetConfig().GetMetadata().GetUid(),
 				},
 				RuntimeHandler: request.GetRuntimeHandler(),
 				Annotations:    request.GetConfig().GetAnnotations(),

--- a/pkg/runtimeproxy/server/docker/server.go
+++ b/pkg/runtimeproxy/server/docker/server.go
@@ -131,6 +131,7 @@ func (d *RuntimeManagerDockerServer) failOver(dockerClient proxyDockerClient) er
 				CgroupParent: s.ContainerJSON.HostConfig.CgroupParent,
 				PodMeta: &v1alpha1.PodSandboxMetadata{
 					Name: s.Name,
+					Uid:  s.ID,
 				},
 				RuntimeHandler: "Docker",
 				Resources:      HostConfigToResource(s.ContainerJSON.HostConfig),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Currently, when proxy restart, the pod uids are not updated to cache, so hooks won't get any information about the id. This PR will add uids when proxy failover
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
