### PR TITLE
[koord-runtime-proxy] fix the loss of new updated resources from UpdateContainerResources request

### DIFF
--- a/pkg/runtimeproxy/resexecutor/cri/container.go
+++ b/pkg/runtimeproxy/resexecutor/cri/container.go
@@ -91,7 +91,12 @@ func (c *ContainerResourceExecutor) ParseRequest(req interface{}) error {
 	case *runtimeapi.StartContainerRequest:
 		return c.loadContainerInfoFromStore(request.GetContainerId(), "StartContainer")
 	case *runtimeapi.UpdateContainerResourcesRequest:
-		return c.loadContainerInfoFromStore(request.GetContainerId(), "UpdateContainerResource")
+		err := c.loadContainerInfoFromStore(request.GetContainerId(), "UpdateContainerResource")
+		if err != nil {
+			return err
+		}
+		c.ContainerResources = updateResourceByUpdateContainerResourceRequest(c.ContainerResources, transferToKoordResources(request.Linux))
+		return nil
 	case *runtimeapi.StopContainerRequest:
 		return c.loadContainerInfoFromStore(request.GetContainerId(), "StopContainer")
 	}

--- a/pkg/runtimeproxy/resexecutor/cri/container_test.go
+++ b/pkg/runtimeproxy/resexecutor/cri/container_test.go
@@ -267,3 +267,199 @@ func TestContainerResourceExecutor_ResourceCheckPoint(t *testing.T) {
 		assert.Equal(t, tt.wantStoreInfo, containerInfo)
 	}
 }
+
+func TestContainerResourceExecutor_ParseRequest_CreateContainerRequest(t *testing.T) {
+	type args struct {
+		podReq       interface{}
+		containerReq interface{}
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		wantContainerExecutor store.ContainerInfo
+	}{
+		{
+			name: "normal case",
+			args: args{
+				podReq: &runtimeapi.RunPodSandboxRequest{
+					Config: &runtimeapi.PodSandboxConfig{
+						Metadata: &runtimeapi.PodSandboxMetadata{
+							Name:      "mock pod sandbox",
+							Namespace: "mock namespace",
+							Uid:       "202207121604",
+						},
+						Annotations: map[string]string{
+							"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Pod": "true",
+						},
+						Labels: map[string]string{
+							"label.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Pod": "true",
+						},
+						Linux: &runtimeapi.LinuxPodSandboxConfig{
+							CgroupParent: "/kubepods/besteffort",
+						},
+					},
+				},
+				containerReq: &runtimeapi.CreateContainerRequest{
+					PodSandboxId: "202207121604",
+					Config: &runtimeapi.ContainerConfig{
+						Metadata: &runtimeapi.ContainerMetadata{
+							Name:    "test container",
+							Attempt: 101010,
+						},
+						Annotations: map[string]string{
+							"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Container": "true",
+						},
+						Labels: map[string]string{
+							"label.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Container": "true",
+						},
+						Linux: &runtimeapi.LinuxContainerConfig{
+							Resources: &runtimeapi.LinuxContainerResources{
+								CpuPeriod:   1000,
+								CpuShares:   500,
+								OomScoreAdj: 10,
+								Unified: map[string]string{
+									"resourceA": "resource A",
+								},
+							},
+						},
+					},
+					SandboxConfig: &runtimeapi.PodSandboxConfig{
+						Linux: &runtimeapi.LinuxPodSandboxConfig{
+							CgroupParent: "/kubepods/besteffort",
+						},
+					},
+				},
+			},
+			wantContainerExecutor: store.ContainerInfo{
+				ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+					PodMeta: &v1alpha1.PodSandboxMetadata{
+						Name:      "mock pod sandbox",
+						Namespace: "mock namespace",
+						Uid:       "202207121604",
+					},
+					PodLabels: map[string]string{
+						"label.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Pod": "true",
+					},
+					PodAnnotations: map[string]string{
+						"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Pod": "true",
+					},
+					ContainerMata: &v1alpha1.ContainerMetadata{
+						Name:    "test container",
+						Attempt: 101010,
+					},
+					ContainerAnnotations: map[string]string{
+						"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Container": "true",
+					},
+					ContainerResources: &v1alpha1.LinuxContainerResources{
+						CpuPeriod:   1000,
+						CpuShares:   500,
+						OomScoreAdj: 10,
+						Unified: map[string]string{
+							"resourceA": "resource A",
+						},
+					},
+					PodCgroupParent: "/kubepods/besteffort",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		// mock pod cache
+		p := NewPodResourceExecutor()
+		_ = p.ParseRequest(tt.args.podReq)
+		_ = store.WritePodSandboxInfo("202207121604", &p.PodSandboxInfo)
+
+		// write container cache
+		c := NewContainerResourceExecutor()
+		_ = c.ParseRequest(tt.args.containerReq)
+
+		// check if container cache is set correctly
+		assert.Equal(t, tt.wantContainerExecutor, c.ContainerInfo)
+	}
+}
+
+func TestContainerResourceExecutor_ParseRequest_UpdateContainerResourcesRequest(t *testing.T) {
+	type args struct {
+		containerID               string
+		containerReq              interface{}
+		ExistingContainerExecutor store.ContainerInfo
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantContainerInfo store.ContainerInfo
+	}{
+		{
+			name: "normal case",
+			args: args{
+				containerID: "10101010",
+				containerReq: &runtimeapi.UpdateContainerResourcesRequest{
+					ContainerId: "10101010",
+					Linux: &runtimeapi.LinuxContainerResources{
+						CpusetCpus: "0-31",
+					},
+				},
+				ExistingContainerExecutor: store.ContainerInfo{
+					ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+						PodMeta: &v1alpha1.PodSandboxMetadata{
+							Name:      "mock pod sandbox",
+							Namespace: "mock namespace",
+							Uid:       "202207121604",
+						},
+						ContainerMata: &v1alpha1.ContainerMetadata{
+							Name:    "test container",
+							Attempt: 101010,
+						},
+						ContainerAnnotations: map[string]string{
+							"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Container": "true",
+						},
+						ContainerResources: &v1alpha1.LinuxContainerResources{
+							CpuPeriod:   1000,
+							CpuShares:   500,
+							OomScoreAdj: 10,
+							Unified: map[string]string{
+								"resourceA": "resource A",
+							},
+						},
+						PodCgroupParent: "/kubepods/besteffort",
+					},
+				},
+			},
+			wantContainerInfo: store.ContainerInfo{
+				ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+					PodMeta: &v1alpha1.PodSandboxMetadata{
+						Name:      "mock pod sandbox",
+						Namespace: "mock namespace",
+						Uid:       "202207121604",
+					},
+					ContainerMata: &v1alpha1.ContainerMetadata{
+						Name:    "test container",
+						Attempt: 101010,
+					},
+					ContainerAnnotations: map[string]string{
+						"annotation.dummy.koordinator.sh/TestContainerResourceExecutor_ParseRequest_CreateContainerRequest_Container": "true",
+					},
+					ContainerResources: &v1alpha1.LinuxContainerResources{
+						CpuPeriod:   1000,
+						CpuShares:   500,
+						OomScoreAdj: 10,
+						CpusetCpus:  "0-31",
+						Unified: map[string]string{
+							"resourceA": "resource A",
+						},
+					},
+					PodCgroupParent: "/kubepods/besteffort",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		c := NewContainerResourceExecutor()
+		// mock container cache
+		_ = store.WriteContainerInfo(tt.args.containerID, &tt.args.ExistingContainerExecutor)
+		_ = c.ParseRequest(tt.args.containerReq)
+
+		// check if container cache is set correctly
+		assert.Equal(t, tt.wantContainerInfo, c.ContainerInfo)
+	}
+}

--- a/pkg/runtimeproxy/resexecutor/cri/utils.go
+++ b/pkg/runtimeproxy/resexecutor/cri/utils.go
@@ -81,10 +81,44 @@ func updateResource(a, b *v1alpha1.LinuxContainerResources) *v1alpha1.LinuxConta
 		a.CpuShares = b.CpuShares
 	}
 	if b.MemoryLimitInBytes > 0 {
-		a.MemoryLimitInBytes = b.MemorySwapLimitInBytes
+		a.MemoryLimitInBytes = b.MemoryLimitInBytes
 	}
 	if b.OomScoreAdj >= -1000 && b.OomScoreAdj <= 1000 {
 		a.OomScoreAdj = b.OomScoreAdj
+	}
+	if b.CpusetCpus != "" {
+		a.CpusetCpus = b.CpusetCpus
+	}
+	if b.CpusetMems != "" {
+		a.CpusetMems = b.CpusetMems
+	}
+	a.Unified = utils.MergeMap(a.Unified, b.Unified)
+	if b.MemorySwapLimitInBytes > 0 {
+		a.MemorySwapLimitInBytes = b.MemorySwapLimitInBytes
+	}
+	return a
+}
+
+// updateResourceByUpdateContainerResourceRequest updates resources in cache by UpdateContainerResource request.
+// updateResourceByUpdateContainerResourceRequest will omit OomScoreAdj.
+//
+// Normally kubelet won't send UpdateContainerResource request, so if some components want to send it and want to update OomScoreAdj,
+// please use hook to achieve it.
+func updateResourceByUpdateContainerResourceRequest(a, b *v1alpha1.LinuxContainerResources) *v1alpha1.LinuxContainerResources {
+	if a == nil || b == nil {
+		return a
+	}
+	if b.CpuPeriod > 0 {
+		a.CpuPeriod = b.CpuPeriod
+	}
+	if b.CpuQuota > 0 {
+		a.CpuQuota = b.CpuQuota
+	}
+	if b.CpuShares > 0 {
+		a.CpuShares = b.CpuShares
+	}
+	if b.MemoryLimitInBytes > 0 {
+		a.MemoryLimitInBytes = b.MemoryLimitInBytes
 	}
 	if b.CpusetCpus != "" {
 		a.CpusetCpus = b.CpusetCpus

--- a/pkg/runtimeproxy/server/docker/handler.go
+++ b/pkg/runtimeproxy/server/docker/handler.go
@@ -263,6 +263,13 @@ func (d *RuntimeManagerDockerServer) HandleUpdateContainer(ctx context.Context, 
 		hookReq = containerMeta.GetContainerResourceHookRequest()
 	}
 
+	// update resources in cache with UpdateConfig
+	if containerConfig != nil && hookReq != nil {
+		if updateReq, ok := hookReq.(*v1alpha1.ContainerResourceHookRequest); ok {
+			updateReq.ContainerResources = MergeResourceByUpdateConfig(updateReq.ContainerResources, containerConfig)
+		}
+	}
+
 	response, err := d.dispatcher.Dispatch(ctx, runtimeHookPath, config.PreHook, hookReq)
 	if err != nil {
 		klog.Errorf("Failed to call pre update hook server %v", err)

--- a/pkg/runtimeproxy/server/docker/utils.go
+++ b/pkg/runtimeproxy/server/docker/utils.go
@@ -188,6 +188,34 @@ func UpdateUpdateConfigByResource(containerConfig *container.UpdateConfig, resou
 	return containerConfig
 }
 
+func MergeResourceByUpdateConfig(resources *v1alpha1.LinuxContainerResources, containerConfig *container.UpdateConfig) *v1alpha1.LinuxContainerResources {
+	if containerConfig == nil || resources == nil {
+		return resources
+	}
+	if containerConfig.CPUPeriod > 0 {
+		resources.CpuPeriod = containerConfig.CPUPeriod
+	}
+	if containerConfig.CPUQuota > 0 {
+		resources.CpuQuota = containerConfig.CPUQuota
+	}
+	if containerConfig.CPUShares > 0 {
+		resources.CpuShares = containerConfig.CPUShares
+	}
+	if containerConfig.Memory > 0 {
+		resources.MemoryLimitInBytes = containerConfig.Memory
+	}
+	if containerConfig.CpusetCpus != "" {
+		resources.CpusetCpus = containerConfig.CpusetCpus
+	}
+	if containerConfig.CpusetMems != "" {
+		resources.CpusetMems = containerConfig.CpusetMems
+	}
+	if containerConfig.MemorySwap > 0 {
+		resources.MemorySwapLimitInBytes = containerConfig.MemorySwap
+	}
+	return resources
+}
+
 // generateExpectedCgroupParent is adapted from Dockershim
 func generateExpectedCgroupParent(cgroupDriver, cgroupParent string) string {
 	if cgroupParent != "" {


### PR DESCRIPTION
Signed-off-by: Cheimu <xerhoneyfc@gmail.com>

### Ⅰ. Describe what this PR does
Requests
* UpdateContainer - docker
* UpdateContainerResources - containerd

try to update container's resources by resources fields within the request. However current implementation directly drop the resources fields, which will block any update operation. This pr fix this problem.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
