### PR TITLE
cpu suppress: only limits cpuset at besteffot container level if kube…

### DIFF
--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -58,16 +58,18 @@ type Config struct {
 	RuntimeHooksAddr          string
 	RuntimeHooksFailurePolicy string
 	RuntimeHookConfigFilePath string
+	RuntimeHookHostEndpoint   string
 	RuntimeHookDisableStages  []string
 	FeatureGates              map[string]bool
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		RuntimeHooksNetwork:       "tcp",
-		RuntimeHooksAddr:          ":9318",
+		RuntimeHooksNetwork:       "unix",
+		RuntimeHooksAddr:          "/host-var-run-koordlet/koordlet.sock",
 		RuntimeHooksFailurePolicy: "Ignore",
 		RuntimeHookConfigFilePath: system.Conf.RuntimeHooksConfigDir,
+		RuntimeHookHostEndpoint:   "/var/run/koordlet/koordlet.sock",
 		RuntimeHookDisableStages:  []string{},
 		FeatureGates:              map[string]bool{},
 	}
@@ -78,6 +80,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.RuntimeHooksAddr, "runtime-hooks-addr", c.RuntimeHooksAddr, "rpc server address for runtime hooks")
 	fs.StringVar(&c.RuntimeHooksFailurePolicy, "runtime-hooks-failure-policy", c.RuntimeHooksFailurePolicy, "failure policy for runtime hooks")
 	fs.StringVar(&c.RuntimeHookConfigFilePath, "runtime-hooks-config-path", c.RuntimeHookConfigFilePath, "config file path for runtime hooks")
+	fs.StringVar(&c.RuntimeHookHostEndpoint, "runtime-hooks-host-endpoint", c.RuntimeHookHostEndpoint, "host endpoint of runtime proxy")
 	fs.Var(cliflag.NewStringSlice(&c.RuntimeHookDisableStages), "runtime-hooks-disable-stages", "disable stages for runtime hooks")
 	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "runtime-hooks",
 		"A set of key=value pairs that describe feature gates for runtime hooks alpha/experimental features. "+

--- a/pkg/koordlet/runtimehooks/config_test.go
+++ b/pkg/koordlet/runtimehooks/config_test.go
@@ -27,10 +27,11 @@ import (
 
 func Test_NewDefaultConfig(t *testing.T) {
 	expectConfig := &Config{
-		RuntimeHooksNetwork:       "tcp",
-		RuntimeHooksAddr:          ":9318",
+		RuntimeHooksNetwork:       "unix",
+		RuntimeHooksAddr:          "/host-var-run-koordlet/koordlet.sock",
 		RuntimeHooksFailurePolicy: "Ignore",
 		RuntimeHookConfigFilePath: system.Conf.RuntimeHooksConfigDir,
+		RuntimeHookHostEndpoint:   "/var/run/koordlet/koordlet.sock",
 		RuntimeHookDisableStages:  []string{},
 		FeatureGates:              map[string]bool{},
 	}

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
@@ -46,6 +46,7 @@ type cpusetPlugin struct {
 func (p *cpusetPlugin) Register() {
 	klog.V(5).Infof("register hook %v", name)
 	hooks.Register(rmconfig.PreCreateContainer, name, description, p.SetContainerCPUSet)
+	hooks.Register(rmconfig.PreUpdateContainerResources, name, description, p.SetContainerCPUSet)
 	rule.Register(name, description,
 		rule.WithParseFunc(statesinformer.RegisterTypeNodeTopology, p.parseRule),
 		rule.WithUpdateCallback(p.ruleUpdateCb))

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -81,6 +81,7 @@ func (r *cpusetRule) getContainerCPUSet(containerReq *protocol.ContainerRequest)
 	if kubeQOS == corev1.PodQOSBestEffort {
 		// besteffort pods including QoS=BE, clear cpuset of BE container to avoid conflict with kubelet static policy,
 		// which will pass cpuset in StartContainerRequest of CRI
+		// TODO remove this in the future since cpu suppress will keep besteffort dir as all cpuset
 		return pointer.String(""), nil
 	}
 

--- a/pkg/koordlet/runtimehooks/proxyserver/server.go
+++ b/pkg/koordlet/runtimehooks/proxyserver/server.go
@@ -36,6 +36,7 @@ import (
 type Options struct {
 	Network        string
 	Address        string
+	HostEndpoint   string
 	FailurePolicy  config.FailurePolicyType
 	ConfigFilePath string
 	DisableStages  map[string]struct{}
@@ -78,11 +79,11 @@ func (s *server) Stop() {
 
 func (s *server) Register() error {
 	hookConfig := &config.RuntimeHookConfig{
-		RemoteEndpoint: s.options.Address,
+		RemoteEndpoint: s.options.HostEndpoint,
 		FailurePolicy:  s.options.FailurePolicy,
 		RuntimeHooks:   hooks.GetStages(s.options.DisableStages),
 	}
-	configData, _ := json.Marshal(hookConfig)
+	configData, _ := json.MarshalIndent(hookConfig, "", "\t")
 	if err := system.CommonFileWrite(filepath.Join(s.options.ConfigFilePath, "koordlet.json"), string(configData)); err != nil {
 		return err
 	}

--- a/pkg/koordlet/runtimehooks/proxyserver/service.go
+++ b/pkg/koordlet/runtimehooks/proxyserver/service.go
@@ -40,7 +40,7 @@ func (s *server) PreRunPodSandboxHook(ctx context.Context,
 	podCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PreRunPodSandbox, podCtx)
 	podCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PreRunPodSandboxHook response %v", resp.String())
+	klog.V(5).Infof("send PreRunPodSandboxHook for pod %v response %v", req.PodMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -57,7 +57,7 @@ func (s *server) PostStopPodSandboxHook(ctx context.Context,
 	podCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PostStopPodSandbox, podCtx)
 	podCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PostStopPodSandboxHook response %v", resp.String())
+	klog.V(5).Infof("send PostStopPodSandboxHook for pod %v response %v", req.PodMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -73,7 +73,8 @@ func (s *server) PreCreateContainerHook(ctx context.Context,
 	containerCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PreCreateContainer, containerCtx)
 	containerCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PreCreateContainerHook response %v", resp.String())
+	klog.V(5).Infof("send PreCreateContainerHook response for pod %v container %v response %v",
+		req.PodMeta.String(), req.ContainerMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -89,7 +90,8 @@ func (s *server) PreStartContainerHook(ctx context.Context,
 	containerCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PreStartContainer, containerCtx)
 	containerCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PreStartContainerHook response %v", resp.String())
+	klog.V(5).Infof("send PreStartContainerHook for pod %v container %v response %v",
+		req.PodMeta.String(), req.ContainerMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -105,7 +107,8 @@ func (s *server) PostStartContainerHook(ctx context.Context,
 	containerCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PostStartContainer, containerCtx)
 	containerCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PostStartContainerHook response %v", resp.String())
+	klog.V(5).Infof("send PostStartContainerHook for pod %v container %v response %v",
+		req.PodMeta.String(), req.ContainerMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -121,7 +124,8 @@ func (s *server) PostStopContainerHook(ctx context.Context,
 	containerCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PostStopContainer, containerCtx)
 	containerCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PostStopContainerHook response %v", resp.String())
+	klog.V(5).Infof("send PostStopContainerHook for pod %v container %v response %v",
+		req.PodMeta.String(), req.ContainerMeta.String(), resp.String())
 	return resp, nil
 }
 
@@ -137,6 +141,7 @@ func (s *server) PreUpdateContainerResourcesHook(ctx context.Context,
 	containerCtx.FromProxy(req)
 	hooks.RunHooks(rmconfig.PreUpdateContainerResources, containerCtx)
 	containerCtx.ProxyDone(resp)
-	klog.V(5).Infof("send PreUpdateContainerResourcesHook response %v", resp.String())
+	klog.V(5).Infof("send PreUpdateContainerResourcesHook for pod %v container %v response %v",
+		req.PodMeta.String(), req.ContainerMeta.String(), resp.String())
 	return resp, nil
 }

--- a/pkg/koordlet/runtimehooks/runtimehooks.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks.go
@@ -65,6 +65,7 @@ func NewRuntimeHook(si statesinformer.StatesInformer, cfg *Config) (RuntimeHook,
 	newServerOptions := proxyserver.Options{
 		Network:        cfg.RuntimeHooksNetwork,
 		Address:        cfg.RuntimeHooksAddr,
+		HostEndpoint:   cfg.RuntimeHookHostEndpoint,
 		FailurePolicy:  failurePolicy,
 		ConfigFilePath: cfg.RuntimeHookConfigFilePath,
 		DisableStages:  getDisableStagesMap(cfg.RuntimeHookDisableStages),

--- a/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
+++ b/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
@@ -24,7 +24,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	v1alpha10 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	statesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	v1 "k8s.io/api/core/v1"
 )
@@ -81,10 +82,10 @@ func (mr *MockStatesInformerMockRecorder) GetNode() *gomock.Call {
 }
 
 // GetNodeSLO mocks base method.
-func (m *MockStatesInformer) GetNodeSLO() *v1alpha1.NodeSLO {
+func (m *MockStatesInformer) GetNodeSLO() *v1alpha10.NodeSLO {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodeSLO")
-	ret0, _ := ret[0].(*v1alpha1.NodeSLO)
+	ret0, _ := ret[0].(*v1alpha10.NodeSLO)
 	return ret0
 }
 
@@ -92,6 +93,20 @@ func (m *MockStatesInformer) GetNodeSLO() *v1alpha1.NodeSLO {
 func (mr *MockStatesInformerMockRecorder) GetNodeSLO() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeSLO", reflect.TypeOf((*MockStatesInformer)(nil).GetNodeSLO))
+}
+
+// GetNodeTopo mocks base method.
+func (m *MockStatesInformer) GetNodeTopo() *v1alpha1.NodeResourceTopology {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeTopo")
+	ret0, _ := ret[0].(*v1alpha1.NodeResourceTopology)
+	return ret0
+}
+
+// GetNodeTopo indicates an expected call of GetNodeTopo.
+func (mr *MockStatesInformerMockRecorder) GetNodeTopo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeTopo", reflect.TypeOf((*MockStatesInformer)(nil).GetNodeTopo))
 }
 
 // HasSynced mocks base method.

--- a/pkg/koordlet/statesinformer/register.go
+++ b/pkg/koordlet/statesinformer/register.go
@@ -128,7 +128,7 @@ func (s *statesInformer) getObjByType(objType RegisterType, cbCtx UpdateCbCtx) i
 	case RegisterTypeAllPods:
 		return &struct{}{}
 	case RegisterTypeNodeTopology:
-		return s.getNodeTopo()
+		return s.GetNodeTopo()
 	}
 	return nil
 }

--- a/pkg/koordlet/statesinformer/states_informer.go
+++ b/pkg/koordlet/statesinformer/states_informer.go
@@ -59,6 +59,8 @@ type StatesInformer interface {
 
 	GetAllPods() []*PodMeta
 
+	GetNodeTopo() *topov1alpha1.NodeResourceTopology
+
 	RegisterCallbacks(objType RegisterType, name, description string, callbackFn UpdateCbFn)
 }
 

--- a/pkg/koordlet/statesinformer/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/states_noderesourcetopology.go
@@ -336,7 +336,7 @@ func (s *statesInformer) setNodeTopo(newTopo *v1alpha1.NodeResourceTopology) {
 	s.nodeTopology = newTopo
 }
 
-func (s *statesInformer) getNodeTopo() *v1alpha1.NodeResourceTopology {
+func (s *statesInformer) GetNodeTopo() *v1alpha1.NodeResourceTopology {
 	s.nodeTopoMutex.RLock()
 	defer s.nodeTopoMutex.RUnlock()
 	return s.nodeTopology.DeepCopy()


### PR DESCRIPTION
…let use static cpu policy

Signed-off-by: 佑祎 <zzw261520@alibaba-inc.com>

### Ⅰ. Describe what this PR does

for kubelet none policy: keep cpu suppress at besteffort root dir level, make sure that new pod can be throttled in time.
for kubelet static policy: keep cpu suppress at container level, so that we can avoid the conflicts during container creating.

after we finish this, we can make cpu suppress policy work well without runtime-proxy.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes #546

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
