### PR TITLE
[koord-runtime-proxy]: fix panic when no hook registered

### DIFF
--- a/pkg/runtimeproxy/server/cri/criserver.go
+++ b/pkg/runtimeproxy/server/cri/criserver.go
@@ -105,7 +105,7 @@ func (c *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeSer
 
 	// pre call hook server
 	// TODO deal with the Dispatch response
-	if response, err := c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil {
+	if response, err := c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil || response == nil {
 		klog.Errorf("fail to call hook server %v", err)
 	} else {
 		if err = resourceExecutor.UpdateRequest(response, request); err != nil {

--- a/pkg/runtimeproxy/server/cri/criserver.go
+++ b/pkg/runtimeproxy/server/cri/criserver.go
@@ -105,8 +105,12 @@ func (c *RuntimeManagerCriServer) interceptRuntimeRequest(serviceType RuntimeSer
 
 	// pre call hook server
 	// TODO deal with the Dispatch response
-	if response, err := c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest()); err != nil || response == nil {
+	response, err := c.hookDispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, resourceExecutor.GenerateHookRequest())
+	if err != nil {
 		klog.Errorf("fail to call hook server %v", err)
+	} else if response == nil {
+		// when hook is not registered, the response will become nil
+		klog.Warningf("runtime hook path %s does not register any PreHooks", string(runtimeHookPath))
 	} else {
 		if err = resourceExecutor.UpdateRequest(response, request); err != nil {
 			klog.Errorf("failed to update cri request %v", err)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
When no hook is registered, the dispatch will return a nil rsp, which will cause panic for UpdateRequest

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
partly fixes #352 (the panic part)
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
