### PR TITLE
koordlet: fix throw Can't get node error during initialization

### DIFF
--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -17,11 +17,13 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -98,8 +100,8 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 		}
 		klog.Infof("can not detect cgroup driver from 'kubepods' cgroup name")
 
-		node := statesInformer.GetNode()
-		if node == nil {
+		node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, v1.GetOptions{})
+		if err != nil || node == nil {
 			klog.Error("Can't get node")
 			return false, nil
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

fix the Koordlet throw "Can't get node" during during initialization, when guessed driver failed from Cgroup name.

### Ⅱ. Does this pull request fix one issue?

fixes https://github.com/koordinator-sh/koordinator/issues/664

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
