### PR TITLE
koordlet: add runtime hook plugin batch resource

### DIFF
--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -24,6 +24,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/featuregate"
 
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/batchresource"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/cpuset"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/gpu"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/groupidentity"
@@ -34,6 +35,7 @@ const (
 	GroupIdentity   featuregate.Feature = "GroupIdentity"
 	CPUSetAllocator featuregate.Feature = "CPUSetAllocator"
 	GPUEnvInject    featuregate.Feature = "GPUEnvInject"
+	BatchResource   featuregate.Feature = "BatchResource"
 )
 
 var (
@@ -44,12 +46,14 @@ var (
 		GroupIdentity:   {Default: false, PreRelease: featuregate.Alpha},
 		CPUSetAllocator: {Default: false, PreRelease: featuregate.Alpha},
 		GPUEnvInject:    {Default: false, PreRelease: featuregate.Alpha},
+		BatchResource:   {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	runtimeHookPlugins = map[featuregate.Feature]HookPlugin{
 		GroupIdentity:   groupidentity.Object(),
 		CPUSetAllocator: cpuset.Object(),
 		GPUEnvInject:    gpu.Object(),
+		BatchResource:   batchresource.Object(),
 	}
 )
 

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"fmt"
+	"sync"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/reconciler"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/rule"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	rmconfig "github.com/koordinator-sh/koordinator/pkg/runtimeproxy/config"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/util/system"
+)
+
+const (
+	name        = "BatchResource"
+	description = "set fundamental cgroups value for batch pod"
+)
+
+type plugin struct {
+	rule        *batchResourceRule
+	ruleRWMutex sync.RWMutex
+}
+
+var podQOSConditions = []string{string(apiext.QoSBE), string(apiext.QoSLS), string(apiext.QoSNone)}
+
+func (p *plugin) Register() {
+	klog.V(5).Infof("register hook %v", name)
+	rule.Register(name, description,
+		rule.WithParseFunc(statesinformer.RegisterTypeNodeSLOSpec, p.parseRule),
+		rule.WithUpdateCallback(p.ruleUpdateCb))
+	hooks.Register(rmconfig.PreRunPodSandbox, name, description+" (pod)", p.SetPodResources)
+	hooks.Register(rmconfig.PreCreateContainer, name, description+" (container)", p.SetContainerResources)
+	hooks.Register(rmconfig.PreUpdateContainerResources, name, description+" (container)", p.SetContainerResources)
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUShares, description+" (pod cpu shares)",
+		p.SetPodCPUShares, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUCFSQuota, description+" (pod cfs quota)",
+		p.SetPodCFSQuota, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.MemoryLimit, description+" (pod memory limit)",
+		p.SetPodMemoryLimit, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.ContainerLevel, sysutil.CPUShares, description+" (container cpu shares)",
+		p.SetContainerCPUShares, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.ContainerLevel, sysutil.CPUCFSQuota, description+" (container cfs quota)",
+		p.SetContainerCFSQuota, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.ContainerLevel, sysutil.MemoryLimit, description+" (container memory limit)",
+		p.SetContainerMemoryLimit, reconciler.PodQOSFilter(), podQOSConditions...)
+}
+
+var singleton *plugin
+
+func Object() *plugin {
+	if singleton == nil {
+		singleton = &plugin{}
+	}
+	return singleton
+}
+
+func (p *plugin) SetPodResources(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("pod protocol is nil for plugin %v", name)
+	}
+
+	err := p.SetPodCPUShares(proto)
+	if err != nil {
+		klog.V(5).Infof("failed to set pod cpu shares in plugin %s, pod %s/%s, err: %v",
+			name, podCtx.Request.PodMeta.Namespace, podCtx.Request.PodMeta.Name, err)
+	}
+
+	err1 := p.SetPodCFSQuota(proto)
+	if err1 != nil {
+		klog.V(5).Infof("failed to set pod cfs quota in plugin %s, pod %s/%s, err: %v",
+			name, podCtx.Request.PodMeta.Namespace, podCtx.Request.PodMeta.Name, err1)
+	}
+
+	err2 := p.SetPodMemoryLimit(proto)
+	if err2 != nil {
+		klog.V(5).Infof("failed to set pod memory limit in plugin %s, pod %s/%s, err: %v",
+			name, podCtx.Request.PodMeta.Namespace, podCtx.Request.PodMeta.Name, err2)
+	}
+
+	return utilerrors.NewAggregate([]error{err, err1, err2})
+}
+
+func (p *plugin) SetPodCPUShares(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("pod protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(podCtx.Request.Labels, podCtx.Request.Annotations) {
+		return nil
+	}
+
+	extendedResourceSpec := podCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if extendedResourceSpec == nil {
+		return nil
+	}
+
+	milliCPURequest := int64(0)
+	// TODO: count init container and pod overhead
+	for _, c := range extendedResourceSpec.Containers {
+		if c.Requests == nil {
+			continue
+		}
+		q, ok := c.Requests[apiext.BatchCPU]
+		if !ok {
+			continue
+		}
+		milliCPURequest += q.Value()
+	}
+	cpuShares := milliCPURequest * sysutil.CPUShareUnitValue / 1000
+	if cpuShares < sysutil.CPUSharesMinValue {
+		cpuShares = sysutil.CPUSharesMinValue
+	}
+
+	podCtx.Response.Resources.CPUShares = pointer.Int64Ptr(cpuShares)
+	return nil
+}
+
+func (p *plugin) SetPodCFSQuota(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("pod protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(podCtx.Request.Labels, podCtx.Request.Annotations) {
+		return nil
+	}
+
+	extendedResourceSpec := podCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if extendedResourceSpec == nil {
+		return nil
+	}
+
+	// if cfs quota is disabled, set as -1
+	if !p.getRule().getEnableCFSQuota() {
+		podCtx.Response.Resources.CFSQuota = pointer.Int64Ptr(-1)
+		klog.V(5).Infof("try to unset pod-level cfs quota since it is disabled in rule of plugin %v", name)
+		return nil
+	}
+
+	milliCPULimit := int64(0)
+	// TODO: count init container and pod overhead
+	for _, c := range extendedResourceSpec.Containers {
+		if c.Limits == nil {
+			continue
+		}
+		q, ok := c.Limits[apiext.BatchCPU]
+		if !ok || q.Value() <= 0 { // pod unlimited once a container is unlimited
+			milliCPULimit = -1
+			break
+		}
+		milliCPULimit += q.Value()
+	}
+
+	cfsQuota := milliCPULimit * sysutil.CFSBasePeriodValue / 1000 // TBD: assert base cfs period not changed
+	if cfsQuota <= 0 {                                            // pod unlimited
+		cfsQuota = -1
+	}
+	if cfsQuota < sysutil.CFSQuotaMinValue { // cfs_quota_us should be no less than 1000
+		cfsQuota = sysutil.CFSQuotaMinValue
+	}
+
+	podCtx.Response.Resources.CFSQuota = pointer.Int64Ptr(cfsQuota)
+	return nil
+}
+
+func (p *plugin) SetPodMemoryLimit(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("pod protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(podCtx.Request.Labels, podCtx.Request.Annotations) {
+		return nil
+	}
+
+	extendedResourceSpec := podCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if extendedResourceSpec == nil {
+		return nil
+	}
+
+	memoryLimit := int64(0)
+	// TODO: count init container and pod overhead
+	for _, c := range extendedResourceSpec.Containers {
+		if c.Limits == nil {
+			continue
+		}
+		q, ok := c.Limits[apiext.BatchMemory]
+		if !ok || q.Value() <= 0 { // pod unlimited once a container is unlimited
+			memoryLimit = -1
+			break
+		}
+		memoryLimit += q.Value()
+	}
+
+	podCtx.Response.Resources.MemoryLimit = pointer.Int64Ptr(memoryLimit)
+	return nil
+}
+
+func (p *plugin) SetContainerResources(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %v", name)
+	}
+
+	err := p.SetContainerCPUShares(proto)
+	if err != nil {
+		klog.V(5).Infof("failed to set container cpu shares in plugin %s, container %s/%s/%s, err: %v",
+			name, containerCtx.Request.PodMeta.Namespace, containerCtx.Request.PodMeta.Name,
+			containerCtx.Request.ContainerMeta.Name, err)
+	}
+
+	err1 := p.SetContainerCFSQuota(proto)
+	if err1 != nil {
+		klog.V(5).Infof("failed to set container cfs quota in plugin %s, container %s/%s/%s, err: %v",
+			name, containerCtx.Request.PodMeta.Namespace, containerCtx.Request.PodMeta.Name,
+			containerCtx.Request.ContainerMeta.Name, err)
+	}
+
+	err2 := p.SetContainerMemoryLimit(proto)
+	if err2 != nil {
+		klog.V(5).Infof("failed to set container memory limit in plugin %s, container %s/%s/%s, err: %v",
+			name, containerCtx.Request.PodMeta.Namespace, containerCtx.Request.PodMeta.Name,
+			containerCtx.Request.ContainerMeta.Name, err)
+	}
+
+	return utilerrors.NewAggregate([]error{err, err1, err2})
+}
+
+func (p *plugin) SetContainerCPUShares(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(containerCtx.Request.PodLabels, containerCtx.Request.PodAnnotations) {
+		return nil
+	}
+
+	containerSpec := containerCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if containerSpec == nil {
+		return nil
+	}
+
+	milliCPURequest := int64(0)
+	if containerSpec.Requests != nil {
+		q, ok := containerSpec.Requests[apiext.BatchCPU]
+		if ok {
+			milliCPURequest = q.Value()
+		}
+	}
+	cpuShares := milliCPURequest * sysutil.CPUShareUnitValue / 1000
+	if cpuShares < sysutil.CPUSharesMinValue {
+		cpuShares = sysutil.CPUSharesMinValue
+	}
+
+	containerCtx.Response.Resources.CPUShares = pointer.Int64Ptr(cpuShares)
+	return nil
+}
+
+func (p *plugin) SetContainerCFSQuota(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(containerCtx.Request.PodLabels, containerCtx.Request.PodAnnotations) {
+		return nil
+	}
+
+	containerSpec := containerCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if containerSpec == nil {
+		return nil
+	}
+
+	// if cfs quota is disabled, set as -1
+	if !p.getRule().getEnableCFSQuota() {
+		containerCtx.Response.Resources.CFSQuota = pointer.Int64Ptr(-1)
+		klog.V(5).Infof("try to unset container-level cfs quota since it is disabled in rule of plugin %v", name)
+		return nil
+	}
+
+	milliCPULimit := int64(0)
+	if containerSpec.Limits != nil {
+		q, ok := containerSpec.Limits[apiext.BatchCPU]
+		if ok {
+			milliCPULimit = q.Value()
+		}
+	}
+	cfsQuota := milliCPULimit * sysutil.CFSBasePeriodValue / 1000
+	if cfsQuota <= 0 {
+		cfsQuota = -1
+	} else if cfsQuota < sysutil.CFSQuotaMinValue {
+		cfsQuota = sysutil.CFSQuotaMinValue
+	}
+
+	containerCtx.Response.Resources.CFSQuota = pointer.Int64Ptr(cfsQuota)
+	return nil
+}
+
+func (p *plugin) SetContainerMemoryLimit(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %v", name)
+	}
+
+	if !isPodQoSBEByAttr(containerCtx.Request.PodLabels, containerCtx.Request.PodAnnotations) {
+		return nil
+	}
+
+	containerSpec := containerCtx.Request.ExtendedResources
+	// if the extendedResourceSpec is empty, do nothing and keep the original cgroup configs
+	if containerSpec == nil {
+		return nil
+	}
+
+	memoryLimit := int64(0)
+	if containerSpec.Limits != nil {
+		q, ok := containerSpec.Limits[apiext.BatchMemory]
+		if ok {
+			memoryLimit = q.Value()
+		}
+	}
+	if memoryLimit <= 0 {
+		memoryLimit = -1
+	}
+
+	containerCtx.Response.Resources.MemoryLimit = pointer.Int64Ptr(memoryLimit)
+	return nil
+}
+
+func isPodQoSBEByAttr(labels map[string]string, annotations map[string]string) bool {
+	if labels == nil || annotations == nil {
+		return false
+	}
+	return apiext.GetQoSClassByAttrs(labels, annotations) == apiext.QoSBE
+}

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource_test.go
@@ -1,0 +1,597 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+)
+
+func Test_plugin_Register(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		p := &plugin{}
+		p.Register()
+	})
+}
+
+func TestObject(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		p := Object()
+		assert.Equal(t, &plugin{}, p)
+	})
+}
+
+func Test_plugin_SetPodResources(t *testing.T) {
+	var testNilProto *protocol.PodContext
+	testEmptySpec := &apiext.ExtendedResourceSpec{}
+	testEmptySpecBytes, err := json.Marshal(testEmptySpec)
+	assert.NoError(t, err)
+	testSpec := &apiext.ExtendedResourceSpec{
+		Containers: map[string]apiext.ExtendedResourceContainerSpec{
+			"container-0": {
+				Requests: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	testSpecBytes, err := json.Marshal(testSpec)
+	assert.NoError(t, err)
+	testSpec1 := &apiext.ExtendedResourceSpec{
+		Containers: map[string]apiext.ExtendedResourceContainerSpec{
+			"container-0": {
+				Requests: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+			"container-1": {
+				Limits: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("1000"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	testSpecBytes1, err := json.Marshal(testSpec1)
+	assert.NoError(t, err)
+	type fields struct {
+		rule *batchResourceRule
+	}
+	type args struct {
+		proto protocol.HooksProtocol
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    protocol.HooksProtocol
+		wantErr bool
+	}{
+		{
+			name: "nil proto",
+			args: args{
+				proto: testNilProto,
+			},
+			want:    testNilProto,
+			wantErr: true,
+		},
+		{
+			name: "not a Batch pod",
+			args: args{
+				proto: &protocol.PodContext{
+					Request: protocol.PodRequest{},
+				},
+			},
+			want: &protocol.PodContext{
+				Request: protocol.PodRequest{},
+			},
+		},
+		{
+			name: "a Batch pod without requests",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.PodContext{
+					Request: protocol.PodRequest{
+						Labels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						Annotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testEmptySpecBytes),
+						},
+					},
+				},
+			},
+			want: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testEmptySpecBytes),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch pod with cfs quota unset",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: false,
+				},
+			},
+			args: args{
+				proto: &protocol.PodContext{
+					Request: protocol.PodRequest{
+						Labels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						Annotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ExtendedResources: testSpec,
+					},
+				},
+			},
+			want: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ExtendedResources: testSpec,
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(1024 * 500 / 1000),
+						CFSQuota:    pointer.Int64Ptr(-1),
+						MemoryLimit: pointer.Int64Ptr(2 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch pod with cpu memory requests",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.PodContext{
+					Request: protocol.PodRequest{
+						Labels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						Annotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ExtendedResources: testSpec,
+					},
+				},
+			},
+			want: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ExtendedResources: testSpec,
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(1024 * 500 / 1000),
+						CFSQuota:    pointer.Int64Ptr(100000 * 500 / 1000),
+						MemoryLimit: pointer.Int64Ptr(2 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch pod with cpu memory requests 1",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.PodContext{
+					Request: protocol.PodRequest{
+						Labels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						Annotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes1),
+						},
+						ExtendedResources: testSpec1,
+					},
+				},
+			},
+			want: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes1),
+					},
+					ExtendedResources: testSpec1,
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(1024 * 500 / 1000),
+						CFSQuota:    pointer.Int64Ptr(100000 * 1500 / 1000),
+						MemoryLimit: pointer.Int64Ptr(4 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &plugin{
+				rule: tt.fields.rule,
+			}
+			err := p.SetPodResources(tt.args.proto)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, tt.args.proto)
+		})
+	}
+}
+
+func Test_plugin_SetContainerResources(t *testing.T) {
+	var testNilProto *protocol.ContainerContext
+	testEmptySpec := &apiext.ExtendedResourceSpec{}
+	testEmptySpecBytes, err := json.Marshal(testEmptySpec)
+	assert.NoError(t, err)
+	testContainerSpec := &apiext.ExtendedResourceContainerSpec{
+		Requests: corev1.ResourceList{
+			apiext.BatchCPU:    resource.MustParse("500"),
+			apiext.BatchMemory: resource.MustParse("2Gi"),
+		},
+		Limits: corev1.ResourceList{
+			apiext.BatchCPU:    resource.MustParse("500"),
+			apiext.BatchMemory: resource.MustParse("2Gi"),
+		},
+	}
+	testSpec := &apiext.ExtendedResourceSpec{
+		Containers: map[string]apiext.ExtendedResourceContainerSpec{
+			"container-0": *testContainerSpec,
+		},
+	}
+	testSpecBytes, err := json.Marshal(testSpec)
+	assert.NoError(t, err)
+	testContainerSpec1 := &apiext.ExtendedResourceContainerSpec{
+		Limits: corev1.ResourceList{
+			apiext.BatchCPU:    resource.MustParse("1000"),
+			apiext.BatchMemory: resource.MustParse("2Gi"),
+		},
+	}
+	testSpec1 := &apiext.ExtendedResourceSpec{
+		Containers: map[string]apiext.ExtendedResourceContainerSpec{
+			"container-0": *testContainerSpec,
+			"container-1": *testContainerSpec1,
+		},
+	}
+	testSpecBytes1, err := json.Marshal(testSpec1)
+	assert.NoError(t, err)
+	type fields struct {
+		rule *batchResourceRule
+	}
+	type args struct {
+		proto protocol.HooksProtocol
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    protocol.HooksProtocol
+		wantErr bool
+	}{
+		{
+			name: "nil proto",
+			args: args{
+				proto: testNilProto,
+			},
+			want:    testNilProto,
+			wantErr: true,
+		},
+		{
+			name: "not a Batch container",
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{},
+			},
+		},
+		{
+			name: "a Batch container without requests",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testEmptySpecBytes),
+						},
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testEmptySpecBytes),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch container with cfs quota unset",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: false,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ContainerMeta: protocol.ContainerMeta{
+							Name: "container-0",
+						},
+						ExtendedResources: testContainerSpec,
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ContainerMeta: protocol.ContainerMeta{
+						Name: "container-0",
+					},
+					ExtendedResources: testContainerSpec,
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(1024 * 500 / 1000),
+						CFSQuota:    pointer.Int64Ptr(-1),
+						MemoryLimit: pointer.Int64Ptr(2 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch container with requests not matched",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ContainerMeta: protocol.ContainerMeta{
+							Name: "container-1",
+						},
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ContainerMeta: protocol.ContainerMeta{
+						Name: "container-1",
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch container with requests",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ContainerMeta: protocol.ContainerMeta{
+							Name: "container-0",
+						},
+						ExtendedResources: testContainerSpec,
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ContainerMeta: protocol.ContainerMeta{
+						Name: "container-0",
+					},
+					ExtendedResources: testContainerSpec,
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(1024 * 500 / 1000),
+						CFSQuota:    pointer.Int64Ptr(100000 * 500 / 1000),
+						MemoryLimit: pointer.Int64Ptr(2 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch container with requests not matched",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+						},
+						ContainerMeta: protocol.ContainerMeta{
+							Name: "container-1",
+						},
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+					},
+					ContainerMeta: protocol.ContainerMeta{
+						Name: "container-1",
+					},
+				},
+			},
+		},
+		{
+			name: "a Batch container with requests 1",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				proto: &protocol.ContainerContext{
+					Request: protocol.ContainerRequest{
+						PodLabels: map[string]string{
+							apiext.LabelPodQoS: string(apiext.QoSBE),
+						},
+						PodAnnotations: map[string]string{
+							apiext.AnnotationExtendedResourceSpec: string(testSpecBytes1),
+						},
+						ContainerMeta: protocol.ContainerMeta{
+							Name: "container-1",
+						},
+						ExtendedResources: testContainerSpec1,
+					},
+				},
+			},
+			want: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+					PodAnnotations: map[string]string{
+						apiext.AnnotationExtendedResourceSpec: string(testSpecBytes1),
+					},
+					ContainerMeta: protocol.ContainerMeta{
+						Name: "container-1",
+					},
+					ExtendedResources: testContainerSpec1,
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CPUShares:   pointer.Int64Ptr(2),
+						CFSQuota:    pointer.Int64Ptr(100000 * 1000 / 1000),
+						MemoryLimit: pointer.Int64Ptr(2 * 1024 * 1024 * 1024),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &plugin{
+				rule: tt.fields.rule,
+			}
+			err := p.SetContainerResources(tt.args.proto)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, tt.args.proto)
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"reflect"
+
+	"k8s.io/klog/v2"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+type batchResourceRule struct {
+	enableCFSQuota bool
+}
+
+func (r *batchResourceRule) getEnableCFSQuota() bool {
+	if r == nil {
+		return true
+	}
+	return r.enableCFSQuota
+}
+
+func (p *plugin) parseRule(mergedNodeSLOIf interface{}) (bool, error) {
+	mergedNodeSLO := mergedNodeSLOIf.(*slov1alpha1.NodeSLOSpec)
+
+	enableCFSQuota := true
+	// NOTE: If CPU Suppress Policy `CPUCfsQuotaPolicy` is enabled for batch pods, batch pods' cfs_quota should be unset
+	// since the cfs quota of `kubepods-besteffort` is required to be no less than the children's. Then the cpu usage
+	// of Batch is limited by pod-level cpu.shares and qos-level cfs_quota.
+	if enable, policy := getCPUSuppressPolicy(mergedNodeSLO); enable && policy == slov1alpha1.CPUCfsQuotaPolicy {
+		enableCFSQuota = false
+	}
+
+	rule := &batchResourceRule{
+		enableCFSQuota: enableCFSQuota,
+	}
+
+	updated := p.updateRule(rule)
+	klog.V(4).Infof("runtime hook plugin %s update rule %v, new rule %v", name, updated, rule)
+	return updated, nil
+}
+
+func (p *plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
+	r := p.getRule()
+	if r == nil {
+		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
+		return nil
+	}
+	for _, podMeta := range pods {
+		podQOS := apiext.GetPodQoSClass(podMeta.Pod)
+		if podQOS != apiext.QoSBE {
+			continue
+		}
+		// pod-level
+		podCtx := &protocol.PodContext{}
+		podCtx.FromReconciler(podMeta)
+		if err := p.SetPodCFSQuota(podCtx); err != nil { // only need to change cfs quota
+			klog.V(4).Infof("failed to set pod cfs quota during callback %v, err: %v", name, err)
+			continue
+		}
+		podCtx.ReconcilerDone()
+		// container-level
+		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+			containerCtx := &protocol.ContainerContext{}
+			containerCtx.FromReconciler(podMeta, containerStat.Name)
+			if err := p.SetContainerCFSQuota(containerCtx); err != nil {
+				klog.V(4).Infof("failed to set container cfs quota during callback %v, container %v, err: %v",
+					name, containerStat.Name, err)
+				continue
+			}
+			containerCtx.ReconcilerDone()
+		}
+	}
+	return nil
+}
+
+func (p *plugin) getRule() *batchResourceRule {
+	p.ruleRWMutex.RLock()
+	defer p.ruleRWMutex.RUnlock()
+	if p.rule == nil {
+		return nil
+	}
+	rule := *p.rule
+	return &rule
+}
+
+func (p *plugin) updateRule(newRule *batchResourceRule) bool {
+	p.ruleRWMutex.Lock()
+	defer p.ruleRWMutex.Unlock()
+	if !reflect.DeepEqual(newRule, p.rule) {
+		p.rule = newRule
+		return true
+	}
+	return false
+}
+
+func getCPUSuppressPolicy(nodeSLOSpec *slov1alpha1.NodeSLOSpec) (bool, slov1alpha1.CPUSuppressPolicy) {
+	if nodeSLOSpec == nil || nodeSLOSpec.ResourceUsedThresholdWithBE == nil ||
+		nodeSLOSpec.ResourceUsedThresholdWithBE.CPUSuppressPolicy == "" {
+		return *util.DefaultResourceThresholdStrategy().Enable,
+			util.DefaultResourceThresholdStrategy().CPUSuppressPolicy
+	}
+	return *nodeSLOSpec.ResourceUsedThresholdWithBE.Enable,
+		nodeSLOSpec.ResourceUsedThresholdWithBE.CPUSuppressPolicy
+}

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/util/system"
+)
+
+func Test_plugin_parseRule(t *testing.T) {
+	type fields struct {
+		rule *batchResourceRule
+	}
+	type args struct {
+		mergedNodeSLO *slov1alpha1.NodeSLOSpec
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     bool
+		wantErr  bool
+		wantRule *batchResourceRule
+	}{
+		{
+			name:    "initialize true",
+			want:    true,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: true,
+			},
+		},
+		{
+			name: "initialize false",
+			args: args{
+				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{
+					ResourceUsedThresholdWithBE: &slov1alpha1.ResourceThresholdStrategy{
+						Enable:            pointer.Bool(true),
+						CPUSuppressPolicy: slov1alpha1.CPUCfsQuotaPolicy,
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: false,
+			},
+		},
+		{
+			name: "rule change to false",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{
+					ResourceUsedThresholdWithBE: &slov1alpha1.ResourceThresholdStrategy{
+						Enable:            pointer.Bool(true),
+						CPUSuppressPolicy: slov1alpha1.CPUCfsQuotaPolicy,
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: false,
+			},
+		},
+		{
+			name: "rule change to true",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: false,
+				},
+			},
+			args: args{
+				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{},
+			},
+			want:    true,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: true,
+			},
+		},
+		{
+			name: "rule not change as true",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{},
+			},
+			want:    false,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: true,
+			},
+		},
+		{
+			name: "rule not change as false",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: false,
+				},
+			},
+			args: args{
+				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{
+					ResourceUsedThresholdWithBE: &slov1alpha1.ResourceThresholdStrategy{
+						Enable:            pointer.Bool(true),
+						CPUSuppressPolicy: slov1alpha1.CPUCfsQuotaPolicy,
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+			wantRule: &batchResourceRule{
+				enableCFSQuota: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := plugin{
+				rule: tt.fields.rule,
+			}
+			got, err := p.parseRule(tt.args.mergedNodeSLO)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantRule, p.rule)
+		})
+	}
+}
+
+func Test_plugin_ruleUpdateCb(t *testing.T) {
+	testSpec := &apiext.ExtendedResourceSpec{
+		Containers: map[string]apiext.ExtendedResourceContainerSpec{
+			"container-0": {
+				Requests: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					apiext.BatchCPU:    resource.MustParse("500"),
+					apiext.BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	testSpecBytes, err := json.Marshal(testSpec)
+	assert.NoError(t, err)
+	type fields struct {
+		rule *batchResourceRule
+	}
+	type args struct {
+		pods []*statesinformer.PodMeta
+	}
+	type want struct {
+		cfsQuota string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		want    []want
+	}{
+		{
+			name:    "rule is nil",
+			wantErr: false,
+			want: []want{
+				{
+					cfsQuota: "-1",
+				},
+			},
+		},
+		{
+			name: "update no Batch pods",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				pods: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "123456",
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										ContainerID: "docker://abcdef",
+									},
+								},
+							},
+						},
+						CgroupDir: "/kubepods-besteffort.slice/kubepods-besteffort-pod123456.slice/",
+					},
+				},
+			},
+			wantErr: false,
+			want: []want{
+				{
+					cfsQuota: "-1",
+				},
+			},
+		},
+		{
+			name: "update a Batch pods",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: true,
+				},
+			},
+			args: args{
+				pods: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "123456",
+								Labels: map[string]string{
+									apiext.LabelPodQoS: string(apiext.QoSBE),
+								},
+								Annotations: map[string]string{
+									apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "container-0",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												apiext.BatchCPU:    resource.MustParse("500"),
+												apiext.BatchMemory: resource.MustParse("2Gi"),
+											},
+											Limits: corev1.ResourceList{
+												apiext.BatchCPU:    resource.MustParse("500"),
+												apiext.BatchMemory: resource.MustParse("2Gi"),
+											},
+										},
+									},
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "container-0",
+										ContainerID: "docker://abcdef",
+									},
+								},
+							},
+						},
+						CgroupDir: "/kubepods-besteffort.slice/kubepods-besteffort-pod123456.slice/",
+					},
+				},
+			},
+			wantErr: false,
+			want: []want{
+				{
+					cfsQuota: "50000",
+				},
+			},
+		},
+		{
+			name: "update a Batch pods for unset cfs quota",
+			fields: fields{
+				rule: &batchResourceRule{
+					enableCFSQuota: false,
+				},
+			},
+			args: args{
+				pods: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "123456",
+								Labels: map[string]string{
+									apiext.LabelPodQoS: string(apiext.QoSBE),
+								},
+								Annotations: map[string]string{
+									apiext.AnnotationExtendedResourceSpec: string(testSpecBytes),
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "container-0",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												apiext.BatchCPU:    resource.MustParse("500"),
+												apiext.BatchMemory: resource.MustParse("2Gi"),
+											},
+											Limits: corev1.ResourceList{
+												apiext.BatchCPU:    resource.MustParse("500"),
+												apiext.BatchMemory: resource.MustParse("2Gi"),
+											},
+										},
+									},
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "container-0",
+										ContainerID: "docker://abcdef",
+									},
+								},
+							},
+						},
+						CgroupDir: "/kubepods-besteffort.slice/kubepods-besteffort-pod123456.slice/",
+					},
+				},
+			},
+			wantErr: false,
+			want: []want{
+				{
+					cfsQuota: "-1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := sysutil.NewFileTestUtil(t)
+			// init cgroups cpuset file
+			for _, podMeta := range tt.args.pods {
+				cgroupDir := util.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+				helper.WriteCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota, "-1")
+				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+					cgroupDir, err := util.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					assert.NoError(t, err, "container "+containerStat.Name)
+					helper.WriteCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota, "-1")
+				}
+			}
+
+			p := plugin{
+				rule: tt.fields.rule,
+			}
+			err := p.ruleUpdateCb(tt.args.pods)
+			assert.Equal(t, tt.wantErr, err != nil)
+			// init cgroups cpuset file
+			for i, podMeta := range tt.args.pods {
+				w := tt.want[i]
+				cgroupDir := util.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+				assert.Equal(t, w.cfsQuota, helper.ReadCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota))
+				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+					cgroupDir, err := util.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					assert.NoError(t, err, "container "+containerStat.Name)
+					assert.Equal(t, w.cfsQuota, helper.ReadCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota))
+				}
+			}
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt.go
@@ -53,10 +53,10 @@ func (b *bvtPlugin) Register() {
 		rule.WithParseFunc(statesinformer.RegisterTypeNodeSLOSpec, b.parseRule),
 		rule.WithUpdateCallback(b.ruleUpdateCb),
 		rule.WithSystemSupported(b.SystemSupported))
-	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUBVTWarpNs, b.SetPodBvtValue,
-		"reconcile pod level cpu bvt value")
-	reconciler.RegisterCgroupReconciler(reconciler.KubeQOSLevel, sysutil.CPUBVTWarpNs, b.SetKubeQOSBvtValue,
-		"reconcile kubeqos level cpu bvt value")
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUBVTWarpNs, "reconcile pod level cpu bvt value",
+		b.SetPodBvtValue, reconciler.NoneFilter())
+	reconciler.RegisterCgroupReconciler(reconciler.KubeQOSLevel, sysutil.CPUBVTWarpNs, "reconcile kubeqos level cpu bvt value",
+		b.SetKubeQOSBvtValue, reconciler.NoneFilter())
 }
 
 func (b *bvtPlugin) SystemSupported() bool {

--- a/pkg/koordlet/runtimehooks/protocol/protocol.go
+++ b/pkg/koordlet/runtimehooks/protocol/protocol.go
@@ -55,28 +55,29 @@ var HooksProtocolBuilder = hooksProtocolBuilder{
 
 type Resources struct {
 	// origin resources
-	CPUShares *int64
-	CFSQuota  *int64
-	CPUSet    *string
+	CPUShares   *int64
+	CFSQuota    *int64
+	CPUSet      *string
+	MemoryLimit *int64
 
 	// extended resources
 	CPUBvt *int64
 }
 
 func (r *Resources) IsOriginResSet() bool {
-	return r.CPUShares != nil || r.CFSQuota != nil || r.CPUSet != nil
+	return r.CPUShares != nil || r.CFSQuota != nil || r.CPUSet != nil || r.MemoryLimit != nil
 }
 
 func injectCPUShares(cgroupParent string, cpuShares int64) error {
 	cpuShareStr := strconv.FormatInt(cpuShares, 10)
-	if err := sysutil.CgroupFileWrite(cgroupParent, sysutil.CPUShares, cpuShareStr); err != nil {
+	if err := sysutil.CgroupFileWriteIfDifferent(cgroupParent, sysutil.CPUShares, cpuShareStr); err != nil {
 		return err
 	}
 	return nil
 }
 
 func injectCPUSet(cgroupParent string, cpuset string) error {
-	if err := sysutil.CgroupFileWrite(cgroupParent, sysutil.CPUSet, cpuset); err != nil {
+	if err := sysutil.CgroupFileWriteIfDifferent(cgroupParent, sysutil.CPUSet, cpuset); err != nil {
 		return err
 	}
 	return nil
@@ -84,7 +85,15 @@ func injectCPUSet(cgroupParent string, cpuset string) error {
 
 func injectCPUQuota(cgroupParent string, cpuQuota int64) error {
 	cpuQuotaStr := strconv.FormatInt(cpuQuota, 10)
-	if err := sysutil.CgroupFileWrite(cgroupParent, sysutil.CPUCFSQuota, cpuQuotaStr); err != nil {
+	if err := sysutil.CgroupFileWriteIfDifferent(cgroupParent, sysutil.CPUCFSQuota, cpuQuotaStr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func injectMemoryLimit(cgroupParent string, memoryLimit int64) error {
+	memoryLimitStr := strconv.FormatInt(memoryLimit, 10)
+	if err := sysutil.CgroupFileWriteIfDifferent(cgroupParent, sysutil.MemoryLimit, memoryLimitStr); err != nil {
 		return err
 	}
 	return nil
@@ -92,7 +101,7 @@ func injectCPUQuota(cgroupParent string, cpuQuota int64) error {
 
 func injectCPUBvt(cgroupParent string, bvtValue int64) error {
 	bvtValueStr := strconv.FormatInt(bvtValue, 10)
-	if err := sysutil.CgroupFileWrite(cgroupParent, sysutil.CPUBVTWarpNs, bvtValueStr); err != nil {
+	if err := sysutil.CgroupFileWriteIfDifferent(cgroupParent, sysutil.CPUBVTWarpNs, bvtValueStr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
@@ -78,7 +78,7 @@ func Test_doKubeQOSCgroup(t *testing.T) {
 				tt.gots.kubeQOSVal[kubeQOS] = tt.args.targetOutput[kubeQOS]
 				return nil
 			}
-			RegisterCgroupReconciler(KubeQOSLevel, tt.args.file, reconcilerFn, tt.name)
+			RegisterCgroupReconciler(KubeQOSLevel, tt.args.file, tt.name, reconcilerFn, NoneFilter())
 			doKubeQOSCgroup()
 			assert.Equal(t, tt.wants.kubeQOSVal, tt.gots.kubeQOSVal, "kube qos map value should be equal")
 		})
@@ -118,8 +118,8 @@ func Test_reconciler_reconcilePodCgroup(t *testing.T) {
 		tryStopFn()
 		return nil
 	}
-	RegisterCgroupReconciler(PodLevel, system.CPUBVTWarpNs, podReconcilerFn, "get pod uid")
-	RegisterCgroupReconciler(ContainerLevel, system.CPUBVTWarpNs, containerReconcilerFn, "get container uid")
+	RegisterCgroupReconciler(PodLevel, system.CPUBVTWarpNs, "get pod uid", podReconcilerFn, NoneFilter())
+	RegisterCgroupReconciler(ContainerLevel, system.CPUBVTWarpNs, "get container uid", containerReconcilerFn, NoneFilter())
 
 	type fields struct {
 		podsMeta *statesinformer.PodMeta

--- a/pkg/koordlet/runtimehooks/rule/rule.go
+++ b/pkg/koordlet/runtimehooks/rule/rule.go
@@ -86,7 +86,7 @@ func UpdateRules(ruleType statesinformer.RegisterType, ruleObj interface{}, pods
 		}
 		if !r.systemSupported {
 			klog.V(4).Infof("system unsupported for rule %s, do nothing during UpdateRules", r.name)
-			return
+			continue
 		}
 		if r.parseRuleFn == nil {
 			continue

--- a/pkg/koordlet/runtimehooks/runtimehooks_test.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks_test.go
@@ -64,6 +64,26 @@ func Test_runtimeHook_Run(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// grpcurl -plaintext -unix $file runtime.v1alpha1.RuntimeHookService/PreRunPodSandboxHook
+			name: "run all feature-gates",
+			fields: fields{
+				config: &Config{
+					RuntimeHooksNetwork:       "unix",
+					RuntimeHooksAddr:          path.Join(tmpDir, "kooordlet.sock"),
+					RuntimeHooksFailurePolicy: "Fail",
+					RuntimeHookDisableStages:  []string{"PreRunPodSandbox"},
+					RuntimeHookConfigFilePath: tmpDir,
+					FeatureGates: map[string]bool{
+						string(GroupIdentity):   true,
+						string(CPUSetAllocator): true,
+						string(GPUEnvInject):    true,
+						string(BatchResource):   true,
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/pod_resources_utils.go
+++ b/pkg/util/pod_resources_utils.go
@@ -19,9 +19,16 @@ package util
 import (
 	corev1 "k8s.io/api/core/v1"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 )
 
 // NOTE: functions in this file can be overwritten for extension
+
+var ExtendedResourceNames = []corev1.ResourceName{
+	apiext.BatchCPU,
+	apiext.BatchMemory,
+}
 
 func GetPodMilliCPULimit(pod *corev1.Pod) int64 {
 	podCPUMilliLimit := int64(0)

--- a/pkg/util/system/cgroup_resource.go
+++ b/pkg/util/system/cgroup_resource.go
@@ -32,6 +32,8 @@ const ( // subsystems
 
 const (
 	CFSBasePeriodValue int64 = 100000
+	CFSQuotaMinValue   int64 = 1000 // min value except `-1`
+	CPUSharesMinValue  int64 = 2
 
 	CPUStatFileName   = "cpu.stat"
 	CPUSharesFileName = "cpu.shares"


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Add a runtime hook plugin named *BatchResource* to apply cpu/memory limitations for batch pods.

It will replace the old BEReconcile reconciler via runtime hook workflow.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #717 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
