### PR TITLE
koordlet: fix cpi collector bad fd err

### DIFF
--- a/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
@@ -18,6 +18,7 @@ package metricsadvisor
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -164,7 +165,9 @@ func Test_profilePerfOnSingleContainer(t *testing.T) {
 	containerStatus := &corev1.ContainerStatus{
 		ContainerID: "containerd://test",
 	}
-	perfCollector, _ := perf.NewPerfCollector(0, []int{})
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	perfCollector, _ := perf.NewPerfCollector(f, []int{})
 
 	c := NewPerformanceCollector(nil, m, 0)
 	assert.NotPanics(t, func() {

--- a/pkg/util/perf/perf_linux_test.go
+++ b/pkg/util/perf/perf_linux_test.go
@@ -26,10 +26,9 @@ import (
 func Test_NewPerfCollector(t *testing.T) {
 	tempDir := t.TempDir()
 	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
-	fd := int(f.Fd())
 	cpus := []int{0}
 	assert.NotPanics(t, func() {
-		_, err := NewPerfCollector(fd, cpus)
+		_, err := NewPerfCollector(f, cpus)
 		if err != nil {
 			return
 		}
@@ -39,10 +38,9 @@ func Test_NewPerfCollector(t *testing.T) {
 func Test_GetAndStartPerfCollectorOnContainer(t *testing.T) {
 	tempDir := t.TempDir()
 	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
-	fd := int(f.Fd())
 	cpus := []int{0}
 	assert.NotPanics(t, func() {
-		_, err := GetAndStartPerfCollectorOnContainer(fd, cpus)
+		_, err := GetAndStartPerfCollectorOnContainer(f, cpus)
 		if err != nil {
 			return
 		}
@@ -52,9 +50,8 @@ func Test_GetAndStartPerfCollectorOnContainer(t *testing.T) {
 func Test_GetContainerCyclesAndInstructions(t *testing.T) {
 	tempDir := t.TempDir()
 	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
-	fd := int(f.Fd())
 	cpus := []int{0}
-	collector, _ := NewPerfCollector(fd, cpus)
+	collector, _ := NewPerfCollector(f, cpus)
 	assert.NotPanics(t, func() {
 		_, _, err := GetContainerCyclesAndInstructions(collector)
 		if err != nil {
@@ -66,9 +63,8 @@ func Test_GetContainerCyclesAndInstructions(t *testing.T) {
 func Test_stopAndClose(t *testing.T) {
 	tempDir := t.TempDir()
 	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
-	fd := int(f.Fd())
 	cpus := []int{0}
-	collector, _ := NewPerfCollector(fd, cpus)
+	collector, _ := NewPerfCollector(f, cpus)
 	assert.NotPanics(t, func() {
 		err := collector.stopAndClose()
 		if err != nil {
@@ -80,11 +76,24 @@ func Test_stopAndClose(t *testing.T) {
 func Test_collect(t *testing.T) {
 	tempDir := t.TempDir()
 	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
-	fd := int(f.Fd())
 	cpus := []int{0}
-	collector, _ := NewPerfCollector(fd, cpus)
+	collector, _ := NewPerfCollector(f, cpus)
 	assert.NotPanics(t, func() {
 		_, err := collector.collect()
+		if err != nil {
+			return
+		}
+	})
+}
+
+func Test_CleanUp(t *testing.T) {
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	cpus := []int{0}
+	collector, _ := NewPerfCollector(f, cpus)
+	f.Close()
+	assert.NotPanics(t, func() {
+		err := collector.CleanUp()
 		if err != nil {
 			return
 		}

--- a/pkg/util/perf/perf_unsupported.go
+++ b/pkg/util/perf/perf_unsupported.go
@@ -19,9 +19,11 @@ limitations under the License.
 
 package perf
 
+import "os"
+
 type PerfCollector struct{}
 
-func NewPerfCollector(cgroupFd int, cpus []int) (*PerfCollector, error) {
+func NewPerfCollector(cgroupFile *os.File, cpus []int) (*PerfCollector, error) {
 	return &PerfCollector{}, nil
 }
 
@@ -29,7 +31,7 @@ func GetContainerCyclesAndInstructions(collector *PerfCollector) (uint64, uint64
 	return 0, 0, nil
 }
 
-func GetAndStartPerfCollectorOnContainer(cgroupFd int, cpus []int) (*PerfCollector, error) {
+func GetAndStartPerfCollectorOnContainer(cgroupFile *os.File, cpus []int) (*PerfCollector, error) {
 	return &PerfCollector{}, nil
 }
 
@@ -53,4 +55,8 @@ type collectResult struct{}
 
 func (c *PerfCollector) collect() (result collectResult, err error) {
 	return collectResult{}, err
+}
+
+func (c *PerfCollector) CleanUp() error {
+	return nil
 }

--- a/pkg/util/stat.go
+++ b/pkg/util/stat.go
@@ -105,11 +105,11 @@ func GetContainerPerfCollector(podCgroupDir string, c *corev1.ContainerStatus, n
 		cpus[i] = i
 	}
 	// get file descriptor for cgroup mode perf_event_open
-	containerCgroupFd, err := getContainerCgroupFd(podCgroupDir, c)
+	containerCgroupFile, err := getContainerCgroupFile(podCgroupDir, c)
 	if err != nil {
 		return nil, err
 	}
-	collector, err := perf.GetAndStartPerfCollectorOnContainer(containerCgroupFd, cpus)
+	collector, err := perf.GetAndStartPerfCollectorOnContainer(containerCgroupFile, cpus)
 	if err != nil {
 		return nil, err
 	}
@@ -120,14 +120,14 @@ func GetContainerCyclesAndInstructions(collector *perf.PerfCollector) (uint64, u
 	return perf.GetContainerCyclesAndInstructions(collector)
 }
 
-func getContainerCgroupFd(podCgroupDir string, c *corev1.ContainerStatus) (int, error) {
+func getContainerCgroupFile(podCgroupDir string, c *corev1.ContainerStatus) (*os.File, error) {
 	containerCgroupFilePath, err := GetContainerCgroupPerfPath(podCgroupDir, c)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	f, err := os.OpenFile(containerCgroupFilePath, os.O_RDONLY, os.ModeDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return int(f.Fd()), nil
+	return f, nil
 }

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -168,7 +168,9 @@ func Test_GetRootCgroupCPUUsageNanoseconds(t *testing.T) {
 }
 
 func Test_GetContainerCyclesAndInstructions(t *testing.T) {
-	collector, _ := perf.NewPerfCollector(0, []int{})
+	tempDir := t.TempDir()
+	f, _ := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	collector, _ := perf.NewPerfCollector(f, []int{})
 	_, _, err := GetContainerCyclesAndInstructions(collector)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Signed-off-by: songtao98 <songtao2603060@gmail.com>

### Ⅰ. Describe what this PR does
This PR fixes the error occurs at koordlet CPI collector when closing container cgroup files after profiling container CPI. Related error information is shown as below:
> E1102 21:10:28.757191  435643 performance_collector_linux.go:99] close CgroupFd 36, err : bad file descriptor

Previously we need to get one container's cgroup directory file descriptor to call `perf_event_open()` as param `pid`, thus we use struct `PerfCollector` to save that fd after open the cgroup path instead of saving a reference to the `*os.File` it self. It turns out that with golang gc mechanism the `*os.File` gets garbage collected, then the fd gets closed. But at `performance_collector_linux.go` we close that file explicitly again and that leads to the above error. 

A solution to the problem is to change `PerfCollector` to record the `*os.File` instead of Fd int and call `File.Fd()` when you need it. For the purpose of minimum change, this PR store both of them. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
