### PR TITLE
fix: use uint32 to record process id

### DIFF
--- a/pkg/koordlet/metricsadvisor/collector_gpu_linux.go
+++ b/pkg/koordlet/metricsadvisor/collector_gpu_linux.go
@@ -156,12 +156,12 @@ func (g *gpuDeviceManager) getNodeGPUUsage() []metriccache.GPUMetric {
 	return rtn
 }
 
-func (g *gpuDeviceManager) getTotalGPUUsageOfPIDs(pids []uint64) []metriccache.GPUMetric {
+func (g *gpuDeviceManager) getTotalGPUUsageOfPIDs(pids []uint32) []metriccache.GPUMetric {
 	g.RLock()
 	defer g.RUnlock()
 	tmp := make(map[int]*rawGPUMetric)
 	for _, pid := range pids {
-		if metrics, exist := g.processesMetrics[uint32(pid)]; exist {
+		if metrics, exist := g.processesMetrics[pid]; exist {
 			for idx, metric := range metrics {
 				if metric == nil {
 					continue

--- a/pkg/koordlet/metricsadvisor/collector_gpu_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/collector_gpu_linux_test.go
@@ -146,7 +146,7 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 		processesMetrics map[uint32][]*rawGPUMetric
 	}
 	type args struct {
-		pids []uint64
+		pids []uint32
 	}
 	tests := []struct {
 		name   string
@@ -157,7 +157,7 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 		{
 			name: "single device",
 			args: args{
-				pids: []uint64{122},
+				pids: []uint32{122},
 			},
 			fields: fields{
 				deviceCount: 1,
@@ -182,7 +182,7 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 		{
 			name: "multiple device",
 			args: args{
-				pids: []uint64{122, 222},
+				pids: []uint32{122, 222},
 			},
 			fields: fields{
 				deviceCount: 2,
@@ -215,7 +215,7 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 		{
 			name: "multiple device-1",
 			args: args{
-				pids: []uint64{122},
+				pids: []uint32{122},
 			},
 			fields: fields{
 				deviceCount: 2,
@@ -241,7 +241,7 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 		{
 			name: "multiple device and multiple processes",
 			args: args{
-				pids: []uint64{122, 222},
+				pids: []uint32{122, 222},
 			},
 			fields: fields{
 				deviceCount: 2,

--- a/pkg/util/container.go
+++ b/pkg/util/container.go
@@ -229,8 +229,8 @@ func GetContainerCurTasks(podParentDir string, c *corev1.ContainerStatus) ([]int
 	return system.GetCgroupCurTasks(cgroupPath)
 }
 
-func GetPIDsInPod(podParentDir string, cs []corev1.ContainerStatus) ([]uint64, error) {
-	pids := make([]uint64, 0)
+func GetPIDsInPod(podParentDir string, cs []corev1.ContainerStatus) ([]uint32, error) {
+	pids := make([]uint32, 0)
 	for i := range cs {
 		p, err := GetPIDsInContainer(podParentDir, &cs[i])
 		if err != nil {
@@ -241,7 +241,7 @@ func GetPIDsInPod(podParentDir string, cs []corev1.ContainerStatus) ([]uint64, e
 	return pids, nil
 }
 
-func GetPIDsInContainer(podParentDir string, c *corev1.ContainerStatus) ([]uint64, error) {
+func GetPIDsInContainer(podParentDir string, c *corev1.ContainerStatus) ([]uint32, error) {
 	cgroupPath, err := GetContainerCgroupCPUProcsPath(podParentDir, c)
 	if err != nil {
 		return nil, err
@@ -251,14 +251,14 @@ func GetPIDsInContainer(podParentDir string, c *corev1.ContainerStatus) ([]uint6
 		return nil, err
 	}
 	pidStrs := strings.Fields(strings.TrimSpace(string(rawContent)))
-	pids := make([]uint64, len(pidStrs))
+	pids := make([]uint32, len(pidStrs))
 
 	for i := 0; i < len(pids); i++ {
-		p, err := strconv.ParseUint(pidStrs[i], 10, 64)
+		p, err := strconv.ParseUint(pidStrs[i], 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		pids[i] = p
+		pids[i] = uint32(p)
 	}
 	return pids, nil
 }

--- a/pkg/util/container_test.go
+++ b/pkg/util/container_test.go
@@ -25,11 +25,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/koordinator-sh/koordinator/apis/extension"
-	"github.com/koordinator-sh/koordinator/pkg/util/system"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
 )
 
 func Test_getContainerCgroupPathWithSystemdDriver(t *testing.T) {
@@ -732,7 +733,7 @@ func TestGetPIDsInContainer(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []uint64
+		want    []uint32
 		wantErr bool
 	}{
 		{
@@ -743,7 +744,7 @@ func TestGetPIDsInContainer(t *testing.T) {
 					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 				},
 			},
-			want: []uint64{12, 23},
+			want: []uint32{12, 23},
 		},
 		{
 			name: "not exist",
@@ -771,7 +772,6 @@ func TestGetPIDsInContainer(t *testing.T) {
 }
 
 func TestGetPIDsInPod(t *testing.T) {
-
 	system.SetupCgroupPathFormatter(system.Systemd)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	dir := t.TempDir()
@@ -795,7 +795,7 @@ func TestGetPIDsInPod(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []uint64
+		want    []uint32
 		wantErr bool
 	}{
 		{
@@ -811,7 +811,7 @@ func TestGetPIDsInPod(t *testing.T) {
 					},
 				},
 			},
-			want:    []uint64{12, 23, 45, 67},
+			want:    []uint32{12, 23, 45, 67},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Jason Liu <jasonliu747@gmail.com>

### Ⅰ. Describe what this PR does
Trying to fix security alert reported by CodeQL one by one.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
![image](https://user-images.githubusercontent.com/24452340/183599069-3195256a-ce28-4332-8a21-3d65c82b863a.png)
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
