### PR TITLE
koord-scheduler: fix succeeded reservation GC and unschedulable retry

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -384,6 +384,7 @@ func Setup(ctx context.Context, opts *options.Options, schedulingHooks []framewo
 		Scheduler: sched,
 	}
 	eventhandlers.AddScheduleEventHandler(sched, schedulerInternalHandler, extendedHandle)
+	eventhandlers.AddReservationErrorHandler(sched, schedulerInternalHandler, extendedHandle)
 
 	return &cc, sched, nil
 }

--- a/pkg/scheduler/eventhandlers/internal_handler.go
+++ b/pkg/scheduler/eventhandlers/internal_handler.go
@@ -43,6 +43,8 @@ type SchedulerInternalQueueHandler interface {
 	Add(pod *corev1.Pod) error
 	Update(oldPod, newPod *corev1.Pod) error
 	Delete(pod *corev1.Pod) error
+	AddUnschedulableIfNotPresent(pod *framework.QueuedPodInfo, podSchedulingCycle int64) error
+	SchedulingCycle() int64
 	AssignedPodAdded(pod *corev1.Pod)
 	AssignedPodUpdated(pod *corev1.Pod)
 }
@@ -110,6 +112,14 @@ func (f *fakeSchedulerInternalHandler) Update(oldPod, newPod *corev1.Pod) error 
 
 func (f *fakeSchedulerInternalHandler) Delete(pod *corev1.Pod) error {
 	return nil
+}
+
+func (f *fakeSchedulerInternalHandler) AddUnschedulableIfNotPresent(pod *framework.QueuedPodInfo, podSchedulingCycle int64) error {
+	return nil
+}
+
+func (f *fakeSchedulerInternalHandler) SchedulingCycle() int64 {
+	return 0
 }
 
 func (f *fakeSchedulerInternalHandler) AssignedPodAdded(pod *corev1.Pod) {

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -968,7 +968,7 @@ func TestReserve(t *testing.T) {
 	})
 	stateForMatch1 := stateForMatch.Clone()
 	cacheNotActive := newReservationCache()
-	cacheNotActive.AddToFailed(rScheduled)
+	cacheNotActive.AddToInactive(rScheduled)
 	cacheMatched := newReservationCache()
 	cacheMatched.AddToActive(rScheduled)
 	cacheAssumed := newReservationCache()
@@ -1151,7 +1151,7 @@ func TestUnreserve(t *testing.T) {
 		preBind: true,
 	})
 	cacheNotActive := newReservationCache()
-	cacheNotActive.AddToFailed(rScheduled)
+	cacheNotActive.AddToInactive(rScheduled)
 	cacheMatched := newReservationCache()
 	cacheMatched.AddToActive(rScheduled)
 	cacheAssumed := newReservationCache()
@@ -1425,7 +1425,7 @@ func TestPreBind(t *testing.T) {
 				pod:        normalPod,
 				nodeName:   testNodeName,
 			},
-			want: framework.NewStatus(framework.Error, ErrReasonReservationFailed),
+			want: framework.NewStatus(framework.Error, ErrReasonReservationInactive),
 		},
 		{
 			name: "failed to update status",
@@ -1607,7 +1607,7 @@ func TestBind(t *testing.T) {
 				pod:      reservePod,
 				nodeName: testNodeName,
 			},
-			want: framework.NewStatus(framework.Error, "failed to bind reservation, err: "+ErrReasonReservationFailed),
+			want: framework.NewStatus(framework.Error, "failed to bind reservation, err: "+ErrReasonReservationInactive),
 		},
 		{
 			name: "failed to update status",


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. Fix succeeded reservations' expiration: Succeeded reservations will not become `Failed`, and they will get cleaned up according to their succeeding timestamp.
2. Fix unschedulable reservations' retry: Once a reservation is marked as unschedulable, it will be put into the unschedulable queue and retry in later scheduling cycles.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #499 

### Ⅲ. Describe how to verify it

For the Fix 1.

1. submit a reservation whose `allocateOnce=true` and  `ttl` is small, then make it get Succeeded
2. check if the reservation would not become Failed

For the Fix 2.

1. submit a reservation that should get unschedulable for some reasons (e.g. request too many resources)
2. check if the scheduled condition timestamp in its status changes by the time

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
