### PR TITLE
koordlet: CPI collector for Interference Detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
+	github.com/hodgesds/perf-utils v0.5.1
 	github.com/jedib0t/go-pretty/v6 v6.4.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
@@ -26,8 +27,10 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.10.0
+	go.uber.org/multierr v1.6.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.28.1
@@ -188,12 +191,10 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,8 @@ github.com/heketi/heketi v10.3.0+incompatible h1:X4DBFPzcyWZWhia32d94UhDECQJHH0M
 github.com/heketi/heketi v10.3.0+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 h1:oJ/NLadJn5HoxvonA6VxG31lg0d6XOURNA09BTtM4fY=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
+github.com/hodgesds/perf-utils v0.5.1 h1:Dlk4yYRQAzLnqiFqvwKj9+a1XysINFuHmRfcIduuXxo=
+github.com/hodgesds/perf-utils v0.5.1/go.mod h1:LAklqfDadNKpkxoAJNHpD5tkY0rkZEVdnCEWN5k4QJY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -1320,6 +1322,7 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -55,6 +55,9 @@ const (
 	// Accelerators enables GPU related feature in koordlet.
 	// Only Nvidia GPUs are supported as of v0.6.
 	Accelerators featuregate.Feature = "Accelerators"
+
+	// PerformanceCollector enables interference detection feature of koordlet.
+	PerformanceCollector featuregate.Feature = "PerformanceCollector"
 )
 
 func init() {
@@ -77,5 +80,6 @@ var (
 		CgroupReconcile:        {Default: false, PreRelease: featuregate.Alpha},
 		NodeTopologyReport:     {Default: false, PreRelease: featuregate.Alpha},
 		Accelerators:           {Default: false, PreRelease: featuregate.Alpha},
+		PerformanceCollector:   {Default: false, PreRelease: featuregate.Alpha},
 	}
 )

--- a/pkg/koordlet/metriccache/api.go
+++ b/pkg/koordlet/metriccache/api.go
@@ -109,3 +109,26 @@ type ContainerThrottledQueryResult struct {
 	QueryResult
 	Metric *ContainerThrottledMetric
 }
+
+type ContainerInterferenceMetric struct {
+	MetricName  InterferenceMetricName
+	PodUID      string
+	ContainerID string
+	MetricValue interface{}
+}
+
+type PodInterferenceMetric struct {
+	MetricName  InterferenceMetricName
+	PodUID      string
+	MetricValue interface{}
+}
+
+type ContainerInterferenceQueryResult struct {
+	QueryResult
+	Metric *ContainerInterferenceMetric
+}
+
+type PodInterferenceQueryResult struct {
+	QueryResult
+	Metric *PodInterferenceMetric
+}

--- a/pkg/koordlet/metriccache/metric_cache.go
+++ b/pkg/koordlet/metriccache/metric_cache.go
@@ -38,6 +38,13 @@ const (
 	AggregationTypeCount AggregationType = "count"
 )
 
+type InterferenceMetricName string
+
+const (
+	MetricNameContainerCPI InterferenceMetricName = "ContainerCPI"
+	MetricNamePodCPI       InterferenceMetricName = "PodCPI"
+)
+
 type QueryParam struct {
 	Aggregate AggregationType
 	Start     *time.Time
@@ -71,6 +78,8 @@ type MetricCache interface {
 	GetBECPUResourceMetric(param *QueryParam) BECPUResourceQueryResult
 	GetPodThrottledMetric(podUID *string, param *QueryParam) PodThrottledQueryResult
 	GetContainerThrottledMetric(containerID *string, param *QueryParam) ContainerThrottledQueryResult
+	GetContainerInterferenceMetric(metricName InterferenceMetricName, podUID *string, containerID *string, param *QueryParam) ContainerInterferenceQueryResult
+	GetPodInterferenceMetric(metricName InterferenceMetricName, podUID *string, param *QueryParam) PodInterferenceQueryResult
 	InsertNodeResourceMetric(t time.Time, nodeResUsed *NodeResourceMetric) error
 	InsertPodResourceMetric(t time.Time, podResUsed *PodResourceMetric) error
 	InsertContainerResourceMetric(t time.Time, containerResUsed *ContainerResourceMetric) error
@@ -78,6 +87,7 @@ type MetricCache interface {
 	InsertBECPUResourceMetric(t time.Time, metric *BECPUResourceMetric) error
 	InsertPodThrottledMetrics(t time.Time, metric *PodThrottledMetric) error
 	InsertContainerThrottledMetrics(t time.Time, metric *ContainerThrottledMetric) error
+	InsertContainerInterferenceMetrics(t time.Time, metric *ContainerInterferenceMetric) error
 }
 
 type metricCache struct {
@@ -466,6 +476,115 @@ func (m *metricCache) GetContainerThrottledMetric(containerID *string, param *Qu
 	return result
 }
 
+func (m *metricCache) GetContainerInterferenceMetric(metricName InterferenceMetricName, podUID *string, containerID *string, param *QueryParam) ContainerInterferenceQueryResult {
+	result := ContainerInterferenceQueryResult{}
+	if param == nil || param.Start == nil || param.End == nil {
+		result.Error = fmt.Errorf("GetContainerInterferenceMetric %v query parameters are illegal %v", containerID, param)
+		return result
+	}
+	metrics, err := m.convertAndGetContainerInterferenceMetric(metricName, containerID, param.Start, param.End)
+	if err != nil {
+		result.Error = fmt.Errorf("GetContainerInterferenceMetric %v of %v failed, query params %v, error %v", metricName, containerID, param, err)
+		return result
+	}
+
+	aggregateFunc := getAggregateFunc(param.Aggregate)
+	metricValue, err := aggregateContainerInterferenceMetricByName(metricName, metrics, aggregateFunc)
+	if err != nil {
+		result.Error = fmt.Errorf("GetContainerInterferenceMetric %v aggregate failed, metrics %v, error %v",
+			containerID, metrics, err)
+		return result
+	}
+
+	count, err := count(metrics)
+	if err != nil {
+		result.Error = fmt.Errorf("GetContainerInterferenceMetric %v aggregate failed, metrics %v, error %v",
+			containerID, metrics, err)
+		return result
+	}
+
+	result.AggregateInfo = &AggregateInfo{MetricsCount: int64(count)}
+	result.Metric = &ContainerInterferenceMetric{
+		MetricName:  metricName,
+		PodUID:      *podUID,
+		ContainerID: *containerID,
+		MetricValue: metricValue,
+	}
+	return result
+}
+
+func (m *metricCache) GetPodInterferenceMetric(metricName InterferenceMetricName, podUID *string, param *QueryParam) PodInterferenceQueryResult {
+	result := PodInterferenceQueryResult{}
+	if param == nil || param.Start == nil || param.End == nil {
+		result.Error = fmt.Errorf("GetPodInterferenceMetric %v query parameters are illegal %v", podUID, param)
+		return result
+	}
+	metrics, err := m.convertAndGetPodInterferenceMetric(metricName, podUID, param.Start, param.End)
+	if err != nil {
+		result.Error = fmt.Errorf("GetPodInterferenceMetric %v of %v failed, query params %v, error %v", metricName, podUID, param, err)
+		return result
+	}
+
+	aggregateFunc := getAggregateFunc(param.Aggregate)
+	metricValue, err := aggregatePodInterferenceMetricByName(metricName, metrics, aggregateFunc)
+	if err != nil {
+		result.Error = fmt.Errorf("GetPodInterferenceMetric %v aggregate failed, metrics %v, error %v",
+			podUID, metrics, err)
+		return result
+	}
+
+	count, err := count(metrics)
+	if err != nil {
+		result.Error = fmt.Errorf("GetPodInterferenceMetric %v aggregate failed, metrics %v, error %v",
+			podUID, metrics, err)
+		return result
+	}
+
+	result.AggregateInfo = &AggregateInfo{MetricsCount: int64(count)}
+	result.Metric = &PodInterferenceMetric{
+		MetricName:  metricName,
+		PodUID:      *podUID,
+		MetricValue: metricValue,
+	}
+	return result
+}
+
+func aggregateContainerInterferenceMetricByName(metricName InterferenceMetricName, metrics interface{}, aggregateFunc AggregationFunc) (interface{}, error) {
+	switch metricName {
+	case MetricNameContainerCPI:
+		return aggregateCPI(metrics, aggregateFunc)
+	default:
+		return nil, fmt.Errorf("get unknown metric name")
+	}
+}
+
+func aggregatePodInterferenceMetricByName(metricName InterferenceMetricName, metrics interface{}, aggregateFunc AggregationFunc) (interface{}, error) {
+	switch metricName {
+	case MetricNamePodCPI:
+		return aggregateCPI(metrics, aggregateFunc)
+	default:
+		return nil, fmt.Errorf("get unknown metric name")
+	}
+}
+
+func aggregateCPI(metrics interface{}, aggregateFunc AggregationFunc) (interface{}, error) {
+	cycles, err := aggregateFunc(metrics, AggregateParam{
+		ValueFieldName: "Cycles", TimeFieldName: "Timestamp"})
+	if err != nil {
+		return nil, err
+	}
+	instructions, err := aggregateFunc(metrics, AggregateParam{
+		ValueFieldName: "Instructions", TimeFieldName: "Timestamp"})
+	if err != nil {
+		return nil, err
+	}
+	metricValue := &CPIMetric{
+		Cycles:       uint64(cycles),
+		Instructions: uint64(instructions),
+	}
+	return metricValue, nil
+}
+
 func (m *metricCache) InsertNodeResourceMetric(t time.Time, nodeResUsed *NodeResourceMetric) error {
 	gpuUsages := make([]gpuResourceMetric, len(nodeResUsed.GPUs))
 	for idx, usage := range nodeResUsed.GPUs {
@@ -575,6 +694,14 @@ func (m *metricCache) InsertContainerThrottledMetrics(t time.Time, metric *Conta
 	return m.db.InsertContainerThrottledMetric(dbItem)
 }
 
+func (m *metricCache) InsertContainerInterferenceMetrics(t time.Time, metric *ContainerInterferenceMetric) error {
+	return m.convertAndInsertContainerInterferenceMetric(t, metric)
+}
+
+func (m *metricCache) InsertPodInterferenceMetrics(t time.Time, metric *PodInterferenceMetric) error {
+	return m.convertAndInsertPodInterferenceMetric(t, metric)
+}
+
 func (m *metricCache) aggregateGPUUsages(gpuResourceMetricsByTime [][]gpuResourceMetric, aggregateFunc AggregationFunc) ([]GPUMetric, error) {
 	if len(gpuResourceMetricsByTime) == 0 {
 		return nil, nil
@@ -641,6 +768,9 @@ func (m *metricCache) recycleDB() {
 	if err := m.db.DeleteContainerThrottledMetric(&oldTime, &expiredTime); err != nil {
 		klog.Warningf("DeleteContainerThrottledMetric failed during recycle, error %v", err)
 	}
+	if err := m.db.DeleteContainerCPIMetric(&oldTime, &expiredTime); err != nil {
+		klog.Warningf("DeleteContainerCPIMetric failed during recycle, error %v", err)
+	}
 	// raw records do not need to cleanup
 	klog.Infof("expired metric data before %v has been recycled", expiredTime)
 }
@@ -663,4 +793,76 @@ func getAggregateFunc(aggregationType AggregationType) AggregationFunc {
 func count(metrics interface{}) (float64, error) {
 	aggregateFunc := getAggregateFunc(AggregationTypeCount)
 	return aggregateFunc(metrics, AggregateParam{})
+}
+
+type CPIMetric struct {
+	Cycles       uint64
+	Instructions uint64
+}
+
+func (m *metricCache) convertAndInsertContainerInterferenceMetric(t time.Time, metric *ContainerInterferenceMetric) error {
+	switch metric.MetricName {
+	case MetricNameContainerCPI:
+		dbItem := &containerCPIMetric{
+			PodUID:       metric.PodUID,
+			ContainerID:  metric.ContainerID,
+			Cycles:       float64(metric.MetricValue.(*CPIMetric).Cycles),
+			Instructions: float64(metric.MetricValue.(*CPIMetric).Instructions),
+			Timestamp:    t,
+		}
+		return m.db.InsertContainerCPIMetric(dbItem)
+	default:
+		return fmt.Errorf("get unknown metric name")
+	}
+}
+
+// todo: do not insert podCPI, will implement at psi branch
+func (m *metricCache) convertAndInsertPodInterferenceMetric(t time.Time, metric *PodInterferenceMetric) error {
+	return nil
+}
+
+func (m *metricCache) convertAndGetContainerInterferenceMetric(metricName InterferenceMetricName, containerID *string, start, end *time.Time) (interface{}, error) {
+	switch metricName {
+	case MetricNameContainerCPI:
+		return m.db.GetContainerCPIMetric(containerID, start, end)
+	default:
+		return nil, fmt.Errorf("get unknown metric name")
+	}
+}
+
+type podCPIMetric struct {
+	PodUID       string
+	Cycles       float64
+	Instructions float64
+	Timestamp    time.Time
+}
+
+func (m *metricCache) convertAndGetPodInterferenceMetric(metricName InterferenceMetricName, podUID *string, start, end *time.Time) (interface{}, error) {
+	switch metricName {
+	case MetricNamePodCPI:
+		// get container CPI and compute pod CPI
+		containerCPIMetrics, err := m.db.GetContainerCPIMetricByPodUid(podUID, start, end)
+		if err != nil {
+			return nil, err
+		}
+		if len(containerCPIMetrics) <= 0 {
+			return []podCPIMetric{}, nil
+		}
+		var sumCycles, sumInstructions float64
+		for _, containerCPI := range containerCPIMetrics {
+			sumCycles += containerCPI.Cycles
+			sumInstructions += containerCPI.Instructions
+		}
+		podMetric := podCPIMetric{
+			PodUID:       *podUID,
+			Cycles:       sumCycles,
+			Instructions: sumInstructions,
+			Timestamp:    containerCPIMetrics[len(containerCPIMetrics)-1].Timestamp,
+		}
+		return []podCPIMetric{
+			podMetric,
+		}, nil
+	default:
+		return nil, fmt.Errorf("get unknown metric name")
+	}
 }

--- a/pkg/koordlet/metriccache/metric_cache_test.go
+++ b/pkg/koordlet/metriccache/metric_cache_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/koordinator-sh/koordinator/pkg/util"
@@ -1352,6 +1354,682 @@ func Test_metricCache_aggregateGPUUsages(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("metricCache.aggregateGPUUsages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_metricCache_ContainerInterferenceMetric_CRUD(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+		samples      map[time.Time]ContainerInterferenceMetric
+	}
+
+	tests := []struct {
+		name            string
+		args            args
+		want            ContainerInterferenceQueryResult
+		wantAfterDelete ContainerInterferenceQueryResult
+	}{
+		// test container CPI CRUD
+		{
+			name: "container-cpi-latest-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNameContainerCPI,
+				containerID:  "container-uid-1",
+				podUID:       "pod-uid-1",
+				aggregateArg: AggregationTypeLast,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &CPIMetric{
+							Cycles:       7,
+							Instructions: 7,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &CPIMetric{
+							Cycles:       6,
+							Instructions: 6,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &CPIMetric{
+							Cycles:       5,
+							Instructions: 5,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-2",
+						PodUID:      "pod-uid-2",
+						MetricValue: &CPIMetric{
+							Cycles:       4,
+							Instructions: 4,
+						},
+					},
+				},
+			},
+			want: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerCPI,
+					ContainerID: "container-uid-1",
+					PodUID:      "pod-uid-1",
+					MetricValue: &CPIMetric{
+						Cycles:       5,
+						Instructions: 5,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 3}},
+			},
+			wantAfterDelete: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerCPI,
+					ContainerID: "container-uid-1",
+					PodUID:      "pod-uid-1",
+					MetricValue: &CPIMetric{
+						Cycles:       5,
+						Instructions: 5,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
+			},
+		},
+		{
+			name: "container-cpi-avg-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNameContainerCPI,
+				containerID:  "container-uid-3",
+				podUID:       "pod-uid-3",
+				aggregateArg: AggregationTypeAVG,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &CPIMetric{
+							Cycles:       7,
+							Instructions: 7,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &CPIMetric{
+							Cycles:       6,
+							Instructions: 6,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &CPIMetric{
+							Cycles:       5,
+							Instructions: 5,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-4",
+						PodUID:      "pod-uid-4",
+						MetricValue: &CPIMetric{
+							Cycles:       4,
+							Instructions: 4,
+						},
+					},
+				},
+			},
+			want: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerCPI,
+					ContainerID: "container-uid-3",
+					PodUID:      "pod-uid-3",
+					MetricValue: &CPIMetric{
+						Cycles:       6,
+						Instructions: 6,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 3}},
+			},
+			wantAfterDelete: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerCPI,
+					ContainerID: "container-uid-3",
+					PodUID:      "pod-uid-3",
+					MetricValue: &CPIMetric{
+						Cycles:       5,
+						Instructions: 5,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+			for ts, sample := range tt.args.samples {
+				err := m.InsertContainerInterferenceMetrics(ts, &sample)
+				if err != nil {
+					t.Errorf("insert interference metric failed %v", err)
+				}
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetContainerInterferenceMetric(tt.args.metricName, &tt.args.podUID, &tt.args.containerID, params)
+			if got.Error != nil {
+				t.Errorf("get interference metric failed %v", got.Error)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetContainerInterferenceMetric() got = %v, want %v", got, tt.want)
+			}
+			// delete expire items
+			m.recycleDB()
+
+			gotAfterDel := m.GetContainerInterferenceMetric(tt.args.metricName, &tt.args.podUID, &tt.args.containerID, params)
+			if gotAfterDel.Error != nil {
+				t.Errorf("get interference metric failed %v", gotAfterDel.Error)
+			}
+			if !reflect.DeepEqual(gotAfterDel, tt.wantAfterDelete) {
+				t.Errorf("GetContainerInterferenceMetric() after delete, got = %v, want %v",
+					gotAfterDel, tt.wantAfterDelete)
+			}
+		})
+	}
+}
+
+func Test_metricCache_PodInterferenceMetric_CRUD(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+		samples      map[time.Time]ContainerInterferenceMetric
+	}
+
+	tests := []struct {
+		name            string
+		args            args
+		want            PodInterferenceQueryResult
+		wantAfterDelete PodInterferenceQueryResult
+	}{
+		// test pod CPI CRUD
+		{
+			name: "pod-cpi-latest-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNamePodCPI,
+				containerID:  "container-uid-5",
+				podUID:       "pod-uid-5",
+				aggregateArg: AggregationTypeLast,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-5",
+						PodUID:      "pod-uid-5",
+						MetricValue: &CPIMetric{
+							Cycles:       7,
+							Instructions: 7,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-5",
+						PodUID:      "pod-uid-5",
+						MetricValue: &CPIMetric{
+							Cycles:       6,
+							Instructions: 6,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-6",
+						PodUID:      "pod-uid-5",
+						MetricValue: &CPIMetric{
+							Cycles:       5,
+							Instructions: 5,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-6",
+						PodUID:      "pod-uid-6",
+						MetricValue: &CPIMetric{
+							Cycles:       4,
+							Instructions: 4,
+						},
+					},
+				},
+			},
+			want: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodCPI,
+					PodUID:     "pod-uid-5",
+					MetricValue: &CPIMetric{
+						Cycles:       18,
+						Instructions: 18,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 1}},
+			},
+			wantAfterDelete: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodCPI,
+					PodUID:     "pod-uid-5",
+					MetricValue: &CPIMetric{
+						Cycles:       11,
+						Instructions: 11,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 1}},
+			},
+		},
+		{
+			name: "pod-cpi-avg-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNamePodCPI,
+				containerID:  "container-uid-7",
+				podUID:       "pod-uid-7",
+				aggregateArg: AggregationTypeAVG,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-7",
+						PodUID:      "pod-uid-7",
+						MetricValue: &CPIMetric{
+							Cycles:       7,
+							Instructions: 7,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-7",
+						PodUID:      "pod-uid-7",
+						MetricValue: &CPIMetric{
+							Cycles:       6,
+							Instructions: 6,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-8",
+						PodUID:      "pod-uid-7",
+						MetricValue: &CPIMetric{
+							Cycles:       5,
+							Instructions: 5,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-8",
+						PodUID:      "pod-uid-8",
+						MetricValue: &CPIMetric{
+							Cycles:       4,
+							Instructions: 4,
+						},
+					},
+				},
+			},
+			want: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodCPI,
+					PodUID:     "pod-uid-7",
+					MetricValue: &CPIMetric{
+						Cycles:       18,
+						Instructions: 18,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 1}},
+			},
+			wantAfterDelete: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodCPI,
+					PodUID:     "pod-uid-7",
+					MetricValue: &CPIMetric{
+						Cycles:       11,
+						Instructions: 11,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 1}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+			for ts, sample := range tt.args.samples {
+				err := m.InsertContainerInterferenceMetrics(ts, &sample)
+				if err != nil {
+					t.Errorf("insert interference metric failed %v", err)
+				}
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			if got.Error != nil {
+				t.Errorf("get interference metric failed %v", got.Error)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got, tt.want)
+			}
+			// delete expire items
+			m.recycleDB()
+
+			gotAfterDel := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			if gotAfterDel.Error != nil {
+				t.Errorf("get interference metric failed %v", gotAfterDel.Error)
+			}
+			if !reflect.DeepEqual(gotAfterDel, tt.wantAfterDelete) {
+				t.Errorf("GetPodInterferenceMetric() after delete, got = %v, want %v",
+					gotAfterDel, tt.wantAfterDelete)
+			}
+		})
+	}
+}
+
+func Test_convertAndGetPodInterferenceMetric_zeroResult(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+		samples      map[time.Time]ContainerInterferenceMetric
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// test get pod CPI 0 result
+		{
+			name: "get-pod-cpi-0-result",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNamePodCPI,
+				containerID:  "container-uid-9",
+				podUID:       "pod-uid-9",
+				aggregateArg: AggregationTypeLast,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerCPI,
+						ContainerID: "container-uid-10",
+						PodUID:      "pod-uid-10",
+						MetricValue: &CPIMetric{
+							Cycles:       4,
+							Instructions: 4,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+			for ts, sample := range tt.args.samples {
+				err := m.InsertContainerInterferenceMetrics(ts, &sample)
+				if err != nil {
+					t.Errorf("insert interference metric failed %v", err)
+				}
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			assert.NotNil(t, got.Error)
+		})
+	}
+}
+
+func Test_GetContainerInterferenceMetric_errWrongMetricName(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// test wrong metric name err
+		{
+			name: "container-wrong-metric-name",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   "WrongMetricName",
+				containerID:  "container-uid-1",
+				podUID:       "pod-uid-1",
+				aggregateArg: AggregationTypeLast,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetContainerInterferenceMetric(tt.args.metricName, &tt.args.podUID, &tt.args.containerID, params)
+			if got.Error == nil {
+				t.Errorf("get interference metric did not report err")
+			}
+		})
+	}
+}
+
+func Test_GetContainerInterferenceMetric_errNilParam(t *testing.T) {
+	type args struct {
+		config      *Config
+		metricName  InterferenceMetricName
+		containerID string
+		podUID      string
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// test nil param err
+		{
+			name: "container-nil-param",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:  MetricNameContainerCPI,
+				containerID: "container-uid-1",
+				podUID:      "pod-uid-1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+
+			got := m.GetContainerInterferenceMetric(tt.args.metricName, &tt.args.podUID, &tt.args.containerID, nil)
+			if got.Error == nil {
+				t.Errorf("get interference metric did not report err")
+			}
+		})
+	}
+}
+
+func Test_GetPodInterferenceMetric_errWrongMetricName(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// test wrong metric name err
+		{
+			name: "pod-wrong-metric-name",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   "WrongMetricName",
+				podUID:       "pod-uid-1",
+				aggregateArg: AggregationTypeLast,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			if got.Error == nil {
+				t.Errorf("get interference metric did not report err")
+			}
+		})
+	}
+}
+
+func Test_GetPodInterferenceMetric_errNilParam(t *testing.T) {
+	type args struct {
+		config      *Config
+		metricName  InterferenceMetricName
+		containerID string
+		podUID      string
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// test nil param err
+		{
+			name: "pod-nil-param",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName: MetricNameContainerCPI,
+				podUID:     "pod-uid-1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+
+			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, nil)
+			if got.Error == nil {
+				t.Errorf("get interference metric did not report err")
 			}
 		})
 	}

--- a/pkg/koordlet/metriccache/mockmetriccache/mock.go
+++ b/pkg/koordlet/metriccache/mockmetriccache/mock.go
@@ -65,6 +65,20 @@ func (mr *MockMetricCacheMockRecorder) GetBECPUResourceMetric(param interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBECPUResourceMetric", reflect.TypeOf((*MockMetricCache)(nil).GetBECPUResourceMetric), param)
 }
 
+// GetContainerInterferenceMetric mocks base method.
+func (m *MockMetricCache) GetContainerInterferenceMetric(metricName metriccache.InterferenceMetricName, podUID, containerID *string, param *metriccache.QueryParam) metriccache.ContainerInterferenceQueryResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerInterferenceMetric", metricName, podUID, containerID, param)
+	ret0, _ := ret[0].(metriccache.ContainerInterferenceQueryResult)
+	return ret0
+}
+
+// GetContainerInterferenceMetric indicates an expected call of GetContainerInterferenceMetric.
+func (mr *MockMetricCacheMockRecorder) GetContainerInterferenceMetric(metricName, podUID, containerID, param interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterferenceMetric", reflect.TypeOf((*MockMetricCache)(nil).GetContainerInterferenceMetric), metricName, podUID, containerID, param)
+}
+
 // GetContainerResourceMetric mocks base method.
 func (m *MockMetricCache) GetContainerResourceMetric(containerID *string, param *metriccache.QueryParam) metriccache.ContainerResourceQueryResult {
 	m.ctrl.T.Helper()
@@ -122,6 +136,20 @@ func (mr *MockMetricCacheMockRecorder) GetNodeResourceMetric(param interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeResourceMetric", reflect.TypeOf((*MockMetricCache)(nil).GetNodeResourceMetric), param)
 }
 
+// GetPodInterferenceMetric mocks base method.
+func (m *MockMetricCache) GetPodInterferenceMetric(metricName metriccache.InterferenceMetricName, podUID *string, param *metriccache.QueryParam) metriccache.PodInterferenceQueryResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodInterferenceMetric", metricName, podUID, param)
+	ret0, _ := ret[0].(metriccache.PodInterferenceQueryResult)
+	return ret0
+}
+
+// GetPodInterferenceMetric indicates an expected call of GetPodInterferenceMetric.
+func (mr *MockMetricCacheMockRecorder) GetPodInterferenceMetric(metricName, podUID, param interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodInterferenceMetric", reflect.TypeOf((*MockMetricCache)(nil).GetPodInterferenceMetric), metricName, podUID, param)
+}
+
 // GetPodResourceMetric mocks base method.
 func (m *MockMetricCache) GetPodResourceMetric(podUID *string, param *metriccache.QueryParam) metriccache.PodResourceQueryResult {
 	m.ctrl.T.Helper()
@@ -162,6 +190,20 @@ func (m *MockMetricCache) InsertBECPUResourceMetric(t time.Time, metric *metricc
 func (mr *MockMetricCacheMockRecorder) InsertBECPUResourceMetric(t, metric interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBECPUResourceMetric", reflect.TypeOf((*MockMetricCache)(nil).InsertBECPUResourceMetric), t, metric)
+}
+
+// InsertContainerInterferenceMetrics mocks base method.
+func (m *MockMetricCache) InsertContainerInterferenceMetrics(t time.Time, metric *metriccache.ContainerInterferenceMetric) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertContainerInterferenceMetrics", t, metric)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertContainerInterferenceMetrics indicates an expected call of InsertContainerInterferenceMetrics.
+func (mr *MockMetricCacheMockRecorder) InsertContainerInterferenceMetrics(t, metric interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertContainerInterferenceMetrics", reflect.TypeOf((*MockMetricCache)(nil).InsertContainerInterferenceMetrics), t, metric)
 }
 
 // InsertContainerResourceMetric mocks base method.

--- a/pkg/koordlet/metriccache/storage_tables.go
+++ b/pkg/koordlet/metriccache/storage_tables.go
@@ -109,6 +109,15 @@ type beCPUResourceMetric struct {
 	Timestamp       time.Time
 }
 
+type containerCPIMetric struct {
+	ID           uint64 `gorm:"primarykey"`
+	PodUID       string `gorm:"index:idx_container_cpi_poduid"`
+	ContainerID  string `gorm:"index:idx_container_cpi_containerid"`
+	Cycles       float64
+	Instructions float64
+	Timestamp    time.Time
+}
+
 type rawRecord struct {
 	RecordType string `gorm:"primarykey"`
 	RecordStr  string

--- a/pkg/koordlet/metricsadvisor/config.go
+++ b/pkg/koordlet/metricsadvisor/config.go
@@ -19,18 +19,25 @@ package metricsadvisor
 import "flag"
 
 type Config struct {
-	CollectResUsedIntervalSeconds     int
-	CollectNodeCPUInfoIntervalSeconds int
+	CollectResUsedIntervalSeconds         int
+	CollectNodeCPUInfoIntervalSeconds     int
+	PerformanceCollectorIntervalSeconds   int
+	PerformanceCollectorTimeWindowSeconds int
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		CollectResUsedIntervalSeconds:     1,
-		CollectNodeCPUInfoIntervalSeconds: 60,
+		CollectResUsedIntervalSeconds:         1,
+		CollectNodeCPUInfoIntervalSeconds:     60,
+		PerformanceCollectorIntervalSeconds:   60,
+		PerformanceCollectorTimeWindowSeconds: 10,
 	}
 }
 
 func (c *Config) InitFlags(fs *flag.FlagSet) {
+	// todo: replace with DurationVar and modify run feature util
 	fs.IntVar(&c.CollectResUsedIntervalSeconds, "collect-res-used-interval-seconds", c.CollectResUsedIntervalSeconds, "Collect node/pod resource usage interval by seconds")
 	fs.IntVar(&c.CollectNodeCPUInfoIntervalSeconds, "collect-node-cpu-info-interval-seconds", c.CollectNodeCPUInfoIntervalSeconds, "Collect node cpu info interval by seconds")
+	fs.IntVar(&c.PerformanceCollectorIntervalSeconds, "collect-interference-interval-seconds", c.PerformanceCollectorIntervalSeconds, "Collect interference interval by seconds")
+	fs.IntVar(&c.PerformanceCollectorTimeWindowSeconds, "collect-interference-timewindow-seconds", c.PerformanceCollectorTimeWindowSeconds, "Collect interference time window by seconds")
 }

--- a/pkg/koordlet/metricsadvisor/config_test.go
+++ b/pkg/koordlet/metricsadvisor/config_test.go
@@ -25,8 +25,10 @@ import (
 
 func Test_NewDefaultConfig(t *testing.T) {
 	expectConfig := &Config{
-		CollectResUsedIntervalSeconds:     1,
-		CollectNodeCPUInfoIntervalSeconds: 60,
+		CollectResUsedIntervalSeconds:         1,
+		CollectNodeCPUInfoIntervalSeconds:     60,
+		PerformanceCollectorIntervalSeconds:   60,
+		PerformanceCollectorTimeWindowSeconds: 10,
 	}
 	defaultConfig := NewDefaultConfig()
 	assert.Equal(t, expectConfig, defaultConfig)
@@ -37,12 +39,16 @@ func Test_InitFlags(t *testing.T) {
 		"",
 		"--collect-res-used-interval-seconds=3",
 		"--collect-node-cpu-info-interval-seconds=90",
+		"--collect-interference-interval-seconds=90",
+		"--collect-interference-timewindow-seconds=15",
 	}
 	fs := flag.NewFlagSet(cmdArgs[0], flag.ExitOnError)
 
 	type fields struct {
-		CollectResUsedIntervalSeconds     int
-		CollectNodeCPUInfoIntervalSeconds int
+		CollectResUsedIntervalSeconds        int
+		CollectNodeCPUInfoIntervalSeconds    int
+		CollectInterferenceIntervalSeconds   int
+		CollectInterferenceTimeWindowSeconds int
 	}
 	type args struct {
 		fs *flag.FlagSet
@@ -55,8 +61,10 @@ func Test_InitFlags(t *testing.T) {
 		{
 			name: "not default",
 			fields: fields{
-				CollectResUsedIntervalSeconds:     3,
-				CollectNodeCPUInfoIntervalSeconds: 90,
+				CollectResUsedIntervalSeconds:        3,
+				CollectNodeCPUInfoIntervalSeconds:    90,
+				CollectInterferenceIntervalSeconds:   90,
+				CollectInterferenceTimeWindowSeconds: 15,
 			},
 			args: args{fs: fs},
 		},
@@ -64,8 +72,10 @@ func Test_InitFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			raw := &Config{
-				CollectResUsedIntervalSeconds:     tt.fields.CollectResUsedIntervalSeconds,
-				CollectNodeCPUInfoIntervalSeconds: tt.fields.CollectNodeCPUInfoIntervalSeconds,
+				CollectResUsedIntervalSeconds:         tt.fields.CollectResUsedIntervalSeconds,
+				CollectNodeCPUInfoIntervalSeconds:     tt.fields.CollectNodeCPUInfoIntervalSeconds,
+				PerformanceCollectorIntervalSeconds:   tt.fields.CollectInterferenceIntervalSeconds,
+				PerformanceCollectorTimeWindowSeconds: tt.fields.CollectInterferenceTimeWindowSeconds,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)

--- a/pkg/koordlet/metricsadvisor/performance_collector_linux.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_linux.go
@@ -1,0 +1,139 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsadvisor
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/pkg/util/perf"
+)
+
+type performanceCollector struct {
+	statesInformer    statesinformer.StatesInformer
+	metricCache       metriccache.MetricCache
+	collectTimeWindow int
+}
+
+func NewPerformanceCollector(statesInformer statesinformer.StatesInformer, metricCache metriccache.MetricCache, collectTimeWindow int) *performanceCollector {
+	return &performanceCollector{
+		statesInformer:    statesInformer,
+		metricCache:       metricCache,
+		collectTimeWindow: collectTimeWindow,
+	}
+}
+
+func (c *performanceCollector) collectContainerCPI() {
+	klog.V(6).Infof("start collectContainerCPI")
+	timeWindow := time.Now()
+	containerStatusesMap := map[*corev1.ContainerStatus]*statesinformer.PodMeta{}
+	podMetas := c.statesInformer.GetAllPods()
+	for _, meta := range podMetas {
+		pod := meta.Pod
+		for i := range pod.Status.ContainerStatuses {
+			containerStat := &pod.Status.ContainerStatuses[i]
+			containerStatusesMap[containerStat] = meta
+		}
+	}
+	collectors := sync.Map{}
+	var wg sync.WaitGroup
+	wg.Add(len(containerStatusesMap))
+	nodeCpuInfo, err := c.metricCache.GetNodeCPUInfo(&metriccache.QueryParam{})
+	if err != nil {
+		klog.Errorf("failed to get node cpu info : %v", err)
+		return
+	}
+	cpuNumber := nodeCpuInfo.TotalInfo.NumberCPUs
+	for containerStatus, parentPod := range containerStatusesMap {
+		go func(status *corev1.ContainerStatus, parent string) {
+			defer wg.Done()
+			collectorOnSingleContainer, err := c.getAndStartCollectorOnSingleContainer(parent, status, cpuNumber)
+			if err != nil {
+				return
+			}
+			collectors.Store(status, collectorOnSingleContainer)
+		}(containerStatus, parentPod.CgroupDir)
+	}
+	wg.Wait()
+
+	time.Sleep(time.Duration(c.collectTimeWindow) * time.Second)
+
+	var wg1 sync.WaitGroup
+	wg1.Add(len(containerStatusesMap))
+	for containerStatus, podMeta := range containerStatusesMap {
+		podUid := podMeta.Pod.UID
+		go func(status *corev1.ContainerStatus, podUid string) {
+			defer wg1.Done()
+			oneCollector, ok := collectors.Load(status)
+			if !ok {
+				return
+			}
+			c.profilePerfOnSingleContainer(status, oneCollector.(*perf.PerfCollector), podUid)
+
+			err1 := unix.Close(oneCollector.(*perf.PerfCollector).CgroupFd)
+			if err1 != nil {
+				klog.Errorf("close CgroupFd %v, err : %v", oneCollector.(*perf.PerfCollector).CgroupFd, err1)
+			}
+		}(containerStatus, string(podUid))
+	}
+	wg1.Wait()
+	klog.V(5).Infof("collectContainerCPI for time window %s finished at %s, container num %d",
+		timeWindow, time.Now(), len(containerStatusesMap))
+}
+
+func (c *performanceCollector) getAndStartCollectorOnSingleContainer(podParentCgroupDir string, containerStatus *corev1.ContainerStatus, number int32) (*perf.PerfCollector, error) {
+	perfCollector, err := util.GetContainerPerfCollector(podParentCgroupDir, containerStatus, number)
+	if err != nil {
+		klog.Errorf("get and start container %s collector err: %v", containerStatus.Name, err)
+		return nil, err
+	}
+	return perfCollector, nil
+}
+
+func (c *performanceCollector) profilePerfOnSingleContainer(containerStatus *corev1.ContainerStatus, collector *perf.PerfCollector, podUid string) {
+	collectTime := time.Now()
+	cycles, instructions, err := util.GetContainerCyclesAndInstructions(collector)
+	if err != nil {
+		klog.Errorf("collect container %s cpi err: %v", containerStatus.Name, err)
+		return
+	}
+	containerCpiMetric := &metriccache.ContainerInterferenceMetric{
+		MetricName:  metriccache.MetricNameContainerCPI,
+		PodUID:      podUid,
+		ContainerID: containerStatus.ContainerID,
+		MetricValue: &metriccache.CPIMetric{
+			Cycles:       cycles,
+			Instructions: instructions,
+		},
+	}
+	err = c.metricCache.InsertContainerInterferenceMetrics(collectTime, containerCpiMetric)
+	if err != nil {
+		klog.Errorf("insert container cpi metrics failed, err %v", err)
+	}
+}
+
+// todo: try to make this collector linux specific, e.g., by build tag linux

--- a/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsadvisor
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	mockmetriccache "github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache/mockmetriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	mockstatesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/mockstatesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/pkg/util/perf"
+)
+
+func TestNewPerformanceCollector(t *testing.T) {
+	type args struct {
+		cfg         *Config
+		metaService statesinformer.StatesInformer
+		metricCache metriccache.MetricCache
+		timeWindow  int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "new-performance-collector",
+			args: args{
+				cfg:         &Config{},
+				metaService: nil,
+				metricCache: nil,
+				timeWindow:  10,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewPerformanceCollector(tt.args.metaService, tt.args.metricCache, tt.args.timeWindow); got == nil {
+				t.Errorf("NewPerformanceCollector() = %v", got)
+			}
+		})
+	}
+}
+
+func Test_collectContainerCPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStatesInformer := mockstatesinformer.NewMockStatesInformer(ctrl)
+	mockMetricCache := mockmetriccache.NewMockMetricCache(ctrl)
+	cpuInfo := mockNodeCPUInfo()
+	mockStatesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{}).AnyTimes()
+	mockMetricCache.EXPECT().GetNodeCPUInfo(&metriccache.QueryParam{}).Return(cpuInfo, nil).AnyTimes()
+
+	c := NewPerformanceCollector(mockStatesInformer, mockMetricCache, 1)
+	assert.NotPanics(t, func() {
+		c.collectContainerCPI()
+	})
+}
+
+func Test_collectContainerCPI_cpuInfoErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStatesInformer := mockstatesinformer.NewMockStatesInformer(ctrl)
+	mockMetricCache := mockmetriccache.NewMockMetricCache(ctrl)
+	cpuInfo := mockNodeCPUInfo()
+	mockStatesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{}).AnyTimes()
+	mockMetricCache.EXPECT().GetNodeCPUInfo(&metriccache.QueryParam{}).Return(cpuInfo, fmt.Errorf("cpu_error")).AnyTimes()
+
+	c := NewPerformanceCollector(mockStatesInformer, mockMetricCache, 1)
+	assert.NotPanics(t, func() {
+		c.collectContainerCPI()
+	})
+}
+
+func Test_collectContainerCPI_mockPod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStatesInformer := mockstatesinformer.NewMockStatesInformer(ctrl)
+	mockMetricCache := mockmetriccache.NewMockMetricCache(ctrl)
+	cpuInfo := mockNodeCPUInfo()
+	pod := mockPodMeta()
+	mockLSPod()
+	mockStatesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{pod}).AnyTimes()
+	mockMetricCache.EXPECT().GetNodeCPUInfo(&metriccache.QueryParam{}).Return(cpuInfo, nil).AnyTimes()
+
+	c := NewPerformanceCollector(mockStatesInformer, mockMetricCache, 1)
+	assert.NotPanics(t, func() {
+		c.collectContainerCPI()
+	})
+}
+
+func mockPodMeta() *statesinformer.PodMeta {
+	return &statesinformer.PodMeta{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: "test-pod-uid",
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						ContainerID: "test-01",
+						Name:        "test-container",
+					},
+				},
+			},
+		},
+	}
+}
+
+func mockNodeCPUInfo() *metriccache.NodeCPUInfo {
+	return &metriccache.NodeCPUInfo{
+		TotalInfo: util.CPUTotalInfo{
+			NumberCPUs: 0,
+		},
+	}
+}
+
+func Test_getAndStartCollectorOnSingleContainer(t *testing.T) {
+	tempDir := t.TempDir()
+	containerStatus := &corev1.ContainerStatus{
+		ContainerID: "containerd://test",
+	}
+	c := NewPerformanceCollector(nil, nil, 0)
+	assert.NotPanics(t, func() {
+		_, err := c.getAndStartCollectorOnSingleContainer(tempDir, containerStatus, 0)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_profilePerfOnSingleContainer(t *testing.T) {
+	config := &metriccache.Config{
+		MetricGCIntervalSeconds: 60,
+		MetricExpireSeconds:     60,
+	}
+	m, _ := metriccache.NewMetricCache(config)
+
+	containerStatus := &corev1.ContainerStatus{
+		ContainerID: "containerd://test",
+	}
+	perfCollector, _ := perf.NewPerfCollector(0, []int{})
+
+	c := NewPerformanceCollector(nil, m, 0)
+	assert.NotPanics(t, func() {
+		c.profilePerfOnSingleContainer(containerStatus, perfCollector, "test-1")
+	})
+}

--- a/pkg/koordlet/metricsadvisor/performance_collector_unsupported.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_unsupported.go
@@ -1,0 +1,33 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsadvisor
+
+import (
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+type performanceCollector struct{}
+
+func NewPerformanceCollector(statesInformer statesinformer.StatesInformer, metricCache metriccache.MetricCache, collectTimeWindow int) *performanceCollector {
+	return &performanceCollector{}
+}
+
+func (p *performanceCollector) collectContainerCPI() {}

--- a/pkg/util/container.go
+++ b/pkg/util/container.go
@@ -57,6 +57,14 @@ func GetContainerCgroupCPUProcsPath(podParentDir string, c *corev1.ContainerStat
 	return system.GetCgroupFilePath(containerPath, system.CPUProcs), nil
 }
 
+func GetContainerCgroupPerfPath(podParentDir string, c *corev1.ContainerStatus) (string, error) {
+	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(system.Conf.CgroupRootDir, "perf_event/", containerPath), nil
+}
+
 func GetContainerCgroupCPUAcctUsagePath(podParentDir string, c *corev1.ContainerStatus) (string, error) {
 	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
 	if err != nil {

--- a/pkg/util/container_test.go
+++ b/pkg/util/container_test.go
@@ -569,6 +569,26 @@ func Test_GetContainerCgroupXXXPath(t *testing.T) {
 			expectPath: "",
 			expectErr:  true,
 		},
+		{
+			name:         "test_perf_path",
+			fn:           GetContainerCgroupPerfPath,
+			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			containerStatus: &corev1.ContainerStatus{
+				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+			},
+			expectPath: "/host-cgroup/perf_event/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope",
+			expectErr:  false,
+		},
+		{
+			name:         "test_perf_path_invalid",
+			fn:           GetContainerCgroupPerfPath,
+			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			containerStatus: &corev1.ContainerStatus{
+				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+			},
+			expectPath: "",
+			expectErr:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/perf/perf_linux.go
+++ b/pkg/util/perf/perf_linux.go
@@ -1,0 +1,151 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// todo: add readme
+package perf
+
+import (
+	"fmt"
+
+	"github.com/hodgesds/perf-utils"
+	"go.uber.org/multierr"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+type PerfCollector struct {
+	CgroupFd          int
+	cpus              []int
+	cpuHwProfilersMap map[int]*perf.HardwareProfiler
+	// todo: cpuSwProfilers map[int]*perf.SoftwareProfiler
+}
+
+func NewPerfCollector(cgroupFd int, cpus []int) (*PerfCollector, error) {
+	collector := &PerfCollector{
+		CgroupFd:          cgroupFd,
+		cpus:              cpus,
+		cpuHwProfilersMap: map[int]*perf.HardwareProfiler{},
+	}
+	for _, cpu := range cpus {
+		cpiProfiler, err := perf.NewHardwareProfiler(cgroupFd, cpu, perf.RefCpuCyclesProfiler|perf.CpuInstrProfiler, unix.PERF_FLAG_PID_CGROUP)
+		if err != nil && !cpiProfiler.HasProfilers() {
+			return nil, err
+		}
+
+		// todo: NewSoftwareProfiler, etc.
+
+		collector.cpuHwProfilersMap[cpu] = &cpiProfiler
+	}
+	return collector, nil
+}
+
+func GetAndStartPerfCollectorOnContainer(cgroupFd int, cpus []int) (*PerfCollector, error) {
+	collector, err := NewPerfCollector(cgroupFd, cpus)
+	if err != nil {
+		return nil, err
+	}
+	for _, cpu := range collector.cpus {
+		go func(cpu int) {
+			if newErr := (*collector.cpuHwProfilersMap[cpu]).Start(); newErr != nil {
+				err = multierr.Append(err, newErr)
+			}
+		}(cpu)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return collector, nil
+}
+
+// todo: call collect() to get all metrics at the same time instead of put it inside GetContainerCyclesAndInstructions
+func GetContainerCyclesAndInstructions(collector *PerfCollector) (uint64, uint64, error) {
+	defer func() {
+		stopErr := collector.stopAndClose()
+		if stopErr != nil {
+			klog.Errorf("stopAndClose perf err %v", stopErr)
+		}
+	}()
+	result, err := collector.collect()
+	if err != nil {
+		return 0, 0, err
+	}
+	return result.instructions, result.cycles, nil
+}
+
+type collectResult struct {
+	cycles       uint64
+	instructions uint64
+
+	// todo: context-switches, etc.
+}
+
+func (c *PerfCollector) collect() (result collectResult, err error) {
+	for _, cpu := range c.cpus {
+		// todo: c.swProfile, etc.
+		profile, err := c.hwProfileOnSingleCPU(cpu)
+		if err != nil {
+			return result, err
+		}
+		// skip not counted cases
+		if profile.RefCPUCycles != nil {
+			result.cycles += *profile.RefCPUCycles
+		}
+		if profile.Instructions != nil {
+			result.instructions += *profile.Instructions
+		}
+	}
+	return result, err
+}
+
+func (c *PerfCollector) hwProfileOnSingleCPU(cpu int) (*perf.HardwareProfile, error) {
+	profile := &perf.HardwareProfile{}
+	if err := (*c.cpuHwProfilersMap[cpu]).Profile(profile); err != nil {
+		return nil, fmt.Errorf("profile err : %v", err)
+	}
+	return profile, nil
+}
+
+func (c *PerfCollector) stopAndClose() (err error) {
+	for _, cpu := range c.cpus {
+		// todo: c.swProfile, etc.
+		newErr := c.stopOnSingleCPU(cpu)
+		if newErr != nil {
+			err = multierr.Append(err, newErr)
+		}
+		newErr = c.closeOnSingleCPU(cpu)
+		if newErr != nil {
+			err = multierr.Append(err, newErr)
+		}
+	}
+	return err
+}
+
+func (c *PerfCollector) stopOnSingleCPU(cpu int) error {
+	if err := (*c.cpuHwProfilersMap[cpu]).Stop(); err != nil {
+		return fmt.Errorf("stop container %v, cpu: %v fd err : %v", c.CgroupFd, cpu, err)
+	}
+	return nil
+}
+
+func (c *PerfCollector) closeOnSingleCPU(cpu int) error {
+	if err := (*c.cpuHwProfilersMap[cpu]).Close(); err != nil {
+		return fmt.Errorf("close container %v, cpu: %v fd err : %v", c.CgroupFd, cpu, err)
+	}
+	return nil
+}

--- a/pkg/util/perf/perf_linux_test.go
+++ b/pkg/util/perf/perf_linux_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package perf
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewPerfCollector(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	fd := int(f.Fd())
+	cpus := []int{0}
+	assert.NotPanics(t, func() {
+		_, err := NewPerfCollector(fd, cpus)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_GetAndStartPerfCollectorOnContainer(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	fd := int(f.Fd())
+	cpus := []int{0}
+	assert.NotPanics(t, func() {
+		_, err := GetAndStartPerfCollectorOnContainer(fd, cpus)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_GetContainerCyclesAndInstructions(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	fd := int(f.Fd())
+	cpus := []int{0}
+	collector, _ := NewPerfCollector(fd, cpus)
+	assert.NotPanics(t, func() {
+		_, _, err := GetContainerCyclesAndInstructions(collector)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_stopAndClose(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	fd := int(f.Fd())
+	cpus := []int{0}
+	collector, _ := NewPerfCollector(fd, cpus)
+	assert.NotPanics(t, func() {
+		err := collector.stopAndClose()
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_collect(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	fd := int(f.Fd())
+	cpus := []int{0}
+	collector, _ := NewPerfCollector(fd, cpus)
+	assert.NotPanics(t, func() {
+		_, err := collector.collect()
+		if err != nil {
+			return
+		}
+	})
+}

--- a/pkg/util/perf/perf_unsupported.go
+++ b/pkg/util/perf/perf_unsupported.go
@@ -1,0 +1,56 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package perf
+
+type PerfCollector struct{}
+
+func NewPerfCollector(cgroupFd int, cpus []int) (*PerfCollector, error) {
+	return &PerfCollector{}, nil
+}
+
+func GetContainerCyclesAndInstructions(collector *PerfCollector) (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
+func GetAndStartPerfCollectorOnContainer(cgroupFd int, cpus []int) (*PerfCollector, error) {
+	return &PerfCollector{}, nil
+}
+
+func (c *PerfCollector) stopAndClose() (err error) {
+	return nil
+}
+
+func (c *PerfCollector) closeOnSingleCPU(cpu int) error { return nil }
+
+func (c *PerfCollector) stopOnSingleCPU(cpu int) error {
+	return nil
+}
+
+type HardwareProfile struct{}
+
+func (c *PerfCollector) hwProfileOnSingleCPU(cpu int) (HardwareProfile, error) {
+	return HardwareProfile{}, nil
+}
+
+type collectResult struct{}
+
+func (c *PerfCollector) collect() (result collectResult, err error) {
+	return collectResult{}, err
+}

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/koordinator-sh/koordinator/pkg/util/perf"
 	"github.com/koordinator-sh/koordinator/pkg/util/system"
 )
 
@@ -164,6 +165,30 @@ func Test_GetRootCgroupCPUUsageNanoseconds(t *testing.T) {
 	got, err := GetRootCgroupCPUUsageNanoseconds(corev1.PodQOSBestEffort)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1356232), got)
+}
+
+func Test_GetContainerCyclesAndInstructions(t *testing.T) {
+	collector, _ := perf.NewPerfCollector(0, []int{})
+	_, _, err := GetContainerCyclesAndInstructions(collector)
+	assert.Nil(t, err)
+}
+
+func Test_GetContainerPerfCollector(t *testing.T) {
+	tempDir := t.TempDir()
+	containerStatus := &corev1.ContainerStatus{
+		ContainerID: "containerd://test",
+	}
+	assert.NotPanics(t, func() {
+		_, err := GetContainerPerfCollector(tempDir, containerStatus, 1)
+		if err != nil {
+			return
+		}
+	})
+	wrongContainerStatus := &corev1.ContainerStatus{
+		ContainerID: "wrong-container-status-test",
+	}
+	_, err := GetContainerPerfCollector(tempDir, wrongContainerStatus, 1)
+	assert.NotNil(t, err)
 }
 
 func getUsageContents() string {


### PR DESCRIPTION
Signed-off-by: songtao98 <songtao2603060@gmail.com>

### Ⅰ. Describe what this PR does
This PR is the first part of koordinator interference detection support, which implements CPI metric collect and store feature. Koordlet collects CPI once a minute in a 10 second time window and store it in metric cache on per container level for future usage. 
Other codes will be commited continuously with other PRs. 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
