### PR TITLE
koordlet: delete deprecated featuregate performance collector

### DIFF
--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -101,13 +101,6 @@ const (
 	Accelerators featuregate.Feature = "Accelerators"
 
 	// owner: @songtao98 @zwzhang0107
-	// nolint:staticcheck // SA1019 this deprecated field still needs to be used for now.
-	// Deprecated: This feature gate will be removed in v1.1,
-	// please use CPICollector instead ASAP.
-	// PerformanceCollector enables cpi collector feature of koordlet.
-	PerformanceCollector featuregate.Feature = "PerformanceCollector"
-
-	// owner: @songtao98 @zwzhang0107
 	// alpha: v1.0
 	//
 	// CPICollector enables cpi collector feature of koordlet.
@@ -140,7 +133,6 @@ var (
 		CgroupReconcile:        {Default: false, PreRelease: featuregate.Alpha},
 		NodeTopologyReport:     {Default: true, PreRelease: featuregate.Beta},
 		Accelerators:           {Default: false, PreRelease: featuregate.Alpha},
-		PerformanceCollector:   {Default: false, PreRelease: featuregate.Alpha},
 		CPICollector:           {Default: false, PreRelease: featuregate.Alpha},
 		PSICollector:           {Default: false, PreRelease: featuregate.Alpha},
 	}

--- a/pkg/koordlet/metricsadvisor/collector.go
+++ b/pkg/koordlet/metricsadvisor/collector.go
@@ -150,7 +150,7 @@ func (c *collector) Run(stopCh <-chan struct{}) error {
 			return
 		}
 		ic.collectContainerCPI()
-	}, []featuregate.Feature{features.PerformanceCollector, features.CPICollector}, c.config.CPICollectorIntervalSeconds, stopCh)
+	}, []featuregate.Feature{features.CPICollector}, c.config.CPICollectorIntervalSeconds, stopCh)
 
 	util.RunFeature(func() {
 		// psi collector support only on anolis os currently


### PR DESCRIPTION
Signed-off-by: songtao98 <songtao2603060@gmail.com>

### Ⅰ. Describe what this PR does
Feature gate `PerformanceCollector` is deprecated now and is already noticed to the community that we will delete it in version v1.1.0. This PR delete it in source code. 
In the charts file of v1.1.0 I already replace it with `CPICollector`. 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
