### PR TITLE
koord-descheduler: resources update by the fake client in dry run mode

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -243,6 +243,11 @@ func (d *Descheduler) Start(ctx context.Context) error {
 			cancel()
 			return
 		}
+		// Now, we only support dry run once
+		if d.dryRun {
+			cancel()
+			return
+		}
 	}, d.deschedulingInterval, ctx.Done())
 	return nil
 }

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -825,7 +825,7 @@ func TestPodEvictor(t *testing.T) {
 			podEvictor.dryRun = false
 		}()
 		result := podEvictor.Evict(ctx, pod, framework.EvictOptions{})
-		assert.True(t, result)
+		assert.False(t, result)
 	})
 
 	t.Run("expect evict Pod successfully", func(t *testing.T) {

--- a/pkg/descheduler/framework/plugins/defaultevictor/evictor.go
+++ b/pkg/descheduler/framework/plugins/defaultevictor/evictor.go
@@ -24,6 +24,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/client-go/listers/core/v1"
+	schedulingv1 "k8s.io/client-go/listers/scheduling/v1"
+	core "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/apis/policy"
 
 	deschedulerconfig "github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/evictions"
@@ -63,6 +70,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		}
 	}
 
+	podLister := handle.SharedInformerFactory().Core().V1().Pods().Lister()
+	nodeLister := handle.SharedInformerFactory().Core().V1().Nodes().Lister()
+	namespaceLister := handle.SharedInformerFactory().Core().V1().Namespaces().Lister()
 	priorityClassLister := handle.SharedInformerFactory().Scheduling().V1().PriorityClasses().Lister()
 	priorityThreshold, err := utils.GetPriorityValueFromPriorityThreshold(priorityClassLister, evictorArgs.PriorityThreshold)
 	if err != nil {
@@ -81,8 +91,22 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		evictions.WithPriorityThreshold(priorityThreshold),
 	)
 
+	var podEvictorClient clientset.Interface
+	if evictorArgs.DryRun {
+		klog.V(3).Infof("Building a fake client from the cluster for the dry run")
+		fakeClientSet, err := fakeClient(podLister, nodeLister, namespaceLister, priorityClassLister)
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+
+		podEvictorClient = fakeClientSet
+	} else {
+		podEvictorClient = handle.ClientSet()
+	}
+
 	podEvictor := evictions.NewPodEvictor(
-		handle.ClientSet(),
+		podEvictorClient,
 		handle.EventRecorder(),
 		"",
 		evictorArgs.DryRun,
@@ -107,4 +131,73 @@ func (d *DefaultEvictor) Filter(pod *corev1.Pod) bool {
 
 func (d *DefaultEvictor) Evict(ctx context.Context, pod *corev1.Pod, evictOptions framework.EvictOptions) bool {
 	return d.evictor.Evict(ctx, pod, evictOptions)
+}
+
+func fakeClient(podLister v1.PodLister, nodeLister v1.NodeLister, namespaceLister v1.NamespaceLister, priorityClassLister schedulingv1.PriorityClassLister) (clientset.Interface, error) {
+	fakeClientSet := fake.NewSimpleClientset()
+	fakeClientSet.PrependReactor("create", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		switch action.GetSubresource() {
+		case "eviction":
+			act, ok := action.(core.CreateActionImpl)
+			if !ok {
+				return false, nil, fmt.Errorf("unable to convert action to core.CreateActionImpl")
+			}
+			evictionObj, ok := act.Object.(*policy.Eviction)
+			if !ok {
+				return false, nil, fmt.Errorf("unable to convert action object into *policy.Eviction")
+			}
+			if err := fakeClientSet.Tracker().Delete(act.GetResource(), evictionObj.GetNamespace(), evictionObj.GetName()); err != nil {
+				return false, nil, fmt.Errorf("unable to delete pod %v/%v in fake: %v", evictionObj.GetNamespace(), evictionObj.GetName(), err)
+			}
+			return true, nil, nil
+		}
+		return false, nil, nil
+	})
+
+	klog.V(3).Infof("Pulling resources for the fake client from the cluster")
+	pods, err := podLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list pods: %v", err)
+	}
+
+	for _, pod := range pods {
+		if _, err := fakeClientSet.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+			return nil, fmt.Errorf("unable to copy pod to fake: %v", err)
+		}
+	}
+
+	nodes, err := nodeLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list nodes: %v", err)
+	}
+
+	for _, node := range nodes {
+		if _, err := fakeClientSet.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{}); err != nil {
+			return nil, fmt.Errorf("unable to copy node to fake: %v", err)
+		}
+	}
+
+	namespaces, err := namespaceLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list namespaces: %v", err)
+	}
+
+	for _, namespace := range namespaces {
+		if _, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{}); err != nil {
+			return nil, fmt.Errorf("unable to copy namespace to fake: %v", err)
+		}
+	}
+
+	priorityClasses, err := priorityClassLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list priorityClasses: %v", err)
+	}
+
+	for _, priorityClass := range priorityClasses {
+		if _, err := fakeClientSet.SchedulingV1().PriorityClasses().Create(context.TODO(), priorityClass, metav1.CreateOptions{}); err != nil {
+			return nil, fmt.Errorf("unable to copy priorityClass to fake: %v", err)
+		}
+	}
+
+	return fakeClientSet, nil
 }


### PR DESCRIPTION
Signed-off-by: LeoLiuYan <929908264@qq.com>

### Ⅰ. Describe what this PR does

When running descheduler in dry run mode,  resources update by the fake client.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [✅] I have written necessary docs and comments
- [✅] I have added necessary unit tests and integration tests
- [✅] All checks passed in `make test`
