### PR TITLE
apis: fix resctrl qos defaults

### DIFF
--- a/apis/slo/v1alpha1/nodeslo_types.go
+++ b/apis/slo/v1alpha1/nodeslo_types.go
@@ -161,7 +161,6 @@ type ResourceThresholdStrategy struct {
 	Enable *bool `json:"enable,omitempty"`
 
 	// cpu suppress threshold percentage (0,100), default = 65
-	// +kubebuilder:default=65
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=0
 	CPUSuppressThresholdPercent *int64 `json:"cpuSuppressThresholdPercent,omitempty"`
@@ -169,7 +168,6 @@ type ResourceThresholdStrategy struct {
 	CPUSuppressPolicy CPUSuppressPolicy `json:"cpuSuppressPolicy,omitempty"`
 
 	// upper: memory evict threshold percentage (0,100), default = 70
-	// +kubebuilder:default=70
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=0
 	MemoryEvictThresholdPercent *int64 `json:"memoryEvictThresholdPercent,omitempty"`
@@ -195,17 +193,14 @@ type ResctrlQOSCfg struct {
 
 type ResctrlQOS struct {
 	// LLC available range start for pods by percentage
-	// +kubebuilder:default=0
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	CATRangeStartPercent *int64 `json:"catRangeStartPercent,omitempty"`
 	// LLC available range end for pods by percentage
-	// +kubebuilder:default=100
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	CATRangeEndPercent *int64 `json:"catRangeEndPercent,omitempty"`
 	// MBA percent
-	// +kubebuilder:default=100
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	MBAPercent *int64 `json:"mbaPercent,omitempty"`
@@ -229,20 +224,16 @@ type CPUBurstConfig struct {
 	// cpu burst percentage for setting cpu.cfs_burst_us, legal range: [0, 10000], default as 1000 (1000%)
 	// +kubebuilder:validation:Maximum=10000
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:default=1000
 	CPUBurstPercent *int64 `json:"cpuBurstPercent,omitempty"`
 	// pod cfs quota scale up ceil percentage, default = 300 (300%)
-	// +kubebuilder:default=300
 	CFSQuotaBurstPercent *int64 `json:"cfsQuotaBurstPercent,omitempty"`
 	// specifies a period of time for pod can use at burst, default = -1 (unlimited)
-	// +kubebuilder:default=-1
 	CFSQuotaBurstPeriodSeconds *int64 `json:"cfsQuotaBurstPeriodSeconds,omitempty"`
 }
 
 type CPUBurstStrategy struct {
 	CPUBurstConfig `json:",inline"`
 	// scale down cfs quota if node cpu overload, default = 50
-	// +kubebuilder:default=50
 	SharePoolThresholdPercent *int64 `json:"sharePoolThresholdPercent,omitempty"`
 }
 

--- a/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
@@ -39,19 +39,16 @@ spec:
                 description: CPU Burst Strategy
                 properties:
                   cfsQuotaBurstPercent:
-                    default: 300
                     description: pod cfs quota scale up ceil percentage, default =
                       300 (300%)
                     format: int64
                     type: integer
                   cfsQuotaBurstPeriodSeconds:
-                    default: -1
                     description: specifies a period of time for pod can use at burst,
                       default = -1 (unlimited)
                     format: int64
                     type: integer
                   cpuBurstPercent:
-                    default: 1000
                     description: 'cpu burst percentage for setting cpu.cfs_burst_us,
                       legal range: [0, 10000], default as 1000 (1000%)'
                     format: int64
@@ -61,7 +58,6 @@ spec:
                   policy:
                     type: string
                   sharePoolThresholdPercent:
-                    default: 50
                     description: scale down cfs quota if node cpu overload, default
                       = 50
                     format: int64
@@ -195,14 +191,12 @@ spec:
                           qos
                         properties:
                           catRangeEndPercent:
-                            default: 100
                             description: LLC available range end for pods by percentage
                             format: int64
                             maximum: 100
                             minimum: 0
                             type: integer
                           catRangeStartPercent:
-                            default: 0
                             description: LLC available range start for pods by percentage
                             format: int64
                             maximum: 100
@@ -213,7 +207,6 @@ spec:
                               is enabled.
                             type: boolean
                           mbaPercent:
-                            default: 100
                             description: MBA percent
                             format: int64
                             maximum: 100
@@ -342,14 +335,12 @@ spec:
                           qos
                         properties:
                           catRangeEndPercent:
-                            default: 100
                             description: LLC available range end for pods by percentage
                             format: int64
                             maximum: 100
                             minimum: 0
                             type: integer
                           catRangeStartPercent:
-                            default: 0
                             description: LLC available range start for pods by percentage
                             format: int64
                             maximum: 100
@@ -360,7 +351,6 @@ spec:
                               is enabled.
                             type: boolean
                           mbaPercent:
-                            default: 100
                             description: MBA percent
                             format: int64
                             maximum: 100
@@ -489,14 +479,12 @@ spec:
                           qos
                         properties:
                           catRangeEndPercent:
-                            default: 100
                             description: LLC available range end for pods by percentage
                             format: int64
                             maximum: 100
                             minimum: 0
                             type: integer
                           catRangeStartPercent:
-                            default: 0
                             description: LLC available range start for pods by percentage
                             format: int64
                             maximum: 100
@@ -507,7 +495,6 @@ spec:
                               is enabled.
                             type: boolean
                           mbaPercent:
-                            default: 100
                             description: MBA percent
                             format: int64
                             maximum: 100
@@ -636,14 +623,12 @@ spec:
                           qos
                         properties:
                           catRangeEndPercent:
-                            default: 100
                             description: LLC available range end for pods by percentage
                             format: int64
                             maximum: 100
                             minimum: 0
                             type: integer
                           catRangeStartPercent:
-                            default: 0
                             description: LLC available range start for pods by percentage
                             format: int64
                             maximum: 100
@@ -654,7 +639,6 @@ spec:
                               is enabled.
                             type: boolean
                           mbaPercent:
-                            default: 100
                             description: MBA percent
                             format: int64
                             maximum: 100
@@ -783,14 +767,12 @@ spec:
                           qos
                         properties:
                           catRangeEndPercent:
-                            default: 100
                             description: LLC available range end for pods by percentage
                             format: int64
                             maximum: 100
                             minimum: 0
                             type: integer
                           catRangeStartPercent:
-                            default: 0
                             description: LLC available range start for pods by percentage
                             format: int64
                             maximum: 100
@@ -801,7 +783,6 @@ spec:
                               is enabled.
                             type: boolean
                           mbaPercent:
-                            default: 100
                             description: MBA percent
                             format: int64
                             maximum: 100
@@ -833,7 +814,6 @@ spec:
                     description: CPUSuppressPolicy
                     type: string
                   cpuSuppressThresholdPercent:
-                    default: 65
                     description: cpu suppress threshold percentage (0,100), default
                       = 65
                     format: int64
@@ -852,7 +832,6 @@ spec:
                     minimum: 0
                     type: integer
                   memoryEvictThresholdPercent:
-                    default: 70
                     description: 'upper: memory evict threshold percentage (0,100),
                       default = 70'
                     format: int64


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fixes the kubebuilder tags of Resctrl QoS to suppress BE pods' cache allocation and memory bandwidth by default.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Currently, the parameters of Resctrl QoS have been set kubebuilder tags `+kubebuilder:default=xxx`, which always sets some values (e.g. 100%) for the corresponding fields in NodeSLO if we do not specify these fields explicitly. This troubles the Resctrl settings for BE pods since when we only specify `ResctrlQOS.Enable=true`, the real default values of BE pods (e.g. 30%) are overwrited.

### Ⅲ. Describe how to verify it

0. Prepare an Intel bare-metal machine that enables Intel RDT (L3 CAT & MBA) in the kernel command line.
1. Edit `slo-controller-config` and enable `ResctrlQOS` for BE pods.
2. Check `/sys/fs/resctrl/BE/schemata` if the L3 cache allocation and memory bandwidth are limited to 30%.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
