### PR TITLE
koord-scheduler: ElasticQuota supports Decorator to decorate Node, Pod and ElasticQuota

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/decorator.go
+++ b/pkg/scheduler/plugins/elasticquota/core/decorator.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulingv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+)
+
+var decorators []Decorator
+
+func RegisterDecorator(decorator Decorator) {
+	decorators = append(decorators, decorator)
+}
+
+// Decorator can decorate the Node, Pod and ElasticQuota as needed
+// e.g: If you want to append some additional resources into Node, Pod and ElasticQuota
+//  such as GPU Resources or modify Spec by GPU model, you can implement the Decorator.
+type Decorator interface {
+	Init(handle framework.Handle) error
+	DecorateNode(node *corev1.Node) *corev1.Node
+	DecoratePod(pod *corev1.Pod) *corev1.Pod
+	DecorateElasticQuota(quota *schedulingv1alpha1.ElasticQuota) *schedulingv1alpha1.ElasticQuota
+}
+
+func RunDecorateInit(handle framework.Handle) error {
+	if len(decorators) == 0 {
+		return nil
+	}
+	for _, decorator := range decorators {
+		if err := decorator.Init(handle); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RunDecorateNode(node *corev1.Node) *corev1.Node {
+	if len(decorators) == 0 {
+		return node
+	}
+	node = node.DeepCopy()
+	for _, decorator := range decorators {
+		node = decorator.DecorateNode(node)
+	}
+	return node
+}
+
+func RunDecoratePod(pod *corev1.Pod) *corev1.Pod {
+	if len(decorators) == 0 {
+		return pod
+	}
+	pod = pod.DeepCopy()
+	for _, decorator := range decorators {
+		pod = decorator.DecoratePod(pod)
+	}
+	return pod
+}
+
+func RunDecorateElasticQuota(quota *schedulingv1alpha1.ElasticQuota) *schedulingv1alpha1.ElasticQuota {
+	if len(decorators) == 0 {
+		return quota
+	}
+	quota = quota.DeepCopy()
+	for _, decorator := range decorators {
+		quota = decorator.DecorateElasticQuota(quota)
+	}
+	return quota
+}

--- a/pkg/scheduler/plugins/elasticquota/pod_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/pod_handler.go
@@ -19,6 +19,8 @@ package elasticquota
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core"
 )
 
 // todo the eventHandler's operation should be a complete transaction in the future work.
@@ -29,6 +31,7 @@ func (g *Plugin) OnPodAdd(obj interface{}) {
 		return
 	}
 
+	pod = core.RunDecoratePod(pod)
 	quotaName := g.getPodAssociateQuotaName(pod)
 	g.groupQuotaManager.OnPodAdd(quotaName, pod)
 	klog.V(5).Infof("OnPodAddFunc %v.%v add success, quotaName:%v", pod.Namespace, pod.Name, quotaName)
@@ -43,6 +46,8 @@ func (g *Plugin) OnPodUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
+	oldPod = core.RunDecoratePod(oldPod)
+	newPod = core.RunDecoratePod(newPod)
 	oldQuotaName := g.getPodAssociateQuotaName(oldPod)
 	newQuotaName := g.getPodAssociateQuotaName(newPod)
 	g.groupQuotaManager.OnPodUpdate(newQuotaName, oldQuotaName, newPod, oldPod)

--- a/pkg/scheduler/plugins/elasticquota/quota_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_handler.go
@@ -41,6 +41,7 @@ func (g *Plugin) OnQuotaAdd(obj interface{}) {
 		return
 	}
 
+	quota = core.RunDecorateElasticQuota(quota)
 	g.groupQuotaManager.UpdateQuota(quota, false)
 	klog.V(5).Infof("OnQuotaAddFunc success: %v.%v", quota.Namespace, quota.Name)
 }
@@ -54,6 +55,7 @@ func (g *Plugin) OnQuotaUpdate(oldObj, newObj interface{}) {
 	}
 	klog.V(5).Infof("OnQuotaUpdateFunc update quota: %v.%v", newQuota.Namespace, newQuota.Name)
 
+	newQuota = core.RunDecorateElasticQuota(newQuota)
 	g.groupQuotaManager.UpdateQuota(newQuota, false)
 	klog.V(5).Infof("OnQuotaUpdateFunc success: %v.%v", newQuota.Namespace, newQuota.Name)
 }
@@ -70,6 +72,7 @@ func (g *Plugin) OnQuotaDelete(obj interface{}) {
 	klog.V(5).Infof("OnQuotaDeleteFunc delete quota:%+v", quota)
 
 	g.migratePods(quota.Name, extension.DefaultQuotaName)
+	quota = core.RunDecorateElasticQuota(quota)
 	if err := g.groupQuotaManager.UpdateQuota(quota, true); err != nil {
 		klog.Errorf("OnQuotaDeleteFunc failed: %v.%v", quota.Namespace, quota.Name)
 	}


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

ElasticQuota scheduling plugin supports `Decorator` interface to decorate Node, Pod and ElasticQuota as needed. 
For example, if you want to append some additional resources into Node, Pod and ElasticQuota such as GPU Resources or modify Spec by GPU model, you can implement the Decorator interface. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
