### PR TITLE
apis: change the required fields in ClusterColocationProfile to optional

### DIFF
--- a/apis/config/v1alpha1/cluster_colocation_profile_types.go
+++ b/apis/config/v1alpha1/cluster_colocation_profile_types.go
@@ -42,7 +42,7 @@ type ClusterColocationProfileSpec struct {
 	// The value will be injected into Pod as label koordinator.sh/qosClass.
 	// Options are LSE/LSR/LS/BE/SYSTEM.
 	// +kubebuilder:validation:Enum=LSE;LSR;LS;BE;SYSTEM
-	// +required
+	// +optional
 	QoSClass string `json:"qosClass"`
 
 	// If specified, the priorityClassName and the priority value defined in PriorityClass
@@ -51,7 +51,7 @@ type ClusterColocationProfileSpec struct {
 	// KoordinatorPriority will affect the scheduling, preemption and
 	// other behaviors of Koordinator system.
 	// +kubebuilder:validation:Enum=koord-prod;koord-mid;koord-batch;koord-free
-	// +required
+	// +optional
 	PriorityClassName string `json:"priorityClassName"`
 
 	// KoordinatorPriority defines the Pod sub-priority in Koordinator.

--- a/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
+++ b/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
@@ -180,9 +180,6 @@ spec:
                       are ANDed.
                     type: object
                 type: object
-            required:
-            - priorityClassName
-            - qosClass
             type: object
           status:
             description: ClusterColocationProfileStatus represents information about


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

The user only wants to use ColocationProfile to change the schedulerName of the Pod. The original required field needs to be changed to optional.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #739 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
