### PR TITLE
koord-scheduler: retrieve reservationInfo from cache first in preFilter hook

### DIFF
--- a/pkg/scheduler/plugins/reservation/hook.go
+++ b/pkg/scheduler/plugins/reservation/hook.go
@@ -153,6 +153,7 @@ func (h *Hook) prepareMatchReservationState(handle frameworkext.ExtendedHandle, 
 		klog.V(6).InfoS("PreFilterHook indexer list reservation on node",
 			"node", node.Name, "count", len(rOnNode))
 		count := 0
+		rCache := getReservationCache()
 		for _, obj := range rOnNode {
 			r, ok := obj.(*schedulingv1alpha1.Reservation)
 			if !ok {
@@ -163,7 +164,12 @@ func (h *Hook) prepareMatchReservationState(handle frameworkext.ExtendedHandle, 
 			if !util.IsReservationAvailable(r) {
 				continue
 			}
-			if matchReservation(pod, newReservationInfo(r)) {
+
+			rInfo := rCache.GetInCache(r)
+			if rInfo == nil {
+				rInfo = newReservationInfo(r)
+			}
+			if matchReservation(pod, rInfo) {
 				matchedCache.Add(r)
 				count++
 			} else {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -117,7 +117,7 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		podLister:        extendedHandle.SharedInformerFactory().Core().V1().Pods().Lister(),
 		client:           extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
 		parallelizeUntil: defaultParallelizeUntil(handle),
-		reservationCache: newReservationCache(),
+		reservationCache: getReservationCache(),
 	}
 
 	// handle reservation event in cache; here only scheduled and expired reservations are considered.

--- a/pkg/scheduler/plugins/reservation/rcache.go
+++ b/pkg/scheduler/plugins/reservation/rcache.go
@@ -228,6 +228,12 @@ type reservationCache struct {
 	assumed  map[string]*assumedInfo                    // reservation key -> assumed (pod allocated) reservation meta
 }
 
+var rCache *reservationCache = newReservationCache()
+
+func getReservationCache() *reservationCache {
+	return rCache
+}
+
 func newReservationCache() *reservationCache {
 	return &reservationCache{
 		inactive: map[string]*schedulingv1alpha1.Reservation{},


### PR DESCRIPTION
fix: prefilter hook get stale reservation from indexer

currently prefilter hook of resource reservation will list reservations from informer cache and construct reservationInfo to judge whether the pod match the reservation(https://github.com/koordinator-sh/koordinator/blob/main/pkg/scheduler/plugins/reservation/hook.go#L147):
```
		rOnNode, err := indexer.ByIndex(NodeNameIndex, node.Name)
		if err != nil {
			klog.V(3).InfoS("PreFilterHook failed to list reservations",
				"node", node.Name, "index", NodeNameIndex, "err", err)
			return
		}
		klog.V(6).InfoS("PreFilterHook indexer list reservation on node",
			"node", node.Name, "count", len(rOnNode))
		count := 0
		for _, obj := range rOnNode {
			r, ok := obj.(*schedulingv1alpha1.Reservation)
			if !ok {
				klog.V(5).Infof("unable to convert to *schedulingv1alpha1.Reservation, obj %T", obj)
				continue
			}
			// only count available reservations, ignore succeeded ones
			if !util.IsReservationAvailable(r) {
				continue
			}
			if matchReservation(pod, newReservationInfo(r)) {
				matchedCache.Add(r)
				count++
			} else {
				klog.V(6).InfoS("got reservation on node does not match the pod",
					"reservation", klog.KObj(r), "pod", klog.KObj(pod), "reason",
					dumpMatchReservationReason(pod, newReservationInfo(r)))
			}
		}
```

However, reservations in informer cache can be stale because in pervious cycles pods can have reserve the resouce of the reservation, which leads to a failed scheduling of the pod:
```
$ k get event | grep busybox-deployment-basic-58868685fc-vk92n
8m54s       Warning   FailedScheduling    pod/busybox-deployment-basic-58868685fc-vk92n    running Reserve plugin "Reservation": reservation is stale and does not match any more
```

How to reproduce：
A reservation with label selector ownership and a deployment:
```
apiVersion: scheduling.koordinator.sh/v1alpha1
kind: Reservation
metadata:
  name: reservation-demo1
spec:
  # allocateOnce: true
  template: # set resource requirements
    namespace: default
    spec:
      containers:
        - resources:
            requests:
              cpu: 100m
              memory: 100Mi
      schedulerName: koord-scheduler # use koord-scheduler
  owners: # set the owner specifications
    - labelSelector:
        matchLabels:
          app: test
  ttl: 1h # set the TTL, the reservation will get expired 1 hour later
---
apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1
kind: Deployment
metadata:
  name: busybox-deployment-basic
  labels:
    app: busybox
spec:
  replicas: 2
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      schedulerName: koord-scheduler
    #  nodeSelector:
    #    env: test-team
      containers:
      - name: busybox
        image: busybox
        command: ["sleep", "1d"]
        ports:
        - containerPort: 80
        resources:
          limits:
            cpu: "100m"
            memory: "100Mi"
```