### PR TITLE
koord-scheduler: fix elasticQuota ut fail

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -134,6 +134,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 
 	ctx := context.TODO()
 
+	elasticQuota.createSystemQuotaIfNotPresent()
+	elasticQuota.createDefaultQuotaIfNotPresent()
+
 	scheSharedInformerFactory.Start(ctx.Done())
 	handle.SharedInformerFactory().Start(ctx.Done())
 
@@ -141,8 +144,6 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	handle.SharedInformerFactory().WaitForCacheSync(ctx.Done())
 
 	elasticQuota.migrateDefaultQuotaGroupsPod()
-	elasticQuota.createSystemQuotaIfNotPresent()
-	elasticQuota.createDefaultQuotaIfNotPresent()
 
 	return elasticQuota, nil
 }


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
查看了抢占UT失败的原因，SystemQuota或者DefaultQuota在测试的两个Quota组Add之后才触发了OnQuotaAdd事件。在重建树的时候，测试的两个quota组的runtimeQuota会被erase，但又没有触发refreshRuntimeQuota的时间，所以runtimeQuota为0。对于UT的解法，先加载SystemQuota以及DefaultQuota，再开始测试。
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
