### PR TITLE
koordlet: fix kubelet pid not found in tcp4 socks

### DIFF
--- a/pkg/util/system/common_linux.go
+++ b/pkg/util/system/common_linux.go
@@ -52,14 +52,14 @@ type portAndPid struct {
 }
 
 func TCPSocks(fn netstat.AcceptFn) ([]netstat.SockTabEntry, error) {
+	v6Socks, v6Err := netstat.TCP6Socks(fn)
+	if v6Err == nil && v6Socks != nil && len(v6Socks) > 0 {
+		return v6Socks, nil
+	}
+
 	socks, err := netstat.TCPSocks(fn)
 	if err == nil && socks != nil {
 		return socks, nil
-	}
-
-	v6Socks, v6Err := netstat.TCP6Socks(fn)
-	if v6Err == nil && v6Socks != nil {
-		return v6Socks, nil
 	}
 
 	return nil, utilerrors.NewAggregate([]error{err, v6Err})


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix when the kubelet uses tcp6 socks stats_noderesourcetopology fails to calculate node topo.

Error msg: `states_noderesourcetopology.go:302] failed to calculate node topology, err: failed to get Kubeletcommand linee with kubeletPort 10250, err: failed to getPIDd, the port is not used`

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

After #744, when retrieving kubelet's PID via netstat, koordlet always uses tcp4 socks instead of tcp6 socks, since even if there is no kubelet port set in tcp4, `netstat.TCP6Socks()` can return an empty result with non-error. It makes the koordlet ignores the kubelet port in tcp6 unexpectedly.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
