### PR TITLE
apis: remove dependency on controller-runtime

### DIFF
--- a/apis/config/v1alpha1/groupversion_info.go
+++ b/apis/config/v1alpha1/groupversion_info.go
@@ -21,7 +21,8 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/koordinator-sh/koordinator/apis/scheme"
 )
 
 var (

--- a/apis/scheduling/v1alpha1/groupversion_info.go
+++ b/apis/scheduling/v1alpha1/groupversion_info.go
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the scheduling v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the scheduling v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=scheduling.koordinator.sh
 package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/koordinator-sh/koordinator/apis/scheme"
 )
 
 var (

--- a/apis/scheme/scheme.go
+++ b/apis/scheme/scheme.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Builder builds a new Scheme for mapping go types to Kubernetes GroupVersionKinds.
+type Builder struct {
+	GroupVersion schema.GroupVersion
+	runtime.SchemeBuilder
+}
+
+// Register adds one or objects to the SchemeBuilder so they can be added to a Scheme.  Register mutates bld.
+func (bld *Builder) Register(object ...runtime.Object) *Builder {
+	bld.SchemeBuilder.Register(func(scheme *runtime.Scheme) error {
+		scheme.AddKnownTypes(bld.GroupVersion, object...)
+		metav1.AddToGroupVersion(scheme, bld.GroupVersion)
+		return nil
+	})
+	return bld
+}
+
+// RegisterAll registers all types from the Builder argument.  RegisterAll mutates bld.
+func (bld *Builder) RegisterAll(b *Builder) *Builder {
+	bld.SchemeBuilder = append(bld.SchemeBuilder, b.SchemeBuilder...)
+	return bld
+}
+
+// AddToScheme adds all registered types to s.
+func (bld *Builder) AddToScheme(s *runtime.Scheme) error {
+	return bld.SchemeBuilder.AddToScheme(s)
+}
+
+// Build returns a new Scheme containing the registered types.
+func (bld *Builder) Build() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	return s, bld.AddToScheme(s)
+}

--- a/apis/slo/v1alpha1/groupversion_info.go
+++ b/apis/slo/v1alpha1/groupversion_info.go
@@ -21,7 +21,8 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/koordinator-sh/koordinator/apis/scheme"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

When publishing Koordinator APIs(https://github.com/koordinator-sh/apis) separately, it is necessary to remove unnecessary dependencies to reduce the impact on those who rely on Koordinator APIs. Therefore, it is necessary to remove the controller-runtime that the APIs package depends on.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
