### PR TITLE
koord-manager: revise node batch resource update

### DIFF
--- a/pkg/slo-controller/noderesource/noderesource_test.go
+++ b/pkg/slo-controller/noderesource/noderesource_test.go
@@ -596,7 +596,7 @@ func Test_updateNodeBEResource(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "failed to update for invalid be resource",
+			name: "notice the update for invalid be resource",
 			fields: fields{
 				Client: fake.NewClientBuilder().WithRuntimeObjects(&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -636,7 +636,7 @@ func Test_updateNodeBEResource(t *testing.T) {
 				},
 				beResource: &nodeBEResource{
 					MilliCPU: resource.NewMilliQuantity(22200, resource.DecimalSI),
-					Memory:   resource.NewQuantity(40*1024*1024*1024, resource.BinarySI),
+					Memory:   resource.NewMilliQuantity(40*1001*1023*1024*1024, resource.BinarySI),
 				},
 			},
 			want: &corev1.Node{
@@ -645,16 +645,16 @@ func Test_updateNodeBEResource(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
-						apiext.BatchCPU:    resource.MustParse("20"),
-						apiext.BatchMemory: resource.MustParse("40G"),
+						apiext.BatchCPU:    resource.MustParse("23"),
+						apiext.BatchMemory: resource.MustParse("42950637650"),
 					},
 					Capacity: corev1.ResourceList{
-						apiext.BatchCPU:    resource.MustParse("20"),
-						apiext.BatchMemory: resource.MustParse("40G"),
+						apiext.BatchCPU:    resource.MustParse("23"),
+						apiext.BatchMemory: resource.MustParse("42950637650"),
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "not update be resource with node-specified config",
@@ -808,6 +808,38 @@ func Test_updateNodeBEResource(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "failed to update for node not found",
+			fields: fields{
+				Client: fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+				config: enabledCfg,
+				SyncContext: &SyncContext{
+					contextMap: map[string]time.Time{"/test-node0": time.Now()},
+				},
+			},
+			args: args{
+				oldNode: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node0",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							apiext.BatchCPU:    resource.MustParse("20"),
+							apiext.BatchMemory: resource.MustParse("40G"),
+						},
+						Capacity: corev1.ResourceList{
+							apiext.BatchCPU:    resource.MustParse("20"),
+							apiext.BatchMemory: resource.MustParse("40G"),
+						},
+					},
+				},
+				beResource: &nodeBEResource{
+					MilliCPU: resource.NewQuantity(30, resource.DecimalSI),
+					Memory:   resource.NewQuantity(50*1024*1024*1024, resource.BinarySI),
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -821,16 +853,18 @@ func Test_updateNodeBEResource(t *testing.T) {
 			}
 			got := r.updateNodeBEResource(tt.args.oldNode, tt.args.beResource)
 			assert.Equal(t, tt.wantErr, got != nil, got)
-			gotNode := &corev1.Node{}
-			_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: tt.args.oldNode.Name}, gotNode)
+			if !tt.wantErr {
+				gotNode := &corev1.Node{}
+				_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: tt.args.oldNode.Name}, gotNode)
 
-			wantCPU := tt.want.Status.Allocatable[apiext.BatchCPU]
-			gotCPU := gotNode.Status.Allocatable[apiext.BatchCPU]
-			assert.Equal(t, wantCPU.Value(), gotCPU.Value())
+				wantCPU := tt.want.Status.Allocatable[apiext.BatchCPU]
+				gotCPU := gotNode.Status.Allocatable[apiext.BatchCPU]
+				assert.Equal(t, wantCPU.Value(), gotCPU.Value())
 
-			wantMem := tt.want.Status.Allocatable[apiext.BatchMemory]
-			gotMem := gotNode.Status.Allocatable[apiext.BatchMemory]
-			assert.Equal(t, wantMem.Value(), gotMem.Value())
+				wantMem := tt.want.Status.Allocatable[apiext.BatchMemory]
+				gotMem := gotNode.Status.Allocatable[apiext.BatchMemory]
+				assert.Equal(t, wantMem.Value(), gotMem.Value())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

revise the node resource update when calculated values are not int64 type

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. submit a pod which has memory request like `0.1Gi`
2. check the noderesource-controller's log if the batch resources failed to update since the memory value is not valid int64 type

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
