### PR TITLE
fix reservation on mutil-scheduler

### DIFF
--- a/pkg/scheduler/plugins/reservation/rpod.go
+++ b/pkg/scheduler/plugins/reservation/rpod.go
@@ -87,3 +87,10 @@ func GetReservePodNodeName(pod *corev1.Pod) string {
 func GetReservationNameFromReservePod(pod *corev1.Pod) string {
 	return pod.Annotations[AnnotationReservationName]
 }
+
+func GetReservationSchedulerName(r *schedulingv1alpha1.Reservation) string {
+	if r == nil || r.Spec.Template == nil || len(r.Spec.Template.Spec.SchedulerName) <= 0 {
+		return corev1.DefaultSchedulerName
+	}
+	return r.Spec.Template.Spec.SchedulerName
+}

--- a/pkg/scheduler/plugins/reservation/utils_test.go
+++ b/pkg/scheduler/plugins/reservation/utils_test.go
@@ -313,3 +313,50 @@ func Test_matchReservationOwners(t *testing.T) {
 		})
 	}
 }
+
+func TestGetReservationSchedulerName(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *schedulingv1alpha1.Reservation
+		want string
+	}{
+		{
+			name: "empty reservation",
+			arg:  nil,
+			want: corev1.DefaultSchedulerName,
+		},
+		{
+			name: "empty template",
+			arg:  &schedulingv1alpha1.Reservation{},
+			want: corev1.DefaultSchedulerName,
+		},
+		{
+			name: "empty scheduler name",
+			arg: &schedulingv1alpha1.Reservation{
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{},
+				},
+			},
+			want: corev1.DefaultSchedulerName,
+		},
+		{
+			name: "get scheduler name successfully",
+			arg: &schedulingv1alpha1.Reservation{
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							SchedulerName: "test-scheduler",
+						},
+					},
+				},
+			},
+			want: "test-scheduler",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetReservationSchedulerName(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the event handler for unscheduled reservations in the mutil-scheduler scenario:

1. When multiple schedulers run in the same cluster, unscheduled reservations should only get enqueued for the specified scheduler (according to field `spec.template.spec.schedulerName`).
2. Ignore the deletion of expired reservations which have been existing before the scheduler started.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Create reservation objects with different scheduler names.
2. Check the log of the koord-scheduler about event handlers' processing.
3. Unscheduled reservations which specify other schedulers should not get enqueued in the koord-scheduler.
4. When the scheduler starts, no ERROR logs for removing expired reservations.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
