### PR TITLE
koord-scheduler: fix deviceshare onPodAdd when its device is not loaded

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/pod_handler.go
+++ b/pkg/scheduler/plugins/deviceshare/pod_handler.go
@@ -32,12 +32,6 @@ func (n *nodeDeviceCache) onPodAdd(obj interface{}) {
 		return
 	}
 
-	info := n.getNodeDevice(pod.Spec.NodeName)
-	if info == nil {
-		klog.Errorf("node device cache not found, nodeName: %v", pod.Spec.NodeName)
-		return
-	}
-
 	podRequest, _ := resource.PodRequestsAndLimits(pod)
 
 	deviceExist := false
@@ -56,6 +50,12 @@ func (n *nodeDeviceCache) onPodAdd(obj interface{}) {
 	if err != nil {
 		klog.Errorf("failed to get device allocation, pod: %v, err: %v", pod.Name, err)
 		return
+	}
+
+	info := n.getNodeDevice(pod.Spec.NodeName)
+	if info == nil {
+		info = n.createNodeDevice(pod.Spec.NodeName)
+		klog.V(5).Infof("node device cache not found, nodeName: %v, pod:%v, createNodeDevice", pod.Spec.NodeName, pod.Name)
 	}
 
 	info.lock.Lock()


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
虽然deviceShare plugin里面确实先处理device，但如果device的crd没有提前安装的话，可能会出现pod的事件先触发的情况，这个pr就是为了修复这种情况。
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
