### PR TITLE
koord-scheduler: fix the lack of gang function conversion

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -196,7 +196,7 @@ func SetDeviceAllocations(pod *corev1.Pod, allocations DeviceAllocations) error 
 	return nil
 }
 
-func GetMinNum(pod *corev1.Pod) (int, error) {
+var GetMinNum = func(pod *corev1.Pod) (int, error) {
 	minRequiredNum, err := strconv.ParseInt(pod.Annotations[AnnotationGangMinNum], 10, 32)
 	if err != nil {
 		return 0, err
@@ -204,6 +204,6 @@ func GetMinNum(pod *corev1.Pod) (int, error) {
 	return int(minRequiredNum), nil
 }
 
-func GetGangName(pod *corev1.Pod) string {
+var GetGangName = func(pod *corev1.Pod) string {
 	return pod.Annotations[AnnotationGangName]
 }


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
gang的函数扩展的时候，漏了func  xxx ->var xxx  = func()。
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
