### PR TITLE
koordlet: enable group identity by sysctl when cpu qos enabled

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt_test.go
@@ -17,17 +17,26 @@ limitations under the License.
 package groupidentity
 
 import (
+	"path/filepath"
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	"github.com/koordinator-sh/koordinator/pkg/util/system"
 )
 
 func initCPUBvt(dirWithKube string, value int64, helper *system.FileTestUtil) {
+	helper.WriteCgroupFileContents(util.GetKubeQosRelativePath(corev1.PodQOSGuaranteed), system.CPUBVTWarpNs,
+		strconv.FormatInt(value, 10))
 	helper.WriteCgroupFileContents(dirWithKube, system.CPUBVTWarpNs, strconv.FormatInt(value, 10))
+}
+
+func initKernelGroupIdentity(value int64, helper *system.FileTestUtil) {
+	helper.WriteProcSubFileContents(filepath.Join(system.SysctlSubDir, system.KernelSchedGroupIdentityEnable), strconv.FormatInt(value, 10))
 }
 
 func getPodCPUBvt(podDirWithKube string, helper *system.FileTestUtil) int64 {
@@ -39,7 +48,8 @@ func getPodCPUBvt(podDirWithKube string, helper *system.FileTestUtil) int64 {
 func Test_bvtPlugin_systemSupported(t *testing.T) {
 	kubeRootDir := util.GetKubeQosRelativePath(corev1.PodQOSGuaranteed)
 	type fields struct {
-		initPath *string
+		initPath                *string
+		initKernelGroupIdentity bool
 	}
 	tests := []struct {
 		name   string
@@ -58,11 +68,21 @@ func Test_bvtPlugin_systemSupported(t *testing.T) {
 			fields: fields{},
 			want:   false,
 		},
+		{
+			name: "system support since bvt kernel file exist",
+			fields: fields{
+				initKernelGroupIdentity: true,
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		testHelper := system.NewFileTestUtil(t)
 		if tt.fields.initPath != nil {
 			initCPUBvt(*tt.fields.initPath, 0, testHelper)
+		}
+		if tt.fields.initKernelGroupIdentity {
+			initKernelGroupIdentity(0, testHelper)
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			b := &bvtPlugin{}
@@ -78,4 +98,129 @@ func Test_bvtPlugin_Register(t *testing.T) {
 		b := &bvtPlugin{}
 		b.Register()
 	})
+}
+
+func Test_bvtPlugin_initialized(t *testing.T) {
+	kubeRootDir := util.GetKubeQosRelativePath(corev1.PodQOSGuaranteed)
+	type fields struct {
+		initPath                     *string
+		initKernelGroupIdentity      bool
+		initKernelGroupIdentityValue int
+		rule                         *bvtRule
+		hasKernelEnable              *bool
+		kernelEnabled                *bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "cannot initialize since system not support",
+			fields: fields{},
+			want:   false,
+		},
+		{
+			name: "no need to initialize",
+			fields: fields{
+				hasKernelEnable: pointer.Bool(false),
+			},
+			want: false,
+		},
+		{
+			name: "failed to initialize",
+			fields: fields{
+				hasKernelEnable: pointer.Bool(true),
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "initialized since only bvt file exist",
+			fields: fields{
+				initPath: &kubeRootDir,
+			},
+			want: false,
+		},
+		{
+			name: "initialized since bvt kernel file exist",
+			fields: fields{
+				initKernelGroupIdentity:      true,
+				initKernelGroupIdentityValue: 0,
+				rule: &bvtRule{
+					enable: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "initialized since bvt kernel file exist 1",
+			fields: fields{
+				initKernelGroupIdentity:      true,
+				initKernelGroupIdentityValue: 1,
+				rule: &bvtRule{
+					enable: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "initialized since bvt kernel file exist 2",
+			fields: fields{
+				initPath:                     &kubeRootDir,
+				initKernelGroupIdentity:      true,
+				initKernelGroupIdentityValue: 0,
+				rule: &bvtRule{
+					enable: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not initialize since bvt file not exist and cpu qos disabled",
+			fields: fields{
+				initKernelGroupIdentity:      true,
+				initKernelGroupIdentityValue: 1,
+				rule: &bvtRule{
+					enable: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip sysctl set since bvt kernel enable not changed",
+			fields: fields{
+				initPath:                     &kubeRootDir,
+				initKernelGroupIdentity:      true,
+				initKernelGroupIdentityValue: 0,
+				rule: &bvtRule{
+					enable: true,
+				},
+				hasKernelEnable: pointer.Bool(true),
+				kernelEnabled:   pointer.Bool(true),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testHelper := system.NewFileTestUtil(t)
+			if tt.fields.initPath != nil {
+				initCPUBvt(*tt.fields.initPath, 0, testHelper)
+			}
+			if tt.fields.initKernelGroupIdentity {
+				initKernelGroupIdentity(int64(tt.fields.initKernelGroupIdentityValue), testHelper)
+			}
+
+			b := &bvtPlugin{
+				rule:             tt.fields.rule,
+				hasKernelEnabled: tt.fields.hasKernelEnable,
+				kernelEnabled:    tt.fields.kernelEnabled,
+			}
+			got, gotErr := b.initialize()
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
@@ -35,6 +35,16 @@ func (b *bvtPlugin) SetPodBvtValue(p protocol.HooksProtocol) error {
 		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
 		return nil
 	}
+	enable, err := b.initialize()
+	if err != nil {
+		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
+		return nil
+	}
+	// skip if the feature is disabled by the kernel config
+	if !enable && b.hasKernelEnable() {
+		klog.V(5).Infof("skip for pod since hook plugin %s has been disabled by kernel config", name)
+		return nil
+	}
 	podCtx := p.(*protocol.PodContext)
 	req := podCtx.Request
 	podQOS := ext.GetQoSClassByAttrs(req.Labels, req.Annotations)
@@ -52,6 +62,16 @@ func (b *bvtPlugin) SetKubeQOSBvtValue(p protocol.HooksProtocol) error {
 	r := b.getRule()
 	if r == nil {
 		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
+		return nil
+	}
+	enable, err := b.initialize()
+	if err != nil {
+		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
+		return nil
+	}
+	// skip if the feature is disabled by the kernel config
+	if !enable && b.hasKernelEnable() {
+		klog.V(5).Infof("skip for qos since hook plugin %s has been disabled by kernel config", name)
 		return nil
 	}
 	kubeQOSCtx := p.(*protocol.KubeQOSContext)

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule_test.go
@@ -141,6 +141,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 				},
 			},
 			wantRule: bvtRule{
+				enable: true,
 				podQOSParams: map[ext.QoSClass]int64{
 					ext.QoSLSR: 2,
 					ext.QoSLS:  2,
@@ -193,6 +194,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 				},
 			},
 			wantRule: bvtRule{
+				enable: true,
 				podQOSParams: map[ext.QoSClass]int64{
 					ext.QoSLSR: 0,
 					ext.QoSLS:  2,
@@ -245,6 +247,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 				},
 			},
 			wantRule: bvtRule{
+				enable: true,
 				podQOSParams: map[ext.QoSClass]int64{
 					ext.QoSLSR: 0,
 					ext.QoSLS:  0,
@@ -297,6 +300,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 				},
 			},
 			wantRule: bvtRule{
+				enable: false,
 				podQOSParams: map[ext.QoSClass]int64{
 					ext.QoSLSR: 0,
 					ext.QoSLS:  0,
@@ -320,6 +324,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 			name: "parse same normal rules",
 			args: args{
 				rule: &bvtRule{
+					enable: true,
 					podQOSParams: map[ext.QoSClass]int64{
 						ext.QoSLSR: 2,
 						ext.QoSLS:  2,
@@ -366,6 +371,7 @@ func Test_bvtPlugin_parseRule(t *testing.T) {
 				},
 			},
 			wantRule: bvtRule{
+				enable: true,
 				podQOSParams: map[ext.QoSClass]int64{
 					ext.QoSLSR: 2,
 					ext.QoSLS:  2,

--- a/pkg/util/system/system_file_test.go
+++ b/pkg/util/system/system_file_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcSysctl(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		helper := NewFileTestUtil(t)
+
+		testProcSysFile := "test_file"
+		testProcSysFilepath := filepath.Join(SysctlSubDir, testProcSysFile)
+		testContent := "0"
+		assert.False(t, FileExists(GetProcSysFilePath(testProcSysFile)))
+		helper.WriteProcSubFileContents(testProcSysFilepath, testContent)
+
+		s := NewProcSysctl()
+		v, err := s.GetSysctl(testProcSysFile)
+		assert.NoError(t, err)
+		assert.Equal(t, testContent, strconv.Itoa(v))
+
+		testValue := 1
+		err = s.SetSysctl(testProcSysFile, testValue)
+		assert.NoError(t, err)
+		got := helper.ReadProcSubFileContents(testProcSysFilepath)
+		gotV, err := strconv.ParseInt(got, 10, 32)
+		assert.NoError(t, err)
+		assert.Equal(t, int(gotV), testValue)
+	})
+}
+
+func TestSetSchedGroupIdentity(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		helper := NewFileTestUtil(t)
+
+		// system not supported
+		err := SetSchedGroupIdentity(false)
+		assert.Error(t, err)
+
+		// system supported, already disabled
+		testProcSysFile := KernelSchedGroupIdentityEnable
+		testProcSysFilepath := filepath.Join(SysctlSubDir, testProcSysFile)
+		testContent := "0"
+		assert.False(t, FileExists(GetProcSysFilePath(testProcSysFile)))
+		helper.WriteProcSubFileContents(testProcSysFilepath, testContent)
+		err = SetSchedGroupIdentity(false)
+		assert.NoError(t, err)
+		got := helper.ReadProcSubFileContents(testProcSysFilepath)
+		assert.Equal(t, got, testContent)
+
+		// system supported, set enabled
+		testContent = "1"
+		err = SetSchedGroupIdentity(true)
+		assert.NoError(t, err)
+		got = helper.ReadProcSubFileContents(testProcSysFilepath)
+		assert.Equal(t, got, testContent)
+	})
+}

--- a/pkg/util/system/util_test_tool.go
+++ b/pkg/util/system/util_test_tool.go
@@ -100,7 +100,7 @@ func (c *FileTestUtil) CreateProcSubFile(fileRelativePath string) {
 func (c *FileTestUtil) WriteProcSubFileContents(relativeFilePath string, contents string) {
 	file := path.Join(Conf.ProcRootDir, relativeFilePath)
 	if !FileExists(file) {
-		c.CreateProcSubFile(file)
+		c.CreateProcSubFile(relativeFilePath)
 	}
 	err := os.WriteFile(file, []byte(contents), 0644)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

In some versions of Anolis OS, the Group Identity (bvt) feature is not enabled by default. When coordinator CPUQOS is enabled, we have to enable the feature via sysctl before we write the cgroup files `cpu.bvt_warp_ns`.

```bash
$ # option 1: write system files
$ echo 1 > /proc/sys/kernel/sched_group_identity_enabled
$ # option 2: use sysctl command
$ sysctl -w kernel.sched_group_identity_enabled=1
$ # option 3: use sysctl command and enable group identity persistently
$ sysctl -w kernel.sched_group_identity_enabled=1 >> /etc/sysctl.conf
```

With this patch, koordlet will initialize Group Identity via sysctl when CPUQOS is set and `kernel.sched_group_identity_enabled` exists.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Without this patch, koordlet cannot successfully update the bvt (group identity) configs if the kernel disables the feature.

e.g.

```bash
$ cat /proc/sys/kernel/sched_group_identity_enabled
0
$ echo "-1" > /sys/fs/cgroup/cpu/kubepods.slice/kubepods-besteffort.slice/cpu.bvt_warp_ns
-bash: echo: write error: Invalid argument
```

### Ⅲ. Describe how to verify it

1. find a node with Anolis OS kernel.
2. enable CPUQOS for any QOS (LSR, LS, BE)
3. check if the cgroup file `cpu.bvt_warp_ns` is successfully updated

e.g. set `BEClass.CPUQOS.Enable=true`, so `/sys/fs/cgroup/cpu/kubepods.slice/kubepods-besteffort.slice/cpu.bvt_warp_ns` should be `-1`.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
