### PR TITLE
koord-scheduler: fix stale reservation status

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -114,3 +114,15 @@ func SetReservationAllocated(pod *corev1.Pod, r *schedulingv1alpha1.Reservation)
 	data, _ := json.Marshal(reservationAllocated) // assert no error
 	pod.Annotations[AnnotationReservationAllocated] = string(data)
 }
+
+func RemoveReservationAllocated(pod *corev1.Pod, r *schedulingv1alpha1.Reservation) (bool, error) {
+	reservationAllocated, err := GetReservationAllocated(pod)
+	if err != nil {
+		return false, err
+	}
+	if reservationAllocated != nil && reservationAllocated.Name == r.Name && reservationAllocated.UID == r.UID {
+		delete(pod.Annotations, AnnotationReservationAllocated)
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/scheduler/plugins/reservation/garbage_collection.go
+++ b/pkg/scheduler/plugins/reservation/garbage_collection.go
@@ -24,10 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/klog/v2"
+	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
 
-	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 const (
@@ -36,7 +38,7 @@ const (
 )
 
 func (p *Plugin) gcReservations() {
-	rList, err := p.lister.List(labels.Everything())
+	rList, err := p.rLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list reservations, abort the GC turn, err: %s", err)
 		return
@@ -49,6 +51,9 @@ func (p *Plugin) gcReservations() {
 			if err = p.expireReservation(r); err != nil {
 				klog.Warningf("failed to update reservation %s as expired, err: %s", klog.KObj(r), err)
 			}
+		} else if IsReservationActive(r) {
+			// sync active reservation for correct owner statuses
+			p.syncActiveReservation(r)
 		} else if IsReservationExpired(r) {
 			p.reservationCache.AddToFailed(r)
 		}
@@ -101,7 +106,7 @@ func (p *Plugin) expireReservation(r *schedulingv1alpha1.Reservation) error {
 	p.reservationCache.AddToFailed(r)
 	// update reservation status
 	return retryOnConflictOrTooManyRequests(func() error {
-		curR, err := p.lister.Get(r.Name)
+		curR, err := p.rLister.Get(r.Name)
 		if errors.IsNotFound(err) {
 			klog.V(4).InfoS("reservation not found, abort the update",
 				"reservation", klog.KObj(r))
@@ -119,48 +124,81 @@ func (p *Plugin) expireReservation(r *schedulingv1alpha1.Reservation) error {
 	})
 }
 
-func (p *Plugin) syncPodDeleted(pod *corev1.Pod) {
-	// assert pod != nil
-	reservationAllocated, err := apiext.GetReservationAllocated(pod)
-	if err != nil {
-		klog.V(3).InfoS("failed to parse reservation allocation info of the pod",
-			"pod", klog.KObj(pod), "err", err)
+func (p *Plugin) syncActiveReservation(r *schedulingv1alpha1.Reservation) {
+	var actualOwners, missedOwners []corev1.ObjectReference
+	actualAllocated := util.NewZeroResourceList()
+	for _, owner := range r.Status.CurrentOwners {
+		pod, err := p.podLister.Pods(owner.Namespace).Get(owner.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				klog.V(5).InfoS("failed to get reservation's owner pod",
+					"reservation", klog.KObj(r), "namespace", owner.Namespace, "name", owner.Name, "err", err)
+			} else {
+				klog.V(3).InfoS("failed to get reservation's owner pod with unexpected reason",
+					"reservation", klog.KObj(r), "namespace", owner.Namespace, "name", owner.Name, "err", err)
+			}
+			missedOwners = append(missedOwners, owner)
+			continue
+		}
+		actualOwners = append(actualOwners, owner)
+		req, _ := resourceapi.PodRequestsAndLimits(pod)
+		actualAllocated = quotav1.Add(actualAllocated, req)
+	}
+
+	// if current owner status is correct
+	if len(missedOwners) <= 0 && quotav1.Equals(actualAllocated, r.Status.Allocated) {
 		return
 	}
+
+	// fix the incorrect owner status
+	newR := r.DeepCopy()
+	newR.Status.Allocated = actualAllocated
+	newR.Status.CurrentOwners = actualOwners
+	// if failed to update, abort and let the next event reconcile
+	_, err := p.client.Reservations().UpdateStatus(context.TODO(), newR, metav1.UpdateOptions{})
+	if err != nil {
+		klog.V(3).InfoS("failed to update status for reservation correction",
+			"reservation", klog.KObj(r), "err", err)
+	}
+	klog.V(5).InfoS("update active reservation for status correction", "reservation", klog.KObj(r))
+}
+
+func (p *Plugin) syncPodDeleted(pod *corev1.Pod) {
+	rInfo := p.reservationCache.GetOwned(pod)
 	// Most pods have no reservation allocated.
-	if reservationAllocated == nil {
+	if rInfo == nil {
 		return
 	}
 
 	// pod has allocated reservation, should remove allocation info in the reservation
-	err = retryOnConflictOrTooManyRequests(func() error {
-		r, err1 := p.lister.Get(reservationAllocated.Name)
+	cached := rInfo.GetReservation()
+	err := retryOnConflictOrTooManyRequests(func() error {
+		r, err1 := p.rLister.Get(cached.Name)
 		if errors.IsNotFound(err1) {
 			klog.V(5).InfoS("skip sync for reservation not found", "reservation", klog.KObj(r))
 			return nil
 		} else if err1 != nil {
-			klog.V(4).InfoS("failed to get reservation",
-				"reservation", klog.KObj(r), "err", err1)
+			klog.V(4).InfoS("failed to get reservation", "reservation", klog.KObj(r), "err", err1)
 			return err1
 		}
 
 		// check if the reservation has been expired
 		if !IsReservationScheduled(r) {
-			klog.V(4).InfoS("abort sync for reservation is no longer available or scheduled",
+			klog.V(4).InfoS("skip sync for reservation no longer available or scheduled",
 				"reservation", klog.KObj(r))
 			return nil
 		}
 		// got different versions of the reservation; still check if the reservation was allocated by this pod
-		if r.UID != reservationAllocated.UID {
+		if r.UID != cached.UID {
 			klog.V(4).InfoS("failed to get original reservation, got reservation with a different UID",
-				"reservation", reservationAllocated.Name, "old UID", reservationAllocated.UID, "current UID", r.UID)
+				"reservation", cached.Name, "old UID", cached.UID, "current UID", r.UID)
 		}
 		curR := r.DeepCopy()
 		err1 = removeReservationAllocated(curR, pod)
 		if err1 != nil {
-			klog.V(4).InfoS("failed to remove reservation allocated",
+			klog.V(5).InfoS("failed to remove reservation allocated",
 				"reservation", klog.KObj(curR), "pod", klog.KObj(pod), "err", err1)
-			return err1
+			return nil
 		}
 
 		_, err1 = p.client.Reservations().UpdateStatus(context.TODO(), curR, metav1.UpdateOptions{})

--- a/pkg/scheduler/plugins/reservation/garbage_collection_test.go
+++ b/pkg/scheduler/plugins/reservation/garbage_collection_test.go
@@ -17,20 +17,40 @@ limitations under the License.
 package reservation
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	apiext "github.com/koordinator-sh/koordinator/apis/extension"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	listercorev1 "k8s.io/client-go/listers/core/v1"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	clientschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/scheduling/v1alpha1"
 	listerschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
+
+type fakePodLister struct {
+	listercorev1.PodNamespaceLister
+	pods   map[string]*corev1.Pod
+	getErr map[string]bool
+}
+
+func (f *fakePodLister) Pods(namespace string) listercorev1.PodNamespaceLister {
+	return f
+}
+
+func (f *fakePodLister) Get(name string) (*corev1.Pod, error) {
+	if f.getErr[name] {
+		return nil, fmt.Errorf("get err")
+	}
+	return f.pods[name], nil
+}
 
 func Test_gcReservations(t *testing.T) {
 	now := time.Now()
@@ -270,14 +290,14 @@ func Test_gcReservations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Plugin{
 				reservationCache: tt.fields.reservationCache,
-				lister:           tt.fields.lister,
+				rLister:          tt.fields.lister,
 				client:           tt.fields.client,
 			}
 			tt.fields.client.lister = tt.fields.lister
 
 			p.gcReservations()
 
-			gotExist, gotExpired, gotErr := testListExistAndExpired(p.lister)
+			gotExist, gotExpired, gotErr := testListExistAndExpired(p.rLister)
 			if tt.fields.listErr {
 				assert.Equal(t, true, gotErr != nil)
 				return
@@ -443,7 +463,7 @@ func Test_expireReservationOnNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Plugin{
 				reservationCache: tt.fields.reservationCache,
-				lister:           tt.fields.lister,
+				rLister:          tt.fields.lister,
 				client:           tt.fields.client,
 				informer:         tt.fields.informer,
 			}
@@ -451,7 +471,7 @@ func Test_expireReservationOnNode(t *testing.T) {
 
 			p.expireReservationOnNode(tt.arg)
 
-			gotExist, gotExpired, gotErr := testListExistAndExpired(p.lister)
+			gotExist, gotExpired, gotErr := testListExistAndExpired(p.rLister)
 			if tt.fields.listErr {
 				assert.Equal(t, true, gotErr != nil)
 				return
@@ -459,6 +479,101 @@ func Test_expireReservationOnNode(t *testing.T) {
 			assert.NoError(t, gotErr)
 			assert.Equal(t, tt.wantFields.exist, gotExist)
 			assert.Equal(t, tt.wantFields.expired, gotExpired)
+		})
+	}
+}
+
+func Test_syncActiveReservation(t *testing.T) {
+	normalPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod-1",
+		},
+	}
+	now := time.Now()
+	testNoOwner := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "r-active",
+			UID:  "0",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Expires: &metav1.Time{Time: now.Add(10 * time.Hour)},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:     schedulingv1alpha1.ReservationAvailable,
+			NodeName:  "node-0",
+			Allocated: util.NewZeroResourceList(),
+		},
+	}
+	testHasOwner := testNoOwner.DeepCopy()
+	setReservationAllocated(testHasOwner, normalPod)
+	testHasOwner1 := testHasOwner.DeepCopy()
+	testHasOwner2 := testHasOwner.DeepCopy()
+	type fields struct {
+		podLister listercorev1.PodLister
+		client    clientschedulingv1alpha1.SchedulingV1alpha1Interface
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		arg    *schedulingv1alpha1.Reservation
+	}{
+		{
+			name: "no owners to re-sync",
+			arg:  testNoOwner,
+		},
+		{
+			name: "does not change for correct owner",
+			fields: fields{
+				podLister: &fakePodLister{
+					pods: map[string]*corev1.Pod{
+						normalPod.Name: normalPod,
+					},
+				},
+			},
+			arg: testHasOwner,
+		},
+		{
+			name: "fix for owner cannot get",
+			fields: fields{
+				podLister: &fakePodLister{
+					getErr: map[string]bool{
+						normalPod.Name: true,
+					},
+				},
+				client: &fakeReservationClient{
+					lister: &fakeReservationLister{
+						reservations: map[string]*schedulingv1alpha1.Reservation{
+							testHasOwner1.Name: testHasOwner1,
+						},
+					},
+				},
+			},
+			arg: testHasOwner1,
+		},
+		{
+			name: "fix for owner but failed to update status",
+			fields: fields{
+				podLister: &fakePodLister{
+					getErr: map[string]bool{
+						normalPod.Name: true,
+					},
+				},
+				client: &fakeReservationClient{
+					updateStatusErr: map[string]bool{
+						testHasOwner2.Name: true,
+					},
+				},
+			},
+			arg: testHasOwner2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{
+				podLister: tt.fields.podLister,
+				client:    tt.fields.client,
+			}
+			p.syncActiveReservation(tt.arg)
 		})
 	}
 }
@@ -497,6 +612,20 @@ func Test_syncPodDeleted(t *testing.T) {
 			UID:  "aaabbbccc",
 		},
 		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
 			Expires: &metav1.Time{Time: now.Add(10 * time.Hour)},
 		},
 		Status: schedulingv1alpha1.ReservationStatus{
@@ -515,25 +644,24 @@ func Test_syncPodDeleted(t *testing.T) {
 			},
 		},
 	}
-	testReservationFailed := &schedulingv1alpha1.Reservation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-reserve-0",
-		},
-		Spec: schedulingv1alpha1.ReservationSpec{
-			Expires: &metav1.Time{Time: now.Add(10 * time.Hour)},
-		},
-		Status: schedulingv1alpha1.ReservationStatus{
-			Phase:    schedulingv1alpha1.ReservationFailed,
-			NodeName: "test-node-0",
-		},
-	}
+	testReservationFailed := testReservation.DeepCopy()
+	testReservationFailed.Status.Phase = schedulingv1alpha1.ReservationFailed
 	testReservationDifferent := testReservation.DeepCopy()
 	testReservationDifferent.UID = "xxxyyyzzz"
 	testReservationNotMatched := testReservation.DeepCopy()
 	testReservationNotMatched.Status.CurrentOwners = nil
+	testCacheHasOwner := newReservationCache()
+	testCacheHasOwner.AddToActive(testReservation)
+	testCacheFailed := newReservationCache()
+	testCacheFailed.AddToActive(testReservationFailed)
+	testCacheOwnerDifferent := newReservationCache()
+	testCacheOwnerDifferent.AddToActive(testReservationDifferent)
+	testCacheOwnerNotMatched := newReservationCache()
+	testCacheOwnerNotMatched.AddToActive(testReservationNotMatched)
 	type fields struct {
-		lister *fakeReservationLister
-		client *fakeReservationClient
+		reservationCache *reservationCache
+		lister           *fakeReservationLister
+		client           *fakeReservationClient
 	}
 	tests := []struct {
 		name   string
@@ -542,16 +670,13 @@ func Test_syncPodDeleted(t *testing.T) {
 	}{
 		{
 			name: "not allocate reservation",
-			arg:  &corev1.Pod{},
-		},
-		{
-			name: "invalid allocate info",
+			fields: fields{
+				reservationCache: newReservationCache(),
+			},
 			arg: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod-0",
-					Annotations: map[string]string{
-						apiext.AnnotationReservationAllocated: "invalid info",
-					},
+					UID:  "5678",
 				},
 			},
 		},
@@ -559,6 +684,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "failed to get reservation",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheHasOwner,
 				lister: &fakeReservationLister{
 					getErr: map[string]bool{
 						testReservation.Name: true,
@@ -570,6 +696,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "failed to update status",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheHasOwner,
 				lister: &fakeReservationLister{
 					reservations: map[string]*schedulingv1alpha1.Reservation{
 						testReservation.Name: testReservation,
@@ -586,6 +713,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "skip for failed reservation",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheFailed,
 				lister: &fakeReservationLister{
 					reservations: map[string]*schedulingv1alpha1.Reservation{
 						testReservationFailed.Name: testReservationFailed,
@@ -597,6 +725,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "sync successfully",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheHasOwner,
 				lister: &fakeReservationLister{
 					reservations: map[string]*schedulingv1alpha1.Reservation{
 						testReservation.Name: testReservation,
@@ -609,6 +738,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "get different versions of the reservation",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheOwnerDifferent,
 				lister: &fakeReservationLister{
 					reservations: map[string]*schedulingv1alpha1.Reservation{
 						testReservationDifferent.Name: testReservationDifferent,
@@ -621,6 +751,7 @@ func Test_syncPodDeleted(t *testing.T) {
 			name: "current owner not match",
 			arg:  testPod,
 			fields: fields{
+				reservationCache: testCacheOwnerNotMatched,
 				lister: &fakeReservationLister{
 					reservations: map[string]*schedulingv1alpha1.Reservation{
 						testReservationNotMatched.Name: testReservationNotMatched,
@@ -633,8 +764,9 @@ func Test_syncPodDeleted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Plugin{
-				lister: tt.fields.lister,
-				client: tt.fields.client,
+				reservationCache: tt.fields.reservationCache,
+				rLister:          tt.fields.lister,
+				client:           tt.fields.client,
 			}
 			if tt.fields.lister != nil && tt.fields.client != nil {
 				tt.fields.client.lister = tt.fields.lister

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -28,12 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	listercorev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/scheduling/config"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	clientschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/scheduling/v1alpha1"
 	listerschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
@@ -50,8 +52,8 @@ const (
 	ErrReasonReservationNotFound = "reservation is not found"
 	// ErrReasonReservationFailed is the reason for the reservation is failed/expired and should not be used.
 	ErrReasonReservationFailed = "reservation is failed"
-	// ErrReasonReservationFailedToReserve is the reason for the assumed reservation does not match the pod any more.
-	ErrReasonReservationFailedToReserve = "reservation failed to reserve and does not match any more"
+	// ErrReasonReservationNotMatchStale is the reason for the assumed reservation does not match the pod any more.
+	ErrReasonReservationNotMatchStale = "reservation is stale and does not match any more"
 	// SkipReasonNotReservation is the reason for pod does not match any reservation.
 	SkipReasonNotReservation = "pod does not match any reservation"
 )
@@ -70,7 +72,8 @@ type Plugin struct {
 	handle           frameworkext.ExtendedHandle
 	args             *config.ReservationArgs
 	informer         cache.SharedIndexInformer
-	lister           listerschedulingv1alpha1.ReservationLister
+	rLister          listerschedulingv1alpha1.ReservationLister
+	podLister        listercorev1.PodLister
 	client           clientschedulingv1alpha1.SchedulingV1alpha1Interface // for updates
 	reservationCache *reservationCache
 }
@@ -103,16 +106,17 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		handle:           extendedHandle,
 		args:             pluginArgs,
 		informer:         reservationInformer,
-		lister:           reservationInterface.Lister(),
+		rLister:          reservationInterface.Lister(),
+		podLister:        extendedHandle.SharedInformerFactory().Core().V1().Pods().Lister(),
 		client:           extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
 		reservationCache: newReservationCache(),
 	}
 
 	// handle reservation event in cache; here only scheduled and expired reservations are considered.
 	reservationInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    p.reservationCache.HandleOnAdd,
-		UpdateFunc: p.reservationCache.HandleOnUpdate,
-		DeleteFunc: p.reservationCache.HandleOnDelete,
+		AddFunc:    p.handleOnAdd,
+		UpdateFunc: p.handleOnUpdate,
+		DeleteFunc: p.handleOnDelete,
 	})
 	// handle reservations on deleted nodes
 	extendedHandle.SharedInformerFactory().Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -132,6 +136,8 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		},
 	})
 	// handle deleting pods which allocate reservation resources
+	// FIXME: the handler does not recognize if the pod belongs to current scheduler, so the reconciliation could be
+	//  duplicated if multiple koord-scheduler runs in same cluster. Now we should keep the reconciliation idempotent.
 	extendedHandle.SharedInformerFactory().Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			switch t := obj.(type) {
@@ -151,6 +157,8 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 
 	// check reservations' expiration
 	go wait.Until(p.gcReservations, defaultGCCheckInterval, nil)
+	// check reservation cache expiration
+	go wait.Until(p.reservationCache.Run, defaultCacheCheckInterval, nil)
 
 	pluginEnabled.Store(true)
 	klog.V(3).InfoS("reservation plugin enabled")
@@ -168,7 +176,7 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 		// validate reserve pod and reservation
 		klog.V(4).InfoS("Attempting to pre-filter reserve pod", "pod", klog.KObj(pod))
 		rName := GetReservationNameFromReservePod(pod)
-		r, err := p.lister.Get(rName)
+		r, err := p.rLister.Get(rName)
 		if errors.IsNotFound(err) {
 			klog.V(3).InfoS("skip the pre-filter for reservation since the object is not found",
 				"pod", klog.KObj(pod), "reservation", rName)
@@ -221,7 +229,7 @@ func (p *Plugin) PostFilter(ctx context.Context, state *framework.CycleState, po
 		klog.V(4).InfoS("Attempting to post-filter reserve pod",
 			"pod", klog.KObj(pod), "reservation", rName)
 		err := retryOnConflictOrTooManyRequests(func() error {
-			r, err1 := p.lister.Get(rName)
+			r, err1 := p.rLister.Get(rName)
 			if errors.IsNotFound(err1) {
 				klog.V(4).InfoS("skip the post-filter for reservation since the object is not found",
 					"pod", klog.KObj(pod), "reservation", rName)
@@ -229,7 +237,7 @@ func (p *Plugin) PostFilter(ctx context.Context, state *framework.CycleState, po
 			} else if err1 != nil {
 				klog.V(3).InfoS("failed to get reservation",
 					"pod", klog.KObj(pod), "reservation", rName, "err", err1)
-				return nil
+				return err1
 			}
 
 			curR := r.DeepCopy()
@@ -309,44 +317,44 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, 
 	// NOTE: matchedCache may be stale, try next reservation when current one does not match any more
 	// TBD: currently Reserve got a failure if any reservation is selected but all failed to reserve
 	for _, rInfo := range rOnNode {
-		target := rInfo.Reservation
-
-		// check the allocation info from cache
-		cached := p.reservationCache.GetActive(target)
-		r := cached.GetReservation()
-		if r == nil { // reservation not found in active cache, abort
+		target := rInfo.GetReservation()
+		// use the cached reservation, in case the version in cycle state is too old/incorrect or mutated by other pods
+		rInfo = p.reservationCache.GetInCache(target)
+		if rInfo == nil {
+			// check if the reservation is marked as expired
 			if p.reservationCache.IsFailed(target) { // in case reservation is marked as failed
 				klog.V(5).InfoS("skip reserve current reservation since it is marked as expired",
 					"pod", klog.KObj(pod), "reservation", klog.KObj(target))
-				continue
+			} else {
+				klog.V(4).InfoS("failed to reserve current reservation since it is not found in cache",
+					"pod", klog.KObj(pod), "reservation", klog.KObj(target))
 			}
-			// the object is just missed in cache, maybe the reservation is deleted or updated unexpectedly
-			klog.V(5).InfoS("skip reserve current reservation since it is not found in active cache",
-				"pod", klog.KObj(pod), "reservation", klog.KObj(target))
-			continue
-		}
-		if !matchReservation(pod, cached) {
-			klog.V(5).InfoS("failed to reserve reservation since the reservation does not match the pod",
-				"pod", klog.KObj(pod), "reservation", klog.KObj(target), "reason", dumpMatchReservationReason(pod, cached))
 			continue
 		}
 
-		reserved := r.DeepCopy()
+		// avoid concurrency conflict inside the scheduler (i.e. scheduling cycle vs. binding cycle)
+		if !matchReservation(pod, rInfo) {
+			klog.V(5).InfoS("failed to reserve reservation since the reservation does not match the pod",
+				"pod", klog.KObj(pod), "reservation", klog.KObj(target), "reason", dumpMatchReservationReason(pod, rInfo))
+			continue
+		}
+
+		reserved := target.DeepCopy()
 		setReservationAllocated(reserved, pod)
 		// update assumed status in cache
-		p.reservationCache.AddToActive(reserved)
+		p.reservationCache.Assume(reserved)
 
 		// update assume state
 		state.assumed = reserved
 		cycleState.Write(preFilterStateKey, state)
 		klog.V(4).InfoS("Attempting to reserve pod to node with reservations", "pod", klog.KObj(pod),
-			"node", nodeName, "matched count", len(rOnNode), "assumed", klog.KObj(r))
+			"node", nodeName, "matched count", len(rOnNode), "assumed", klog.KObj(reserved))
 		return nil
 	}
 
 	klog.V(3).InfoS("failed to reserve pod with reservations, no reservation matched any more",
 		"pod", klog.KObj(pod), "node", nodeName, "tried count", len(rOnNode))
-	return framework.NewStatus(framework.Error, ErrReasonReservationFailedToReserve)
+	return framework.NewStatus(framework.Error, ErrReasonReservationNotMatchStale)
 }
 
 func (p *Plugin) Unreserve(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) {
@@ -374,29 +382,77 @@ func (p *Plugin) Unreserve(ctx context.Context, cycleState *framework.CycleState
 	state.assumed = nil
 	cycleState.Write(preFilterStateKey, state)
 
-	// remove the allocation info in cache
-	rInfo := p.reservationCache.GetActive(target)
-	r := rInfo.GetReservation()
-	if r == nil { // reservation not found in active cache, abort
-		if p.reservationCache.IsFailed(target) { // in case reservation is marked as failed
-			klog.V(5).InfoS("skip unreserve reservations since it is marked as expired",
-				"pod", klog.KObj(pod), "reservation", klog.KObj(target))
-			return
-		}
-		// the object is just missed in cache, maybe the reservation is deleted or updated unexpectedly
-		klog.V(5).InfoS("skip unreserve reservations since it is not found in active cache",
-			"pod", klog.KObj(pod), "reservation", klog.KObj(target))
+	// update assume cache
+	unreserved := target.DeepCopy()
+	err := removeReservationAllocated(unreserved, pod)
+	if err == nil {
+		p.reservationCache.Unassume(unreserved, true)
+	} else {
+		klog.V(4).InfoS("Unreserve failed to unassume reservation in cache, current owner not matched",
+			"pod", klog.KObj(pod), "reservation", klog.KObj(target), "err", err)
+	}
+
+	if !state.preBind { // the pod failed at Reserve, does not reach PreBind
 		return
 	}
 
-	reserved := r.DeepCopy()
-	err := removeReservationAllocated(reserved, pod)
-	if err == nil {
-		// update assumed status in cache
-		p.reservationCache.AddToActive(reserved)
-	} else {
-		klog.V(5).InfoS("skip unreserve reservation since the reservation does not match the pod",
-			"pod", klog.KObj(pod), "reservation", klog.KObj(target), "reason", dumpMatchReservationReason(pod, rInfo))
+	// update reservation and pod
+	err = retryOnConflictOrTooManyRequests(func() error {
+		// get the latest reservation
+		curR, err1 := p.rLister.Get(target.Name)
+		if errors.IsNotFound(err1) {
+			klog.V(4).InfoS("abort the update, reservation not found", "reservation", klog.KObj(target))
+			return nil
+		} else if err1 != nil {
+			return err1
+		}
+		if !IsReservationScheduled(curR) {
+			klog.V(5).InfoS("skip unreserve resources on a non-scheduled reservation",
+				"reservation", klog.KObj(curR), "phase", curR.Status.Phase)
+			return nil
+		}
+
+		// update reservation status
+		curR = curR.DeepCopy()
+		err1 = removeReservationAllocated(curR, pod)
+		// normally there is no need to update reservation status if failed in Reserve and PreBind
+		if err1 != nil {
+			klog.V(5).InfoS("skip unreserve reservation since the reservation does not match the pod",
+				"reservation", klog.KObj(curR), "pod", klog.KObj(pod), "err", err1)
+			return nil
+		}
+
+		_, err1 = p.client.Reservations().UpdateStatus(context.TODO(), curR, metav1.UpdateOptions{})
+		if err1 != nil {
+			klog.V(4).InfoS("failed to update reservation status for unreserve",
+				"reservation", klog.KObj(curR), "pod", klog.KObj(pod), "err", err1)
+			return err1
+		}
+
+		return nil
+	})
+	if err != nil {
+		klog.ErrorS(err, "Unreserve failed to update reservation status",
+			"reservation", klog.KObj(target), "pod", klog.KObj(pod), "node", nodeName)
+	}
+
+	// update pod annotation
+	newPod := pod.DeepCopy()
+	needPatch, _ := apiext.RemoveReservationAllocated(newPod, target)
+	if !needPatch {
+		return
+	}
+	patchBytes, err := generatePodPatch(pod, newPod)
+	if err != nil {
+		klog.V(4).InfoS("failed to generate patch for pod unreserve",
+			"pod", klog.KObj(pod), "patch", patchBytes, "err", err)
+		return
+	}
+	_, err = p.handle.ClientSet().CoreV1().Pods(pod.Namespace).
+		Patch(ctx, pod.Name, apimachinerytypes.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		klog.V(4).InfoS("failed to patch pod for unreserve",
+			"pod", klog.KObj(pod), "patch", patchBytes, "err", err)
 	}
 }
 
@@ -424,7 +480,8 @@ func (p *Plugin) PreBind(ctx context.Context, cycleState *framework.CycleState, 
 
 	// update: update current owner and allocated resources info for assumed reservation
 	err := retryOnConflictOrTooManyRequests(func() error {
-		curR, err1 := p.lister.Get(target.Name)
+		// here we just use the latest version, assert the reservation status is correct eventually
+		curR, err1 := p.rLister.Get(target.Name)
 		if errors.IsNotFound(err1) {
 			klog.Warningf("reservation %v not found, abort the update", klog.KObj(target))
 			return nil
@@ -436,8 +493,13 @@ func (p *Plugin) PreBind(ctx context.Context, cycleState *framework.CycleState, 
 		if !IsReservationScheduled(curR) {
 			klog.Warningf("failed to allocate resources on a non-scheduled reservation %v, phase %v",
 				klog.KObj(curR), curR.Status.Phase)
-			// TBD: may try with the next candidate instead of return error
 			return fmt.Errorf(ErrReasonReservationFailed)
+		}
+		// double-check if the latest version does not match the pod any more
+		if !matchReservation(pod, newReservationInfo(curR)) {
+			klog.V(5).InfoS("failed to allocate reservation since the reservation does not match the pod",
+				"pod", klog.KObj(pod), "reservation", klog.KObj(target), "reason", dumpMatchReservationReason(pod, newReservationInfo(curR)))
+			return fmt.Errorf(ErrReasonReservationNotMatchStale)
 		}
 
 		curR = curR.DeepCopy()
@@ -454,24 +516,29 @@ func (p *Plugin) PreBind(ctx context.Context, cycleState *framework.CycleState, 
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 
+	// assume accepted
+	p.reservationCache.Unassume(target, false)
+	// set the pre-bind flag, unreserve should try to resume
+	state.preBind = true
+
 	// update reservation allocation of the pod
+	// NOTE: the pod annotation can be stale, we should use reservation status as the ground-truth
 	newPod := pod.DeepCopy()
 	apiext.SetReservationAllocated(newPod, target)
 	patchBytes, err := generatePodPatch(pod, newPod)
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		klog.V(4).InfoS("failed to generate patch for pod PreBind",
+			"pod", klog.KObj(pod), "patch", patchBytes, "err", err)
+		return nil
 	}
 	err = retryOnConflictOrTooManyRequests(func() error {
 		_, err1 := p.handle.ClientSet().CoreV1().Pods(pod.Namespace).
 			Patch(ctx, pod.Name, apimachinerytypes.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-		if err1 != nil {
-			klog.Error("failed to patch Pod %s/%s, patch %v, err: %v",
-				pod.Namespace, pod.Name, string(patchBytes), err1)
-		}
 		return err1
 	})
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		klog.V(4).InfoS("failed to patch pod for PreBind allocating reservation",
+			"pod", klog.KObj(pod), "patch", patchBytes, "err", err)
 	}
 
 	return nil
@@ -487,7 +554,7 @@ func (p *Plugin) Bind(ctx context.Context, cycleState *framework.CycleState, pod
 			"pod", klog.KObj(pod), "reservation", rName, "node", nodeName)
 		err := retryOnConflictOrTooManyRequests(func() error {
 			// get latest version of the reservation
-			r, err1 := p.lister.Get(rName)
+			r, err1 := p.rLister.Get(rName)
 			if errors.IsNotFound(err1) {
 				klog.V(3).InfoS("reservation not found, abort the update", "pod", klog.KObj(pod))
 				return fmt.Errorf(ErrReasonReservationNotFound)
@@ -518,4 +585,66 @@ func (p *Plugin) Bind(ctx context.Context, cycleState *framework.CycleState, pod
 	}
 
 	return framework.NewStatus(framework.Skip, SkipReasonNotReservation)
+}
+
+func (p *Plugin) handleOnAdd(obj interface{}) {
+	r, ok := obj.(*schedulingv1alpha1.Reservation)
+	if !ok {
+		klog.V(3).Infof("reservation cache add failed to parse, obj %T", obj)
+		return
+	}
+	if IsReservationActive(r) {
+		p.reservationCache.AddToActive(r)
+	} else if IsReservationFailed(r) {
+		p.reservationCache.AddToFailed(r)
+	}
+	klog.V(5).InfoS("reservation cache add", "reservation", klog.KObj(r))
+}
+
+func (p *Plugin) handleOnUpdate(oldObj, newObj interface{}) {
+	oldR, oldOK := oldObj.(*schedulingv1alpha1.Reservation)
+	newR, newOK := newObj.(*schedulingv1alpha1.Reservation)
+	if !oldOK || !newOK {
+		klog.V(3).InfoS("reservation cache update failed to parse, old %T, new %T", oldObj, newObj)
+		return
+	}
+	if oldR == nil || newR == nil {
+		klog.V(4).InfoS("reservation cache update get nil object", "old", oldObj, "new", newObj)
+		return
+	}
+
+	// in case delete and created of two reservations with same namespaced name are merged into update
+	if oldR.UID != newR.UID {
+		klog.V(4).InfoS("reservation cache update get merged update event",
+			"reservation", klog.KObj(newR), "oldUID", oldR.UID, "newUID", newR.UID)
+		p.handleOnDelete(oldObj)
+		p.handleOnAdd(newObj)
+		return
+	}
+
+	if IsReservationActive(newR) {
+		p.reservationCache.AddToActive(newR)
+	} else if IsReservationFailed(newR) {
+		p.reservationCache.AddToFailed(newR)
+	}
+	klog.V(5).InfoS("reservation cache update", "reservation", klog.KObj(newR))
+}
+
+func (p *Plugin) handleOnDelete(obj interface{}) {
+	var r *schedulingv1alpha1.Reservation
+	switch t := obj.(type) {
+	case *schedulingv1alpha1.Reservation:
+		r = t
+	case cache.DeletedFinalStateUnknown:
+		deletedReservation, ok := t.Obj.(*schedulingv1alpha1.Reservation)
+		if ok {
+			r = deletedReservation
+		}
+	}
+	if r == nil {
+		klog.V(4).InfoS("reservation cache delete failed to parse, obj %T", obj)
+		return
+	}
+	p.reservationCache.Delete(r)
+	klog.V(5).InfoS("reservation cache delete", "reservation", klog.KObj(r))
 }


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix stale reservation statuses when pod failed to bind on reserved node or scheduler restarts unexpectedly.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #468 

### Ⅲ. Describe how to verify it

1. Start the koord-scheduler.
2. Submit an available reservation R.
3. Submit a pod P that allocates reserved resources.
4. Stop the koord-scheduler.
5. Delete the pod P.
6. Restart the koord-scheduler.
7. Wait about 1 minute and verify if the reservation status is corrected.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
