### PR TITLE
koord-scheduler: fix ElasticQuota plugin failover panic

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -350,6 +350,12 @@ func (gqm *GroupQuotaManager) buildSubParGroupTopoNoLock() {
 			continue
 		}
 		parQuotaTopoNode := gqm.quotaTopoNodeMap[topoNode.quotaInfo.ParentName]
+		// incase load child before its parent
+		if parQuotaTopoNode == nil {
+			parQuotaTopoNode = NewQuotaTopoNode(&QuotaInfo{
+				Name: topoNode.quotaInfo.ParentName,
+			})
+		}
 		topoNode.parQuotaTopoNode = parQuotaTopoNode
 		parQuotaTopoNode.addChildGroupQuotaInfo(topoNode)
 	}

--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
@@ -139,6 +139,13 @@ func TestGroupQuotaManager_UpdateQuotaInternal(t *testing.T) {
 	assert.Equal(t, int64(120*GigaByte), quotaInfo.CalculateInfo.SharedWeight.Memory().Value())
 }
 
+func TestGroupQuotaManager_UpdateQuota(t *testing.T) {
+	gqm := NewGroupQuotaManager4Test()
+	quota := CreateQuota("test1", "test-parent", 64, 100*GigaByte, 50, 80*GigaByte, true, false)
+	gqm.UpdateQuota(quota, false)
+	assert.Equal(t, len(gqm.quotaInfoMap), 3)
+}
+
 func TestGroupQuotaManager_UpdateQuotaInternalAndRequest(t *testing.T) {
 	gqm := NewGroupQuotaManager4Test()
 	deltaRes := createResourceList(96, 160*GigaByte)

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -1386,7 +1386,8 @@ func TestPlugin_Recover(t *testing.T) {
 		suit.Handle.ClientSet().CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 	}
 	time.Sleep(100 * time.Millisecond)
-	suit.AddQuota("test1", "", 100, 1000, 0, 0, 0, 0, false, "")
+	suit.AddQuota("test1", "test-parent", 100, 1000, 0, 0, 0, 0, false, "")
+	suit.AddQuota("test-parent", "root", 100, 1000, 0, 0, 0, 0, true, "")
 	time.Sleep(100 * time.Millisecond)
 	pods := []*corev1.Pod{
 		defaultCreatePodWithQuotaName("1", "test1", 10, 10, 10),
@@ -1404,6 +1405,7 @@ func TestPlugin_Recover(t *testing.T) {
 	assert.Equal(t, pl.groupQuotaManager.GetQuotaInfoByName("test1").GetRequest(), createResourceList(40, 40))
 	assert.Equal(t, pl.groupQuotaManager.GetQuotaInfoByName("test1").GetUsed(), createResourceList(40, 40))
 	assert.True(t, v1.IsZero(pl.groupQuotaManager.GetQuotaInfoByName("default").GetRequest()))
+	assert.Equal(t, len(pl.groupQuotaManager.GetAllQuotaNames()), 4)
 }
 
 func TestPlugin_migrateDefaultQuotaGroupsPod(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
fix the panic when failover, because the child is loaded before the parent.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
