### PR TITLE
koord-descheduler: fix failed evict with StatefulSet Pod

### DIFF
--- a/cmd/koord-descheduler/app/server.go
+++ b/cmd/koord-descheduler/app/server.go
@@ -323,7 +323,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 func podAssignedToNode(clt client.Client) descheduler.PodAssignedToNodeFn {
 	return func(nodeName string) ([]*corev1.Pod, error) {
 		podList := &corev1.PodList{}
-		err := clt.List(context.TODO(), podList, &client.ListOptions{FieldSelector: fields.OneTermEqualSelector(fieldindex.IndexNodeName, nodeName)})
+		err := clt.List(context.TODO(), podList, &client.ListOptions{FieldSelector: fields.OneTermEqualSelector(fieldindex.IndexPodByNodeName, nodeName)})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/descheduler/controllers/migration/controller.go
+++ b/pkg/descheduler/controllers/migration/controller.go
@@ -347,13 +347,9 @@ func (r *Reconciler) doMigrate(ctx context.Context, job *sev1alpha1.PodMigration
 	}
 
 	if job.Status.Phase == "" || job.Status.Phase == sev1alpha1.PodMigrationJobPending {
-		if aborted, err := r.abortJobIfUnretriablePodFilterFailed(ctx, job); aborted {
-			return reconcile.Result{}, err
+		if result, err := r.preparePendingJob(ctx, job); err != nil || !result.IsZero() {
+			return result, err
 		}
-		if requeue, err := r.requeueJobIfRetriablePodFilterFailed(ctx, job); requeue || err != nil {
-			return reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
-		}
-		job.Status.Phase = sev1alpha1.PodMigrationJobRunning
 	}
 
 	if job.Spec.Mode == sev1alpha1.PodMigrationJobModeEvictionDirectly {
@@ -407,11 +403,7 @@ func (r *Reconciler) doMigrate(ctx context.Context, job *sev1alpha1.PodMigration
 		}
 	}
 
-	if err = r.syncReservationScheduleSuccess(ctx, job, reservationObj); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if aborted, err := r.abortJobIfReserveOnSameNode(ctx, job, reservationObj); aborted || err != nil {
+	if err = r.prepareJobWithReservationScheduleSuccess(ctx, job, reservationObj); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -453,6 +445,54 @@ func (r *Reconciler) doMigrate(ctx context.Context, job *sev1alpha1.PodMigration
 		r.eventRecorder.Eventf(job, nil, corev1.EventTypeNormal, "Complete", "Migrating", job.Status.Message)
 	}
 	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) preparePendingJob(ctx context.Context, job *sev1alpha1.PodMigrationJob) (reconcile.Result, error) {
+	changed, err := r.preparePodRef(ctx, job)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if changed {
+		if err = r.Client.Update(ctx, job); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	if aborted, err := r.abortJobIfUnretriablePodFilterFailed(ctx, job); aborted || err != nil {
+		if err == nil {
+			err = fmt.Errorf("abort job since failed to unretriable Pod filter")
+		}
+		return reconcile.Result{}, err
+	}
+	if requeue, err := r.requeueJobIfRetriablePodFilterFailed(ctx, job); requeue || err != nil {
+		return reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
+	}
+
+	job.Status.Phase = sev1alpha1.PodMigrationJobRunning
+	err = r.Client.Status().Update(ctx, job)
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) preparePodRef(ctx context.Context, job *sev1alpha1.PodMigrationJob) (bool, error) {
+	if job.Spec.PodRef.Namespace == "" || job.Spec.PodRef.Name == "" {
+		_ = r.abortJobByInvalidPodRef(ctx, job)
+		return false, fmt.Errorf("abort job by invalid podRef")
+	}
+
+	podNamespacedName := types.NamespacedName{
+		Namespace: job.Spec.PodRef.Namespace,
+		Name:      job.Spec.PodRef.Name,
+	}
+	var pod corev1.Pod
+	err := r.Client.Get(ctx, podNamespacedName, &pod)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_ = r.abortJobByMissingPod(ctx, job, podNamespacedName)
+		}
+		return false, err
+	}
+	job.Spec.PodRef.UID = pod.UID
+	return true, nil
 }
 
 func (r *Reconciler) abortJobIfTimeout(ctx context.Context, job *sev1alpha1.PodMigrationJob) (bool, error) {
@@ -522,6 +562,17 @@ func (r *Reconciler) abortJobIfUnretriablePodFilterFailed(ctx context.Context, j
 	}
 
 	return false, nil
+}
+
+func (r *Reconciler) abortJobByInvalidPodRef(ctx context.Context, job *sev1alpha1.PodMigrationJob) error {
+	job.Status.Phase = sev1alpha1.PodMigrationJobFailed
+	job.Status.Reason = "InvalidPodRef"
+	job.Status.Message = fmt.Sprintf("Abort job caused by invalid PodRef")
+	err := r.Status().Update(ctx, job)
+	if err == nil {
+		r.eventRecorder.Eventf(job, nil, corev1.EventTypeWarning, "InvalidPodRef", "Migrating", job.Status.Message)
+	}
+	return err
 }
 
 func (r *Reconciler) abortJobByMissingPod(ctx context.Context, job *sev1alpha1.PodMigrationJob, podNamespacedName types.NamespacedName) error {
@@ -666,6 +717,9 @@ func (r *Reconciler) waitForPodBindReservation(ctx context.Context, job *sev1alp
 			Reason: sev1alpha1.PodMigrationJobReasonWaitForPodBindReservation,
 		}
 		err := r.updateCondition(ctx, job, cond)
+		if err == nil {
+			r.eventRecorder.Eventf(job, nil, corev1.EventTypeNormal, sev1alpha1.PodMigrationJobReasonWaitForPodBindReservation, "Migrating", "Waiting for Pod bind Reservation")
+		}
 		return false, reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
 	}
 
@@ -700,7 +754,7 @@ func (r *Reconciler) evictPod(ctx context.Context, job *sev1alpha1.PodMigrationJ
 	pod := &corev1.Pod{}
 	podNamespacedName := types.NamespacedName{Namespace: job.Spec.PodRef.Namespace, Name: job.Spec.PodRef.Name}
 	err := r.Client.Get(ctx, podNamespacedName, pod)
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || (err == nil && cond != nil && job.Spec.PodRef.UID != "" && job.Spec.PodRef.UID != pod.UID) {
 		if job.Status.Status != string(sev1alpha1.PodMigrationJobConditionEviction) {
 			err = r.abortJobByMissingPod(ctx, job, podNamespacedName)
 			return false, reconcile.Result{}, err
@@ -752,17 +806,31 @@ func (r *Reconciler) evictPod(ctx context.Context, job *sev1alpha1.PodMigrationJ
 	return false, reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
 }
 
-func (r *Reconciler) syncReservationScheduleSuccess(ctx context.Context, job *sev1alpha1.PodMigrationJob, reservationObj reservation.Object) error {
+func (r *Reconciler) prepareJobWithReservationScheduleSuccess(ctx context.Context, job *sev1alpha1.PodMigrationJob, reservationObj reservation.Object) error {
 	scheduledNodeName := reservationObj.GetScheduledNodeName()
 	if scheduledNodeName == "" || job.Status.NodeName != "" {
 		return nil
 	}
+
+	_, cond := util.GetCondition(&job.Status, sev1alpha1.PodMigrationJobConditionReservationScheduled)
+	if cond != nil && cond.Status == sev1alpha1.PodMigrationJobConditionStatusTrue {
+		return nil
+	}
+
+	aborted, err := r.abortJobIfReserveOnSameNode(ctx, job, reservationObj)
+	if err != nil {
+		return err
+	}
+	if aborted {
+		return fmt.Errorf("abort job since reservation assigned on same node as Pod")
+	}
+
 	job.Status.NodeName = scheduledNodeName
-	cond := &sev1alpha1.PodMigrationJobCondition{
+	cond = &sev1alpha1.PodMigrationJobCondition{
 		Type:   sev1alpha1.PodMigrationJobConditionReservationScheduled,
 		Status: sev1alpha1.PodMigrationJobConditionStatusTrue,
 	}
-	err := r.updateCondition(ctx, job, cond)
+	err = r.updateCondition(ctx, job, cond)
 	if err == nil {
 		r.eventRecorder.Eventf(job, nil, corev1.EventTypeNormal, string(sev1alpha1.PodMigrationJobConditionReservationScheduled), "Migrating", "Assigned Reservation %q to node %q", reservationObj, scheduledNodeName)
 	}

--- a/pkg/descheduler/controllers/migration/controller_test.go
+++ b/pkg/descheduler/controllers/migration/controller_test.go
@@ -356,7 +356,7 @@ func TestHandleScheduleSuccess(t *testing.T) {
 			NodeName: "test-node",
 		},
 	})
-	assert.Nil(t, reconciler.syncReservationScheduleSuccess(context.TODO(), job, reservationObj))
+	assert.Nil(t, reconciler.prepareJobWithReservationScheduleSuccess(context.TODO(), job, reservationObj))
 	_, cond := util.GetCondition(&job.Status, sev1alpha1.PodMigrationJobConditionReservationScheduled)
 	assert.NotNil(t, cond)
 	expectCond := &sev1alpha1.PodMigrationJobCondition{
@@ -818,6 +818,113 @@ func TestMigrate(t *testing.T) {
 		_, cond := util.GetCondition(&job.Status, sev1alpha1.PodMigrationJobConditionEviction)
 		if cond != nil && cond.Status == sev1alpha1.PodMigrationJobConditionStatusFalse {
 			assert.Nil(t, reconciler.Client.Delete(context.TODO(), pod))
+		}
+	}
+	assert.Nil(t, reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: job.Name}, job))
+	assert.Equal(t, sev1alpha1.PodMigrationJobSucceeded, job.Status.Phase)
+	assert.Equal(t, "Complete", job.Status.Status)
+}
+
+func TestMigrateWithSamePodName(t *testing.T) {
+	reconciler := newTestReconciler()
+	reconciler.evictorInterpreter = fakeEvictionInterpreter{}
+
+	job := &sev1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: sev1alpha1.PodMigrationJobSpec{
+			Paused: true,
+			PodRef: &corev1.ObjectReference{
+				Namespace: "default",
+				Name:      "test-pod",
+			},
+		},
+	}
+	assert.Nil(t, reconciler.Client.Create(context.TODO(), job))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod",
+			UID:       uuid.NewUUID(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Controller: pointer.Bool(true),
+					Kind:       "StatefulSet",
+					Name:       "test",
+					UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	podCopy := pod.DeepCopy()
+	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
+
+	reconciler.reservationInterpreter = fakeReservationInterpreter{
+		reservation: &sev1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-reservation",
+			},
+			Spec: sev1alpha1.ReservationSpec{
+				Owners: []sev1alpha1.ReservationOwner{
+					{
+						Controller: &sev1alpha1.ReservationControllerReference{
+							Namespace: "default",
+							OwnerReference: metav1.OwnerReference{
+								APIVersion: "apps/v1",
+								Controller: pointer.Bool(true),
+								Kind:       "StatefulSet",
+								Name:       "test",
+								UID:        "2f96233d-a6b9-4981-b594-7c90c987aed9",
+							},
+						},
+					},
+				},
+			},
+			Status: sev1alpha1.ReservationStatus{
+				Phase: sev1alpha1.ReservationAvailable,
+				Conditions: []sev1alpha1.ReservationCondition{
+					{
+						Type:   sev1alpha1.ReservationConditionScheduled,
+						Reason: sev1alpha1.ReasonReservationScheduled,
+						Status: sev1alpha1.ConditionStatusTrue,
+					},
+				},
+				CurrentOwners: []corev1.ObjectReference{
+					{
+						Namespace: "default",
+						Name:      "test-pod-1",
+					},
+				},
+				NodeName: "test-node-1",
+			},
+		},
+	}
+	for {
+		_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: job.Name}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Nil(t, reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: job.Name}, job))
+
+		if job.Spec.Paused {
+			job.Spec.Paused = false
+			assert.Nil(t, reconciler.Client.Update(context.TODO(), job))
+		}
+
+		if job.Status.Phase != "" && job.Status.Phase != sev1alpha1.PodMigrationJobRunning {
+			break
+		}
+		_, cond := util.GetCondition(&job.Status, sev1alpha1.PodMigrationJobConditionEviction)
+		if cond != nil && cond.Status == sev1alpha1.PodMigrationJobConditionStatusFalse {
+			assert.Nil(t, reconciler.Client.Delete(context.TODO(), pod))
+			podCopy.UID = uuid.NewUUID()
+			assert.NoError(t, reconciler.Client.Create(context.TODO(), podCopy))
 		}
 	}
 	assert.Nil(t, reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: job.Name}, job))
@@ -1421,7 +1528,7 @@ func TestAbortJobIfUnretriablePodFilterFailed(t *testing.T) {
 
 	result, err := reconciler.doMigrate(context.TODO(), job)
 	assert.True(t, enter)
-	assert.NoError(t, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 
 	assert.NoError(t, reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: job.Name}, job))

--- a/pkg/descheduler/controllers/migration/controllerfinder/pods_finder.go
+++ b/pkg/descheduler/controllers/migration/controllerfinder/pods_finder.go
@@ -101,7 +101,7 @@ func (r *ControllerFinder) GetPodsForRef(apiVersion, kind, name, ns string, labe
 		podList := &corev1.PodList{}
 		listOption := &client.ListOptions{
 			Namespace:     ns,
-			FieldSelector: fields.SelectorFromSet(fields.Set{fieldindex.IndexPodOwnerRefUID: string(uid)}),
+			FieldSelector: fields.SelectorFromSet(fields.Set{fieldindex.IndexPodByOwnerRefUID: string(uid)}),
 		}
 		if selector != nil {
 			listOption.LabelSelector = selector


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

1. When evict StatefulSet pod via PodMigrationJob,  koord-descheduler cannot confirm whether the Pod has been migrated successfully since the newly created Pod has the same name. So koord-descheduler should check if the evicting Pod's UID is different from the previous Pod. 
2. Also in the scene,  the logic of check whether the Reservation reserved on same on with Pod is also invalid.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
