### PR TITLE
koord-descheduler: stop migration when reserved on the same node

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -192,6 +192,5 @@ func SetDeviceAllocations(pod *corev1.Pod, dType schedulingv1alpha1.DeviceType, 
 		return err
 	}
 	pod.Annotations[AnnotationDeviceAllocated] = string(data)
-	
 	return nil
 }

--- a/apis/scheduling/v1alpha1/pod_migration_job_types.go
+++ b/apis/scheduling/v1alpha1/pod_migration_job_types.go
@@ -168,19 +168,19 @@ const (
 
 // These are valid reasons of PodMigrationJob.
 const (
-	PodMigrationJobReasonTimeout                      = "Timeout"
-	PodMigrationJobReasonFailedCreateReservation      = "FailedCreateReservation"
-	PodMigrationJobReasonReservationExpired           = "ReservationExpired"
-	PodMigrationJobReasonReservationBoundByAnotherPod = "ReservationBoundByAnotherPod"
-	PodMigrationJobReasonUnschedulable                = "Unschedulable"
-	PodMigrationJobReasonMissingPod                   = "MissingPod"
-	PodMigrationJobReasonMissingReservation           = "MissingReservation"
-	PodMigrationJobReasonPreempting                   = "Preempting"
-	PodMigrationJobReasonPreemptComplete              = "PreemptComplete"
-	PodMigrationJobReasonEvicting                     = "Evicting"
-	PodMigrationJobReasonFailedEvict                  = "FailedEvict"
-	PodMigrationJobReasonEvictComplete                = "EvictComplete"
-	PodMigrationJobReasonWaitForPodBindReservation    = "WaitForPodBindReservation"
+	PodMigrationJobReasonTimeout                   = "Timeout"
+	PodMigrationJobReasonFailedCreateReservation   = "FailedCreateReservation"
+	PodMigrationJobReasonReservationExpired        = "ReservationExpired"
+	PodMigrationJobReasonUnschedulable             = "Unschedulable"
+	PodMigrationJobReasonForbiddenMigratePod       = "ForbiddenMigratePod"
+	PodMigrationJobReasonMissingPod                = "MissingPod"
+	PodMigrationJobReasonMissingReservation        = "MissingReservation"
+	PodMigrationJobReasonPreempting                = "Preempting"
+	PodMigrationJobReasonPreemptComplete           = "PreemptComplete"
+	PodMigrationJobReasonEvicting                  = "Evicting"
+	PodMigrationJobReasonFailedEvict               = "FailedEvict"
+	PodMigrationJobReasonEvictComplete             = "EvictComplete"
+	PodMigrationJobReasonWaitForPodBindReservation = "WaitForPodBindReservation"
 )
 
 type PodMigrationJobConditionStatus string


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

When scheduler assigned the Reservation on the same node as the Pod, Migration controller should stop the job.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
