### PR TITLE
koordlet: PSI collector and use Prometheus to record interference metrics 

### DIFF
--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -60,8 +60,17 @@ const (
 	// Only Nvidia GPUs are supported as of v0.6.
 	Accelerators featuregate.Feature = "Accelerators"
 
-	// PerformanceCollector enables interference detection feature of koordlet.
+	// nolint:staticcheck // SA1019 this deprecated field still needs to be used for now.
+	// Deprecated: This feature gate will be removed in v1.1,
+	// please use CPICollector instead ASAP.
+	// PerformanceCollector enables cpi collector feature of koordlet.
 	PerformanceCollector featuregate.Feature = "PerformanceCollector"
+
+	// CPICollector enables cpi collector feature of koordlet.
+	CPICollector featuregate.Feature = "CPICollector"
+
+	// PSICollector enables psi collector feature of koordlet.
+	PSICollector featuregate.Feature = "PSICollector"
 )
 
 func init() {
@@ -85,6 +94,8 @@ var (
 		NodeTopologyReport:     {Default: false, PreRelease: featuregate.Alpha},
 		Accelerators:           {Default: false, PreRelease: featuregate.Alpha},
 		PerformanceCollector:   {Default: false, PreRelease: featuregate.Alpha},
+		CPICollector:           {Default: false, PreRelease: featuregate.Alpha},
+		PSICollector:           {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/koordlet/metriccache/metric_cache_test.go
+++ b/pkg/koordlet/metriccache/metric_cache_test.go
@@ -1535,6 +1535,217 @@ func Test_metricCache_ContainerInterferenceMetric_CRUD(t *testing.T) {
 				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
 			},
 		},
+		// test container PSI CRUD
+		{
+			name: "container-psi-latest-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNameContainerPSI,
+				containerID:  "container-uid-1",
+				podUID:       "pod-uid-1",
+				aggregateArg: AggregationTypeLast,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.7,
+							SomeMemAvg10:     0.7,
+							SomeIOAvg10:      0.7,
+							FullCPUAvg10:     0.7,
+							FullMemAvg10:     0.7,
+							FullIOAvg10:      0.7,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.6,
+							SomeMemAvg10:     0.6,
+							SomeIOAvg10:      0.6,
+							FullCPUAvg10:     0.6,
+							FullMemAvg10:     0.6,
+							FullIOAvg10:      0.6,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-1",
+						PodUID:      "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.5,
+							SomeMemAvg10:     0.5,
+							SomeIOAvg10:      0.5,
+							FullCPUAvg10:     0.5,
+							FullMemAvg10:     0.5,
+							FullIOAvg10:      0.5,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-2",
+						PodUID:      "pod-uid-2",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.4,
+							SomeMemAvg10:     0.4,
+							SomeIOAvg10:      0.4,
+							FullCPUAvg10:     0.4,
+							FullMemAvg10:     0.4,
+							FullIOAvg10:      0.4,
+							CPUFullSupported: true,
+						},
+					},
+				},
+			},
+			want: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerPSI,
+					ContainerID: "container-uid-1",
+					PodUID:      "pod-uid-1",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10:     0.5,
+						SomeMemAvg10:     0.5,
+						SomeIOAvg10:      0.5,
+						FullCPUAvg10:     0.5,
+						FullMemAvg10:     0.5,
+						FullIOAvg10:      0.5,
+						CPUFullSupported: true,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 3}},
+			},
+			wantAfterDelete: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerPSI,
+					ContainerID: "container-uid-1",
+					PodUID:      "pod-uid-1",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10:     0.5,
+						SomeMemAvg10:     0.5,
+						SomeIOAvg10:      0.5,
+						FullCPUAvg10:     0.5,
+						FullMemAvg10:     0.5,
+						FullIOAvg10:      0.5,
+						CPUFullSupported: true,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
+			},
+		},
+		{
+			name: "container-psi-avg-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNameContainerPSI,
+				containerID:  "container-uid-3",
+				podUID:       "pod-uid-3",
+				aggregateArg: AggregationTypeAVG,
+				samples: map[time.Time]ContainerInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.7,
+							SomeMemAvg10:     0.7,
+							SomeIOAvg10:      0.7,
+							FullCPUAvg10:     0.7,
+							FullMemAvg10:     0.7,
+							FullIOAvg10:      0.7,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.6,
+							SomeMemAvg10:     0.6,
+							SomeIOAvg10:      0.6,
+							FullCPUAvg10:     0.6,
+							FullMemAvg10:     0.6,
+							FullIOAvg10:      0.6,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-3",
+						PodUID:      "pod-uid-3",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.5,
+							SomeMemAvg10:     0.5,
+							SomeIOAvg10:      0.5,
+							FullCPUAvg10:     0.5,
+							FullMemAvg10:     0.5,
+							FullIOAvg10:      0.5,
+							CPUFullSupported: true,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName:  MetricNameContainerPSI,
+						ContainerID: "container-uid-4",
+						PodUID:      "pod-uid-4",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10:     0.4,
+							SomeMemAvg10:     0.4,
+							SomeIOAvg10:      0.4,
+							FullCPUAvg10:     0.4,
+							FullMemAvg10:     0.4,
+							FullIOAvg10:      0.4,
+							CPUFullSupported: true,
+						},
+					},
+				},
+			},
+			want: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerPSI,
+					ContainerID: "container-uid-3",
+					PodUID:      "pod-uid-3",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10:     0.6,
+						SomeMemAvg10:     0.6,
+						SomeIOAvg10:      0.6,
+						FullCPUAvg10:     0.6,
+						FullMemAvg10:     0.6,
+						FullIOAvg10:      0.6,
+						CPUFullSupported: true,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 3}},
+			},
+			wantAfterDelete: ContainerInterferenceQueryResult{
+				Metric: &ContainerInterferenceMetric{
+					MetricName:  MetricNameContainerPSI,
+					ContainerID: "container-uid-3",
+					PodUID:      "pod-uid-3",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10:     0.55,
+						SomeMemAvg10:     0.55,
+						SomeIOAvg10:      0.55,
+						FullCPUAvg10:     0.55,
+						FullMemAvg10:     0.55,
+						FullIOAvg10:      0.55,
+						CPUFullSupported: true,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1580,7 +1791,7 @@ func Test_metricCache_ContainerInterferenceMetric_CRUD(t *testing.T) {
 	}
 }
 
-func Test_metricCache_PodInterferenceMetric_CRUD(t *testing.T) {
+func Test_metricCache_PodCPIMetric_CRUD(t *testing.T) {
 	now := time.Now()
 	type args struct {
 		config       *Config
@@ -2038,6 +2249,165 @@ func Test_GetPodInterferenceMetric_errNilParam(t *testing.T) {
 			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, nil)
 			if got.Error == nil {
 				t.Errorf("get interference metric did not report err")
+			}
+		})
+	}
+}
+
+func Test_metricCache_PodPSIMetric_CRUD(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		config       *Config
+		metricName   InterferenceMetricName
+		containerID  string
+		podUID       string
+		aggregateArg AggregationType
+		samples      map[time.Time]PodInterferenceMetric
+	}
+
+	tests := []struct {
+		name            string
+		args            args
+		want            PodInterferenceQueryResult
+		wantAfterDelete PodInterferenceQueryResult
+	}{
+		// test pod PSI CRUD
+		{
+			name: "pod-psi-latest-crud",
+			args: args{
+				config: &Config{
+					MetricGCIntervalSeconds: 60,
+					MetricExpireSeconds:     60,
+				},
+				metricName:   MetricNamePodPSI,
+				podUID:       "pod-uid-1",
+				aggregateArg: AggregationTypeLast,
+				samples: map[time.Time]PodInterferenceMetric{
+					now.Add(-time.Second * 120): {
+						MetricName: MetricNamePodPSI,
+						PodUID:     "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10: 7,
+							SomeMemAvg10: 7,
+							SomeIOAvg10:  7,
+							FullCPUAvg10: 7,
+							FullMemAvg10: 7,
+							FullIOAvg10:  7,
+						},
+					},
+					now.Add(-time.Second * 10): {
+						MetricName: MetricNamePodPSI,
+						PodUID:     "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10: 6,
+							SomeMemAvg10: 6,
+							SomeIOAvg10:  6,
+							FullCPUAvg10: 6,
+							FullMemAvg10: 6,
+							FullIOAvg10:  6,
+						},
+					},
+					now.Add(-time.Second * 5): {
+						MetricName: MetricNamePodPSI,
+						PodUID:     "pod-uid-1",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10: 5,
+							SomeMemAvg10: 5,
+							SomeIOAvg10:  5,
+							FullCPUAvg10: 5,
+							FullMemAvg10: 5,
+							FullIOAvg10:  5,
+						},
+					},
+					now.Add(-time.Second * 4): {
+						MetricName: MetricNamePodPSI,
+						PodUID:     "pod-uid-2",
+						MetricValue: &PSIMetric{
+							SomeCPUAvg10: 4,
+							SomeMemAvg10: 4,
+							SomeIOAvg10:  4,
+							FullCPUAvg10: 4,
+							FullMemAvg10: 4,
+							FullIOAvg10:  4,
+						},
+					},
+				},
+			},
+			want: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodPSI,
+					PodUID:     "pod-uid-1",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10: 5,
+						SomeMemAvg10: 5,
+						SomeIOAvg10:  5,
+						FullCPUAvg10: 5,
+						FullMemAvg10: 5,
+						FullIOAvg10:  5,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 3}},
+			},
+			wantAfterDelete: PodInterferenceQueryResult{
+				Metric: &PodInterferenceMetric{
+					MetricName: MetricNamePodPSI,
+					PodUID:     "pod-uid-1",
+					MetricValue: &PSIMetric{
+						SomeCPUAvg10: 5,
+						SomeMemAvg10: 5,
+						SomeIOAvg10:  5,
+						FullCPUAvg10: 5,
+						FullMemAvg10: 5,
+						FullIOAvg10:  5,
+					},
+				},
+				QueryResult: QueryResult{AggregateInfo: &AggregateInfo{MetricsCount: 2}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := NewStorage()
+			m := &metricCache{
+				config: tt.args.config,
+				db:     s,
+			}
+			for ts, sample := range tt.args.samples {
+				err := m.InsertPodInterferenceMetrics(ts, &sample)
+				if err != nil {
+					t.Errorf("insert interference metric failed %v", err)
+				}
+			}
+
+			oldStartTime := time.Unix(0, 0)
+			params := &QueryParam{
+				Aggregate: tt.args.aggregateArg,
+				Start:     &oldStartTime,
+				End:       &now,
+			}
+
+			got := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			if got.Error != nil {
+				t.Errorf("get interference metric failed %v", got.Error)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got, tt.want)
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got.Metric.MetricName, tt.want.Metric.MetricName)
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got.QueryResult.AggregateInfo.MetricsCount, tt.want.QueryResult.AggregateInfo.MetricsCount)
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got.Metric.PodUID, tt.want.Metric.PodUID)
+				t.Errorf("GetPodInterferenceMetric() got = %v, want %v", got.Metric.MetricValue.(*CPIMetric).Cycles, tt.want.Metric.MetricValue.(*CPIMetric).Cycles)
+			}
+			// delete expire items
+			m.recycleDB()
+
+			gotAfterDel := m.GetPodInterferenceMetric(tt.args.metricName, &tt.args.podUID, params)
+			if gotAfterDel.Error != nil {
+				t.Errorf("get interference metric failed %v", gotAfterDel.Error)
+			}
+			if !reflect.DeepEqual(gotAfterDel, tt.wantAfterDelete) {
+				t.Errorf("GetPodInterferenceMetric() after delete, got = %v, want %v",
+					gotAfterDel, tt.wantAfterDelete)
 			}
 		})
 	}

--- a/pkg/koordlet/metriccache/mockmetriccache/mock.go
+++ b/pkg/koordlet/metriccache/mockmetriccache/mock.go
@@ -262,6 +262,20 @@ func (mr *MockMetricCacheMockRecorder) InsertNodeResourceMetric(t, nodeResUsed i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertNodeResourceMetric", reflect.TypeOf((*MockMetricCache)(nil).InsertNodeResourceMetric), t, nodeResUsed)
 }
 
+// InsertPodInterferenceMetrics mocks base method.
+func (m *MockMetricCache) InsertPodInterferenceMetrics(t time.Time, metric *metriccache.PodInterferenceMetric) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertPodInterferenceMetrics", t, metric)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertPodInterferenceMetrics indicates an expected call of InsertPodInterferenceMetrics.
+func (mr *MockMetricCacheMockRecorder) InsertPodInterferenceMetrics(t, metric interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertPodInterferenceMetrics", reflect.TypeOf((*MockMetricCache)(nil).InsertPodInterferenceMetrics), t, metric)
+}
+
 // InsertPodResourceMetric mocks base method.
 func (m *MockMetricCache) InsertPodResourceMetric(t time.Time, podResUsed *metriccache.PodResourceMetric) error {
 	m.ctrl.T.Helper()

--- a/pkg/koordlet/metriccache/storage_tables.go
+++ b/pkg/koordlet/metriccache/storage_tables.go
@@ -118,6 +118,33 @@ type containerCPIMetric struct {
 	Timestamp    time.Time
 }
 
+type containerPSIMetric struct {
+	ID               uint64 `gorm:"primarykey"`
+	PodUID           string `gorm:"index:idx_container_pdi_poduid"`
+	ContainerID      string `gorm:"index:idx_container_psi_containerid"`
+	SomeCPUAvg10     float64
+	SomeMemAvg10     float64
+	SomeIOAvg10      float64
+	FullCPUAvg10     float64
+	FullMemAvg10     float64
+	FullIOAvg10      float64
+	CPUFullSupported bool
+	Timestamp        time.Time
+}
+
+type podPSIMetric struct {
+	ID               uint64 `gorm:"primarykey"`
+	PodUID           string `gorm:"index:idx_pod_psi_uid"`
+	SomeCPUAvg10     float64
+	SomeMemAvg10     float64
+	SomeIOAvg10      float64
+	FullCPUAvg10     float64
+	FullMemAvg10     float64
+	FullIOAvg10      float64
+	CPUFullSupported bool
+	Timestamp        time.Time
+}
+
 type rawRecord struct {
 	RecordType string `gorm:"primarykey"`
 	RecordStr  string

--- a/pkg/koordlet/metrics/common.go
+++ b/pkg/koordlet/metrics/common.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
 	KoordletStartTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/koordlet/metrics/cpi.go
+++ b/pkg/koordlet/metrics/cpi.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	CPIField = "cpi_field"
+
+	Cycles       = "cycles"
+	Instructions = "instructions"
+)
+
+var (
+	ContainerCPI = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "container_cpi",
+		Help:      "Container cpi collected by koordlet",
+	}, []string{NodeKey, ContainerID, ContainerName, PodUID, PodName, PodNamespace, CPIField})
+
+	CPICollectors = []prometheus.Collector{
+		ContainerCPI,
+	}
+)
+
+func ResetContainerCPI() {
+	ContainerCPI.Reset()
+}
+
+func RecordContainerCPI(status *corev1.ContainerStatus, pod *corev1.Pod, cycles, instructions float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[ContainerID] = status.ContainerID
+	labels[ContainerName] = status.Name
+	labels[PodUID] = string(pod.UID)
+	labels[PodName] = pod.Name
+	labels[PodNamespace] = pod.Namespace
+	labels[CPIField] = Cycles
+	ContainerCPI.With(labels).Set(cycles)
+
+	labels[CPIField] = Instructions
+	ContainerCPI.With(labels).Set(instructions)
+}

--- a/pkg/koordlet/metrics/metrics.go
+++ b/pkg/koordlet/metrics/metrics.go
@@ -26,6 +26,8 @@ import (
 
 func init() {
 	prometheus.MustRegister(CommonCollectors...)
+	prometheus.MustRegister(CPICollectors...)
+	prometheus.MustRegister(PSICollectors...)
 }
 
 const (
@@ -39,6 +41,13 @@ const (
 
 	EvictionReasonKey = "reason"
 	BESuppressTypeKey = "type"
+
+	ContainerID   = "container_id"
+	ContainerName = "container_name"
+
+	PodUID       = "pod_uid"
+	PodName      = "pod_name"
+	PodNamespace = "pod_namespace"
 )
 
 var (

--- a/pkg/koordlet/metrics/metrics_test.go
+++ b/pkg/koordlet/metrics/metrics_test.go
@@ -25,6 +25,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
 )
 
 func TestGenNodeLabels(t *testing.T) {
@@ -61,6 +64,64 @@ func TestCommonCollectors(t *testing.T) {
 	}
 	testingErr := fmt.Errorf("test error")
 	testingNow := time.Now()
+	testingContainer := &corev1.ContainerStatus{
+		ContainerID: "containerd://1",
+		Name:        "test_container",
+	}
+	testingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_pod",
+			Namespace: "test_pod_namespace",
+			UID:       "test01",
+		},
+	}
+	testingPSI := &util.PSIByResource{
+		CPU: system.PSIStats{
+			Some: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			Full: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			FullSupported: true,
+		},
+		Mem: system.PSIStats{
+			Some: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			Full: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			FullSupported: true,
+		},
+		IO: system.PSIStats{
+			Some: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			Full: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			FullSupported: true,
+		},
+	}
 
 	t.Run("test not panic", func(t *testing.T) {
 		Register(testingNode)
@@ -71,5 +132,11 @@ func TestCommonCollectors(t *testing.T) {
 		RecordCollectNodeCPUInfoStatus(nil)
 		RecordBESuppressCores("cfsQuota", float64(1000))
 		RecordPodEviction("evictByCPU")
+		ResetContainerCPI()
+		RecordContainerCPI(testingContainer, testingPod, 1, 1)
+		ResetContainerPSI()
+		RecordContainerPSI(testingContainer, testingPod, testingPSI)
+		ResetPodPSI()
+		RecordPodPSI(testingPod, testingPSI)
 	})
 }

--- a/pkg/koordlet/metrics/psi.go
+++ b/pkg/koordlet/metrics/psi.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	PSIDegree       = "psi_degree"
+	PSIPrecision    = "psi_precision"
+	PSIResourceType = "psi_resource_type"
+
+	CPUFullSupported = "cpu_full_supported"
+)
+
+const (
+	ResourceTypeCPU = "cpu"
+	ResourceTypeMem = "mem"
+	ResourceTypeIO  = "io"
+
+	Precision10  = "avg10"
+	Precision60  = "avg60"
+	Precision300 = "avg300"
+
+	DegreeSome = "some"
+	DegreeFull = "full"
+)
+
+var (
+	ContainerPSI = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "container_psi",
+		Help:      "Container psi collected by koordlet",
+	}, []string{NodeKey, ContainerID, ContainerName, PodUID, PodName, PodNamespace, PSIResourceType, PSIPrecision, PSIDegree, CPUFullSupported})
+
+	PodPSI = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "pod_psi",
+		Help:      "Pod psi collected by koordlet",
+	}, []string{NodeKey, PodUID, PodName, PodNamespace, PSIResourceType, PSIPrecision, PSIDegree, CPUFullSupported})
+
+	PSICollectors = []prometheus.Collector{
+		ContainerPSI,
+		PodPSI,
+	}
+)
+
+type PSIRecord struct {
+	ResourceType     string
+	Precision        string
+	Degree           string
+	Value            float64
+	CPUFullSupported bool
+}
+
+func getPSIRecords(psi *util.PSIByResource) []PSIRecord {
+	var psiRecordAll []PSIRecord
+	psiRecordAll = append(psiRecordAll, makePSIRecordSlice(ResourceTypeCPU, psi.CPU)...)
+	psiRecordAll = append(psiRecordAll, makePSIRecordSlice(ResourceTypeMem, psi.Mem)...)
+	psiRecordAll = append(psiRecordAll, makePSIRecordSlice(ResourceTypeIO, psi.IO)...)
+	return psiRecordAll
+}
+
+func makePSIRecordSlice(resourceType string, psiStats system.PSIStats) []PSIRecord {
+	records := []PSIRecord{
+		{
+			ResourceType:     resourceType,
+			Precision:        Precision10,
+			Degree:           DegreeSome,
+			Value:            psiStats.Some.Avg10,
+			CPUFullSupported: psiStats.FullSupported,
+		},
+		{
+			ResourceType:     resourceType,
+			Precision:        Precision60,
+			Degree:           DegreeSome,
+			Value:            psiStats.Some.Avg60,
+			CPUFullSupported: psiStats.FullSupported,
+		},
+		{
+			ResourceType:     resourceType,
+			Precision:        Precision300,
+			Degree:           DegreeSome,
+			Value:            psiStats.Some.Avg300,
+			CPUFullSupported: psiStats.FullSupported,
+		},
+	}
+	if psiStats.FullSupported {
+		records = append(records, []PSIRecord{
+			{
+				ResourceType:     resourceType,
+				Precision:        Precision10,
+				Degree:           DegreeFull,
+				Value:            psiStats.Full.Avg10,
+				CPUFullSupported: psiStats.FullSupported,
+			},
+			{
+				ResourceType:     resourceType,
+				Precision:        Precision60,
+				Degree:           DegreeFull,
+				Value:            psiStats.Full.Avg60,
+				CPUFullSupported: psiStats.FullSupported,
+			},
+			{
+				ResourceType:     resourceType,
+				Precision:        Precision300,
+				Degree:           DegreeFull,
+				Value:            psiStats.Full.Avg300,
+				CPUFullSupported: psiStats.FullSupported,
+			},
+		}...)
+	}
+
+	return records
+}
+
+func RecordContainerPSI(status *corev1.ContainerStatus, pod *corev1.Pod, psi *util.PSIByResource) {
+	psiRecords := getPSIRecords(psi)
+	for _, record := range psiRecords {
+		labels := genNodeLabels()
+		if labels == nil {
+			return
+		}
+		labels[ContainerID] = status.ContainerID
+		labels[ContainerName] = status.Name
+		labels[PodUID] = string(pod.UID)
+		labels[PodName] = pod.Name
+		labels[PodNamespace] = pod.Namespace
+
+		labels[PSIResourceType] = record.ResourceType
+		labels[PSIPrecision] = record.Precision
+		labels[PSIDegree] = record.Degree
+		labels[CPUFullSupported] = strconv.FormatBool(record.CPUFullSupported)
+		ContainerPSI.With(labels).Set(record.Value)
+	}
+}
+
+func RecordPodPSI(pod *corev1.Pod, psi *util.PSIByResource) {
+	psiRecords := getPSIRecords(psi)
+	for _, record := range psiRecords {
+		labels := genNodeLabels()
+		if labels == nil {
+			return
+		}
+		labels[PodUID] = string(pod.UID)
+		labels[PodName] = pod.Name
+		labels[PodNamespace] = pod.Namespace
+
+		labels[PSIResourceType] = record.ResourceType
+		labels[PSIPrecision] = record.Precision
+		labels[PSIDegree] = record.Degree
+		labels[CPUFullSupported] = strconv.FormatBool(record.CPUFullSupported)
+		PodPSI.With(labels).Set(record.Value)
+	}
+}
+
+func ResetContainerPSI() {
+	ContainerPSI.Reset()
+}
+
+func ResetPodPSI() {
+	PodPSI.Reset()
+}

--- a/pkg/koordlet/metrics/psi_test.go
+++ b/pkg/koordlet/metrics/psi_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
+)
+
+func TestGetPSIRecords(t *testing.T) {
+	testingRecords := &util.PSIByResource{
+		CPU: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
+			FullSupported: true,
+		},
+		Mem: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
+			FullSupported: true,
+		},
+		IO: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
+			FullSupported: true,
+		},
+	}
+	assert.NotPanics(t, func() {
+		getPSIRecords(testingRecords)
+	})
+}

--- a/pkg/koordlet/metricsadvisor/config.go
+++ b/pkg/koordlet/metricsadvisor/config.go
@@ -19,18 +19,20 @@ package metricsadvisor
 import "flag"
 
 type Config struct {
-	CollectResUsedIntervalSeconds         int
-	CollectNodeCPUInfoIntervalSeconds     int
-	PerformanceCollectorIntervalSeconds   int
-	PerformanceCollectorTimeWindowSeconds int
+	CollectResUsedIntervalSeconds     int
+	CollectNodeCPUInfoIntervalSeconds int
+	CPICollectorIntervalSeconds       int
+	PSICollectorIntervalSeconds       int
+	CPICollectorTimeWindowSeconds     int
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		CollectResUsedIntervalSeconds:         1,
-		CollectNodeCPUInfoIntervalSeconds:     60,
-		PerformanceCollectorIntervalSeconds:   60,
-		PerformanceCollectorTimeWindowSeconds: 10,
+		CollectResUsedIntervalSeconds:     1,
+		CollectNodeCPUInfoIntervalSeconds: 60,
+		CPICollectorIntervalSeconds:       60,
+		PSICollectorIntervalSeconds:       10,
+		CPICollectorTimeWindowSeconds:     10,
 	}
 }
 
@@ -38,6 +40,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	// todo: replace with DurationVar and modify run feature util
 	fs.IntVar(&c.CollectResUsedIntervalSeconds, "collect-res-used-interval-seconds", c.CollectResUsedIntervalSeconds, "Collect node/pod resource usage interval by seconds")
 	fs.IntVar(&c.CollectNodeCPUInfoIntervalSeconds, "collect-node-cpu-info-interval-seconds", c.CollectNodeCPUInfoIntervalSeconds, "Collect node cpu info interval by seconds")
-	fs.IntVar(&c.PerformanceCollectorIntervalSeconds, "collect-interference-interval-seconds", c.PerformanceCollectorIntervalSeconds, "Collect interference interval by seconds")
-	fs.IntVar(&c.PerformanceCollectorTimeWindowSeconds, "collect-interference-timewindow-seconds", c.PerformanceCollectorTimeWindowSeconds, "Collect interference time window by seconds")
+	fs.IntVar(&c.CPICollectorIntervalSeconds, "cpi-collector-interval-seconds", c.CPICollectorIntervalSeconds, "Collect cpi interval by seconds")
+	fs.IntVar(&c.PSICollectorIntervalSeconds, "psi-collector-interval-seconds", c.PSICollectorIntervalSeconds, "Collect psi interval by seconds")
+	fs.IntVar(&c.CPICollectorTimeWindowSeconds, "collect-cpi-timewindow-seconds", c.CPICollectorTimeWindowSeconds, "Collect cpi time window by seconds")
 }

--- a/pkg/koordlet/metricsadvisor/config_test.go
+++ b/pkg/koordlet/metricsadvisor/config_test.go
@@ -25,10 +25,11 @@ import (
 
 func Test_NewDefaultConfig(t *testing.T) {
 	expectConfig := &Config{
-		CollectResUsedIntervalSeconds:         1,
-		CollectNodeCPUInfoIntervalSeconds:     60,
-		PerformanceCollectorIntervalSeconds:   60,
-		PerformanceCollectorTimeWindowSeconds: 10,
+		CollectResUsedIntervalSeconds:     1,
+		CollectNodeCPUInfoIntervalSeconds: 60,
+		CPICollectorIntervalSeconds:       60,
+		PSICollectorIntervalSeconds:       10,
+		CPICollectorTimeWindowSeconds:     10,
 	}
 	defaultConfig := NewDefaultConfig()
 	assert.Equal(t, expectConfig, defaultConfig)
@@ -39,16 +40,18 @@ func Test_InitFlags(t *testing.T) {
 		"",
 		"--collect-res-used-interval-seconds=3",
 		"--collect-node-cpu-info-interval-seconds=90",
-		"--collect-interference-interval-seconds=90",
-		"--collect-interference-timewindow-seconds=15",
+		"--cpi-collector-interval-seconds=90",
+		"--psi-collector-interval-seconds=5",
+		"--collect-cpi-timewindow-seconds=15",
 	}
 	fs := flag.NewFlagSet(cmdArgs[0], flag.ExitOnError)
 
 	type fields struct {
-		CollectResUsedIntervalSeconds        int
-		CollectNodeCPUInfoIntervalSeconds    int
-		CollectInterferenceIntervalSeconds   int
-		CollectInterferenceTimeWindowSeconds int
+		CollectResUsedIntervalSeconds     int
+		CollectNodeCPUInfoIntervalSeconds int
+		CPICollectorIntervalSeconds       int
+		PSICollectorIntervalSeconds       int
+		CPICollectorTimeWindowSeconds     int
 	}
 	type args struct {
 		fs *flag.FlagSet
@@ -61,10 +64,11 @@ func Test_InitFlags(t *testing.T) {
 		{
 			name: "not default",
 			fields: fields{
-				CollectResUsedIntervalSeconds:        3,
-				CollectNodeCPUInfoIntervalSeconds:    90,
-				CollectInterferenceIntervalSeconds:   90,
-				CollectInterferenceTimeWindowSeconds: 15,
+				CollectResUsedIntervalSeconds:     3,
+				CollectNodeCPUInfoIntervalSeconds: 90,
+				CPICollectorIntervalSeconds:       90,
+				PSICollectorIntervalSeconds:       5,
+				CPICollectorTimeWindowSeconds:     15,
 			},
 			args: args{fs: fs},
 		},
@@ -72,10 +76,11 @@ func Test_InitFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			raw := &Config{
-				CollectResUsedIntervalSeconds:         tt.fields.CollectResUsedIntervalSeconds,
-				CollectNodeCPUInfoIntervalSeconds:     tt.fields.CollectNodeCPUInfoIntervalSeconds,
-				PerformanceCollectorIntervalSeconds:   tt.fields.CollectInterferenceIntervalSeconds,
-				PerformanceCollectorTimeWindowSeconds: tt.fields.CollectInterferenceTimeWindowSeconds,
+				CollectResUsedIntervalSeconds:     tt.fields.CollectResUsedIntervalSeconds,
+				CollectNodeCPUInfoIntervalSeconds: tt.fields.CollectNodeCPUInfoIntervalSeconds,
+				CPICollectorIntervalSeconds:       tt.fields.CPICollectorIntervalSeconds,
+				PSICollectorIntervalSeconds:       tt.fields.PSICollectorIntervalSeconds,
+				CPICollectorTimeWindowSeconds:     tt.fields.CPICollectorTimeWindowSeconds,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)

--- a/pkg/koordlet/metricsadvisor/performance_collector_unsupported.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_unsupported.go
@@ -31,3 +31,7 @@ func NewPerformanceCollector(statesInformer statesinformer.StatesInformer, metri
 }
 
 func (p *performanceCollector) collectContainerCPI() {}
+
+func (c *performanceCollector) collectContainerPSI() {}
+
+func (c *performanceCollector) collectPodPSI() {}

--- a/pkg/koordlet/qosmanager/metricsquery/metrics_query.go
+++ b/pkg/koordlet/qosmanager/metricsquery/metrics_query.go
@@ -57,13 +57,13 @@ type metricsQuery struct {
 	statesInformer statesinformer.StatesInformer
 }
 
-//  CollectNodeMetricsAvg impl plugins.MetricQuery interface.
+// CollectNodeMetricsAvg impl plugins.MetricQuery interface.
 func (r *metricsQuery) CollectNodeMetricsAvg(windowSeconds int64) metriccache.NodeResourceQueryResult {
 	queryParam := GenerateQueryParamsAvg(windowSeconds)
 	return r.collectNodeMetric(queryParam)
 }
 
-//  CollectNodeAndPodMetricLast impl plugins.MetricQuery interface.
+// CollectNodeAndPodMetricLast impl plugins.MetricQuery interface.
 func (r *metricsQuery) CollectNodeAndPodMetricLast(collectResUsedIntervalSeconds int64) (
 	*metriccache.NodeResourceMetric, []*metriccache.PodResourceMetric) {
 
@@ -71,7 +71,7 @@ func (r *metricsQuery) CollectNodeAndPodMetricLast(collectResUsedIntervalSeconds
 	return r.CollectNodeAndPodMetrics(queryParam)
 }
 
-//  CollectNodeAndPodMetrics impl plugins.MetricQuery interface.
+// CollectNodeAndPodMetrics impl plugins.MetricQuery interface.
 func (r *metricsQuery) CollectNodeAndPodMetrics(queryParam *metriccache.QueryParam) (
 	*metriccache.NodeResourceMetric, []*metriccache.PodResourceMetric) {
 

--- a/pkg/util/container.go
+++ b/pkg/util/container.go
@@ -74,6 +74,19 @@ func GetContainerCgroupCPUAcctUsagePath(podParentDir string, c *corev1.Container
 	return system.GetCgroupFilePath(containerPath, system.CpuacctUsage), nil
 }
 
+func GetContainerCgroupCPUAcctPSIPath(podParentDir string, c *corev1.ContainerStatus) (PSIPath, error) {
+	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
+	if err != nil {
+		return PSIPath{}, err
+	}
+	// psi file saved in cpuacct for cgroup v1 file system
+	return PSIPath{
+		CPU: system.GetCgroupFilePath(containerPath, system.CpuacctCPUPressure),
+		Mem: system.GetCgroupFilePath(containerPath, system.CpuacctMemPressure),
+		IO:  system.GetCgroupFilePath(containerPath, system.CpuacctIOPressure),
+	}, nil
+}
+
 func GetContainerCgroupMemStatPath(podParentDir string, c *corev1.ContainerStatus) (string, error) {
 	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
 	if err != nil {

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -92,6 +92,15 @@ func GetPodCgroupCPUStatPath(podParentDir string) string {
 	return system.GetCgroupFilePath(podPath, system.CPUStat)
 }
 
+func GetPodCgroupCPUAcctPSIPath(podParentDir string) PSIPath {
+	podPath := GetPodCgroupDirWithKube(podParentDir)
+	return PSIPath{
+		CPU: system.GetCgroupFilePath(podPath, system.CpuacctCPUPressure),
+		Mem: system.GetCgroupFilePath(podPath, system.CpuacctMemPressure),
+		IO:  system.GetCgroupFilePath(podPath, system.CpuacctIOPressure),
+	}
+}
+
 func GetKubeQoSByCgroupParent(cgroupDir string) corev1.PodQOSClass {
 	if strings.Contains(cgroupDir, "besteffort") {
 		return corev1.PodQOSBestEffort

--- a/pkg/util/pod_test.go
+++ b/pkg/util/pod_test.go
@@ -269,6 +269,30 @@ func Test_GetPodCgroupStatPath(t *testing.T) {
 				return GetPodCgroupCPUStatPath(p)
 			},
 		},
+		{
+			name:         "cpupressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/cpu.pressure",
+			fn: func(p string) string {
+				return GetPodCgroupCPUAcctPSIPath(p).CPU
+			},
+		},
+		{
+			name:         "mempressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/memory.pressure",
+			fn: func(p string) string {
+				return GetPodCgroupCPUAcctPSIPath(p).Mem
+			},
+		},
+		{
+			name:         "iopressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/io.pressure",
+			fn: func(p string) string {
+				return GetPodCgroupCPUAcctPSIPath(p).IO
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/util/psi.go
+++ b/pkg/util/psi.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
+)
+
+type PSIPath struct {
+	CPU string
+	Mem string
+	IO  string
+}
+
+type PSIByResource struct {
+	CPU system.PSIStats
+	Mem system.PSIStats
+	IO  system.PSIStats
+}
+
+func GetPSIByResource(paths PSIPath) (*PSIByResource, error) {
+	cpuStats, err := system.ReadPSI(paths.CPU)
+	if err != nil {
+		return nil, err
+	}
+	memStats, err := system.ReadPSI(paths.Mem)
+	if err != nil {
+		return nil, err
+	}
+	ioStats, err := system.ReadPSI(paths.IO)
+	if err != nil {
+		return nil, err
+	}
+	return &PSIByResource{
+		CPU: cpuStats,
+		Mem: memStats,
+		IO:  ioStats,
+	}, nil
+}

--- a/pkg/util/psi_test.go
+++ b/pkg/util/psi_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/system"
+)
+
+const (
+	FullCorrectPSIContents = "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0"
+)
+
+func TestGetPSIByResource_CPUErr(t *testing.T) {
+	dir := t.TempDir()
+	psiPath := PSIPath{
+		CPU: path.Join(dir, "cpu.pressure"),
+		Mem: path.Join(dir, "memory.pressure"),
+		IO:  path.Join(dir, "io.pressure"),
+	}
+	assert.NotPanics(t, func() {
+		_, err := GetPSIByResource(psiPath)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func TestGetPSIByResource_MemErr(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
+	psiPath := PSIPath{
+		CPU: path.Join(helper.TempDir, "cpu.pressure"),
+		Mem: path.Join(helper.TempDir, "memory.pressure"),
+		IO:  path.Join(helper.TempDir, "io.pressure"),
+	}
+	assert.NotPanics(t, func() {
+		_, err := GetPSIByResource(psiPath)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func TestGetPSIByResource_IOErr(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
+	helper.CreateFile("memory.pressure")
+	helper.WriteFileContents("memory.pressure", FullCorrectPSIContents)
+	psiPath := PSIPath{
+		CPU: path.Join(helper.TempDir, "cpu.pressure"),
+		Mem: path.Join(helper.TempDir, "memory.pressure"),
+		IO:  path.Join(helper.TempDir, "io.pressure"),
+	}
+	assert.NotPanics(t, func() {
+		_, err := GetPSIByResource(psiPath)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func TestGetPSIByResource(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
+	helper.CreateFile("memory.pressure")
+	helper.WriteFileContents("memory.pressure", FullCorrectPSIContents)
+	helper.CreateFile("io.pressure")
+	helper.WriteFileContents("io.pressure", FullCorrectPSIContents)
+	psiPath := PSIPath{
+		CPU: path.Join(helper.TempDir, "cpu.pressure"),
+		Mem: path.Join(helper.TempDir, "memory.pressure"),
+		IO:  path.Join(helper.TempDir, "io.pressure"),
+	}
+	assert.NotPanics(t, func() {
+		_, err := GetPSIByResource(psiPath)
+		if err != nil {
+			return
+		}
+	})
+}

--- a/pkg/util/stat.go
+++ b/pkg/util/stat.go
@@ -131,3 +131,24 @@ func getContainerCgroupFile(podCgroupDir string, c *corev1.ContainerStatus) (*os
 	}
 	return f, nil
 }
+
+func GetPodPSI(podCgroupDir string) (*PSIByResource, error) {
+	paths := GetPodCgroupCPUAcctPSIPath(podCgroupDir)
+	psi, err := GetPSIByResource(paths)
+	if err != nil {
+		return nil, err
+	}
+	return psi, nil
+}
+
+func GetContainerPSI(podCgroupDir string, c *corev1.ContainerStatus) (*PSIByResource, error) {
+	paths, err := GetContainerCgroupCPUAcctPSIPath(podCgroupDir, c)
+	if err != nil {
+		return nil, err
+	}
+	psi, err := GetPSIByResource(paths)
+	if err != nil {
+		return nil, err
+	}
+	return psi, nil
+}

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -193,6 +193,21 @@ func Test_GetContainerPerfCollector(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func Test_GetPodPSI(t *testing.T) {
+	tempDir := t.TempDir()
+	_, err := GetPodPSI(tempDir)
+	assert.NotNil(t, err)
+}
+
+func Test_GetContainerPSI(t *testing.T) {
+	tempDir := t.TempDir()
+	c := &corev1.ContainerStatus{
+		ContainerID: "containerd://test",
+	}
+	_, err := GetContainerPSI(tempDir, c)
+	assert.NotNil(t, err)
+}
+
 func getUsageContents() string {
 	return "1356232"
 }

--- a/pkg/util/system/cgroup_resource.go
+++ b/pkg/util/system/cgroup_resource.go
@@ -42,7 +42,10 @@ const (
 	CPUSFileName      = "cpuset.cpus"
 	CPUTaskFileName   = "tasks"
 
-	CpuacctUsageFileName = "cpuacct.usage"
+	CpuacctUsageFileName       = "cpuacct.usage"
+	CpuacctCPUPressureFileName = "cpu.pressure"
+	CpuacctMemPressureFileName = "memory.pressure"
+	CpuacctIOPressureFileName  = "io.pressure"
 
 	MemWmarkRatioFileName       = "memory.wmark_ratio"
 	MemWmarkScaleFactorFileName = "memory.wmark_scale_factor"
@@ -95,7 +98,10 @@ var (
 
 	CPUSet = CgroupFile{ResourceFileName: CPUSFileName, Subfs: CgroupCPUSetDir, IsAnolisOS: false}
 
-	CpuacctUsage = CgroupFile{ResourceFileName: CpuacctUsageFileName, Subfs: CgroupCPUacctDir, IsAnolisOS: false}
+	CpuacctUsage       = CgroupFile{ResourceFileName: CpuacctUsageFileName, Subfs: CgroupCPUacctDir, IsAnolisOS: false}
+	CpuacctCPUPressure = CgroupFile{ResourceFileName: CpuacctCPUPressureFileName, Subfs: CgroupCPUacctDir, IsAnolisOS: true}
+	CpuacctMemPressure = CgroupFile{ResourceFileName: CpuacctMemPressureFileName, Subfs: CgroupCPUacctDir, IsAnolisOS: true}
+	CpuacctIOPressure  = CgroupFile{ResourceFileName: CpuacctIOPressureFileName, Subfs: CgroupCPUacctDir, IsAnolisOS: true}
 
 	MemStat             = CgroupFile{ResourceFileName: MemStatFileName, Subfs: CgroupMemDir, IsAnolisOS: false}
 	MemorySWLimit       = CgroupFile{ResourceFileName: MemorySWLimitFileName, Subfs: CgroupMemDir, IsAnolisOS: false}

--- a/pkg/util/system/psi_file.go
+++ b/pkg/util/system/psi_file.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const psiLineFormat = "avg10=%f avg60=%f avg300=%f total=%d"
+
+type PSILine struct {
+	Avg10  float64
+	Avg60  float64
+	Avg300 float64
+	Total  uint64
+}
+
+type PSIStats struct {
+	Some *PSILine
+	Full *PSILine
+
+	FullSupported bool
+}
+
+func ReadPSI(pressureFilePath string) (PSIStats, error) {
+	fileContents, err := os.ReadFile(pressureFilePath)
+	if err != nil {
+		return PSIStats{}, err
+	}
+	//todo: delete these logs after panic handled
+	klog.V(4).Infof("read psi file contents: %s", string(fileContents))
+	stats, err := parsePSIStats(bytes.NewReader(fileContents))
+	if err != nil {
+		return PSIStats{}, err
+	}
+	return stats, nil
+}
+
+// parsePSIStats parses the specified file for pressure stall information.
+func parsePSIStats(r io.Reader) (PSIStats, error) {
+	psiStats := PSIStats{}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		l := scanner.Text()
+		prefix := strings.Split(l, " ")[0]
+		switch prefix {
+		case "some":
+			psi := PSILine{}
+			_, err := fmt.Sscanf(l, fmt.Sprintf("some %s", psiLineFormat), &psi.Avg10, &psi.Avg60, &psi.Avg300, &psi.Total)
+			if err != nil {
+				return PSIStats{}, err
+			}
+			psiStats.Some = &psi
+		case "full":
+			psi := PSILine{}
+			_, err := fmt.Sscanf(l, fmt.Sprintf("full %s", psiLineFormat), &psi.Avg10, &psi.Avg60, &psi.Avg300, &psi.Total)
+			if err != nil {
+				return PSIStats{}, err
+			}
+			psiStats.Full = &psi
+		default:
+			return PSIStats{}, fmt.Errorf("unknown PSI prefix: %s", prefix)
+		}
+	}
+
+	// full cpu pressure not supported in old kernel versions
+	psiStats.FullSupported = true
+	if psiStats.Full == nil {
+		psiStats.FullSupported = false
+		psiStats.Full = &PSILine{}
+	}
+
+	return psiStats, nil
+}

--- a/pkg/util/system/psi_file_test.go
+++ b/pkg/util/system/psi_file_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPSIRecords(t *testing.T) {
+	helper := NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0")
+
+	assert.NotPanics(t, func() {
+		_, err := ReadPSI(helper.TempDir + "/cpu.pressure")
+		if err != nil {
+			return
+		}
+	})
+}
+
+func TestGetPSIRecords_wrongSomeFormat(t *testing.T) {
+	helper := NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0")
+
+	_, err := ReadPSI(helper.TempDir + "/cpu.pressure")
+	assert.NotNil(t, err)
+}
+
+func TestGetPSIRecords_wrongFullFormat(t *testing.T) {
+	helper := NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 total=0\nfull 0.00 avg300=0.00 total=0")
+
+	_, err := ReadPSI(helper.TempDir + "/cpu.pressure")
+	assert.NotNil(t, err)
+}
+
+func TestGetPSIRecords_wrongPrefix(t *testing.T) {
+	helper := NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", "wrong avg10=0.00 total=0\nfull 0.00 avg300=0.00 total=0")
+
+	_, err := ReadPSI(helper.TempDir + "/cpu.pressure")
+	assert.NotNil(t, err)
+}
+
+func TestGetPSIRecords_FullNotSupported(t *testing.T) {
+	helper := NewFileTestUtil(t)
+	helper.CreateFile("cpu.pressure")
+	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n")
+
+	psi, err := ReadPSI(helper.TempDir + "/cpu.pressure")
+	assert.Nil(t, err)
+	assert.Equal(t, false, psi.FullSupported)
+}


### PR DESCRIPTION
… to record metrics

Signed-off-by: songtao98 <songtao2603060@gmail.com>

### Ⅰ. Describe what this PR does
This PR implements PSI collector for interference detection feature of koordlet. The PSI collector only works on **kernels that support and open PSI feature**. 

For the first stage of koordlet interference detection feature, metrics will be recorded by Prometheus, so that interference detection algorithm can use these metrics. The complete data report path will be implemented in the near future. 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
