### PR TITLE
koord-scheduler: fix PodGroupController init error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,11 +50,11 @@ jobs:
           git diff --cached --exit-code || (echo 'Please run "make generate" to generate Go codes' && exit 1);
       - name: Verify gofmt
         run: |
-          make fmt && git add pkg cmd &&
+          make fmt && git add apis pkg cmd &&
           git diff --cached --exit-code || (echo 'Please run "make fmt" to verify gofmt' && exit 1);
       - name: Verify govet
         run: |
-          make vet && git add pkg cmd &&
+          make vet && git add apis pkg cmd &&
           git diff --cached --exit-code || (echo 'Please run "make vet" to verify govet' && exit 1);
       - name: Run Go build
         run: make build

--- a/apis/slo/v1alpha1/nodemetric_types.go
+++ b/apis/slo/v1alpha1/nodemetric_types.go
@@ -27,11 +27,11 @@ type AggregationType string
 
 const (
 	// max is not welcomed since it may import outliers
-	AVG    AggregationType = "avg"
-	P99    AggregationType = "p99"
-	P95    AggregationType = "p95"
-	P90    AggregationType = "p90"
-	P50    AggregationType = "p50"
+	AVG AggregationType = "avg"
+	P99 AggregationType = "p99"
+	P95 AggregationType = "p95"
+	P90 AggregationType = "p90"
+	P50 AggregationType = "p50"
 )
 
 type NodeMetricInfo struct {

--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
@@ -33,10 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformer "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/kubernetes"
 	corelister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	schedv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
@@ -55,7 +53,6 @@ const (
 
 // PodGroupController  is used to control that process pod groups using provided Handler interface
 type PodGroupController struct {
-	eventRecorder   events.EventRecorder
 	pgQueue         workqueue.RateLimitingInterface
 	pgLister        schedlister.PodGroupLister
 	podLister       corelister.PodLister
@@ -67,13 +64,14 @@ type PodGroupController struct {
 }
 
 // NewPodGroupController returns a new *PodGroupController
-func NewPodGroupController(client kubernetes.Interface,
+func NewPodGroupController(
 	pgInformer schedinformer.PodGroupInformer,
 	podInformer coreinformer.PodInformer,
-	pgClient schedclientset.Interface, podGroupManager *core.PodGroupManager, recorder events.EventRecorder, workers int) *PodGroupController {
-
+	pgClient schedclientset.Interface,
+	podGroupManager *core.PodGroupManager,
+	workers int,
+) *PodGroupController {
 	ctrl := &PodGroupController{
-		eventRecorder:   recorder,
 		pgManager:       podGroupManager,
 		pgClient:        pgClient,
 		pgLister:        pgInformer.Lister(),

--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
@@ -271,7 +271,7 @@ func setUp(ctx context.Context, podNames []string, pgName string, podPhase v1.Po
 	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
 
 	pgMgr := core.NewPodGroupManager(pgClient, pgInformerFactory, informerFactory, &config.CoschedulingArgs{DefaultTimeout: &metav1.Duration{Duration: time.Second}})
-	ctrl := NewPodGroupController(kubeClient, pgInformer, podInformer, pgClient, pgMgr, nil, 1)
+	ctrl := NewPodGroupController(pgInformer, podInformer, pgClient, pgMgr, 1)
 	return ctrl, kubeClient, pgClient
 }
 

--- a/pkg/scheduler/plugins/coscheduling/plugin_controller.go
+++ b/pkg/scheduler/plugins/coscheduling/plugin_controller.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Koordinator Authors.
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coscheduling
+
+import (
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/controller"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/core"
+)
+
+var _ frameworkext.ControllerProvider = &Coscheduling{}
+
+func (cs *Coscheduling) NewControllers() ([]frameworkext.Controller, error) {
+	handle := cs.frameworkHandler
+	podInformer := handle.SharedInformerFactory().Core().V1().Pods()
+	pgMgr := cs.pgMgr.(*core.PodGroupManager)
+	var controllerWorkers int
+	if cs.args == nil {
+		controllerWorkers = 1
+	} else {
+		controllerWorkers = int(*cs.args.ControllerWorkers)
+	}
+	podGroupController := controller.NewPodGroupController(cs.pgInformer, podInformer, cs.pgClient, pgMgr, controllerWorkers)
+	return []frameworkext.Controller{podGroupController}, nil
+}

--- a/pkg/scheduler/plugins/coscheduling/plugin_service.go
+++ b/pkg/scheduler/plugins/coscheduling/plugin_service.go
@@ -11,12 +11,12 @@ import (
 
 var _ services.APIServiceProvider = &Coscheduling{}
 
-func (p *Coscheduling) RegisterEndpoints(group *gin.RouterGroup) {
+func (cs *Coscheduling) RegisterEndpoints(group *gin.RouterGroup) {
 	group.GET("/gang/:namespace/:name", func(c *gin.Context) {
 		gangNamespace := c.Param("namespace")
 		gangName := c.Param("name")
 		gangId := util.GetId(gangNamespace, gangName)
-		gangSummary, exist := p.pgMgr.GetGangSummary(gangId)
+		gangSummary, exist := cs.pgMgr.GetGangSummary(gangId)
 		if !exist {
 			services.ResponseErrorMessage(c, http.StatusNotFound, "cannot find gang %s/%s", gangNamespace, gangName)
 			return
@@ -24,7 +24,7 @@ func (p *Coscheduling) RegisterEndpoints(group *gin.RouterGroup) {
 		c.JSON(http.StatusOK, gangSummary)
 	})
 	group.GET("/gangs", func(c *gin.Context) {
-		allGangSummaries := p.pgMgr.GetGangSummaries()
+		allGangSummaries := cs.pgMgr.GetGangSummaries()
 		c.JSON(http.StatusOK, allGangSummaries)
 	})
 }


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

The PodGroupController could not find the target PodGroup because the PodGroup Informer was not started.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
