### PR TITLE
koord-scheduler: support debug scores

### DIFF
--- a/cmd/koord-scheduler/app/options/options.go
+++ b/cmd/koord-scheduler/app/options/options.go
@@ -58,7 +58,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 
 	return &schedulerappconfig.Config{
 		Config:                           config,
-		ServicesEngine:                   services.NewEngine(gin.Default()),
+		ServicesEngine:                   services.NewEngine(gin.New()),
 		KoordinatorClient:                koordinatorClient,
 		KoordinatorSharedInformerFactory: koordinatorSharedInformerFactory,
 	}, nil

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
+	github.com/jedib0t/go-pretty/v6 v6.3.8
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
 	github.com/openkruise/kruise v1.2.0
@@ -113,6 +114,7 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 // indirect
@@ -135,6 +137,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jedib0t/go-pretty/v6 v6.3.8 h1:p5eZqLFMEGr7CC+9915lC4Dk7Gub6mH7NE35jDhkJsQ=
+github.com/jedib0t/go-pretty/v6 v6.3.8/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -712,6 +714,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -846,6 +850,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -898,6 +903,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -998,6 +1005,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/scheduler/frameworkext/debug_scores.go
+++ b/pkg/scheduler/frameworkext/debug_scores.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	prettytable "github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+var (
+	debugTopNScores = 0
+)
+
+func AddFlags(fs *pflag.FlagSet) {
+	fs.IntVarP(&debugTopNScores, "debug-scores", "s", debugTopNScores, "logging topN nodes score and scores for each plugin after running the score extension, disable if set to 0")
+}
+
+// DebugScoresSetter updates debugTopNScores to specified value
+func DebugScoresSetter(val string) (string, error) {
+	topN, err := strconv.Atoi(val)
+	if err != nil {
+		return "", fmt.Errorf("failed set debugTopNScores %s: %v", val, err)
+	}
+	debugTopNScores = topN
+	return fmt.Sprintf("successfully set debugTopNScores to %s", val), nil
+}
+
+func debugScores(topN int, pod *corev1.Pod, pluginToNodeScores map[string]framework.NodeScoreList, nodes []*corev1.Node) prettytable.Writer {
+	// Summarize all scores.
+	result := make(framework.NodeScoreList, 0, len(nodes))
+	nodeOrders := make(map[string]int, len(nodes))
+
+	for i, node := range nodes {
+		nodeOrders[node.Name] = i
+		result = append(result, framework.NodeScore{Name: node.Name, Score: 0})
+		for j := range pluginToNodeScores {
+			result[i].Score += pluginToNodeScores[j][i].Score
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Score > result[j].Score
+	})
+
+	pluginNames := make([]string, 0, len(pluginToNodeScores))
+	for name := range pluginToNodeScores {
+		pluginNames = append(pluginNames, name)
+	}
+	sort.Strings(pluginNames)
+
+	w := prettytable.NewWriter()
+	headerRow := prettytable.Row{"#", "Pod", "Node", "Score"}
+	for _, name := range pluginNames {
+		headerRow = append(headerRow, name)
+	}
+	w.AppendHeader(headerRow)
+
+	podRef := klog.KObj(pod)
+	for i, node := range result {
+		if i >= topN {
+			break
+		}
+		row := prettytable.Row{strconv.Itoa(i), podRef.String(), node.Name, node.Score}
+		if nodeIndex, ok := nodeOrders[node.Name]; ok {
+			for _, pluginName := range pluginNames {
+				if scores, ok := pluginToNodeScores[pluginName]; ok {
+					row = append(row, scores[nodeIndex].Score)
+				} else {
+					row = append(row, -1)
+				}
+			}
+		}
+		w.AppendRow(row)
+	}
+	klog.Infof("Top%d scores for Pod: %v, feasibleNodes: %v, plugins:%v\n%v", topN, podRef, len(nodes), pluginNames, w.RenderMarkdown())
+	return w // return writer for UT
+}

--- a/pkg/scheduler/frameworkext/debug_scores_test.go
+++ b/pkg/scheduler/frameworkext/debug_scores_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestDebugScoresSetter(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "integer",
+			value:   "123",
+			wantErr: false,
+		},
+		{
+			name:    "float",
+			value:   "11.22",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DebugScoresSetter(tt.value)
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("expected no error but got err: %v", err)
+			}
+		})
+	}
+}
+
+func TestDebugScores(t *testing.T) {
+	pluginToNodeScores := map[string]framework.NodeScoreList{
+		"ImageLocality": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 0},
+		},
+		"InterPodAffinity": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 0},
+		},
+		"LoadAwareScheduling": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 85},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 87},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 55},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 15},
+		},
+		"NodeAffinity": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 0},
+		},
+		"NodeNUMAResource": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 0},
+		},
+		"NodeResourcesBalancedAllocation": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 96},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 96},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 95},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 90},
+		},
+		"NodeResourcesFit": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 93},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 94},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 91},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 82},
+		},
+		"PodTopologySpread": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 200},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 200},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 200},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 200},
+		},
+		"Reservation": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 0},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 0},
+		},
+		"TaintToleration": {
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.50", Score: 100},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.51", Score: 100},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.19", Score: 100},
+			framework.NodeScore{Name: "cn-hangzhou.10.0.4.18", Score: 100},
+		},
+	}
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "cn-hangzhou.10.0.4.50"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cn-hangzhou.10.0.4.51"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cn-hangzhou.10.0.4.19"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cn-hangzhou.10.0.4.18"}},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "curlimage-545745d8f8-rngp7",
+		},
+	}
+
+	w := debugScores(4, pod, pluginToNodeScores, nodes)
+	expectedResult := `| # | Pod | Node | Score | ImageLocality | InterPodAffinity | LoadAwareScheduling | NodeAffinity | NodeNUMAResource | NodeResourcesBalancedAllocation | NodeResourcesFit | PodTopologySpread | Reservation | TaintToleration |
+| --- | --- | --- | ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:|
+| 0 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.51 | 577 | 0 | 0 | 87 | 0 | 0 | 96 | 94 | 200 | 0 | 100 |
+| 1 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.50 | 574 | 0 | 0 | 85 | 0 | 0 | 96 | 93 | 200 | 0 | 100 |
+| 2 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.19 | 541 | 0 | 0 | 55 | 0 | 0 | 95 | 91 | 200 | 0 | 100 |
+| 3 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.18 | 487 | 0 | 0 | 15 | 0 | 0 | 90 | 82 | 200 | 0 | 100 |`
+	assert.Equal(t, expectedResult, w.RenderMarkdown())
+}

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -208,6 +208,14 @@ func (ext *frameworkExtenderImpl) RunFilterPluginsWithNominatedPods(ctx context.
 	return ext.Framework.RunFilterPluginsWithNominatedPods(ctx, cycleState, pod, nodeInfo)
 }
 
+func (ext *frameworkExtenderImpl) RunScorePlugins(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodes []*corev1.Node) (framework.PluginToNodeScores, *framework.Status) {
+	pluginToNodeScores, status := ext.handle.RunScorePlugins(ctx, state, pod, nodes)
+	if status.IsSuccess() && debugTopNScores > 0 {
+		debugScores(debugTopNScores, pod, pluginToNodeScores, nodes)
+	}
+	return pluginToNodeScores, status
+}
+
 // PluginFactoryProxy is used to proxy the call to the PluginFactory function and pass in the ExtendedHandle for the custom plugin
 func PluginFactoryProxy(extendHandle ExtendedHandle, factoryFn frameworkruntime.PluginFactory) frameworkruntime.PluginFactory {
 	return func(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {

--- a/pkg/util/routes/flags.go
+++ b/pkg/util/routes/flags.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"path"
+	"sync"
+
+	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/klog/v2"
+)
+
+var (
+	lock            = &sync.RWMutex{}
+	registeredFlags = map[string]debugFlag{}
+)
+
+// DebugFlags adds handlers for flags under /debug/flags.
+type DebugFlags struct {
+	c *mux.PathRecorderMux
+}
+
+func NewDebugFlags(c *mux.PathRecorderMux) DebugFlags {
+	f := DebugFlags{
+		c: c,
+	}
+	c.UnlistedHandle("/debug/flags", http.HandlerFunc(f.Index))
+	c.UnlistedHandlePrefix("/debug/flags/", http.HandlerFunc(f.Index))
+	return f
+}
+
+// Install registers the APIServer's flags handler.
+func (f DebugFlags) Install(flag string, handler func(http.ResponseWriter, *http.Request)) {
+	url := path.Join("/debug/flags", flag)
+	f.c.UnlistedHandleFunc(url, handler)
+
+	f.addFlag(flag)
+}
+
+// Index responds with the `/debug/flags` request.
+// For example, "/debug/flags/v" serves the "--v" flag.
+// Index responds to a request for "/debug/flags/" with an HTML page
+// listing the available flags.
+func (f DebugFlags) Index(w http.ResponseWriter, r *http.Request) {
+	lock.RLock()
+	defer lock.RUnlock()
+	if err := indexTmpl.Execute(w, registeredFlags); err != nil {
+		klog.Error(err)
+	}
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`<html>
+<head>
+<title>/debug/flags/</title>
+</head>
+<body>
+/debug/flags/<br>
+<br>
+flags:<br>
+<table>
+{{range .}}
+<tr>{{.Flag}}<br>
+{{end}}
+</table>
+<br>
+full flags configurable<br>
+</body>
+</html>
+`))
+
+type debugFlag struct {
+	Flag string
+}
+
+func (f DebugFlags) addFlag(flag string) {
+	lock.Lock()
+	defer lock.Unlock()
+	registeredFlags[flag] = debugFlag{flag}
+}
+
+// StringFlagSetterFunc is a func used for setting string type flag.
+type StringFlagSetterFunc func(string) (string, error)
+
+// StringFlagPutHandler wraps an http Handler to set string type flag.
+func StringFlagPutHandler(setter StringFlagSetterFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == "PUT":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				writePlainText(http.StatusBadRequest, "error reading request body: "+err.Error(), w)
+				return
+			}
+			defer req.Body.Close()
+			response, err := setter(string(body))
+			if err != nil {
+				writePlainText(http.StatusBadRequest, err.Error(), w)
+				return
+			}
+			writePlainText(http.StatusOK, response, w)
+			return
+		default:
+			writePlainText(http.StatusNotAcceptable, "unsupported http method", w)
+			return
+		}
+	})
+}
+
+// writePlainText renders a simple string response.
+func writePlainText(statusCode int, text string, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+	fmt.Fprintln(w, text)
+}


### PR DESCRIPTION
koord-scheduler: support debug scores

Users can enable debug scores via flags -s, --debug-scores or set on demand via the following commands:

curl -X PUT leaderSchedulerIP:port/debug/flags/s --data '100'

Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

Users can enable debug scores via flags -s, --debug-scores or set on demand via the following commands:

```bash
curl -X PUT <leaderSchedulerIP>:<port>/debug/flags/s --data '100'
```

and the scheduler will logging the following content with markdown style:

```
| # | Pod | Node | Score | ImageLocality | InterPodAffinity | LoadAwareScheduling | NodeAffinity | NodeNUMAResource | NodeResourcesBalancedAllocation | NodeResourcesFit | PodTopologySpread | Reservation | TaintToleration |
| --- | --- | --- | ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:|
| 0 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.51 | 577 | 0 | 0 | 87 | 0 | 0 | 96 | 94 | 200 | 0 | 100 |
| 1 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.50 | 574 | 0 | 0 | 85 | 0 | 0 | 96 | 93 | 200 | 0 | 100 |
| 2 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.19 | 541 | 0 | 0 | 55 | 0 | 0 | 95 | 91 | 200 | 0 | 100 |
| 3 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.18 | 487 | 0 | 0 | 15 | 0 | 0 | 90 | 82 | 200 | 0 | 100 |
```

| # | Pod | Node | Score | ImageLocality | InterPodAffinity | LoadAwareScheduling | NodeAffinity | NodeNUMAResource | NodeResourcesBalancedAllocation | NodeResourcesFit | PodTopologySpread | Reservation | TaintToleration |
| --- | --- | --- | ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:| ---:|
| 0 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.51 | 577 | 0 | 0 | 87 | 0 | 0 | 96 | 94 | 200 | 0 | 100 |
| 1 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.50 | 574 | 0 | 0 | 85 | 0 | 0 | 96 | 93 | 200 | 0 | 100 |
| 2 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.19 | 541 | 0 | 0 | 55 | 0 | 0 | 95 | 91 | 200 | 0 | 100 |
| 3 | default/curlimage-545745d8f8-rngp7 | cn-hangzhou.10.0.4.18 | 487 | 0 | 0 | 15 | 0 | 0 | 90 | 82 | 200 | 0 | 100 |

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

implements #462 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
