### PR TITLE
koord-scheduler: LoadAware scheduling adds ScoreAccordingProdUsage parameter

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -48,6 +48,8 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
+	// ScoreAccordingProdUsage controls whether to score according to the utilization rate of Prod Pod
+	ScoreAccordingProdUsage bool `json:"scoreAccordingProdUsage,omitempty"`
 }
 
 // ScoringStrategyType is a "string" type.

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -48,6 +48,8 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
+	// ScoreAccordingProdUsage controls whether to score according to the utilization rate of Prod Pod
+	ScoreAccordingProdUsage *bool `json:"scoreAccordingProdUsage,omitempty"`
 }
 
 // ScoringStrategyType is a "string" type.

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -162,6 +162,9 @@ func autoConvert_v1beta2_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.ScoreAccordingProdUsage, &out.ScoreAccordingProdUsage, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -177,6 +180,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta2_LoadAwareSchedulingAr
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	if err := v1.Convert_bool_To_Pointer_bool(&in.ScoreAccordingProdUsage, &out.ScoreAccordingProdUsage, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -159,6 +159,11 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ScoreAccordingProdUsage != nil {
+		in, out := &in.ScoreAccordingProdUsage, &out.ScoreAccordingProdUsage
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -237,7 +237,7 @@ func (p *Plugin) Score(ctx context.Context, state *framework.CycleState, pod *co
 		return 0, nil
 	}
 
-	prodPod := extension.GetPriorityClass(pod) == extension.PriorityProd
+	prodPod := extension.GetPriorityClass(pod) == extension.PriorityProd && p.args.ScoreAccordingProdUsage
 	podMetrics := buildPodMetricMap(p.podLister, nodeMetric, prodPod)
 
 	estimatedUsed := estimatedPodUsed(pod, p.args.ResourceWeights, p.args.EstimatedScalingFactors)

--- a/pkg/scheduler/plugins/loadaware/load_aware_test.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware_test.go
@@ -769,13 +769,14 @@ func TestFilterUsage(t *testing.T) {
 
 func TestScore(t *testing.T) {
 	tests := []struct {
-		name        string
-		pod         *corev1.Pod
-		assignedPod []*podAssignInfo
-		nodeName    string
-		nodeMetric  *slov1alpha1.NodeMetric
-		wantScore   int64
-		wantStatus  *framework.Status
+		name                    string
+		pod                     *corev1.Pod
+		assignedPod             []*podAssignInfo
+		nodeName                string
+		nodeMetric              *slov1alpha1.NodeMetric
+		scoreAccordingProdUsage bool
+		wantScore               int64
+		wantStatus              *framework.Status
 	}{
 		{
 			name:     "score node with expired nodeMetric",
@@ -1212,7 +1213,8 @@ func TestScore(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
-			name: "score prod Pod",
+			name:                    "score prod Pod",
+			scoreAccordingProdUsage: true,
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -1380,6 +1382,7 @@ func TestScore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var v1beta2args v1beta2.LoadAwareSchedulingArgs
+			v1beta2args.ScoreAccordingProdUsage = &tt.scoreAccordingProdUsage
 			v1beta2.SetDefaults_LoadAwareSchedulingArgs(&v1beta2args)
 			var loadAwareSchedulingArgs config.LoadAwareSchedulingArgs
 			err := v1beta2.Convert_v1beta2_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(&v1beta2args, &loadAwareSchedulingArgs, nil)


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

Add `ScoreAccordingProdUsage` in LoadAware scheduling plugin args to control whether to score according to the utilization of Prod Pod and keep the original default score according to node utilization 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
