### PR TITLE
koordlet: Other qos features support cgroups v2

### DIFF
--- a/pkg/koordlet/resmanager/cpu_suppress_test.go
+++ b/pkg/koordlet/resmanager/cpu_suppress_test.go
@@ -50,6 +50,7 @@ func newTestCPUSuppress(r *resmanager) *CPUSuppress {
 			Config:        resourceexecutor.NewDefaultConfig(),
 			ResourceCache: cache.NewCacheDefault(),
 		},
+		cgroupReader:           resourceexecutor.NewCgroupReader(),
 		suppressPolicyStatuses: map[string]suppressPolicyStatus{},
 	}
 }

--- a/pkg/koordlet/resmanager/metrics_query.go
+++ b/pkg/koordlet/resmanager/metrics_query.go
@@ -74,11 +74,11 @@ func (r *resmanager) collectPodMetric(podMeta *statesinformer.PodMeta, queryPara
 	podUID := string(podMeta.Pod.UID)
 	queryResult := r.metricCache.GetPodResourceMetric(&podUID, queryParam)
 	if queryResult.Error != nil {
-		klog.Warningf("get pod %v resource metric failed, error %v", podUID, queryResult.Error)
+		klog.V(5).Infof("get pod %v resource metric failed, error %v", podUID, queryResult.Error)
 		return queryResult
 	}
 	if queryResult.Metric == nil {
-		klog.Warningf("pod %v metric not exist", podUID)
+		klog.V(5).Infof("pod %v metric not exist", podUID)
 		return queryResult
 	}
 	return queryResult
@@ -109,14 +109,14 @@ func (r *resmanager) collectContainerThrottledMetricLast(containerID *string) me
 			QueryResult: metriccache.QueryResult{Error: fmt.Errorf("container is nil")},
 		}
 	}
-	queryParam := generateQueryParamsLast(r.collectResUsedIntervalSeconds * 2)
+	queryParam := generateQueryParamsLast(r.collectResUsedIntervalSeconds * 5)
 	queryResult := r.metricCache.GetContainerThrottledMetric(containerID, queryParam)
 	if queryResult.Error != nil {
-		klog.Warningf("get container %v throttled metric failed, error %v", containerID, queryResult.Error)
+		klog.V(5).Infof("get container %v throttled metric failed, error %v", *containerID, queryResult.Error)
 		return queryResult
 	}
 	if queryResult.Metric == nil {
-		klog.Warningf("container %v metric not exist", containerID)
+		klog.V(5).Infof("container %v metric not exist", *containerID)
 		return queryResult
 	}
 	return queryResult

--- a/pkg/koordlet/resourceexecutor/config.go
+++ b/pkg/koordlet/resourceexecutor/config.go
@@ -21,6 +21,7 @@ import "flag"
 const (
 	ReasonUpdateCgroups      = "UpdateCgroups"
 	ReasonUpdateSystemConfig = "UpdateSystemConfig"
+	ReasonUpdateResctrl      = "UpdateResctrl" // update resctrl tasks, schemata
 
 	EvictPodByNodeMemoryUsage = "EvictPodByNodeMemoryUsage"
 

--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -35,6 +35,7 @@ type CgroupReader interface {
 	ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, error)
 	ReadMemoryLimit(parentDir string) (int64, error)
 	ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRaw, error)
+	ReadCPUTasks(parentDir string) ([]int32, error)
 }
 
 var _ CgroupReader = &CgroupV1Reader{}
@@ -140,6 +141,15 @@ func (r *CgroupV1Reader) ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRa
 		return nil, fmt.Errorf("cannot parse cgroup value %s, err: %v", s, err)
 	}
 	return v, nil
+}
+
+func (r *CgroupV1Reader) ReadCPUTasks(parentDir string) ([]int32, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV1, sysutil.CPUTasksName)
+	if !ok {
+		return nil, ErrResourceNotRegistered
+	}
+	// content: `7742\n10971\n11049\n11051...`
+	return sysutil.ReadCgroupAndParseInt32Slice(parentDir, resource)
 }
 
 var _ CgroupReader = &CgroupV2Reader{}
@@ -272,6 +282,15 @@ func (r *CgroupV2Reader) ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRa
 		return nil, fmt.Errorf("cannot parse cgroup value %s, err: %v", s, err)
 	}
 	return v, nil
+}
+
+func (r *CgroupV2Reader) ReadCPUTasks(parentDir string) ([]int32, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV2, sysutil.CPUTasksName)
+	if !ok {
+		return nil, ErrResourceNotRegistered
+	}
+	// content: `7742\n10971\n11049\n11051...`
+	return sysutil.ReadCgroupAndParseInt32Slice(parentDir, resource)
 }
 
 func NewCgroupReader() CgroupReader {

--- a/pkg/koordlet/resourceexecutor/resctrl_updater.go
+++ b/pkg/koordlet/resourceexecutor/resctrl_updater.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceexecutor
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+var _ ResourceUpdater = &ResctrlSchemataResourceUpdater{}
+
+type ResctrlSchemataResourceUpdater struct {
+	DefaultResourceUpdater
+	schemataRaw *sysutil.ResctrlSchemataRaw
+}
+
+func (r *ResctrlSchemataResourceUpdater) Key() string {
+	return r.schemataRaw.Prefix() + r.file
+}
+
+func (r *ResctrlSchemataResourceUpdater) Update() error {
+	return r.DefaultResourceUpdater.updateFunc(r)
+}
+
+func (r *ResctrlSchemataResourceUpdater) Clone() ResourceUpdater {
+	return &ResctrlSchemataResourceUpdater{
+		DefaultResourceUpdater: *(r.DefaultResourceUpdater.Clone().(*DefaultResourceUpdater)),
+		schemataRaw:            r.schemataRaw.DeepCopy(),
+	}
+}
+
+func NewResctrlL3SchemataResource(group, schemataDelta string, l3Num int) ResourceUpdater {
+	schemataFile := sysutil.ResctrlSchemata.Path(group)
+	l3SchemataKey := sysutil.L3SchemataPrefix + ":" + schemataFile
+	schemata := sysutil.NewResctrlSchemataRaw().WithL3Num(l3Num).WithL3Mask(schemataDelta)
+	klog.V(6).Infof("generate new resctrl l3 schemata resource, file %s, key %s, value %s",
+		schemataFile, l3SchemataKey, schemata.L3String())
+
+	return &ResctrlSchemataResourceUpdater{
+		DefaultResourceUpdater: DefaultResourceUpdater{
+			key:        l3SchemataKey,
+			file:       schemataFile,
+			value:      schemata.L3String(),
+			updateFunc: UpdateResctrlSchemataFunc,
+		},
+		schemataRaw: schemata,
+	}
+}
+
+func NewResctrlMbSchemataResource(group, schemataDelta string, l3Num int) ResourceUpdater {
+	schemataFile := sysutil.ResctrlSchemata.Path(group)
+	mbSchemataKey := sysutil.MbSchemataPrefix + ":" + schemataFile
+	schemata := sysutil.NewResctrlSchemataRaw().WithL3Num(l3Num).WithMBPercent(schemataDelta)
+	klog.V(6).Infof("generate new resctrl mba schemata resource, file %s, key %s, value %s",
+		schemataFile, mbSchemataKey, schemata.MBString())
+
+	return &ResctrlSchemataResourceUpdater{
+		DefaultResourceUpdater: DefaultResourceUpdater{
+			key:        mbSchemataKey,
+			file:       schemataFile,
+			value:      schemata.MBString(),
+			updateFunc: UpdateResctrlSchemataFunc,
+		},
+		schemataRaw: schemata,
+	}
+}
+
+func CalculateResctrlL3TasksResource(group string, taskIds []int32) (ResourceUpdater, error) {
+	// join ids into updater value and make the id updates one by one
+	tasksPath := sysutil.GetResctrlTasksFilePath(group)
+
+	// use ordered slice
+	sort.Slice(taskIds, func(i, j int) bool {
+		return taskIds[i] < taskIds[j]
+	})
+	var builder strings.Builder
+	for _, id := range taskIds {
+		builder.WriteString(strconv.FormatInt(int64(id), 10))
+		builder.WriteByte('\n')
+	}
+
+	return NewCommonDefaultUpdaterWithUpdateFunc(tasksPath, tasksPath, builder.String(), UpdateResctrlTasksFunc)
+}
+
+func UpdateResctrlSchemataFunc(u ResourceUpdater) error {
+	r, ok := u.(*ResctrlSchemataResourceUpdater)
+	if !ok {
+		return fmt.Errorf("not a ResctrlSchemataResourceUpdater")
+	}
+
+	schemataFile := r.Path()
+
+	oldR, err := sysutil.ReadResctrlSchemataRaw(schemataFile, r.schemataRaw.L3Number())
+	if err != nil {
+		return fmt.Errorf("failed to read current resctrl schemata, path %s, err: %v", schemataFile, err)
+	}
+
+	isEqual, msg := oldR.Equal(r.schemataRaw)
+	if isEqual { // schemata unchanged, no need to update
+		klog.V(6).Infof("skip update resctrl schemata, old l3 %s, mba %s, new %s, l3Num %v",
+			oldR.L3String(), oldR.MBString(), r.Value(), r.schemataRaw.L3Number())
+		return nil
+	}
+	klog.V(5).Infof("need to update resctrl schemata, old l3 %s, mba %s, new %s, l3Num %v, msg: %s",
+		oldR.L3String(), oldR.MBString(), r.Value(), r.schemataRaw.L3Number(), msg)
+
+	// NOTE: currently, only l3 and mba schemata are to update, so do not read or compare before the write
+	// eg.
+	// $ cat /sys/fs/resctrl/schemata/BE/schemata
+	// L3:0=7ff;1=7ff
+	// MB:0=100;1=100
+	// $ echo "L3:0=3f;1=3f" > /sys/fs/resctrl/BE/schemata
+	// $ cat /sys/fs/resctrl/BE/schemata
+	// L3:0=03f;1=03f
+	// MB:0=100;1=100
+	_ = audit.V(5).Reason(ReasonUpdateResctrl).Message("update %v to %v", u.Key(), u.Value()).Do()
+	return sysutil.CommonFileWrite(u.Path(), u.Value())
+}
+
+func UpdateResctrlTasksFunc(resource ResourceUpdater) error {
+	// NOTE: resctrl/{...}/tasks file is required to appending write a task id once a time, and any duplicate would be
+	//       dropped automatically without an exception
+	// eg.
+	// $ echo 123 > /sys/fs/resctrl/BE/tasks
+	// $ echo 124 > /sys/fs/resctrl/BE/tasks
+	// $ echo 123 > /sys/fs/resctrl/BE/tasks
+	// $ echo 122 > /sys/fs/resctrl/BE/tasks
+	// $ tail -n 3 /sys/fs/resctrl/BE/tasks
+	// 122
+	// 123
+	// 124
+	_ = audit.V(5).Reason(ReasonUpdateResctrl).Message("update %v to %v", resource.Key(), resource.Value()).Do()
+
+	f, err := os.OpenFile(resource.Path(), os.O_RDWR|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+
+	success, total := 0, 0
+
+	ids := strings.Split(strings.Trim(resource.Value(), "\n"), "\n")
+	for _, id := range ids {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		total++
+		_, err = f.WriteString(id)
+		// any thread can exit before the writing
+		if err == nil {
+			success++
+			continue
+		}
+		klog.V(6).Infof("failed to write resctrl task id %v for dir %s, err: %s", id,
+			resource.Key(), err)
+	}
+
+	klog.V(5).Infof("write Cat L3 task ids for dir %s finished: %v succeed, %v total",
+		resource.Key(), success, total)
+
+	return f.Close()
+}

--- a/pkg/koordlet/resourceexecutor/resctrl_updater_test.go
+++ b/pkg/koordlet/resourceexecutor/resctrl_updater_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceexecutor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func testingPrepareResctrlL3CatPath(t *testing.T, cbmStr, rootSchemataStr string) {
+	resctrlDir := filepath.Join(system.Conf.SysFSRootDir, system.ResctrlDir)
+	l3CatDir := filepath.Join(resctrlDir, system.RdtInfoDir, system.L3CatDir)
+	err := os.MkdirAll(l3CatDir, 0700)
+	assert.NoError(t, err)
+
+	cbmPath := filepath.Join(l3CatDir, system.ResctrlCbmMaskName)
+	err = os.WriteFile(cbmPath, []byte(cbmStr), 0666)
+	assert.NoError(t, err)
+
+	schemataPath := filepath.Join(resctrlDir, system.ResctrlSchemataName)
+	err = os.WriteFile(schemataPath, []byte(rootSchemataStr), 0666)
+	assert.NoError(t, err)
+}
+
+func testingPrepareResctrlL3CatGroups(t *testing.T, cbmStr, rootSchemataStr string) {
+	testingPrepareResctrlL3CatPath(t, cbmStr, rootSchemataStr)
+	resctrlDir := filepath.Join(system.Conf.SysFSRootDir, system.ResctrlDir)
+
+	beSchemataData := []byte("    L3:0=f;1=f\n    MB:0=100;1=100")
+	beSchemataDir := filepath.Join(resctrlDir, "BE")
+	err := os.MkdirAll(beSchemataDir, 0700)
+	assert.NoError(t, err)
+	beSchemataPath := filepath.Join(beSchemataDir, system.ResctrlSchemataName)
+	err = os.WriteFile(beSchemataPath, beSchemataData, 0666)
+	assert.NoError(t, err)
+	beTasksPath := filepath.Join(beSchemataDir, system.ResctrlTasksName)
+	err = os.WriteFile(beTasksPath, []byte{}, 0666)
+	assert.NoError(t, err)
+
+	lsSchemataData := []byte("    L3:0=ff;1=ff\n    MB:0=100;1=100")
+	lsSchemataDir := filepath.Join(resctrlDir, "LS")
+	err = os.MkdirAll(lsSchemataDir, 0700)
+	assert.NoError(t, err)
+	lsSchemataPath := filepath.Join(lsSchemataDir, system.ResctrlSchemataName)
+	err = os.WriteFile(lsSchemataPath, lsSchemataData, 0666)
+	assert.NoError(t, err)
+	lsTasksPath := filepath.Join(lsSchemataDir, system.ResctrlTasksName)
+	err = os.WriteFile(lsTasksPath, []byte{}, 0666)
+	assert.NoError(t, err)
+
+	lsrSchemataData := []byte("    L3:0=ff;1=ff\n    MB:0=100;1=100")
+	lsrSchemataDir := filepath.Join(resctrlDir, "LSR")
+	err = os.MkdirAll(lsrSchemataDir, 0700)
+	assert.NoError(t, err)
+	lsrSchemataPath := filepath.Join(lsrSchemataDir, system.ResctrlSchemataName)
+	err = os.WriteFile(lsrSchemataPath, lsrSchemataData, 0666)
+	assert.NoError(t, err)
+	lsrTasksPath := filepath.Join(lsrSchemataDir, system.ResctrlTasksName)
+	err = os.WriteFile(lsrTasksPath, []byte{}, 0666)
+	assert.NoError(t, err)
+}
+
+func TestNewResctrlL3SchemataResource(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		helper := system.NewFileTestUtil(t)
+		defer helper.Cleanup()
+
+		sysFSRootDirName := "NewResctrlL3SchemataResource"
+		helper.MkDirAll(sysFSRootDirName)
+		system.Conf.SysFSRootDir = filepath.Join(helper.TempDir, sysFSRootDirName)
+
+		testingPrepareResctrlL3CatGroups(t, "7ff", "    L3:0=ff;1=ff\n    MB:0=100;1=100")
+		updater := NewResctrlL3SchemataResource("BE", "3c", 2)
+		assert.Equal(t, updater.Value(), "L3:0=3c;1=3c;\n")
+		err := updater.Update()
+		assert.NoError(t, err)
+	})
+}
+
+func TestNewResctrlMbSchemataResource(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		helper := system.NewFileTestUtil(t)
+		defer helper.Cleanup()
+
+		sysFSRootDirName := "NewResctrlMbSchemataResource"
+		helper.MkDirAll(sysFSRootDirName)
+		system.Conf.SysFSRootDir = filepath.Join(helper.TempDir, sysFSRootDirName)
+
+		testingPrepareResctrlL3CatGroups(t, "7ff", "    L3:0=ff;1=ff\n    MB:0=100;1=100")
+		updater := NewResctrlMbSchemataResource("BE", "90", 2)
+		assert.Equal(t, updater.Value(), "MB:0=90;1=90;\n")
+		err := updater.Update()
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/koordlet/resourceexecutor/updater_test.go
+++ b/pkg/koordlet/resourceexecutor/updater_test.go
@@ -236,9 +236,9 @@ func TestDefaultResourceUpdater_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			helper := sysutil.NewFileTestUtil(t)
 			defer helper.Cleanup()
-			dir := filepath.Join(helper.TempDir, tt.args.subDir)
 
-			u, gotErr := NewCommonDefaultUpdater(tt.args.file, dir, tt.args.value)
+			file := filepath.Join(helper.TempDir, tt.args.subDir, tt.args.file)
+			u, gotErr := NewCommonDefaultUpdater(file, file, tt.args.value)
 			assert.NoError(t, gotErr)
 			_, ok := u.(*DefaultResourceUpdater)
 			assert.True(t, ok)

--- a/pkg/koordlet/statesinformer/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/states_noderesourcetopology.go
@@ -400,7 +400,7 @@ func (s *nodeTopoInformer) calCPUSharePools(sharedPoolCPUs map[int32]*extension.
 func (s *nodeTopoInformer) calCPUTopology() (*metriccache.NodeCPUInfo, *extension.CPUTopology, map[int32]*extension.CPUInfo, error) {
 	nodeCPUInfo, err := s.metricCache.GetNodeCPUInfo(&metriccache.QueryParam{})
 	if err != nil {
-		klog.Errorf("failed to get node cpu info")
+		klog.V(4).Infof("failed to get node cpu info")
 		return nil, nil, nil, err
 	}
 

--- a/pkg/koordlet/util/container.go
+++ b/pkg/koordlet/util/container.go
@@ -190,6 +190,8 @@ func GetContainerCurMemLimitBytes(podParentDir string, c *corev1.ContainerStatus
 	return strconv.ParseInt(strings.TrimSpace(string(rawContent)), 10, 64)
 }
 
+// GetContainerCurTasks gets the TIDs of the given container's cgroup.
+// DEPRECATED: use resourceexecutor.CgroupReader instead.
 func GetContainerCurTasks(podParentDir string, c *corev1.ContainerStatus) ([]int, error) {
 	cgroupPath, err := GetContainerCurTasksPath(podParentDir, c)
 	if err != nil {

--- a/pkg/koordlet/util/system/resctrl.go
+++ b/pkg/koordlet/util/system/resctrl.go
@@ -30,17 +30,23 @@ import (
 )
 
 const (
-	ResctrlDir string = "resctrl/"
-	RdtInfoDir string = "info"
-	L3CatDir   string = "L3"
-
-	SchemataFileName      string = "schemata"
-	CbmMaskFileName       string = "cbm_mask"
-	ResctrlTaskFileName   string = "tasks"
 	CPUInfoFileName       string = "cpuinfo"
 	KernelCmdlineFileName string = "cmdline"
 
 	ResctrlName string = "resctrl"
+
+	ResctrlDir string = "resctrl/"
+	RdtInfoDir string = "info"
+	L3CatDir   string = "L3"
+
+	ResctrlSchemataName string = "schemata"
+	ResctrlCbmMaskName  string = "cbm_mask"
+	ResctrlTasksName    string = "tasks"
+
+	// L3SchemataPrefix is the prefix of l3 cat schemata
+	L3SchemataPrefix = "L3"
+	// MbSchemataPrefix is the prefix of mba schemata
+	MbSchemataPrefix = "MB"
 )
 
 var (
@@ -55,7 +61,7 @@ func isCPUSupportResctrl() (bool, error) {
 		klog.Errorf("isResctrlAvailableByCpuInfo error: %v", err)
 		return false, err
 	}
-	klog.Infof("isResctrlAvailableByCpuInfo result,isCatFlagSet: %v,isMbaFlagSet: %v", isCatFlagSet, isMbaFlagSet)
+	klog.Infof("isResctrlAvailableByCpuInfo result, isCatFlagSet: %v, isMbaFlagSet: %v", isCatFlagSet, isMbaFlagSet)
 	isInit = true
 	return isCatFlagSet && isMbaFlagSet, nil
 }
@@ -89,6 +95,243 @@ func IsSupportResctrl() (bool, error) {
 	return isSupportResctrl, nil
 }
 
+var (
+	ResctrlSchemata  = NewCommonResctrlResource(ResctrlSchemataName, "")
+	ResctrlTasks     = NewCommonResctrlResource(ResctrlTasksName, "")
+	ResctrlL3CbmMask = NewCommonResctrlResource(ResctrlCbmMaskName, filepath.Join(RdtInfoDir, L3CatDir))
+)
+
+var _ Resource = &ResctrlResource{}
+
+type ResctrlResource struct {
+	Type           ResourceType
+	FileName       string
+	Subdir         string
+	CheckSupported func(r Resource, parentDir string) (isSupported bool, msg string)
+	Validator      ResourceValidator
+}
+
+func (r *ResctrlResource) ResourceType() ResourceType {
+	if len(r.Type) > 0 {
+		return r.Type
+	}
+	return ResourceType(filepath.Join(r.Subdir, r.FileName))
+}
+
+func (r *ResctrlResource) Path(parentDir string) string {
+	// parentDir for resctrl is like: `/`, `LS/`, `BE`
+	return filepath.Join(Conf.SysFSRootDir, ResctrlDir, parentDir, r.Subdir, r.FileName)
+}
+
+func (r *ResctrlResource) IsSupported(parentDir string) (bool, string) {
+	if r.CheckSupported == nil {
+		return true, ""
+	}
+	return r.CheckSupported(r, parentDir)
+}
+
+func (r *ResctrlResource) IsValid(v string) (bool, string) {
+	if r.Validator == nil {
+		return true, ""
+	}
+	return r.Validator.Validate(v)
+}
+
+func (r *ResctrlResource) WithValidator(validator ResourceValidator) Resource {
+	r.Validator = validator
+	return r
+}
+
+func (r *ResctrlResource) WithSupported(isSupported bool, msg string) Resource {
+	return r
+}
+
+func (r *ResctrlResource) WithCheckSupported(checkSupportedFn func(r Resource, parentDir string) (isSupported bool, msg string)) Resource {
+	r.CheckSupported = checkSupportedFn
+	return r
+}
+
+func NewCommonResctrlResource(filename string, subdir string) Resource {
+	return &ResctrlResource{
+		Type:           ResourceType(filename),
+		FileName:       filename,
+		Subdir:         subdir,
+		CheckSupported: SupportedIfFileExists,
+	}
+}
+
+type ResctrlSchemataRaw struct {
+	L3    []int64
+	MB    []int64
+	L3Num int
+}
+
+func NewResctrlSchemataRaw() *ResctrlSchemataRaw {
+	return &ResctrlSchemataRaw{L3Num: 1}
+}
+
+func (r *ResctrlSchemataRaw) WithL3Num(l3Num int) *ResctrlSchemataRaw {
+	r.L3Num = l3Num
+	return r
+}
+
+func (r *ResctrlSchemataRaw) WithL3Mask(mask string) *ResctrlSchemataRaw {
+	// l3 mask MUST be a valid hex
+	maskValue, err := strconv.ParseInt(strings.TrimSpace(mask), 16, 64)
+	if err != nil {
+		klog.V(5).Infof("failed to parse l3 mask %s, err: %v", mask, err)
+	}
+	r.L3 = make([]int64, r.L3Num)
+	for i := 0; i < r.L3Num; i++ {
+		r.L3[i] = maskValue
+	}
+	return r
+}
+
+func (r *ResctrlSchemataRaw) WithMBPercent(percent string) *ResctrlSchemataRaw {
+	// mba percent MUST be a valid integer
+	percentValue, err := strconv.ParseInt(strings.TrimSpace(percent), 10, 64)
+	if err != nil {
+		klog.V(5).Infof("failed to parse mba percent %s, err: %v", percent, err)
+	}
+	r.MB = make([]int64, r.L3Num)
+	for i := 0; i < r.L3Num; i++ {
+		r.MB[i] = percentValue
+	}
+	return r
+}
+
+func (r *ResctrlSchemataRaw) DeepCopy() *ResctrlSchemataRaw {
+	n := NewResctrlSchemataRaw().WithL3Num(r.L3Num)
+	for i := range r.L3 {
+		n.L3 = append(n.L3, r.L3[i])
+	}
+	for i := range r.MB {
+		n.MB = append(n.MB, r.MB[i])
+	}
+	return n
+}
+
+func (r *ResctrlSchemataRaw) Prefix() string {
+	var prefix string
+	if len(r.L3) > 0 {
+		prefix += L3SchemataPrefix + ":"
+	}
+	if len(r.MB) > 0 {
+		prefix += MbSchemataPrefix + ":"
+	}
+	return prefix
+}
+
+func (r *ResctrlSchemataRaw) L3Number() int {
+	return r.L3Num
+}
+
+func (r *ResctrlSchemataRaw) L3String() string {
+	if len(r.L3) <= 0 {
+		return ""
+	}
+	schemata := L3SchemataPrefix + ":"
+	// the last ';' will be auto ignored
+	for i := range r.L3 {
+		schemata = schemata + strconv.Itoa(i) + "=" + strconv.FormatInt(r.L3[i], 16) + ";"
+	}
+	// the trailing '\n' is necessary to append
+	schemata += "\n"
+	return schemata
+}
+
+func (r *ResctrlSchemataRaw) MBString() string {
+	if len(r.MB) <= 0 {
+		return ""
+	}
+	schemata := MbSchemataPrefix + ":"
+	// the last ';' will be auto ignored
+	for i := range r.MB {
+		schemata = schemata + strconv.Itoa(i) + "=" + strconv.FormatInt(r.MB[i], 10) + ";"
+	}
+	// the trailing '\n' is necessary to append
+	schemata += "\n"
+	return schemata
+}
+
+func (r *ResctrlSchemataRaw) Equal(a *ResctrlSchemataRaw) (bool, string) {
+	if r.L3Num != a.L3Num {
+		return false, "l3 number not equal"
+	}
+	if a.L3 != nil {
+		if len(r.L3) != len(a.L3) || r.L3 == nil {
+			return false, "the number of l3 masks not equal"
+		}
+		for i := 0; i < len(r.L3); i++ {
+			if r.L3[i] != a.L3[i] {
+				return false, "the value of l3 mask not equal"
+			}
+		}
+	}
+	if a.MB != nil {
+		if len(r.MB) != len(a.MB) || r.MB == nil {
+			return false, "the number of mba percent not equal"
+		}
+		for i := 0; i < len(r.MB); i++ {
+			if r.MB[i] != a.MB[i] {
+				return false, "the value of mba percent not equal"
+			}
+		}
+	}
+	return true, ""
+}
+
+// ParseResctrlSchemata parses the resctrl schemata of given cgroup, and returns the l3_cat masks and mba masks.
+// @content `L3:0=fff;1=fff\nMB:0=100;1=100\n` (may have additional lines (e.g. ARM MPAM))
+// @l3Num 2
+// @return { L3: ["fff", "fff"], MB: ["100", "100"] }, nil
+func (r *ResctrlSchemataRaw) ParseResctrlSchemata(content string, l3Num int) error {
+	schemataMap := ParseResctrlSchemataMap(content)
+
+	for _, t := range []struct {
+		prefix string
+		base   int
+		v      *[]int64
+	}{
+		{
+			prefix: L3SchemataPrefix,
+			base:   16,
+			v:      &r.L3,
+		},
+		{
+			prefix: MbSchemataPrefix,
+			base:   10,
+			v:      &r.MB,
+		},
+	} {
+		maskMap := schemataMap[t.prefix]
+		if maskMap == nil {
+			klog.V(5).Infof("read resctrl schemata of %s aborted, mask not found", t.prefix)
+			continue
+		}
+		if len(maskMap) != l3Num {
+			return fmt.Errorf("read resctrl schemata failed, %s masks has invalid count %v",
+				t.prefix, len(maskMap))
+		}
+		for i := 0; i < l3Num; i++ {
+			mask, ok := maskMap[i]
+			if !ok {
+				return fmt.Errorf("read resctrl schemata failed, %s masks of node %v is missing",
+					t.prefix, i)
+			}
+			maskValue, err := strconv.ParseInt(strings.TrimSpace(mask), t.base, 64)
+			if err != nil {
+				return fmt.Errorf("read resctrl schemata failed, %s masks is invalid, value %s, err: %s",
+					t.prefix, mask, err)
+			}
+			*t.v = append(*t.v, maskValue)
+		}
+	}
+
+	return nil
+}
+
 // @return /sys/fs/resctrl
 func GetResctrlSubsystemDirPath() string {
 	return filepath.Join(Conf.SysFSRootDir, ResctrlDir)
@@ -102,40 +345,93 @@ func GetResctrlGroupRootDirPath(groupPath string) string {
 
 // @return /sys/fs/resctrl/info/L3/cbm_mask
 func GetResctrlL3CbmFilePath() string {
-	return filepath.Join(Conf.SysFSRootDir, ResctrlDir, RdtInfoDir, L3CatDir, CbmMaskFileName)
+	return ResctrlL3CbmMask.Path("")
 }
 
 // @groupPath BE
 // @return /sys/fs/resctrl/BE/schemata
 func GetResctrlSchemataFilePath(groupPath string) string {
-	return filepath.Join(Conf.SysFSRootDir, ResctrlDir, groupPath, SchemataFileName)
+	return ResctrlSchemata.Path(groupPath)
 }
 
 // @groupPath BE
 // @return /sys/fs/resctrl/BE/tasks
 func GetResctrlTasksFilePath(groupPath string) string {
-	return filepath.Join(Conf.SysFSRootDir, ResctrlDir, groupPath, ResctrlTaskFileName)
+	return ResctrlTasks.Path(groupPath)
 }
 
-// ReadCatL3Cbm reads and returns the value of cat l3 cbm_mask
+func ReadResctrlSchemataRaw(schemataFile string, l3Num int) (*ResctrlSchemataRaw, error) {
+	content, err := os.ReadFile(schemataFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schemata file, err: %v", err)
+	}
+
+	schemataRaw := NewResctrlSchemataRaw()
+	err = schemataRaw.ParseResctrlSchemata(string(content), l3Num)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse l3 schemata, content %s, err: %v", string(content), err)
+	}
+
+	return schemataRaw, nil
+}
+
+// ParseResctrlSchemataMap parses the content of resctrl schemata.
+// e.g. schemata=`L3:0=fff;1=fff\nMB:0=100;1=100\n` -> `{"L3": {0: "fff", 1: "fff"}, "MB": {0: "100", 1: "100"}}`
+func ParseResctrlSchemataMap(content string) map[string]map[int]string {
+	schemataMap := map[string]map[int]string{}
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line) // `L3:0=fff;1=fff`, `MB:0=100;1=100`
+		if len(line) <= 0 {
+			continue
+		}
+
+		pair := strings.Split(line, ":") // {`L3`, `0=fff;1=fff`}, {`MB`, `0=100;1=100`}
+		if len(pair) != 2 {
+			klog.V(6).Infof("failed to parse resctrl schemata, line %s, err: invalid key value pair", line)
+			continue
+		}
+
+		masks := strings.Split(pair[1], ";") // {`0=fff`, `1=fff`}, {`0=100`, `1=100`}
+		maskMap := map[int]string{}
+		for _, mask := range masks {
+			maskPair := strings.Split(mask, "=") // {`0`, `fff`}, {`1`, `100`}
+			if len(maskPair) != 2 {
+				klog.V(6).Infof("failed to parse resctrl schemata, mask %s, err: invalid key value pair", mask)
+				continue
+			}
+			nodeID, err := strconv.ParseInt(maskPair[0], 10, 32)
+			if err != nil {
+				klog.V(6).Infof("failed to parse resctrl schemata, mask %s, err: %s", mask, err)
+				continue
+			}
+			maskMap[int(nodeID)] = maskPair[1] // {0: `fff`}
+		}
+		schemataMap[pair[0]] = maskMap // {`L3`: {0: `fff`, 1: `fff`} }
+	}
+
+	return schemataMap
+}
+
+// ReadCatL3CbmString reads and returns the value of cat l3 cbm_mask
 func ReadCatL3CbmString() (string, error) {
 	cbmFile := GetResctrlL3CbmFilePath()
 	out, err := os.ReadFile(cbmFile)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to read l3 cbm, path %s, err: %v", cbmFile, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
 // ReadResctrlTasksMap reads and returns the map of given resctrl group's task ids
-func ReadResctrlTasksMap(groupPath string) (map[int]struct{}, error) {
+func ReadResctrlTasksMap(groupPath string) (map[int32]struct{}, error) {
 	tasksPath := GetResctrlTasksFilePath(groupPath)
 	rawContent, err := os.ReadFile(tasksPath)
 	if err != nil {
 		return nil, err
 	}
 
-	tasksMap := map[int]struct{}{}
+	tasksMap := map[int32]struct{}{}
 
 	lines := strings.Split(string(rawContent), "\n")
 	for _, line := range lines {
@@ -143,11 +439,11 @@ func ReadResctrlTasksMap(groupPath string) (map[int]struct{}, error) {
 		if len(line) <= 0 {
 			continue
 		}
-		task, err := strconv.Atoi(line)
+		task, err := strconv.ParseInt(line, 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		tasksMap[task] = struct{}{}
+		tasksMap[int32(task)] = struct{}{}
 	}
 	return tasksMap, nil
 }

--- a/pkg/koordlet/util/system/resource.go
+++ b/pkg/koordlet/util/system/resource.go
@@ -20,10 +20,13 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
+
+const ErrResourceUnsupportedPrefix = "resource is unsupported"
 
 type ResourceType string
 
@@ -59,6 +62,14 @@ func ValidateResourceValue(value *int64, parentDir string, r Resource) bool {
 		return false
 	}
 	return true
+}
+
+func ResourceUnsupportedErr(msg string) error {
+	return fmt.Errorf("%s, reason: %s", ErrResourceUnsupportedPrefix, msg)
+}
+
+func IsResourceUnsupportedErr(err error) bool {
+	return strings.HasPrefix(err.Error(), ErrResourceUnsupportedPrefix)
 }
 
 func SupportedIfFileExists(r Resource, parentDir string) (bool, string) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

CgroupReconcile & RdtResctrl features support cgroups-v2.

The functions `system.NewCommonCgroupResource()` and `resourceexecutor.NewDetailCgroupUpdater()` are added for developing custom cgroup operations.

The logs related to cgroups operations are revised. e.g. the logs for reading non-running pods' cgroups should be more verbose, and logs for writing unsupported cgroup resources should be more verbose.

After #885, #892 and this PR, most of the QoS features in koordlet will be compatible with Linux cgroups-v2. (The remaining features CPUEvict and PerformanceCollector are also assigned.)

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

part of #407.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
