### PR TITLE
koord-scheduler: support force sync data from informer

### DIFF
--- a/pkg/scheduler/frameworkext/helper/synced_eventhandler.go
+++ b/pkg/scheduler/frameworkext/helper/synced_eventhandler.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"reflect"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+type forceSyncEventHandler struct {
+	handler cache.ResourceEventHandler
+	syncCh  chan struct{}
+	objects map[apimachinerytypes.UID]int64
+}
+
+func newForceSyncEventHandler(handler cache.ResourceEventHandler) *forceSyncEventHandler {
+	return &forceSyncEventHandler{
+		handler: handler,
+		syncCh:  make(chan struct{}, 1),
+		objects: map[apimachinerytypes.UID]int64{},
+	}
+}
+
+func (h *forceSyncEventHandler) syncDone() {
+	close(h.syncCh)
+}
+
+func (h *forceSyncEventHandler) waitForSyncDone() {
+	<-h.syncCh
+}
+
+func (h *forceSyncEventHandler) OnAdd(obj interface{}) {
+	h.waitForSyncDone()
+	if metaAccessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		objectMeta := metaAccessor.GetObjectMeta()
+		objectUID := objectMeta.GetUID()
+		if oldResourceVersion, ok := h.objects[objectUID]; ok && oldResourceVersion != 0 {
+			resourceVersion, err := strconv.ParseInt(objectMeta.GetResourceVersion(), 10, 64)
+			if err == nil && resourceVersion <= oldResourceVersion {
+				return
+			}
+			delete(h.objects, objectUID)
+		}
+	}
+	h.handler.OnAdd(obj)
+}
+
+func (h *forceSyncEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	h.waitForSyncDone()
+	if h.objects != nil {
+		// Release objects map to reduce memory usage and reduce GC pressure
+		h.objects = nil
+	}
+	h.handler.OnUpdate(oldObj, newObj)
+}
+
+func (h *forceSyncEventHandler) OnDelete(obj interface{}) {
+	h.waitForSyncDone()
+	if h.objects != nil {
+		// Release objects map to reduce memory usage and reduce GC pressure
+		h.objects = nil
+	}
+	h.handler.OnDelete(obj)
+}
+
+func (h *forceSyncEventHandler) addDirectly(obj interface{}) {
+	h.handler.OnAdd(obj)
+	if metaAccessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		objectMeta := metaAccessor.GetObjectMeta()
+		resourceVersion, err := strconv.ParseInt(objectMeta.GetResourceVersion(), 10, 64)
+		if err == nil {
+			h.objects[objectMeta.GetUID()] = resourceVersion
+		}
+	}
+}
+
+type CacheSyncer interface {
+	Start(stopCh <-chan struct{})
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+// ForceSyncFromInformer ensures that the EventHandler will synchronize data immediately after registration,
+// helping those plugins that need to build memory status through EventHandler to correctly synchronize data
+func ForceSyncFromInformer(stopCh <-chan struct{}, cacheSyncer CacheSyncer, informer cache.SharedInformer, handler cache.ResourceEventHandler) {
+	syncEventHandler := newForceSyncEventHandler(handler)
+	informer.AddEventHandler(syncEventHandler)
+	cacheSyncer.Start(stopCh)
+	cacheSyncer.WaitForCacheSync(stopCh)
+	allObjects := informer.GetStore().List()
+	for _, obj := range allObjects {
+		syncEventHandler.addDirectly(obj)
+	}
+	syncEventHandler.syncDone()
+	return
+}

--- a/pkg/scheduler/frameworkext/helper/synced_eventhandler_test.go
+++ b/pkg/scheduler/frameworkext/helper/synced_eventhandler_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSyncedEventHandler(t *testing.T) {
+	var objects []runtime.Object
+	for i := 0; i < 10; i++ {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:             uuid.NewUUID(),
+				Name:            fmt.Sprintf("node-%d", i),
+				ResourceVersion: fmt.Sprintf("%d", i+1),
+			},
+		}
+		objects = append(objects, node)
+	}
+	fakeClientSet := kubefake.NewSimpleClientset(objects...)
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
+	addTimes := map[string]int{}
+	var wg sync.WaitGroup
+	wg.Add(10)
+	ForceSyncFromInformer(context.TODO().Done(), sharedInformerFactory, nodeInformer.Informer(), cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			node := obj.(*corev1.Node)
+			addTimes[node.Name]++
+			wg.Done()
+		},
+	})
+	wg.Wait()
+	for _, v := range addTimes {
+		if v > 1 {
+			t.Errorf("unexpected add times, want 1 but got %d", v)
+			break
+		}
+	}
+	node, err := nodeInformer.Lister().Get("node-0")
+	assert.NoError(t, err)
+	assert.NotNil(t, node)
+	node = node.DeepCopy()
+	node.ResourceVersion = "100"
+	_, err = fakeClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
+		node, err := nodeInformer.Lister().Get("node-0")
+		assert.NoError(t, err)
+		assert.NotNil(t, node)
+		return node.ResourceVersion == "100", nil
+	}, wait.NeverStop)
+	assert.NoError(t, err)
+}

--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
@@ -270,13 +270,8 @@ func setUp(ctx context.Context, podNames []string, pgName string, podPhase v1.Po
 	podInformer := informerFactory.Core().V1().Pods()
 	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
 
-	pgMgr := core.NewPodGroupManager(pgClient, pgInformer, podInformer, &config.CoschedulingArgs{DefaultTimeout: &metav1.Duration{Duration: time.Second}})
+	pgMgr := core.NewPodGroupManager(pgClient, pgInformerFactory, informerFactory, &config.CoschedulingArgs{DefaultTimeout: &metav1.Duration{Duration: time.Second}})
 	ctrl := NewPodGroupController(kubeClient, pgInformer, podInformer, pgClient, pgMgr, nil, 1)
-
-	pgInformerFactory.Start(ctx.Done())
-	informerFactory.Start(ctx.Done())
-	pgInformerFactory.WaitForCacheSync(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
 	return ctrl, kubeClient, pgClient
 }
 

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -45,15 +45,14 @@ type Mgr struct {
 	pgInformer pginformer.PodGroupInformer
 }
 
-func NewManager4Test() *Mgr {
+func NewManagerForTest() *Mgr {
 	pgClient := fakepgclientset.NewSimpleClientset()
 	pgInformerFactory := pgformers.NewSharedInformerFactory(pgClient, 0)
 	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
 
 	podClient := clientsetfake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(podClient, 0)
-	podInformer := informerFactory.Core().V1().Pods()
-	pgManager := NewPodGroupManager(pgClient, pgInformer, podInformer, &config.CoschedulingArgs{DefaultTimeout: &metav1.Duration{Duration: 300 * time.Second}})
+	pgManager := NewPodGroupManager(pgClient, pgInformerFactory, informerFactory, &config.CoschedulingArgs{DefaultTimeout: &metav1.Duration{Duration: 300 * time.Second}})
 	return &Mgr{
 		pgMgr:      pgManager,
 		pgInformer: pgInformer,
@@ -77,7 +76,7 @@ func makePg(name, namespace string, min int32, creationTime *time.Time, minResou
 
 func TestPlugin_PreFilter(t *testing.T) {
 	gangACreatedTime := time.Now()
-	mgr := NewManager4Test().pgMgr
+	mgr := NewManagerForTest().pgMgr
 	tests := []struct {
 		name string
 		// test pod
@@ -379,7 +378,7 @@ func TestPermit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mgr := NewManager4Test().pgMgr
+			mgr := NewManagerForTest().pgMgr
 			// pg create
 			for _, pg := range tt.pgs {
 				if tt.needGangGroup {
@@ -444,7 +443,7 @@ func TestPostBind(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bigMgr := NewManager4Test()
+			bigMgr := NewManagerForTest()
 			mgr, pginforme := bigMgr.pgMgr, bigMgr.pgInformer
 			// pg create
 			if tt.annotation != nil {

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -78,12 +78,8 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 		pgClient = pgclientset.NewForConfigOrDie(&kubeConfig)
 	}
 	pgInformerFactory := pgformers.NewSharedInformerFactory(pgClient, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	podInformer := handle.SharedInformerFactory().Core().V1().Pods()
 
-	ctx := context.TODO()
-
-	pgMgr := core.NewPodGroupManager(pgClient, pgInformer, podInformer, args)
+	pgMgr := core.NewPodGroupManager(pgClient, pgInformerFactory, handle.SharedInformerFactory(), args)
 	var controllerWorkers int
 	if args == nil {
 		controllerWorkers = 1
@@ -95,12 +91,6 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 		pgMgr:            pgMgr,
 		workers:          controllerWorkers,
 	}
-
-	pgInformerFactory.Start(ctx.Done())
-	handle.SharedInformerFactory().Start(ctx.Done())
-
-	pgInformerFactory.WaitForCacheSync(ctx.Done())
-	handle.SharedInformerFactory().WaitForCacheSync(ctx.Done())
 
 	return plugin, nil
 }

--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -613,6 +613,11 @@ func (gqm *GroupQuotaManager) OnPodAdd(quotaName string, pod *v1.Pod) {
 	gqm.hierarchyUpdateLock.RLock()
 	defer gqm.hierarchyUpdateLock.RUnlock()
 
+	quotaInfo := gqm.getQuotaInfoByNameNoLock(quotaName)
+	if quotaInfo != nil && quotaInfo.isPodExist(pod) {
+		return
+	}
+
 	gqm.updatePodCacheNoLock(quotaName, pod, true)
 	gqm.updatePodRequestNoLock(quotaName, nil, pod)
 	// in case failOver, update pod isAssigned explicitly according to its phase and NodeName.

--- a/pkg/scheduler/plugins/elasticquota/core/quota_info.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info.go
@@ -36,7 +36,7 @@ type QuotaCalculateInfo struct {
 	// equal to "min", the quota group can obtain equivalent resources to the "request"
 	Min v1.ResourceList
 	// If Child's sumMin is larger than totalResource, the value of Min should be scaled in equal proportion
-	//to ensure the correctness and fairness of min
+	// to ensure the correctness and fairness of min
 	AutoScaleMin v1.ResourceList
 	// All assigned pods used
 	Used v1.ResourceList
@@ -170,7 +170,7 @@ func (qi *QuotaInfo) getLimitRequestNoLock() v1.ResourceList {
 	for resName, quantity := range limitRequest {
 		if maxQuantity, ok := qi.CalculateInfo.Max[resName]; ok {
 			if quantity.Cmp(maxQuantity) == 1 {
-				//req > max, limitRequest = max
+				// req > max, limitRequest = max
 				limitRequest[resName] = maxQuantity.DeepCopy()
 			}
 		}
@@ -271,6 +271,13 @@ func (qi *QuotaInfo) isQuotaMetaChange(quotaInfo *QuotaInfo) bool {
 		return true
 	}
 	return false
+}
+
+func (qi *QuotaInfo) isPodExist(pod *v1.Pod) bool {
+	qi.lock.Lock()
+	defer qi.lock.Unlock()
+	_, exist := qi.PodCache[string(pod.UID)]
+	return exist
 }
 
 func (qi *QuotaInfo) addPodIfNotPresent(pod *v1.Pod) {

--- a/pkg/scheduler/plugins/elasticquota/node_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/node_handler.go
@@ -39,12 +39,9 @@ func (g *Plugin) OnNodeAdd(obj interface{}) {
 	defer g.nodeResourceMapLock.Unlock()
 
 	if _, ok := g.nodeResourceMap[node.Name]; ok {
-		klog.Infof("OnNodeAddFunc skip due onAdd twice:%v", node.Name)
 		return
-	} else {
-		g.nodeResourceMap[node.Name] = struct{}{}
 	}
-
+	g.nodeResourceMap[node.Name] = struct{}{}
 	g.groupQuotaManager.UpdateClusterTotalResource(allocatable)
 	klog.V(5).Infof("OnNodeAddFunc success %v", node.Name)
 }

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
@@ -40,10 +40,11 @@ func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 		pg.pluginArgs.RevokePodInterval.Duration, pg.groupQuotaManager, *pg.pluginArgs.MonitorAllQuotas)
 	quotaOverUsedRevokeController.syncQuota()
 	monitor := quotaOverUsedRevokeController.monitors["test1"]
+	var pod *corev1.Pod
 	{
 		usedQuota := createResourceList(0, 0)
 		usedQuota["extended"] = *resource.NewQuantity(10000, resource.DecimalSI)
-		pod := makePod2("pod", usedQuota)
+		pod = makePod2("pod", usedQuota)
 		gqm.OnPodAdd("test1", pod)
 
 		result := monitor.monitor()
@@ -54,8 +55,9 @@ func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 	{
 		usedQuota := createResourceList(1000, 0)
 		usedQuota["extended"] = *resource.NewQuantity(10000, resource.DecimalSI)
-		pod := makePod2("pod", usedQuota)
-		gqm.OnPodAdd("test1", pod)
+		oldPod := pod
+		pod = makePod2("pod", usedQuota)
+		gqm.OnPodUpdate("test1", "test1", pod, oldPod)
 
 		result := monitor.monitor()
 		if result {
@@ -65,8 +67,9 @@ func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 	{
 		usedQuota := createResourceList(-1000, 0)
 		usedQuota["extended"] = *resource.NewQuantity(10000, resource.DecimalSI)
-		pod := makePod2("pod", usedQuota)
-		gqm.OnPodAdd("test1", pod)
+		oldPod := pod
+		pod = makePod2("pod", usedQuota)
+		gqm.OnPodUpdate("test1", "test1", pod, oldPod)
 
 		result := monitor.monitor()
 		if result {
@@ -76,8 +79,9 @@ func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 	{
 		usedQuota := createResourceList(1000, 0)
 		usedQuota["extended"] = *resource.NewQuantity(10000, resource.DecimalSI)
-		pod := makePod2("pod", usedQuota)
-		gqm.OnPodAdd("test1", pod)
+		oldPod := pod
+		pod = makePod2("pod", usedQuota)
+		gqm.OnPodUpdate("test1", "test1", pod, oldPod)
 
 		monitor.overUsedTriggerEvictDuration = 0 * time.Second
 

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -36,6 +36,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/validation"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 )
 
 const (
@@ -82,7 +83,8 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	}
 
 	assignCache := newPodAssignCache()
-	frameworkExtender.SharedInformerFactory().Core().V1().Pods().Informer().AddEventHandler(assignCache)
+	podInformer := frameworkExtender.SharedInformerFactory().Core().V1().Pods().Informer()
+	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), frameworkExtender.SharedInformerFactory(), podInformer, assignCache)
 	nodeMetricLister := frameworkExtender.KoordinatorSharedInformerFactory().Slo().V1alpha1().NodeMetrics().Lister()
 
 	return &Plugin{

--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
@@ -17,10 +17,13 @@ limitations under the License.
 package nodenumaresource
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
@@ -30,9 +33,11 @@ type podEventHandler struct {
 }
 
 func registerPodEventHandler(handle framework.Handle, cpuManager CPUManager) {
-	handle.SharedInformerFactory().Core().V1().Pods().Informer().AddEventHandler(&podEventHandler{
+	podInformer := handle.SharedInformerFactory().Core().V1().Pods().Informer()
+	eventHandler := &podEventHandler{
 		cpuManager: cpuManager,
-	})
+	}
+	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), handle.SharedInformerFactory(), podInformer, eventHandler)
 }
 
 func (c *podEventHandler) OnAdd(obj interface{}) {

--- a/pkg/scheduler/plugins/nodenumaresource/topology_eventhandler.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_eventhandler.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
@@ -53,9 +54,7 @@ func registerNodeResourceTopologyEventHandler(handle framework.Handle, topologyM
 	eventHandler := &nodeResourceTopologyEventHandler{
 		topologyManager: topologyManager,
 	}
-	nodeResTopologyInformer.AddEventHandler(eventHandler)
-	nodeResTopologyInformerFactory.Start(context.TODO().Done())
-	nodeResTopologyInformerFactory.WaitForCacheSync(context.TODO().Done())
+	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), nodeResTopologyInformerFactory, nodeResTopologyInformer, eventHandler)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

Currently, the existing scheduling plugins of koord-scheduler will construct the internal state data of the plugin based on the data in the Informer, such as which Pods are maintained in NodeNUMAResource and which CPUs are allocated, which Pods are maintained in DeviceShare and which GPU instances are allocated, and so on. These data must be correct, otherwise it may cause problems with the resources allocated during Pod scheduling, or the orchestration results may not meet expectations, which will seriously affect the runtime problems or availability of workloads.

In the current existing code, the EventHandler is registered with the Informer, and the internal state can be constructed after WaitForCacheSync returns, but WaitForCacheSync only means that the data queried from the APIServer is synchronized to the Store inside the Informer, and does not perceive the Event in the EventHandler whether processing is complete. This also means that when WaitForCacheSync returns, EventHandler may not have finished processing the existing Add Event, and this problem will be more obvious in a larger cluster.

Therefore, we need a mechanism that can help the plugin to correctly convert the data in the Informer to the internal state of the plugin, and ensure that subsequent Add/Update/Delete Events can be processed correctly. Hence the introduction of `ForceSyncedEventHandler`.

When the plugin is initialized, you can register the EventHandler through `frameworkexthelp.ForceSyncFromInformer`. This function will automatically start the Informer, and wait for the data to be synchronized successfully before pouring the current data into the EventHandler.
