### PR TITLE
RuntimeProxy: Support hook server deployed by k8s pod

### DIFF
--- a/cmd/koord-runtime-proxy/main.go
+++ b/cmd/koord-runtime-proxy/main.go
@@ -39,6 +39,11 @@ func main() {
 		"backend image service endpoint.")
 	flag.StringVar(&options.BackendRuntimeMode, "backend-runtime-mode", options.DefaultBackendRuntimeMode,
 		"backend container engine(Containerd|Docker).")
+	flag.StringVar(&options.RuntimeHookServerKey, "runtime-hook-server-key", options.DefaultHookServerKey,
+		"if pod tag itself with runtime-hook-server-key in annotations, runtime-proxy would regard this pod as runtime hook server and "+
+			"skip transferring cri events to hook server")
+	flag.StringVar(&options.RuntimeHookServerVal, "runtime-hook-server-val", options.DefaultHookServerVal,
+		"working combined with runtime-hook-server-key")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/cmd/koord-runtime-proxy/options/options.go
+++ b/cmd/koord-runtime-proxy/options/options.go
@@ -25,6 +25,9 @@ const (
 	BackendRuntimeModeContainerd = "Containerd"
 	BackendRuntimeModeDocker     = "Docker"
 	DefaultBackendRuntimeMode    = BackendRuntimeModeContainerd
+
+	DefaultHookServerKey = "runtimeproxy.koordinator.sh/is-hookserver"
+	DefaultHookServerVal = "true"
 )
 
 var (
@@ -34,4 +37,7 @@ var (
 
 	// BackendRuntimeMode default to 'containerd'
 	BackendRuntimeMode string
+
+	RuntimeHookServerKey string
+	RuntimeHookServerVal string
 )

--- a/pkg/runtimeproxy/resexecutor/cri/utils.go
+++ b/pkg/runtimeproxy/resexecutor/cri/utils.go
@@ -155,3 +155,15 @@ func transferToCRIContainerEnvs(envs map[string]string) []*runtimeapi.KeyValue {
 	}
 	return res
 }
+
+func IsKeyValExistInAnnotations(annotations map[string]string, key, val string) bool {
+	if annotations == nil {
+		return false
+	}
+	for curKey, curVal := range annotations {
+		if curKey == key && curVal == val {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runtimeproxy/resexecutor/resource_executor.go
+++ b/pkg/runtimeproxy/resexecutor/resource_executor.go
@@ -20,12 +20,17 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/runtime/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/runtimeproxy/resexecutor/cri"
 	"github.com/koordinator-sh/koordinator/pkg/runtimeproxy/store"
+	"github.com/koordinator-sh/koordinator/pkg/runtimeproxy/utils"
 )
 
 type RuntimeResourceExecutor interface {
 	GetMetaInfo() string
 	GenerateHookRequest() interface{}
-	ParseRequest(request interface{}) error
+	// ParseRequest would be the first function after request intercepted, during which,
+	// pod/container's meta/resource info would be parsed from request or loaded from local store,
+	// and some hint info should also be offered during ParseRequest stage, e.g. to check if executor
+	// should call hook plugins when pod/container is system component.
+	ParseRequest(request interface{}) (utils.CallHookPluginOperation, error)
 	ResourceCheckPoint(response interface{}) error
 	DeleteCheckpointIfNeed(request interface{}) error
 	UpdateRequest(response interface{}, request interface{}) error
@@ -66,8 +71,8 @@ func (n *NoopResourceExecutor) GenerateHookRequest() interface{} {
 	return store.ContainerInfo{}
 }
 
-func (n *NoopResourceExecutor) ParseRequest(request interface{}) error {
-	return nil
+func (n *NoopResourceExecutor) ParseRequest(request interface{}) (utils.CallHookPluginOperation, error) {
+	return utils.Unknown, nil
 }
 func (n *NoopResourceExecutor) ResourceCheckPoint(response interface{}) error {
 	return nil

--- a/pkg/runtimeproxy/utils/utils.go
+++ b/pkg/runtimeproxy/utils/utils.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package utils
 
+type CallHookPluginOperation string
+
+const (
+	ShouldCallHookPlugin          CallHookPluginOperation = "ShouldCallHookPlugin"
+	ShouldNotCallHookPluginAlways CallHookPluginOperation = "ShouldNotCallHookPluginAlways"
+	Unknown                       CallHookPluginOperation = "Unknown"
+)
+
 func MergeMap(a, b map[string]string) map[string]string {
 	if a == nil {
 		a = make(map[string]string)


### PR DESCRIPTION
If hookserver is deployed as k8s pod, there may exist cycled dependency: If hookserver is updated, the new hookserver pod create CRI request would come to kubelet, runtime-proxy and then hookserver, however, at this time, the previous pod may have exited, which results in calling hookserver timeout. If RuntimeHookConfig.FailurePolicy is configed as FailurePolicyType, such pod hookserver would always be rejected by RuntimeProxy to re-create.

To fix this issue, we introduce annotations to tag pod as hook server. For such tagged pods, runtime-proxy would transfer cri request to backend runtime engine transparently to solve the cycled dependency.

Signed-off-by: honpey <honpey@gmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
