### PR TITLE
koord-scheduler: reservation support allocateOnce

### DIFF
--- a/pkg/scheduler/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/eventhandlers/reservation_handler.go
@@ -37,7 +37,7 @@ func AddScheduleEventHandler(sched *scheduler.Scheduler, internalHandler Schedul
 		FilterFunc: func(obj interface{}) bool {
 			switch t := obj.(type) {
 			case *schedulingv1alpha1.Reservation:
-				return reservation.IsReservationScheduled(t)
+				return reservation.IsReservationAvailable(t)
 			case cache.DeletedFinalStateUnknown:
 				if _, ok := t.Obj.(*schedulingv1alpha1.Reservation); ok {
 					// DeletedFinalStateUnknown object can be stale, so just try to cleanup without check.
@@ -67,7 +67,8 @@ func AddScheduleEventHandler(sched *scheduler.Scheduler, internalHandler Schedul
 		FilterFunc: func(obj interface{}) bool {
 			switch t := obj.(type) {
 			case *schedulingv1alpha1.Reservation:
-				return !reservation.IsReservationScheduled(t) && !reservation.IsReservationFailed(t) && isResponsibleForReservation(sched.Profiles, t)
+				return isResponsibleForReservation(sched.Profiles, t) && !reservation.IsReservationAvailable(t) &&
+					!reservation.IsReservationFailed(t) && !reservation.IsReservationSucceeded(t)
 			case cache.DeletedFinalStateUnknown:
 				if r, ok := t.Obj.(*schedulingv1alpha1.Reservation); ok {
 					// DeletedFinalStateUnknown object can be stale, so just try to cleanup without check.

--- a/pkg/scheduler/plugins/reservation/garbage_collection.go
+++ b/pkg/scheduler/plugins/reservation/garbage_collection.go
@@ -182,8 +182,8 @@ func (p *Plugin) syncPodDeleted(pod *corev1.Pod) {
 			return err1
 		}
 
-		// check if the reservation has been expired
-		if !IsReservationScheduled(r) {
+		// check if the reservation is still scheduled; succeeded ones are ignored to update
+		if !IsReservationAvailable(r) {
 			klog.V(4).InfoS("skip sync for reservation no longer available or scheduled",
 				"reservation", klog.KObj(r))
 			return nil

--- a/pkg/scheduler/plugins/reservation/hook.go
+++ b/pkg/scheduler/plugins/reservation/hook.go
@@ -159,7 +159,8 @@ func (h *Hook) prepareMatchReservationState(handle frameworkext.ExtendedHandle, 
 				klog.V(5).Infof("unable to convert to *schedulingv1alpha1.Reservation, obj %T", obj)
 				continue
 			}
-			if !IsReservationScheduled(r) { // only count scheduled reservations
+			// only count available reservations, ignore succeeded ones
+			if !IsReservationAvailable(r) {
 				continue
 			}
 			if matchReservation(pod, newReservationInfo(r)) {

--- a/pkg/scheduler/plugins/reservation/rcache.go
+++ b/pkg/scheduler/plugins/reservation/rcache.go
@@ -106,7 +106,7 @@ func newAvailableCache(rList ...*schedulingv1alpha1.Reservation) *AvailableCache
 		ownerToR:     map[string]*reservationInfo{},
 	}
 	for _, r := range rList {
-		if !IsReservationScheduled(r) {
+		if !IsReservationAvailable(r) {
 			continue
 		}
 		rInfo := newReservationInfo(r)


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Reservation supports `allocateOnce`.

Once a pod allocates an available reservation with `allocateOnce` set to true, the reservation will become `Succeeded` and no longer allocatable to other owners.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #440 

### Ⅲ. Describe how to verify it

1. Submit an available reservation with `allocateOnce` set.
2. Submit a pod A that matches the reservation.
3. Watch the reservation is allocated, and its status becomes `Succeeded`.
4. Submit another pod B that also matches the reservation (if it is available).
5. Check if the reservation is not allocatable to pod B.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
