### PR TITLE
koord-scheduler: fix schedulingPhaseHook registerd log nil pointer bug

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -159,16 +159,18 @@ func NewFrameworkExtenderFactory(handle ExtendedHandle, hooks ...SchedulingPhase
 		preFilter, ok := h.(PreFilterPhaseHook)
 		if ok {
 			i.preFilterHooks = append(i.preFilterHooks, preFilter)
+			klog.V(4).InfoS("framework extender got scheduling hooks registered", "preFilter", preFilter.Name())
 		}
 		filter, ok := h.(FilterPhaseHook)
 		if ok {
 			i.filterHooks = append(i.filterHooks, filter)
+			klog.V(4).InfoS("framework extender got scheduling hooks registered", "filter", filter.Name())
 		}
 		score, ok := h.(ScorePhaseHook)
 		if ok {
 			i.scoreHooks = append(i.scoreHooks, score)
+			klog.V(4).InfoS("framework extender got scheduling hooks registered", "score", score.Name())
 		}
-		klog.V(4).InfoS("framework extender got scheduling hooks registered", "preFilter", preFilter.Name(), "filter", filter.Name())
 	}
 	return i
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When schedulingPhase hook is registered, we print the registerd hook type info in one log before. But if hook doesn't implement all type hooks, log will lead to nil pointer err.
This pr fix this bug.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
