### PR TITLE
fix: error to init option(SysRootDir)

### DIFF
--- a/pkg/util/system/config.go
+++ b/pkg/util/system/config.go
@@ -86,7 +86,7 @@ func SetConf(config Config) {
 
 func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.CgroupRootDir, "cgroup-root-dir", c.CgroupRootDir, "Cgroup root dir")
-	fs.StringVar(&c.SysFSRootDir, "sys-root-dir", c.SysFSRootDir, "host /sys dir in container")
+	fs.StringVar(&c.SysRootDir, "sys-root-dir", c.SysRootDir, "host /sys dir in container")
 	fs.StringVar(&c.SysFSRootDir, "sys-fs-root-dir", c.SysFSRootDir, "host /sys/fs dir in container, used by resctrl fs")
 	fs.StringVar(&c.ProcRootDir, "proc-root-dir", c.ProcRootDir, "host /proc dir in container")
 	fs.StringVar(&c.VarRunRootDir, "var-run-root-dir", c.VarRunRootDir, "host /var/run dir in container")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
option(SysRootDir) initialization error, but this variable is also useless, should we keep it?

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
