### PR TITLE
koord-schedler: fix queuesortplugin of coscheduling

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 
@@ -42,6 +43,7 @@ const (
 
 // Gang  basic podGroup info recorded in gangCache:
 type Gang struct {
+	ID         types.UID
 	Name       string
 	WaitTime   time.Duration
 	CreateTime time.Time
@@ -170,6 +172,7 @@ func (gang *Gang) tryInitByPodGroup(pg *v1alpha1.PodGroup, args *config.Coschedu
 	}
 	minRequiredNumber := pg.Spec.MinMember
 	gang.MinRequiredNumber = int(minRequiredNumber)
+	gang.ID = pg.UID
 
 	totalChildrenNum, err := strconv.ParseInt(pg.Annotations[extension.AnnotationGangTotalNum], 10, 32)
 	if err != nil {

--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
@@ -132,7 +132,11 @@ func (gangCache *GangCache) onPodAdd(obj interface{}) {
 				retry.DefaultRetry,
 				errors.IsTooManyRequests,
 				func() error {
-					_, err := gangCache.pgClient.SchedulingV1alpha1().PodGroups(pod.Namespace).Create(context.TODO(), pgFromAnnotation, metav1.CreateOptions{})
+					pg, err := gangCache.pgClient.SchedulingV1alpha1().PodGroups(pod.Namespace).Create(context.TODO(), pgFromAnnotation, metav1.CreateOptions{})
+					if err == nil && pg != nil {
+						gang.ID = pg.UID
+					}
+
 					return err
 				})
 			if err != nil {

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -131,8 +131,9 @@ func (cs *Coscheduling) Less(podInfo1, podInfo2 *framework.QueuedPodInfo) bool {
 	creationTime1 := cs.pgMgr.GetCreatTime(podInfo1)
 	creationTime2 := cs.pgMgr.GetCreatTime(podInfo2)
 	if creationTime1.Equal(creationTime2) {
-		return util.GetId(podInfo1.Pod.Namespace, podInfo1.Pod.Name) < util.GetId(podInfo2.Pod.Namespace, podInfo2.Pod.Name)
+		return cs.pgMgr.GetID(podInfo1) < cs.pgMgr.GetID(podInfo2)
 	}
+
 	return creationTime1.Before(creationTime2)
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -386,7 +386,7 @@ func TestLess(t *testing.T) {
 				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
 				InitialAttemptTimestamp: earltTime,
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			expected: false, // p1 should be ahead of p2 in the queue
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
`coscheduling.Less`, the id of the pg should be compared, and the old logic is compare with `{pod.namespace}/{pod.name}` maybe not right.
Our ultimate goal should be to put pods belonging to the same pg together in schedulerqueue.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
