### PR TITLE
support Reservation select order

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -26,16 +26,24 @@ import (
 )
 
 const (
+	// LabelReservationOrder controls the preference logic for Reservation.
+	// Reservation with lower order is preferred to be selected before Reservation with higher order.
+	// But if it is 0, Reservation will be selected according to the capacity score.
+	LabelReservationOrder = SchedulingDomainPrefix + "/reservation-order"
+
+	// AnnotationReservationAllocated represents the reservation allocated by the pod.
+	AnnotationReservationAllocated = SchedulingDomainPrefix + "/reservation-allocated"
+)
+
+const (
 	// AnnotationCustomUsageThresholds represents the user-defined resource utilization threshold.
 	// For specific value definitions, see CustomUsageThresholds
 	AnnotationCustomUsageThresholds = SchedulingDomainPrefix + "/usage-thresholds"
 
-	// AnnotationReservationAllocated represents the reservation allocated by the pod.
-	AnnotationReservationAllocated = SchedulingDomainPrefix + "/reservation-allocated"
-
 	// AnnotationDeviceAllocated represents the device allocated by the pod
 	AnnotationDeviceAllocated = SchedulingDomainPrefix + "/device-allocated"
 )
+
 const (
 	AnnotationGangPrefix = "gang.scheduling.koordinator.sh"
 	// AnnotationGangName specifies the name of the gang

--- a/pkg/descheduler/controllers/migration/controller_test.go
+++ b/pkg/descheduler/controllers/migration/controller_test.go
@@ -760,45 +760,48 @@ func TestMigrate(t *testing.T) {
 	}
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
-	reconciler.reservationInterpreter = fakeReservationInterpreter{
-		reservation: &sev1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-reservation",
-			},
-			Spec: sev1alpha1.ReservationSpec{
-				Owners: []sev1alpha1.ReservationOwner{
-					{
-						Controller: &sev1alpha1.ReservationControllerReference{
-							Namespace: "default",
-							OwnerReference: metav1.OwnerReference{
-								APIVersion: "apps/v1",
-								Controller: pointer.Bool(true),
-								Kind:       "StatefulSet",
-								Name:       "test",
-								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
-							},
+	r := &sev1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-reservation",
+		},
+		Spec: sev1alpha1.ReservationSpec{
+			Owners: []sev1alpha1.ReservationOwner{
+				{
+					Controller: &sev1alpha1.ReservationControllerReference{
+						Namespace: "default",
+						OwnerReference: metav1.OwnerReference{
+							APIVersion: "apps/v1",
+							Controller: pointer.Bool(true),
+							Kind:       "StatefulSet",
+							Name:       "test",
+							UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
 						},
 					},
 				},
 			},
-			Status: sev1alpha1.ReservationStatus{
-				Phase: sev1alpha1.ReservationAvailable,
-				Conditions: []sev1alpha1.ReservationCondition{
-					{
-						Type:   sev1alpha1.ReservationConditionScheduled,
-						Reason: sev1alpha1.ReasonReservationScheduled,
-						Status: sev1alpha1.ConditionStatusTrue,
-					},
-				},
-				CurrentOwners: []corev1.ObjectReference{
-					{
-						Namespace: "default",
-						Name:      "test-pod-1",
-					},
-				},
-				NodeName: "test-node-1",
-			},
 		},
+		Status: sev1alpha1.ReservationStatus{
+			Phase: sev1alpha1.ReservationAvailable,
+			Conditions: []sev1alpha1.ReservationCondition{
+				{
+					Type:   sev1alpha1.ReservationConditionScheduled,
+					Reason: sev1alpha1.ReasonReservationScheduled,
+					Status: sev1alpha1.ConditionStatusTrue,
+				},
+			},
+			CurrentOwners: []corev1.ObjectReference{
+				{
+					Namespace: "default",
+					Name:      "test-pod-1",
+				},
+			},
+			NodeName: "test-node-1",
+		},
+	}
+	assert.NoError(t, reconciler.Client.Create(context.TODO(), r))
+
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: r,
 	}
 	for {
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})
@@ -863,45 +866,47 @@ func TestMigrateWhenEvictingWithSucceededReservation(t *testing.T) {
 	}
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
-	reconciler.reservationInterpreter = fakeReservationInterpreter{
-		reservation: &sev1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-reservation",
-			},
-			Spec: sev1alpha1.ReservationSpec{
-				Owners: []sev1alpha1.ReservationOwner{
-					{
-						Controller: &sev1alpha1.ReservationControllerReference{
-							Namespace: "default",
-							OwnerReference: metav1.OwnerReference{
-								APIVersion: "apps/v1",
-								Controller: pointer.Bool(true),
-								Kind:       "StatefulSet",
-								Name:       "test",
-								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
-							},
+	r := &sev1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-reservation",
+		},
+		Spec: sev1alpha1.ReservationSpec{
+			Owners: []sev1alpha1.ReservationOwner{
+				{
+					Controller: &sev1alpha1.ReservationControllerReference{
+						Namespace: "default",
+						OwnerReference: metav1.OwnerReference{
+							APIVersion: "apps/v1",
+							Controller: pointer.Bool(true),
+							Kind:       "StatefulSet",
+							Name:       "test",
+							UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
 						},
 					},
 				},
 			},
-			Status: sev1alpha1.ReservationStatus{
-				Phase: sev1alpha1.ReservationSucceeded,
-				Conditions: []sev1alpha1.ReservationCondition{
-					{
-						Type:   sev1alpha1.ReservationConditionScheduled,
-						Reason: sev1alpha1.ReasonReservationScheduled,
-						Status: sev1alpha1.ConditionStatusTrue,
-					},
-				},
-				CurrentOwners: []corev1.ObjectReference{
-					{
-						Namespace: "default",
-						Name:      "test-pod-1",
-					},
-				},
-				NodeName: "test-node-1",
-			},
 		},
+		Status: sev1alpha1.ReservationStatus{
+			Phase: sev1alpha1.ReservationSucceeded,
+			Conditions: []sev1alpha1.ReservationCondition{
+				{
+					Type:   sev1alpha1.ReservationConditionScheduled,
+					Reason: sev1alpha1.ReasonReservationScheduled,
+					Status: sev1alpha1.ConditionStatusTrue,
+				},
+			},
+			CurrentOwners: []corev1.ObjectReference{
+				{
+					Namespace: "default",
+					Name:      "test-pod-1",
+				},
+			},
+			NodeName: "test-node-1",
+		},
+	}
+	assert.NoError(t, reconciler.Create(context.TODO(), r))
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: r,
 	}
 	for {
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})
@@ -964,38 +969,40 @@ func TestMigrateWithReservationScheduleFailed(t *testing.T) {
 	}
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
-	reconciler.reservationInterpreter = fakeReservationInterpreter{
-		reservation: &sev1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-reservation",
-			},
-			Spec: sev1alpha1.ReservationSpec{
-				Owners: []sev1alpha1.ReservationOwner{
-					{
-						Controller: &sev1alpha1.ReservationControllerReference{
-							Namespace: "default",
-							OwnerReference: metav1.OwnerReference{
-								APIVersion: "apps/v1",
-								Controller: pointer.Bool(true),
-								Kind:       "StatefulSet",
-								Name:       "test",
-								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
-							},
+	r := &sev1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-reservation",
+		},
+		Spec: sev1alpha1.ReservationSpec{
+			Owners: []sev1alpha1.ReservationOwner{
+				{
+					Controller: &sev1alpha1.ReservationControllerReference{
+						Namespace: "default",
+						OwnerReference: metav1.OwnerReference{
+							APIVersion: "apps/v1",
+							Controller: pointer.Bool(true),
+							Kind:       "StatefulSet",
+							Name:       "test",
+							UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
 						},
 					},
 				},
 			},
-			Status: sev1alpha1.ReservationStatus{
-				Phase: sev1alpha1.ReservationFailed,
-				Conditions: []sev1alpha1.ReservationCondition{
-					{
-						Type:    sev1alpha1.ReservationConditionScheduled,
-						Reason:  sev1alpha1.ReasonReservationUnschedulable,
-						Message: "expired reservation",
-					},
+		},
+		Status: sev1alpha1.ReservationStatus{
+			Phase: sev1alpha1.ReservationFailed,
+			Conditions: []sev1alpha1.ReservationCondition{
+				{
+					Type:    sev1alpha1.ReservationConditionScheduled,
+					Reason:  sev1alpha1.ReasonReservationUnschedulable,
+					Message: "expired reservation",
 				},
 			},
 		},
+	}
+	assert.NoError(t, reconciler.Create(context.TODO(), r))
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: r,
 	}
 	for {
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})
@@ -1050,46 +1057,48 @@ func TestMigrateWithReservationSucceeded(t *testing.T) {
 	}
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
-	reconciler.reservationInterpreter = fakeReservationInterpreter{
-		reservation: &sev1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-reservation",
-			},
-			Spec: sev1alpha1.ReservationSpec{
-				Owners: []sev1alpha1.ReservationOwner{
-					{
-						Controller: &sev1alpha1.ReservationControllerReference{
-							Namespace: "default",
-							OwnerReference: metav1.OwnerReference{
-								APIVersion: "apps/v1",
-								Controller: pointer.Bool(true),
-								Kind:       "StatefulSet",
-								Name:       "test",
-								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
-							},
+	r := &sev1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-reservation",
+		},
+		Spec: sev1alpha1.ReservationSpec{
+			Owners: []sev1alpha1.ReservationOwner{
+				{
+					Controller: &sev1alpha1.ReservationControllerReference{
+						Namespace: "default",
+						OwnerReference: metav1.OwnerReference{
+							APIVersion: "apps/v1",
+							Controller: pointer.Bool(true),
+							Kind:       "StatefulSet",
+							Name:       "test",
+							UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
 						},
 					},
 				},
 			},
-			Status: sev1alpha1.ReservationStatus{
-				NodeName: "test-node-1",
-				Phase:    sev1alpha1.ReservationSucceeded,
-				Conditions: []sev1alpha1.ReservationCondition{
-					{
-						Type:   sev1alpha1.ReservationConditionScheduled,
-						Reason: sev1alpha1.ReasonReservationScheduled,
-						Status: sev1alpha1.ConditionStatusTrue,
-					},
+		},
+		Status: sev1alpha1.ReservationStatus{
+			NodeName: "test-node-1",
+			Phase:    sev1alpha1.ReservationSucceeded,
+			Conditions: []sev1alpha1.ReservationCondition{
+				{
+					Type:   sev1alpha1.ReservationConditionScheduled,
+					Reason: sev1alpha1.ReasonReservationScheduled,
+					Status: sev1alpha1.ConditionStatusTrue,
 				},
-				CurrentOwners: []corev1.ObjectReference{
-					{
-						Namespace: "test",
-						Name:      "other-pod",
-						UID:       uuid.NewUUID(),
-					},
+			},
+			CurrentOwners: []corev1.ObjectReference{
+				{
+					Namespace: "test",
+					Name:      "other-pod",
+					UID:       uuid.NewUUID(),
 				},
 			},
 		},
+	}
+	assert.NoError(t, reconciler.Client.Create(context.TODO(), r))
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: r,
 	}
 	for {
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})
@@ -1144,38 +1153,40 @@ func TestMigrateWithReservationExpired(t *testing.T) {
 	}
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
-	reconciler.reservationInterpreter = fakeReservationInterpreter{
-		reservation: &sev1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-reservation",
-			},
-			Spec: sev1alpha1.ReservationSpec{
-				Owners: []sev1alpha1.ReservationOwner{
-					{
-						Controller: &sev1alpha1.ReservationControllerReference{
-							Namespace: "default",
-							OwnerReference: metav1.OwnerReference{
-								APIVersion: "apps/v1",
-								Controller: pointer.Bool(true),
-								Kind:       "StatefulSet",
-								Name:       "test",
-								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
-							},
+	r := &sev1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-reservation",
+		},
+		Spec: sev1alpha1.ReservationSpec{
+			Owners: []sev1alpha1.ReservationOwner{
+				{
+					Controller: &sev1alpha1.ReservationControllerReference{
+						Namespace: "default",
+						OwnerReference: metav1.OwnerReference{
+							APIVersion: "apps/v1",
+							Controller: pointer.Bool(true),
+							Kind:       "StatefulSet",
+							Name:       "test",
+							UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
 						},
 					},
 				},
 			},
-			Status: sev1alpha1.ReservationStatus{
-				NodeName: "test-node-1",
-				Phase:    sev1alpha1.ReservationFailed,
-				Conditions: []sev1alpha1.ReservationCondition{
-					{
-						Type:   sev1alpha1.ReservationConditionReady,
-						Reason: sev1alpha1.ReasonReservationExpired,
-					},
+		},
+		Status: sev1alpha1.ReservationStatus{
+			NodeName: "test-node-1",
+			Phase:    sev1alpha1.ReservationFailed,
+			Conditions: []sev1alpha1.ReservationCondition{
+				{
+					Type:   sev1alpha1.ReservationConditionReady,
+					Reason: sev1alpha1.ReasonReservationExpired,
 				},
 			},
 		},
+	}
+	assert.NoError(t, reconciler.Client.Create(context.TODO(), r))
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: r,
 	}
 	for {
 		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})

--- a/pkg/descheduler/controllers/migration/reservation/util.go
+++ b/pkg/descheduler/controllers/migration/reservation/util.go
@@ -17,11 +17,15 @@ limitations under the License.
 package reservation
 
 import (
+	"strconv"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
 
@@ -78,6 +82,7 @@ func CreateOrUpdateReservationOptions(job *sev1alpha1.PodMigrationJob, pod *core
 		reservationOptions.Template.ObjectMeta.Labels = map[string]string{}
 	}
 	reservationOptions.Template.ObjectMeta.Labels[LabelCreatedBy] = DefaultCreator
+	reservationOptions.Template.ObjectMeta.Labels[extension.LabelReservationOrder] = strconv.FormatInt(time.Now().UnixMilli(), 10)
 
 	if (reservationOptions.Template.Spec.TTL == nil && reservationOptions.Template.Spec.Expires == nil) &&
 		job.Spec.TTL != nil && job.Spec.TTL.Duration > 0 {

--- a/pkg/scheduler/plugins/reservation/hook.go
+++ b/pkg/scheduler/plugins/reservation/hook.go
@@ -35,7 +35,7 @@ import (
 // for internal interface testing
 type parallelizeUntilFunc func(ctx context.Context, pieces int, doWorkPiece workqueue.DoWorkPieceFunc)
 
-func defaultParallelizeUntil(handle frameworkext.ExtendedHandle) parallelizeUntilFunc {
+func defaultParallelizeUntil(handle framework.Handle) parallelizeUntilFunc {
 	return handle.Parallelizer().Until
 }
 
@@ -45,7 +45,7 @@ var (
 )
 
 type Hook struct {
-	parallelizeUntil func(handle frameworkext.ExtendedHandle) parallelizeUntilFunc
+	parallelizeUntil func(handle framework.Handle) parallelizeUntilFunc
 }
 
 func NewHook() *Hook {

--- a/pkg/scheduler/plugins/reservation/hook_test.go
+++ b/pkg/scheduler/plugins/reservation/hook_test.go
@@ -88,7 +88,7 @@ func TestPreFilterHook(t *testing.T) {
 	}
 	type fields struct {
 		pluginEnabled    bool
-		parallelizeUntil func(handle frameworkext.ExtendedHandle) parallelizeUntilFunc
+		parallelizeUntil func(handle framework.Handle) parallelizeUntilFunc
 	}
 	type args struct {
 		handle     frameworkext.ExtendedHandle


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

The label `scheduling.koordinator.sh/reservation-order` controls the preference logic for Reservation.
The Reservation with lower order is preferred to be selected before Reservation with higher order.
But if it is 0, Reservation will be selected according to the capacity score.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

implements #441 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. create two Reservations with same owner, add label `scheduling.koordinator.sh/reservation-order` with non-zero value on one of the Reservations.
2. create Pod that can match these Reservations.
3. watch the scheduler result. The Reservation has label `scheduling.koordinator.sh/reservation-order` will be selected.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
