### PR TITLE
koordlet: fix incompatibility with kubelet v1.18 flags

### DIFF
--- a/pkg/util/kubelet/kubelet.go
+++ b/pkg/util/kubelet/kubelet.go
@@ -67,10 +67,11 @@ func NewKubeletOptions(args []string) (*KubeletOptions, error) {
 		return nil, err
 	}
 
+	// NOTE: options.ValidateKubeletFlags is not compatible with kubelet v1.18, now skip validation
 	// validate the initial KubeletFlags
-	if err := options.ValidateKubeletFlags(kubeletFlags); err != nil {
-		return nil, fmt.Errorf("failed to validate kubelet flags: %w", err)
-	}
+	// if err := options.ValidateKubeletFlags(kubeletFlags); err != nil {
+	// 	return nil, fmt.Errorf("failed to validate kubelet flags: %w", err)
+	// }
 
 	// load kubelet config file, if provided
 	if configFile := kubeletFlags.KubeletConfigFile; len(configFile) > 0 {


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

When building `KubeletOptions`, koordlet will fail with `kubelet v1.18` because the feature gate `DynamicKubeletConfig` is different between `kubelet v1.18` and `kubelet v1.22`. Now just skip the internal validating  to compatible with `kubelet v1.18`

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
