### PR TITLE
koord-scheduler: ElasticQuota uses Pod Namespace/Name as cache key

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -539,7 +539,7 @@ func (gqm *GroupQuotaManager) updatePodCacheNoLock(quotaName string, pod *v1.Pod
 	if isAdd {
 		quotaInfo.addPodIfNotPresent(pod)
 	} else {
-		quotaInfo.removePodIfPresent(pod.Name)
+		quotaInfo.removePodIfPresent(pod)
 	}
 }
 
@@ -552,7 +552,7 @@ func (gqm *GroupQuotaManager) UpdatePodIsAssigned(quotaName string, pod *v1.Pod,
 
 func (gqm *GroupQuotaManager) updatePodIsAssignedNoLock(quotaName string, pod *v1.Pod, isAssigned bool) error {
 	quotaInfo := gqm.getQuotaInfoByNameNoLock(quotaName)
-	return quotaInfo.UpdatePodIsAssigned(pod.Name, isAssigned)
+	return quotaInfo.UpdatePodIsAssigned(pod, isAssigned)
 }
 
 func (gqm *GroupQuotaManager) getPodIsAssignedNoLock(quotaName string, pod *v1.Pod) bool {

--- a/pkg/scheduler/plugins/elasticquota/core/quota_info_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info_test.go
@@ -30,13 +30,13 @@ func TestQuotaInfo_AddPodIfNotPresent_RemovePodIfPresent_GetPodCache(t *testing.
 	assert.Equal(t, 1, len(qi.GetPodCache()))
 	qi.addPodIfNotPresent(pod)
 	assert.False(t, qi.GetPodIsAssigned(pod))
-	err := qi.UpdatePodIsAssigned(pod.Name, false)
+	err := qi.UpdatePodIsAssigned(pod, false)
 	assert.NotNil(t, err)
-	err = qi.UpdatePodIsAssigned(pod.Name, true)
+	err = qi.UpdatePodIsAssigned(pod, true)
 	assert.Nil(t, err)
 	assert.True(t, qi.GetPodIsAssigned(pod))
 
-	qi.removePodIfPresent(pod.Name)
+	qi.removePodIfPresent(pod)
 	assert.Equal(t, 0, len(qi.GetPodCache()))
 }
 

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -191,7 +191,7 @@ func (g *Plugin) AddPod(ctx context.Context, state *framework.CycleState, podToS
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	quotaInfo := postFilterState.quotaInfo
-	if err = quotaInfo.UpdatePodIsAssigned(podInfoToAdd.Pod.Name, true); err != nil {
+	if err = quotaInfo.UpdatePodIsAssigned(podInfoToAdd.Pod, true); err != nil {
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	podReq, _ := resource.PodRequestsAndLimits(podInfoToAdd.Pod)
@@ -209,7 +209,7 @@ func (g *Plugin) RemovePod(ctx context.Context, state *framework.CycleState, pod
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	quotaInfo := postFilterState.quotaInfo
-	if err = quotaInfo.UpdatePodIsAssigned(podInfoToRemove.Pod.Name, false); err != nil {
+	if err = quotaInfo.UpdatePodIsAssigned(podInfoToRemove.Pod, false); err != nil {
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	podReq, _ := resource.PodRequestsAndLimits(podInfoToRemove.Pod)

--- a/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
@@ -117,8 +117,8 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 		assert.Equal(t, quotaSummary.IsParent, quotaExpected.IsParent)
 		assert.Equal(t, quotaSummary.AllowLentResource, quotaExpected.AllowLentResource)
 		assert.Equal(t, len(quotaSummary.PodCache), 1)
-		assert.Equal(t, quotaSummary.PodCache["pod1"].IsAssigned, true)
-		assert.True(t, quotav1.Equals(quotaSummary.PodCache["pod1"].Resource, createResourceList(33, 33)))
+		assert.Equal(t, quotaSummary.PodCache[podToCreate.Namespace+"/"+podToCreate.Name].IsAssigned, true)
+		assert.True(t, quotav1.Equals(quotaSummary.PodCache[podToCreate.Namespace+"/"+podToCreate.Name].Resource, createResourceList(33, 33)))
 	}
 	{
 		engine := gin.Default()
@@ -145,7 +145,7 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 		assert.Equal(t, quotaSummary.IsParent, quotaExpected.IsParent)
 		assert.Equal(t, quotaSummary.AllowLentResource, quotaExpected.AllowLentResource)
 		assert.Equal(t, len(quotaSummary.PodCache), 1)
-		assert.Equal(t, quotaSummary.PodCache["pod1"].IsAssigned, true)
-		assert.True(t, quotav1.Equals(quotaSummary.PodCache["pod1"].Resource, createResourceList(33, 33)))
+		assert.Equal(t, quotaSummary.PodCache[podToCreate.Namespace+"/"+podToCreate.Name].IsAssigned, true)
+		assert.True(t, quotav1.Equals(quotaSummary.PodCache[podToCreate.Namespace+"/"+podToCreate.Name].Resource, createResourceList(33, 33)))
 	}
 }

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
@@ -130,7 +130,7 @@ func TestQuotaOverUsedRevokeController_GetToRevokePodList(t *testing.T) {
 	if len(result) != 4 {
 		t.Errorf("error:%v", len(result))
 	}
-	err := quotaInfo.UpdatePodIsAssigned("4", false)
+	err := quotaInfo.UpdatePodIsAssigned(pod4, false)
 	pod4.Status.Phase = corev1.PodPending
 	assert.Nil(t, err)
 	result = con.monitors["test1"].getToRevokePodList("test1")


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
Use pod.Namesapce/Name as the key of the QuotaInfo's PodCache instead of pod.Name.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fix #839
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
