### PR TITLE
koord-scheduler: check whether the number of Pods meets minMember first in Coscheduling

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -116,11 +116,9 @@ func TestPlugin_PreFilter(t *testing.T) {
 			expectedScheduleCycle:      1,
 		},
 		{
-			name: "gang ResourceSatisfied",
-			pod:  st.MakePod().Name("podq").UID("podq").Namespace("gangq_ns").Label(v1alpha1.PodGroupLabel, "gangq").Obj(),
-			expectedChildCycleMap: map[string]int{
-				"gangq_ns/podq": 1,
-			},
+			name:                       "gang ResourceSatisfied",
+			pod:                        st.MakePod().Name("podq").UID("podq").Namespace("gangq_ns").Label(v1alpha1.PodGroupLabel, "gangq").Obj(),
+			expectedChildCycleMap:      map[string]int{},
 			pgs:                        makePg("gangq", "gangq_ns", 4, &gangACreatedTime, nil),
 			expectedScheduleCycleValid: true,
 			expectedScheduleCycle:      1,
@@ -132,13 +130,10 @@ func TestPlugin_PreFilter(t *testing.T) {
 			pods: []*corev1.Pod{
 				st.MakePod().Name("pod3-1").UID("pod3-1").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
 			},
-			pgs:                   makePg("ganga", "ganga_ns", 4, &gangACreatedTime, nil),
-			expectedErrorMessage:  "gang child pod not collect enough, gangName: ganga_ns/ganga, podName: ganga_ns/pod3",
-			expectedScheduleCycle: 1,
-			expectedChildCycleMap: map[string]int{
-				"ganga_ns/pod3":   1,
-				"ganga_ns/pod3-1": 1,
-			},
+			pgs:                        makePg("ganga", "ganga_ns", 4, &gangACreatedTime, nil),
+			expectedErrorMessage:       "gang child pod not collect enough, gangName: ganga_ns/ganga, podName: ganga_ns/pod3",
+			expectedScheduleCycle:      1,
+			expectedChildCycleMap:      map[string]int{},
 			expectedScheduleCycleValid: true,
 		},
 		{
@@ -166,10 +161,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 			totalNum:                      5,
 			expectedScheduleCycle:         1,
 			expectedChildCycleMap: map[string]int{
-				"ganga_ns/pod6":   1,
-				"ganga_ns/pod6-1": 1,
-				"ganga_ns/pod6-2": 1,
-				"ganga_ns/pod6-3": 1,
+				"ganga_ns/pod6": 1,
 			},
 			expectedErrorMessage:       "pod's schedule cycle too large, gangName: ganga_ns/gangc, podName: ganga_ns/pod6, podCycle: 1, gangCycle: 1",
 			expectedScheduleCycleValid: true,
@@ -185,10 +177,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 			pgs:                   makePg("gangd", "ganga_ns", 4, &gangACreatedTime, nil),
 			expectedScheduleCycle: 1,
 			expectedChildCycleMap: map[string]int{
-				"ganga_ns/pod7":   1,
-				"ganga_ns/pod7-1": 1,
-				"ganga_ns/pod7-2": 1,
-				"ganga_ns/pod7-3": 1,
+				"ganga_ns/pod7": 1,
 			},
 			expectedScheduleCycleValid: false,
 			expectedErrorMessage:       "gang scheduleCycle not valid, gangName: ganga_ns/gangd, podName: ganga_ns/pod7",
@@ -206,10 +195,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 			totalNum:              5,
 			expectedScheduleCycle: 1,
 			expectedChildCycleMap: map[string]int{
-				"ganga_ns/pod8":   1,
-				"ganga_ns/pod8-1": 1,
-				"ganga_ns/pod8-2": 1,
-				"ganga_ns/pod8-3": 1,
+				"ganga_ns/pod8": 1,
 			},
 			expectedScheduleCycleValid: true,
 			expectedErrorMessage:       "",

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -143,11 +143,11 @@ func (cs *Coscheduling) Less(podInfo1, podInfo2 *framework.QueuedPodInfo) bool {
 // iii.Check whether the Gang has met the scheduleCycleValid check, and reject the pod if negative.
 // iv.Try update scheduleCycle, scheduleCycleValid, childrenScheduleRoundMap as mentioned above.
 func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod) *framework.Status {
-	// If PreFilter fails, return framework.UnschedulableAndUnresolvable to avoid
+	// If PreFilter fails, return framework.Error to avoid
 	// any preemption attempts.
 	if err := cs.pgMgr.PreFilter(ctx, pod); err != nil {
 		klog.ErrorS(err, "PreFilter failed", "pod", klog.KObj(pod))
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
+		return framework.AsStatus(err)
 	}
 	return framework.NewStatus(framework.Success, "")
 }


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

1. Coscheduling Plugin checks whether the number of Pods meetes minMember first in Prefilter stage.
2. If  Prefilter failed, return `framework.Error` to force avoid any preemption attempts even `Coscheduling.PostFilter`

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #874 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
