### PR TITLE
Fix #705 for the error of "io/ioutil" is deprecated

### DIFF
--- a/pkg/util/system/common.go
+++ b/pkg/util/system/common.go
@@ -54,8 +54,8 @@ func CommonFileWrite(file string, data string) error {
 	return os.WriteFile(file, []byte(data), 0644)
 }
 
-// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
-// This is similar to ioutil.ReadFile but without the call to os.Stat, because
+// ReadFileNoStat uses io.ReadAll to read contents of entire file.
+// This is similar to io.ReadFile but without the call to os.Stat, because
 // many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
 // Reads a max file size of 512kB.  For files larger than this, a scanner
 // should be used.

--- a/pkg/util/system/system_file.go
+++ b/pkg/util/system/system_file.go
@@ -18,7 +18,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -65,7 +65,7 @@ func NewProcSysctl() utilsysctl.Interface {
 }
 
 func (*ProcSysctl) GetSysctl(sysctl string) (int, error) {
-	data, err := ioutil.ReadFile(GetProcSysFilePath(sysctl))
+	data, err := os.ReadFile(GetProcSysFilePath(sysctl))
 	if err != nil {
 		return -1, err
 	}
@@ -78,7 +78,7 @@ func (*ProcSysctl) GetSysctl(sysctl string) (int, error) {
 
 // SetSysctl modifies the specified sysctl flag to the new value
 func (*ProcSysctl) SetSysctl(sysctl string, newVal int) error {
-	return ioutil.WriteFile(GetProcSysFilePath(sysctl), []byte(strconv.Itoa(newVal)), 0640)
+	return os.WriteFile(GetProcSysFilePath(sysctl), []byte(strconv.Itoa(newVal)), 0640)
 }
 
 func SetSchedGroupIdentity(enable bool) error {


### PR DESCRIPTION
Signed-off-by: denverdino <denverdino@gmail.com>

### Ⅰ. Describe what this PR does

Fix the error for "io/ioutil" is deprecated

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fix #705

### Ⅲ. Describe how to verify it

make build

### Ⅳ. Special notes for reviews

### V. Checklist

- [Y] I have written necessary docs and comments
- [Y] I have added necessary unit tests and integration tests
- [Y ] All checks passed in `make test`
