### PR TITLE
koord-scheduler: fix NodeNUMAResource sortCPUsByRefCount

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator.go
@@ -727,8 +727,8 @@ func (a *cpuAccumulator) sortCPUsByRefCount(cpus []int) {
 	sort.Slice(cpus, func(i, j int) bool {
 		iCPU := cpus[i]
 		jCPU := cpus[j]
-		iRefCount := a.topology.CPUDetails[iCPU].RefCount
-		jRefCount := a.topology.CPUDetails[jCPU].RefCount
+		iRefCount := a.allocatableCPUs[iCPU].RefCount
+		jRefCount := a.allocatableCPUs[jCPU].RefCount
 		if iRefCount != jRefCount {
 			return iRefCount < jRefCount
 		}


### PR DESCRIPTION
Signed-off-by: wangjianyu <zmsjianyu@gmail.com>

### Ⅰ. Describe what this PR does

this pr fixes NodeNUMAResource sortCPUsByRefCount bug and supply UT for it.

A node has 16 CPUs, and the maxRefCount of CPUTopologyOptions is set to 2, there are 32 CPUs to allocate at this time. After allocating 32C according to the SpreadByPCPUs and FullPCPUsOnly strategies, and then following the SpreadByPCPUs allocation, there should be 16 CPUs left to allocate. But at this time koord-scheduler will report insufficient CPU resources.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
