### PR TITLE
fix:delete unuse logic

### DIFF
--- a/pkg/koordlet/resmanager/cpu_evict.go
+++ b/pkg/koordlet/resmanager/cpu_evict.go
@@ -156,9 +156,6 @@ func (c *CPUEvictor) killAndEvictBEPodsRelease(node *corev1.Node, bePodInfos []*
 	var killedPods []*corev1.Pod
 	for _, bePod := range bePodInfos {
 		if cpuMilliReleased < cpuNeedMilliRelease {
-			podKillMsg := fmt.Sprintf("%s, kill pod : %s", message, bePod.pod.Name)
-			killContainers(bePod.pod, podKillMsg)
-
 			killedPods = append(killedPods, bePod.pod)
 			cpuMilliReleased = cpuMilliReleased + bePod.milliRequest
 		}

--- a/pkg/koordlet/resmanager/memory_evict.go
+++ b/pkg/koordlet/resmanager/memory_evict.go
@@ -135,8 +135,6 @@ func (m *MemoryEvictor) killAndEvictBEPods(node *corev1.Node, podMetrics []*metr
 	var killedPods []*corev1.Pod
 	for _, bePod := range bePodInfos {
 		if memoryReleased < memoryNeedRelease {
-			killMsg := fmt.Sprintf("%v, kill pod: %v", message, bePod.pod.Name)
-			killContainers(bePod.pod, killMsg)
 			killedPods = append(killedPods, bePod.pod)
 			if bePod.podMetric != nil {
 				memoryReleased += bePod.podMetric.MemoryUsed.MemoryWithoutCache.Value()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
containers of bepod is controlled by kubelet, so container will restart according to pod's restartPolicy when stop container,and in after logic will do evict,so delete container is unuseless in there.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
