### PR TITLE
koord-scheduler: fix CPUTopologyManager get&update race condition

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/cpu_topology_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_topology_manager.go
@@ -25,7 +25,7 @@ import (
 // CPUTopologyManager manages the CPU Topology and CPU assignments options.
 type CPUTopologyManager interface {
 	GetCPUTopologyOptions(nodeName string) CPUTopologyOptions
-	UpdateCPUTopologyOptions(nodeName string, options CPUTopologyOptions)
+	UpdateCPUTopologyOptions(nodeName string, updateFn func(options *CPUTopologyOptions))
 	Delete(nodeName string)
 }
 
@@ -54,12 +54,14 @@ func (m *cpuTopologyManager) GetCPUTopologyOptions(nodeName string) CPUTopologyO
 	return m.topologyOptions[nodeName]
 }
 
-func (m *cpuTopologyManager) UpdateCPUTopologyOptions(nodeName string, options CPUTopologyOptions) {
+func (m *cpuTopologyManager) UpdateCPUTopologyOptions(nodeName string, updateFn func(options *CPUTopologyOptions)) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	options := m.topologyOptions[nodeName]
+	updateFn(&options)
 	if options.MaxRefCount == 0 {
 		options.MaxRefCount = 1
 	}
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	m.topologyOptions[nodeName] = options
 }
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_service_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_service_test.go
@@ -48,7 +48,9 @@ func TestEndpointsQueryCPUTopologyOptions(t *testing.T) {
 			},
 		},
 	}
-	p.topologyManager.UpdateCPUTopologyOptions("test-node-1", expectedCPUTopologyOptions)
+	p.topologyManager.UpdateCPUTopologyOptions("test-node-1", func(options *CPUTopologyOptions) {
+		*options = expectedCPUTopologyOptions
+	})
 
 	engine := gin.Default()
 	p.RegisterEndpoints(engine.Group("/"))
@@ -80,7 +82,9 @@ func TestEndpointsQueryAvailableCPUsOptions(t *testing.T) {
 			},
 		},
 	}
-	p.topologyManager.UpdateCPUTopologyOptions("test-node-1", cpuTopologyOptions)
+	p.topologyManager.UpdateCPUTopologyOptions("test-node-1", func(options *CPUTopologyOptions) {
+		*options = cpuTopologyOptions
+	})
 
 	p.cpuManager.UpdateAllocatedCPUSet("test-node-1", uuid.NewUUID(), MustParse("0,2,4,6"), schedulingconfig.CPUExclusivePolicyNone)
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -549,7 +549,9 @@ func TestPlugin_Filter(t *testing.T) {
 					CPUTopology: tt.cpuTopology,
 					Policy:      tt.kubeletPolicy,
 				}
-				plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, topologyOptions)
+				plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, func(options *CPUTopologyOptions) {
+					*options = topologyOptions
+				})
 
 				cpuManager := plg.cpuManager.(*cpuManagerImpl)
 				cpuManager.allocationStates[tt.allocationState.nodeName] = tt.allocationState
@@ -763,8 +765,8 @@ func TestPlugin_Score(t *testing.T) {
 			plg := p.(*Plugin)
 			if tt.allocationState != nil {
 				if tt.cpuTopology != nil {
-					plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, CPUTopologyOptions{
-						CPUTopology: tt.cpuTopology,
+					plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, func(options *CPUTopologyOptions) {
+						options.CPUTopology = tt.cpuTopology
 					})
 				}
 
@@ -937,8 +939,8 @@ func TestPlugin_Reserve(t *testing.T) {
 			plg := p.(*Plugin)
 			if tt.allocationState != nil {
 				if tt.cpuTopology != nil {
-					plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, CPUTopologyOptions{
-						CPUTopology: tt.cpuTopology,
+					plg.topologyManager.UpdateCPUTopologyOptions(tt.allocationState.nodeName, func(options *CPUTopologyOptions) {
+						options.CPUTopology = tt.cpuTopology
 					})
 					if len(tt.allocatedCPUs) > 0 {
 						tt.allocationState.addCPUs(tt.cpuTopology, uuid.NewUUID(), NewCPUSet(tt.allocatedCPUs...), schedulingconfig.CPUExclusivePolicyNone)
@@ -991,8 +993,8 @@ func TestPlugin_Unreserve(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	cycleState.Write(stateKey, state)
 	topologyManager := NewCPUTopologyManager()
-	topologyManager.UpdateCPUTopologyOptions("test-node-1", CPUTopologyOptions{
-		CPUTopology: cpuTopology,
+	topologyManager.UpdateCPUTopologyOptions("test-node-1", func(options *CPUTopologyOptions) {
+		options.CPUTopology = cpuTopology
 	})
 	plg := &Plugin{
 		cpuManager: &cpuManagerImpl{

--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
@@ -103,8 +103,8 @@ func TestPodEventHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cpuTopology := buildCPUTopologyForTest(2, 2, 4, 2)
 			topologyManager := NewCPUTopologyManager()
-			topologyManager.UpdateCPUTopologyOptions("test-node-1", CPUTopologyOptions{
-				CPUTopology: cpuTopology,
+			topologyManager.UpdateCPUTopologyOptions("test-node-1", func(options *CPUTopologyOptions) {
+				options.CPUTopology = cpuTopology
 			})
 			cpuManager := &cpuManagerImpl{
 				topologyManager:  topologyManager,

--- a/pkg/scheduler/plugins/nodenumaresource/topology_eventhandler.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_eventhandler.go
@@ -120,11 +120,13 @@ func (m *nodeResourceTopologyEventHandler) updateNodeResourceTopology(oldNodeRes
 	reservedCPUs := m.getPodAllocsCPUSet(podCPUAllocs)
 
 	nodeName := newNodeResTopology.Name
-	m.topologyManager.UpdateCPUTopologyOptions(nodeName, CPUTopologyOptions{
-		CPUTopology:  cpuTopology,
-		ReservedCPUs: reservedCPUs,
-		MaxRefCount:  0,
-		Policy:       kubeletPolicy,
+	m.topologyManager.UpdateCPUTopologyOptions(nodeName, func(options *CPUTopologyOptions) {
+		*options = CPUTopologyOptions{
+			CPUTopology:  cpuTopology,
+			ReservedCPUs: reservedCPUs,
+			Policy:       kubeletPolicy,
+			MaxRefCount:  options.MaxRefCount,
+		}
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

koord-scheduler: fix CPUTopologyManager get&update race condition

- T1: goroutineA get CPUTopologyOptions and modify
- T1' goroutineB get CPUTopologyOptions, modify and update. 
- T2 then goroutineA updates the modified CPUTopologyOptions, the data that be updated by goroutineB is overridden by goroutineB.

Thanks @ZiMengSheng  report the issue.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
