### PR TITLE
apis: update Reservation kubebuilder:printcolumn comments

### DIFF
--- a/apis/scheduling/v1alpha1/reservation_types.go
+++ b/apis/scheduling/v1alpha1/reservation_types.go
@@ -177,9 +177,9 @@ type ReservationCondition struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The phase of reservation"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeName",priority=10
-// +kubebuilder:printcolumn:name="TTL",type="string",JSONPath=".spec.ttl",priority=10
-// +kubebuilder:printcolumn:name="Expires",type="string",JSONPath=".spec.expires",priority=10
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeName"
+// +kubebuilder:printcolumn:name="TTL",type="string",JSONPath=".spec.ttl"
+// +kubebuilder:printcolumn:name="Expires",type="string",JSONPath=".spec.expires"
 
 // Reservation is the Schema for the reservation API.
 // A Reservation object is non-namespaced.

--- a/config/crd/bases/scheduling.koordinator.sh_reservations.yaml
+++ b/config/crd/bases/scheduling.koordinator.sh_reservations.yaml
@@ -25,15 +25,12 @@ spec:
       type: date
     - jsonPath: .status.nodeName
       name: Node
-      priority: 10
       type: string
     - jsonPath: .spec.ttl
       name: TTL
-      priority: 10
       type: string
     - jsonPath: .spec.expires
       name: Expires
-      priority: 10
       type: string
     name: v1alpha1
     schema:


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

if apply the koordinator 0.6, kubectl cannot print the node field of Reservation, as the following:
```bash
$ kubectl get reservation
kubectl get reservation
NAME                                                                      PHASE   AGE   
ea8a865f-073b-4dbb-b383-7d4adb6e5439                    9s 
```

after fixed,
```bash
kubectl get reservation
NAME                                   PHASE       AGE    NODE                  TTL     EXPIRES
bd62f3c2-4c14-40fb-ba5e-83a94cb7908b   Available   3m2s   cn-hangzhou.1.2.3.4   30m0s
```

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
