### PR TITLE
koord-scheduler: fix failed scheduling since missing CPUTopology

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -247,7 +247,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 
 	cpuTopologyOptions := p.topologyManager.GetCPUTopologyOptions(node.Name)
 	if cpuTopologyOptions.CPUTopology == nil {
-		return framework.NewStatus(framework.Error, ErrNotFoundCPUTopology)
+		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrNotFoundCPUTopology)
 	}
 
 	// It's necessary to force node to have NodeResourceTopology and CPUTopology

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -417,7 +417,7 @@ func TestPlugin_Filter(t *testing.T) {
 				skip: false,
 			},
 			pod:  &corev1.Pod{},
-			want: framework.NewStatus(framework.Error, ErrNotFoundCPUTopology),
+			want: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrNotFoundCPUTopology),
 		},
 		{
 			name: "error with invalid cpu topology",


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

If there are suitable resources in the cluster but some nodes do not have CPUTopology, the Pod cannot be scheduled.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Deploy koordlet on a subset of nodes in a cluster
2. Create a LSR Pod 
3. Pod failed scheduling with the message `running "NodeNUMAResource" filter plugin: node(s) CPU Topology not found` 

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
