### PR TITLE
koord-scheduler: fix errors caused by incorrect lock in ElasticQuota

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -564,8 +564,8 @@ func (gqm *GroupQuotaManager) getPodIsAssignedNoLock(quotaName string, pod *v1.P
 }
 
 func (gqm *GroupQuotaManager) MigratePod(pod *v1.Pod, out, in string) {
-	gqm.hierarchyUpdateLock.RLock()
-	defer gqm.hierarchyUpdateLock.RUnlock()
+	gqm.hierarchyUpdateLock.Lock()
+	defer gqm.hierarchyUpdateLock.Unlock()
 
 	isAssigned := gqm.getPodIsAssignedNoLock(out, pod)
 	gqm.updatePodRequestNoLock(out, pod, nil)


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
When deleting QuotaGroup, the pod in the QuotaGroup will be moved to defaultQuota, while the background loop will move the defaultQuota to another quotaGroup. The two processes only have readLock constraints, it will result in some errors. So this PR will change the readLock to writeLock to fix the problem. 
As the migrate operation is low-frequency, the writeLock will not influence the performance.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
