### PR TITLE
api: pass extended resource spec via annotation

### DIFF
--- a/apis/extension/resource_test.go
+++ b/apis/extension/resource_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package extension
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -43,4 +45,131 @@ func TestSetResourceStatus(t *testing.T) {
 	assert.NoError(t, err)
 	expectedResourceStatus := `{"cpuset":"0-3"}`
 	assert.Equal(t, expectedResourceStatus, pod.Annotations[AnnotationResourceStatus])
+}
+
+func TestGetGetExtendedResourceSpec(t *testing.T) {
+	testSpec := &ExtendedResourceSpec{
+		Containers: map[string]ExtendedResourceContainerSpec{
+			"test-container-1": {
+				Requests: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("1Gi"),
+				},
+			},
+			"test-container-2": {
+				Requests: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	testBytes, err := json.Marshal(testSpec)
+	assert.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod-1",
+			Annotations: map[string]string{
+				AnnotationExtendedResourceSpec: string(testBytes),
+			},
+		},
+	}
+
+	got, err := GetExtendedResourceSpec(pod.Annotations)
+	assert.NoError(t, err)
+	assert.Equal(t, testSpec, got)
+
+	got, err = GetExtendedResourceSpec(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+
+	testInvalidAnnotations := map[string]string{
+		AnnotationExtendedResourceSpec: "invalidValue",
+	}
+	got, err = GetExtendedResourceSpec(testInvalidAnnotations)
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestSetExtendedResourceSpec(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod-1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							BatchCPU:    resource.MustParse("500"),
+							BatchMemory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							BatchCPU:    resource.MustParse("500"),
+							BatchMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+				{
+					Name: "test-container-2",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							BatchCPU:    resource.MustParse("500"),
+							BatchMemory: resource.MustParse("2Gi"),
+						},
+						Limits: corev1.ResourceList{
+							BatchCPU:    resource.MustParse("500"),
+							BatchMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	testSpec := &ExtendedResourceSpec{
+		Containers: map[string]ExtendedResourceContainerSpec{
+			"test-container-1": {
+				Requests: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("1Gi"),
+				},
+			},
+			"test-container-2": {
+				Requests: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					BatchCPU:    resource.MustParse("500"),
+					BatchMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+
+	err := SetExtendedResourceSpec(pod, testSpec)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, pod.Annotations)
+	gotValue := pod.Annotations[AnnotationExtendedResourceSpec]
+	gotSpec := &ExtendedResourceSpec{}
+	err = json.Unmarshal([]byte(gotValue), gotSpec)
+	assert.NoError(t, err)
+	assert.Equal(t, testSpec, gotSpec)
 }


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Add an annotation protocol for passing extended resource spec throughout CRI.

Currently, the CRI server cannot get the original pod spec but a calculated linux resource configuration derived from native resources (i.e. `CPU` and `Memory`). So the koordlet runtime hooks have no way to calculate Batch pods' `cpu.cfs_quota_us`, `cpu.shares` `memory.limit_in_bytes`, since Batch pods only specify extended resources.

With this patch, the extended cpu and memory resource requirements of Batch pods will be passed via the pod annotation, allowing the runtime hooks and other components to calculate correct `cpu.cfs_quota_us`, `cpu.shares` `memory.limit_in_bytes` for Batch pods.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Partially for #717.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
