### PR TITLE
koordlet: fix cpi collector return value sequence

### DIFF
--- a/pkg/koordlet/util/perf/perf_linux.go
+++ b/pkg/koordlet/util/perf/perf_linux.go
@@ -87,7 +87,7 @@ func GetContainerCyclesAndInstructions(collector *PerfCollector) (uint64, uint64
 	if err != nil {
 		return 0, 0, err
 	}
-	return result.instructions, result.cycles, nil
+	return result.cycles, result.instructions, nil
 }
 
 type collectResult struct {


### PR DESCRIPTION
Signed-off-by: songtao98 <songtao2603060@gmail.com>

### Ⅰ. Describe what this PR does
Previously the cpi collector utils has a return value sequence bug, which reverses the sequence of `cycles` and `instructions` , leading that when compute CPI we actually get the reciprocal of it. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
