### PR TITLE
koordlet: refine initJiffies with default value

### DIFF
--- a/pkg/koordlet/metricsadvisor/collector.go
+++ b/pkg/koordlet/metricsadvisor/collector.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metricsadvisor
 
 import (
-	"fmt"
+	"bytes"
 	"os"
 	"os/exec"
 	"strconv"
@@ -46,8 +46,7 @@ const (
 
 var (
 	// jiffies is the duration unit of CPU stats
-	jiffies = float64(10 * time.Millisecond)
-
+	jiffies            = float64(10 * time.Millisecond)
 	localCPUInfoGetter = util.GetLocalCPUInfo
 )
 
@@ -148,26 +147,24 @@ func (c *collector) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
+// initJiffies use command "getconf CLK_TCK" to fetch the clock tick on current host,
+// if the command doesn't exist, uses the default value 10ms for jiffies
 func initJiffies() error {
-	// retrieve jiffies
-	clkTckStdout, err := exec.Command("getconf", "CLK_TCK").Output()
+	getconf, err := exec.LookPath("getconf")
+	if err != nil {
+		return nil
+	}
+	cmd := exec.Command(getconf, "CLK_TCK")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	ticks, err := strconv.ParseFloat(strings.TrimSpace(out.String()), 64)
 	if err != nil {
 		return err
 	}
-	clkTckStdoutStrs := strings.Split(string(clkTckStdout), "\n")
-	if len(clkTckStdoutStrs) <= 0 {
-		return fmt.Errorf("getconf CLK_TCK returns empty")
-	}
-	clkTckStdoutStr := strings.Fields(clkTckStdoutStrs[0])
-	if len(clkTckStdoutStr) <= 0 {
-		return fmt.Errorf("getconf CLK_TCK returns empty")
-	}
-	clkTck, err := strconv.Atoi(clkTckStdoutStr[0])
-	if err != nil {
-		return err
-	}
-	// clkTck (Hz)
-	jiffies = float64(time.Second / time.Duration(clkTck))
+	jiffies = float64(time.Second / time.Duration(ticks))
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>

### Ⅰ. Describe what this PR does
initJiffies use command "getconf CLK_TCK" to fetch the clock tick on current host.
However base image `gcr.io/distroless/base:latest` doesn't have this command. So this PR will allow koordlet to use the default value 10ms for jiffies if the command doesn't exist .
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
