### PR TITLE
koord-scheduler: CPU allocate algorithm supports maxRefCount 

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/cpu_allocation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_allocation.go
@@ -82,8 +82,11 @@ func (n *cpuAllocation) releaseCPUs(podUID types.UID) {
 	}
 }
 
-func (n *cpuAllocation) getAvailableCPUs(cpuTopology *CPUTopology, reservedCPUs CPUSet) (availableCPUs CPUSet, allocated CPUDetails) {
-	allocated = n.allocatedCPUs.Clone()
-	availableCPUs = cpuTopology.CPUDetails.CPUs().Difference(allocated.CPUs()).Difference(reservedCPUs)
+func (n *cpuAllocation) getAvailableCPUs(cpuTopology *CPUTopology, maxRefCount int, reservedCPUs CPUSet) (availableCPUs CPUSet, allocateInfo CPUDetails) {
+	allocateInfo = n.allocatedCPUs.Clone()
+	allocated := allocateInfo.CPUs().Filter(func(cpuID int) bool {
+		return allocateInfo[cpuID].RefCount >= maxRefCount
+	})
+	availableCPUs = cpuTopology.CPUDetails.CPUs().Difference(allocated).Difference(reservedCPUs)
 	return
 }

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_allocation_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_allocation_test.go
@@ -53,8 +53,33 @@ func TestNodeAllocationStateAddCPUs(t *testing.T) {
 	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
 
+	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, NewCPUSet())
+	expectAvailableCPUs := MustParse("0-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+
 	// test with add already allocated Pod
 	allocationState.addCPUs(cpuTopology, podUID, MustParse("1-4"), schedulingconfig.CPUExclusivePolicyPCPULevel)
+	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
+	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
+
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, NewCPUSet())
+	MustParse("0-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+
+	// test with add already allocated cpu(refCount > 1 but less than maxRefCount) and another pod
+	anotherPodUID := uuid.NewUUID()
+	allocationState.addCPUs(cpuTopology, anotherPodUID, MustParse("2-5"), schedulingconfig.CPUExclusivePolicyPCPULevel)
+	anotherCPUSet := MustParse("2-5")
+	expectAllocatedPods[anotherPodUID] = anotherCPUSet
+	for _, cpuID := range anotherCPUSet.ToSliceNoSort() {
+		cpuInfo, ok := expectAllocatedCPUs[cpuID]
+		if !ok {
+			cpuInfo = cpuTopology.CPUDetails[cpuID]
+		}
+		cpuInfo.ExclusivePolicy = schedulingconfig.CPUExclusivePolicyPCPULevel
+		cpuInfo.RefCount++
+		expectAllocatedCPUs[cpuID] = cpuInfo
+	}
 	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
 }
@@ -77,4 +102,36 @@ func TestNodeAllocationStateReleaseCPUs(t *testing.T) {
 	expectAllocatedCPUs := CPUDetails{}
 	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
+	for i := 0; i < 16; i++ {
+		assert.Equal(t, 0, allocationState.allocatedCPUs[i].RefCount)
+	}
+}
+
+func Test_cpuAllocation_getAvailableCPUs(t *testing.T) {
+	cpuTopology := buildCPUTopologyForTest(2, 1, 4, 2)
+	for _, v := range cpuTopology.CPUDetails {
+		v.CoreID = v.SocketID<<16 | v.CoreID
+		cpuTopology.CPUDetails[v.CPUID] = v
+	}
+
+	allocationState := newCPUAllocation("test-node-1")
+	assert.NotNil(t, allocationState)
+	podUID := uuid.NewUUID()
+	allocationState.addCPUs(cpuTopology, podUID, MustParse("1-4"), schedulingconfig.CPUExclusivePolicyPCPULevel)
+
+	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, NewCPUSet())
+	expectAvailableCPUs := MustParse("0-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+
+	// test with add already allocated cpu(refCount > 1 but less than maxRefCount) and another pod
+	anotherPodUID := uuid.NewUUID()
+	allocationState.addCPUs(cpuTopology, anotherPodUID, MustParse("2-5"), schedulingconfig.CPUExclusivePolicyPCPULevel)
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, NewCPUSet())
+	expectAvailableCPUs = MustParse("0-1,5-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+
+	allocationState.releaseCPUs(podUID)
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 1, NewCPUSet())
+	expectAvailableCPUs = MustParse("0-1,6-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 }

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_manager.go
@@ -130,10 +130,11 @@ func (c *cpuManagerImpl) Allocate(
 	allocation.lock.Lock()
 	defer allocation.lock.Unlock()
 
-	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, reservedCPUs)
+	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs)
 	numaAllocateStrategy := c.getNUMAAllocateStrategy(node)
 	result, err := takeCPUs(
 		cpuTopologyOptions.CPUTopology,
+		cpuTopologyOptions.MaxRefCount,
 		availableCPUs,
 		allocated,
 		numCPUsNeeded,
@@ -183,9 +184,10 @@ func (c *cpuManagerImpl) Score(
 	defer allocation.lock.Unlock()
 
 	cpuTopology := cpuTopologyOptions.CPUTopology
-	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopology, reservedCPUs)
+	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs)
 	acc := newCPUAccumulator(
 		cpuTopology,
+		cpuTopologyOptions.MaxRefCount,
 		availableCPUs,
 		allocated,
 		numCPUsNeeded,
@@ -286,6 +288,6 @@ func (c *cpuManagerImpl) GetAvailableCPUs(nodeName string) (availableCPUs CPUSet
 	allocation := c.getOrCreateAllocation(nodeName)
 	allocation.lock.Lock()
 	defer allocation.lock.Unlock()
-	availableCPUs, allocated = allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.ReservedCPUs)
+	availableCPUs, allocated = allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, cpuTopologyOptions.ReservedCPUs)
 	return availableCPUs, allocated, nil
 }


### PR DESCRIPTION
Signed-off-by: wangjianyu <zmsjianyu@gmail.com>

### Ⅰ. Describe what this PR does

In some over-commitment scenario, a logic cpu can be allocated more than once and less than a upper bound. We call the uppder bound “MaxRefCount” and call the number of allocations of a logic cpu “RefCount” of that cpu.
This PR noticed RefCount logic has been partial supported in NodeNUMAResourcePlugin. This PR supports MaxRefCount and makes RefCount logic complete in CPU allocate algorithm.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
