### PR TITLE
koord-scheduler: support kubelet reserved cpus

### DIFF
--- a/docs/proposals/scheduling/20220530-fine-grained-cpu-orchestration.md
+++ b/docs/proposals/scheduling/20220530-fine-grained-cpu-orchestration.md
@@ -133,7 +133,7 @@ As the application scaling or rolling deployment, the best-fit allocatable space
 
 1. Only supports the CPU allocation mechanism of the Pod dimension.
 1. Koordinator divides the CPU on the machine into `CPU Shared Pool`, `statically exclusive CPUs` and `BE CPU Shared Pool`. 
-    1. The `CPU Shared Pool` is the set of CPUs on which any containers in `K8s Burstable` and `Koordinator LSE` Pods run. Containers in `K8s Guaranteed` pods with `fractional CPU requests` also run on CPUs in the shared pool. The shared pool contains all unallocated CPUs in the node but excluding CPUs allocated by K8s Guaranteed, LSE and LSR Pods. If kubelet reserved CPUs, the shared pool includes the reserved CPUs. 
+    1. The `CPU Shared Pool` is the set of CPUs on which any containers in `K8s Burstable` and `Koordinator LS` Pods run. Containers in `K8s Guaranteed` pods with `fractional CPU requests` also run on CPUs in the shared pool. The shared pool contains all unallocated CPUs in the node but excluding CPUs allocated by K8s Guaranteed, LSE and LSR Pods. If kubelet reserved CPUs, the shared pool includes the reserved CPUs. 
     1. The `statically exclusive CPUs` are the set of CPUs on which any containers in `K8s Guaranteed`, `Koordinator LSE` and `LSR` Pods that have integer CPU run. When K8s Guaranteed, LSE and LSR Pods request CPU, koord-scheduler will be allocated from the `CPU Shared Pool`.
     1. The `BE CPU Shared pool` is the set of CPUs on which any containers in `K8s BestEffort` and `Koordinator BE` Pods run. The `BE CPU Shared Pool` contains all CPUs in the node but excluding CPUs allocated by K8s Guaranteed and Koordinator Pods.
 
@@ -360,6 +360,7 @@ const (
 type KubeletCPUManagerPolicy struct {
   Policy  string            `json:"policy,omitempty"`
   Options map[string]string `json:"options,omitempty"`
+  ReservedCPUs string       `json:"reservedCPUs,omitempty"`
 }
 
 ```
@@ -399,8 +400,8 @@ type PodCPUAllocs []PodCPUAlloc
 type NUMACPUSharedPools []CPUSharedPool
 
 type CPUSharedPool struct {
-  Socket int32  `json:"socket,omitempty"`
-  Node   int32  `json:"node,omitempty"`
+  Socket int32  `json:"socket"`
+  Node   int32  `json:"node"`
   CPUSet string `json:"cpuset,omitempty"`
 }
 ```
@@ -702,3 +703,4 @@ type ScoringStrategy struct {
 - 2022-06-24: Fix typo
 - 2022-07-11: Adjust CPUBindPolicyNone to CPUBindPolicyDefault
 - 2022-08-02: Update PodCPUAllocs definition
+- 2022-09-08: Add ReservedCPUs in KubeletCPUManagerPolicy

--- a/pkg/koordlet/statesinformer/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/states_noderesourcetopology.go
@@ -194,9 +194,9 @@ func (s *statesInformer) reportNodeTopology() {
 		}
 		cpuManagerPolicy.ReservedCPUs = reservedCPUs.String()
 
-		for _, cpuID := range reservedCPUs.ToSliceNoSort() {
-			delete(sharedPoolCPUs, int32(cpuID))
-		}
+		// NOTE: We should not remove reservedCPUs from sharedPoolCPUs to
+		//  ensure that Burstable Pods (e.g. Pods request 0C but are limited to 4C)
+		//  at least there are reservedCPUs available when nodes are allocated
 	}
 
 	cpuManagerPolicyJSON, err := json.Marshal(cpuManagerPolicy)

--- a/pkg/koordlet/statesinformer/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/states_noderesourcetopology_test.go
@@ -320,6 +320,6 @@ func Test_reportNodeTopology(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectKubeletCPUManagerPolicy, kubeletCPUManagerPolicy)
 
-	assert.Equal(t, `[{"socket":0,"node":0,"cpuset":"2"},{"socket":1,"node":1,"cpuset":"6-7"}]`, topology.Annotations[extension.AnnotationNodeCPUSharedPools])
+	assert.Equal(t, `[{"socket":0,"node":0,"cpuset":"0-2"},{"socket":1,"node":1,"cpuset":"6-7"}]`, topology.Annotations[extension.AnnotationNodeCPUSharedPools])
 	assert.Equal(t, `{"detail":[{"id":0,"core":0,"socket":0,"node":0},{"id":1,"core":0,"socket":0,"node":0},{"id":2,"core":1,"socket":0,"node":0},{"id":3,"core":1,"socket":0,"node":0},{"id":4,"core":2,"socket":1,"node":1},{"id":5,"core":2,"socket":1,"node":1},{"id":6,"core":3,"socket":1,"node":1},{"id":7,"core":3,"socket":1,"node":1}]}`, topology.Annotations[extension.AnnotationNodeCPUTopology])
 }


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

The koord-scheduler plugin `NodeNUMAResource` supports kubelet reserved CPUs, and these kubelet reserved CPUs are no longer allocated when allocating to prevent CPU stacking.

the correlative PR #592 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
