### PR TITLE
cleanup: Use the structure as the key of the map instead of string

### DIFF
--- a/pkg/runtimeproxy/dispatcher/hookclient.go
+++ b/pkg/runtimeproxy/dispatcher/hookclient.go
@@ -17,7 +17,6 @@ limitations under the License.
 package dispatcher
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/golang/groupcache/lru"
@@ -69,11 +68,7 @@ func newRuntimeHookClient(sockPath string) (*RuntimeHookClient, error) {
 }
 
 func (cm *HookServerClientManager) RuntimeHookServerClient(serverPath HookServerPath) (*RuntimeHookClient, error) {
-	cacheKey, err := json.Marshal(serverPath)
-	if err != nil {
-		return nil, err
-	}
-	if client, ok := cm.cache.Get(string(cacheKey)); ok {
+	if client, ok := cm.cache.Get(serverPath); ok {
 		return client.(*RuntimeHookClient), nil
 	}
 
@@ -82,6 +77,6 @@ func (cm *HookServerClientManager) RuntimeHookServerClient(serverPath HookServer
 		klog.Errorf("fail to create client %v", err)
 		return nil, err
 	}
-	cm.cache.Add(string(cacheKey), runtimeHookClient)
+	cm.cache.Add(serverPath, runtimeHookClient)
 	return runtimeHookClient, nil
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Use the structure as the key of the map instead of string

refer：
https://github.com/golang/groupcache/blob/41bb18bfe9da5321badc438f91158cd790a33aa3/lru/lru.go#L36-L37
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
