### PR TITLE
koord-scheduler: fix runtime quota calculation error if the total amount of resources is insufficient

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator_test.go
@@ -300,7 +300,7 @@ func TestRuntimeQuotaCalculator_NeedUpdateOneGroupRequest(t *testing.T) {
 
 func TestRuntimeQuotaCalculator_UpdateOneGroupRequest(t *testing.T) {
 	qtw := createRuntimeQuotaCalculator()
-	totalResource := createResourceList(50, 5000)
+	totalResource := createResourceList(150, 15000)
 	qtw.setClusterTotalResource(totalResource)
 	quotaCount := 5
 	for i := 1; i <= quotaCount; i++ {
@@ -375,7 +375,7 @@ func TestRuntimeQuotaCalculator_UpdateOneGroupRuntimeQuota(t *testing.T) {
 	assert.Equal(t, request, test1.CalculateInfo.Runtime)
 
 	qtw.updateOneGroupRuntimeQuota(test2)
-	assert.Equal(t, test2.CalculateInfo.AutoScaleMin, test2.CalculateInfo.Runtime)
+	assert.Equal(t, createResourceList(40, 400), test2.CalculateInfo.Runtime)
 }
 
 func TestRuntimeQuotaCalculator_UpdateOneGroupRuntimeQuota2(t *testing.T) {
@@ -435,4 +435,24 @@ func TestQuotaInfo_GetRuntime(t *testing.T) {
 	assert.Equal(t, qi.getMaskedRuntimeNoLock(), corev1.ResourceList{
 		"cpu": *resource.NewQuantity(10, resource.DecimalSI),
 	})
+}
+
+func TestQuotaInfo_SortQuota(t *testing.T) {
+	ss := []*quotaNode{
+		{quotaName: "a1", min: 20},
+		{quotaName: "a2", min: 10},
+		{quotaName: "a3", min: 30},
+		{quotaName: "a4", min: 10},
+		{quotaName: "a5", min: 30},
+	}
+	sq := SortQ{}
+	for _, i := range ss {
+		sq.insert(i)
+	}
+	assert.Equal(t, 5, len(sq.items))
+	assert.Equal(t, int64(20), sq.items[0].min)
+	assert.Equal(t, int64(10), sq.items[1].min)
+	assert.Equal(t, int64(30), sq.items[2].min)
+	assert.Equal(t, int64(10), sq.items[3].min)
+	assert.Equal(t, int64(30), sq.items[4].min)
 }


### PR DESCRIPTION
Signed-off-by: fjding <dingfangjie@bytedance.com>

### Ⅰ. Describe what this PR does
fixed two problems:
1、when the total resource is not enough, the runtime is error
2、quota  runtime random calculate error，because of traverse the key of the go map is random。
case：
total resource 100
quotaA request :60  quotaB request:70
but after syncHandler function run
the quotaA runtime= 60, quotaB runtime=70.




<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
