### PR TITLE
koord-scheduler: modify cpu and memory quantity formats and scales

### DIFF
--- a/apis/scheduling/config/v1beta2/defaults.go
+++ b/apis/scheduling/config/v1beta2/defaults.go
@@ -73,7 +73,7 @@ var (
 
 	defaultQuotaGroupNamespace = "koordinator-system"
 
-	defaultMonitorAllQuotas = pointer.Bool(true)
+	defaultMonitorAllQuotas = pointer.Bool(false)
 
 	defaultTimeout           = 600 * time.Second
 	defaultControllerWorkers = 1

--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
@@ -39,14 +39,6 @@ const (
 	GigaByte = 1024 * 1048576
 )
 
-func setLoglevel(logLevel string) {
-	var level klog.Level
-	if err := level.Set(logLevel); err != nil {
-		fmt.Printf("failed set klog.logging.verbosity %v: %v", 5, err)
-	}
-	fmt.Printf("successfully set klog.logging.verbosity to %v", 5)
-}
-
 func TestGroupQuotaManager_QuotaAdd(t *testing.T) {
 	gqm := NewGroupQuotaManager4Test()
 	gqm.UpdateClusterTotalResource(createResourceList(10000000, 3000*GigaByte))
@@ -150,7 +142,6 @@ func TestGroupQuotaManager_UpdateQuotaInternal(t *testing.T) {
 func TestGroupQuotaManager_UpdateQuotaInternalAndRequest(t *testing.T) {
 	gqm := NewGroupQuotaManager4Test()
 
-	setLoglevel("3")
 	deltaRes := createResourceList(96, 160*GigaByte)
 	gqm.UpdateClusterTotalResource(deltaRes)
 	assert.Equal(t, deltaRes, gqm.totalResource)
@@ -476,22 +467,22 @@ func TestGroupQuotaManager_MultiUpdateQuotaRequest_WithScaledMinQuota1(t *testin
 	gqm.RefreshRuntime("b")
 	gqm.RefreshRuntime("c")
 	runtime = gqm.RefreshRuntime("a")
-	assert.Equal(t, createResourceList(67, 200*GigaByte/3+1), runtime)
+	assert.Equal(t, createResourceList2(66667, 200*GigaByte/3+1), runtime)
 	// after group "c" refreshRuntime, the runtime of "a" and "b" has changed
-	assert.Equal(t, createResourceList(67, 200*GigaByte/3+1), gqm.RefreshRuntime("a"))
-	assert.Equal(t, createResourceList(67, 200*GigaByte/3+1), gqm.RefreshRuntime("b"))
+	assert.Equal(t, createResourceList2(66667, 200*GigaByte/3+1), gqm.RefreshRuntime("a"))
+	assert.Equal(t, createResourceList2(66667, 200*GigaByte/3+1), gqm.RefreshRuntime("b"))
 
 	quotaInfo := gqm.GetQuotaInfoByName("p")
 	assert.Equal(t, createResourceList(200, 200*GigaByte), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("a")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("b")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("c")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	// large
 	deltaRes = createResourceList(400, 400*GigaByte)
@@ -560,13 +551,13 @@ func TestGroupQuotaManager_MultiUpdateQuotaRequest_WithScaledMinQuota2(t *testin
 	assert.Equal(t, createResourceList(200, 200*GigaByte), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("a")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("b")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 
 	quotaInfo = gqm.GetQuotaInfoByName("c")
-	assert.Equal(t, createResourceList(66, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
+	assert.Equal(t, createResourceList2(66666, 200*GigaByte/3), quotaInfo.CalculateInfo.AutoScaleMin)
 }
 
 func TestGroupQuotaManager_MultiUpdateQuotaUsed(t *testing.T) {
@@ -861,9 +852,7 @@ func TestGroupQuotaManager_MultiChildMaxGreaterParentMax(t *testing.T) {
 }
 
 func TestGroupQuotaManager_UpdateQuotaTreeDimension_UpdateQuota(t *testing.T) {
-	setLoglevel("3")
 	gqm := NewGroupQuotaManager4Test()
-
 	info3 := CreateQuota("3", extension.RootQuotaName, 1000, 10000, 100, 1000, true, false)
 	info3.Spec.Max["tmp"] = *resource.NewQuantity(1, resource.DecimalSI)
 	res := createResourceList(1000, 10000)

--- a/pkg/scheduler/plugins/elasticquota/core/quota_info.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/klog/v2"
 	resourcev1 "k8s.io/kubernetes/pkg/api/v1/resource"
@@ -186,14 +185,14 @@ func (qi *QuotaInfo) getLimitRequestNoLock() v1.ResourceList {
 func (qi *QuotaInfo) addRequestNonNegativeNoLock(delta v1.ResourceList) {
 	qi.CalculateInfo.Request = quotav1.Add(qi.CalculateInfo.Request, delta)
 	for _, resName := range quotav1.IsNegative(qi.CalculateInfo.Request) {
-		qi.CalculateInfo.Request[resName] = *resource.NewQuantity(0, resource.DecimalSI)
+		qi.CalculateInfo.Request[resName] = createQuantity(0, resName)
 	}
 }
 
 func (qi *QuotaInfo) addUsedNonNegativeNoLock(delta v1.ResourceList) {
 	qi.CalculateInfo.Used = quotav1.Add(qi.CalculateInfo.Used, delta)
 	for _, resName := range quotav1.IsNegative(qi.CalculateInfo.Used) {
-		qi.CalculateInfo.Used[resName] = *resource.NewQuantity(0, resource.DecimalSI)
+		qi.CalculateInfo.Used[resName] = createQuantity(0, resName)
 	}
 }
 

--- a/pkg/scheduler/plugins/elasticquota/core/scale_minquota_when_over_root_res.go
+++ b/pkg/scheduler/plugins/elasticquota/core/scale_minquota_when_over_root_res.go
@@ -139,11 +139,11 @@ func (s *ScaleMinQuotaManager) getScaledMinQuota(newTotalRes v1.ResourceList, pa
 
 			newMinQuotaValue := int64(0)
 			if enableTotalValue.Value() > 0 {
-				newMinQuotaValue = int64(float64(needScaleTotal.Value()) *
-					float64(originalMinQuotaValue.Value()) / float64(enableTotalValue.Value()))
+				newMinQuotaValue = int64(float64(getQuantityValue(needScaleTotal, resourceDimension)) *
+					float64(getQuantityValue(*originalMinQuotaValue, resourceDimension)) / float64(getQuantityValue(*enableTotalValue, resourceDimension)))
 			}
 
-			newMinQuota[resourceDimension] = *resource.NewQuantity(newMinQuotaValue, resource.DecimalSI)
+			newMinQuota[resourceDimension] = createQuantity(newMinQuotaValue, resourceDimension)
 		}
 	}
 	return true, newMinQuota

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -579,8 +579,10 @@ func defaultCreateNode(nodeName string) *corev1.Node {
 
 func createResourceList(cpu, mem int64) corev1.ResourceList {
 	return corev1.ResourceList{
-		corev1.ResourceCPU:    *resource.NewQuantity(cpu, resource.DecimalSI),
-		corev1.ResourceMemory: *resource.NewQuantity(mem, resource.DecimalSI),
+		// use NewMilliQuantity to calculate the runtimeQuota correctly in cpu dimension
+		// when the request is smaller than 1 core.
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(cpu*1000, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(mem, resource.BinarySI),
 	}
 }
 

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
@@ -157,7 +157,7 @@ func TestQuotaOverUsedRevokeController_GetToMonitorQuotas(t *testing.T) {
 	gqm := plugin.groupQuotaManager
 	gqm.UpdateClusterTotalResource(createResourceList(10850060000, 0))
 	cc := NewQuotaOverUsedRevokeController(plugin.handle.ClientSet(), 0*time.Second,
-		plugin.pluginArgs.RevokePodInterval.Duration, plugin.groupQuotaManager, *plugin.pluginArgs.MonitorAllQuotas)
+		plugin.pluginArgs.RevokePodInterval.Duration, plugin.groupQuotaManager, true)
 
 	suit.AddQuota("test1", "root", 4797411900, 0, 1085006000, 0, 4797411900, 0, true, "extended")
 	suit.AddQuota("test2", "root", 4797411900, 0, 1085006000, 0, 4797411900, 0, true, "extended")


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
Change pod's cpu quantity to MilliQuantity in order to calculate runtimeQuota correctly, change memory's format from DecimalSI to BinarySI, fix UT.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
