### PR TITLE
koordlet: add metrics for batch resources

### DIFF
--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -199,7 +199,7 @@ func (d *daemon) Run(stopCh <-chan struct{}) {
 
 	go func() {
 		if err := d.runtimeHook.Run(stopCh); err != nil {
-			klog.Errorf("Unable to run the runtimeHook: ", err)
+			klog.Error("Unable to run the runtimeHook: ", err)
 			os.Exit(1)
 		}
 	}()

--- a/pkg/koordlet/metrics/common.go
+++ b/pkg/koordlet/metrics/common.go
@@ -26,6 +26,7 @@ var (
 		Name:      "start_time",
 		Help:      "the start time of koordlet",
 	}, []string{NodeKey})
+
 	CollectNodeCPUInfoStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: KoordletSubsystem,
 		Name:      "collect_node_cpu_info_status",

--- a/pkg/koordlet/metrics/metrics.go
+++ b/pkg/koordlet/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 
 func init() {
 	prometheus.MustRegister(CommonCollectors...)
+	prometheus.MustRegister(ResourceSummaryCollectors...)
 	prometheus.MustRegister(CPICollectors...)
 	prometheus.MustRegister(PSICollectors...)
 	prometheus.MustRegister(CPUSuppressCollector...)
@@ -38,7 +39,7 @@ const (
 	NodeKey = "node"
 
 	StatusKey     = "status"
-	StatusSucceed = "succeed"
+	StatusSucceed = "succeeded"
 	StatusFailed  = "failed"
 
 	EvictionReasonKey = "reason"
@@ -50,6 +51,8 @@ const (
 	PodUID       = "pod_uid"
 	PodName      = "pod_name"
 	PodNamespace = "pod_namespace"
+
+	ResourceKey = "resource"
 )
 
 var (

--- a/pkg/koordlet/metrics/metrics_test.go
+++ b/pkg/koordlet/metrics/metrics_test.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 func TestGenNodeLabels(t *testing.T) {
@@ -131,8 +133,8 @@ func TestCommonCollectors(t *testing.T) {
 		RecordCollectNodeCPUInfoStatus(testingErr)
 		RecordCollectNodeCPUInfoStatus(nil)
 		RecordBESuppressCores("cfsQuota", float64(1000))
-		RecordBESuppressLSUsedCPU(float64(1000))
-		RecordNodeUsedCPU(float64(2000))
+		RecordBESuppressLSUsedCPU(1.0)
+		RecordNodeUsedCPU(2.0)
 		RecordContainerScaledCFSBurstUS(testingPod.Namespace, testingPod.Name, testingContainer.ContainerID, testingContainer.Name, 1000000)
 		RecordContainerScaledCFSQuotaUS(testingPod.Namespace, testingPod.Name, testingContainer.ContainerID, testingContainer.Name, 1000000)
 		RecordPodEviction("evictByCPU")
@@ -142,5 +144,109 @@ func TestCommonCollectors(t *testing.T) {
 		RecordContainerPSI(testingContainer, testingPod, testingPSI)
 		ResetPodPSI()
 		RecordPodPSI(testingPod, testingPSI)
+	})
+}
+
+func TestResourceSummaryCollectors(t *testing.T) {
+	testingNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-node",
+			Labels: map[string]string{},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("200Gi"),
+				apiext.BatchCPU:       resource.MustParse("50000"),
+				apiext.BatchMemory:    resource.MustParse("80Gi"),
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("200Gi"),
+				apiext.BatchCPU:       resource.MustParse("50000"),
+				apiext.BatchMemory:    resource.MustParse("80Gi"),
+			},
+		},
+	}
+	testingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_pod",
+			Namespace: "test_pod_namespace",
+			UID:       "test01",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test_container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:        "test_container",
+					ContainerID: "containerd://testxxx",
+				},
+			},
+		},
+	}
+	testingBatchPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_batch_pod",
+			Namespace: "test_batch_pod_namespace",
+			UID:       "batch01",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test_batch_container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							apiext.BatchCPU:    resource.MustParse("1000"),
+							apiext.BatchMemory: resource.MustParse("2Gi"),
+						},
+						Limits: corev1.ResourceList{
+							apiext.BatchCPU:    resource.MustParse("1000"),
+							apiext.BatchMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:        "test_batch_container",
+					ContainerID: "containerd://batchxxx",
+				},
+			},
+		},
+	}
+
+	t.Run("test not panic", func(t *testing.T) {
+		Register(testingNode)
+		defer Register(nil)
+
+		RecordNodeResourceAllocatable(string(apiext.BatchCPU), float64(util.QuantityPtr(testingNode.Status.Allocatable[apiext.BatchCPU]).Value()))
+		RecordNodeResourceAllocatable(string(apiext.BatchMemory), float64(util.QuantityPtr(testingNode.Status.Allocatable[apiext.BatchMemory]).Value()))
+		RecordContainerResourceRequests(string(corev1.ResourceCPU), &testingPod.Status.ContainerStatuses[0], testingPod, float64(testingPod.Spec.Containers[0].Resources.Requests.Cpu().Value()))
+		RecordContainerResourceRequests(string(corev1.ResourceMemory), &testingPod.Status.ContainerStatuses[0], testingPod, float64(testingPod.Spec.Containers[0].Resources.Requests.Memory().Value()))
+		RecordContainerResourceRequests(string(apiext.BatchCPU), &testingBatchPod.Status.ContainerStatuses[0], testingBatchPod, float64(util.QuantityPtr(testingBatchPod.Spec.Containers[0].Resources.Requests[apiext.BatchCPU]).Value()))
+		RecordContainerResourceRequests(string(apiext.BatchMemory), &testingBatchPod.Status.ContainerStatuses[0], testingBatchPod, float64(util.QuantityPtr(testingBatchPod.Spec.Containers[0].Resources.Requests[apiext.BatchMemory]).Value()))
+		RecordContainerResourceLimits(string(apiext.BatchCPU), &testingBatchPod.Status.ContainerStatuses[0], testingBatchPod, float64(util.QuantityPtr(testingBatchPod.Spec.Containers[0].Resources.Limits[apiext.BatchCPU]).Value()))
+		RecordContainerResourceLimits(string(apiext.BatchMemory), &testingBatchPod.Status.ContainerStatuses[0], testingBatchPod, float64(util.QuantityPtr(testingBatchPod.Spec.Containers[0].Resources.Limits[apiext.BatchMemory]).Value()))
+
+		ResetContainerResourceRequests()
+		ResetContainerResourceLimits()
 	})
 }

--- a/pkg/koordlet/metrics/resource_summary.go
+++ b/pkg/koordlet/metrics/resource_summary.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	NodeResourceAllocatable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "node_resource_allocatable",
+		Help:      "the node allocatable of resources updated by koordinator",
+	}, []string{NodeKey, ResourceKey})
+
+	ContainerResourceRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "container_resource_requests",
+		Help:      "the container requests of resources updated by koordinator",
+	}, []string{NodeKey, ResourceKey, PodUID, PodName, PodNamespace, ContainerID, ContainerName})
+
+	ContainerResourceLimits = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "container_resource_limits",
+		Help:      "the container limits of resources updated by koordinator",
+	}, []string{NodeKey, ResourceKey, PodUID, PodName, PodNamespace, ContainerID, ContainerName})
+
+	ResourceSummaryCollectors = []prometheus.Collector{
+		NodeResourceAllocatable,
+		ContainerResourceRequests,
+		ContainerResourceLimits,
+	}
+)
+
+func RecordNodeResourceAllocatable(resourceName string, value float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[ResourceKey] = resourceName
+	NodeResourceAllocatable.With(labels).Set(value)
+}
+
+func RecordContainerResourceRequests(resourceName string, status *corev1.ContainerStatus, pod *corev1.Pod, value float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[ResourceKey] = resourceName
+	labels[PodUID] = string(pod.UID)
+	labels[PodName] = pod.Name
+	labels[PodNamespace] = pod.Namespace
+	labels[ContainerID] = status.ContainerID
+	labels[ContainerName] = status.Name
+	ContainerResourceRequests.With(labels).Set(value)
+}
+
+func ResetContainerResourceRequests() {
+	ContainerResourceRequests.Reset()
+}
+
+func RecordContainerResourceLimits(resourceName string, status *corev1.ContainerStatus, pod *corev1.Pod, value float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[ResourceKey] = resourceName
+	labels[PodUID] = string(pod.UID)
+	labels[PodName] = pod.Name
+	labels[PodNamespace] = pod.Namespace
+	labels[ContainerID] = status.ContainerID
+	labels[ContainerName] = status.Name
+	ContainerResourceLimits.With(labels).Set(value)
+}
+
+func ResetContainerResourceLimits() {
+	ContainerResourceLimits.Reset()
+}

--- a/pkg/koordlet/metricsadvisor/collector.go
+++ b/pkg/koordlet/metricsadvisor/collector.go
@@ -125,11 +125,11 @@ func (c *collector) Run(stopCh <-chan struct{}) error {
 	go wait.Until(func() {
 		c.collectGPUUsage()
 		c.collectNodeResUsed()
-		// add sync metaService cache check before collect pod information
+		// add sync statesInformer cache check before collect pod information
 		// because collect function will get all pods.
 		if !cache.WaitForCacheSync(stopCh, c.statesInformer.HasSynced) {
-			klog.Errorf("timed out waiting for meta service caches to sync")
-			// Koordlet exit because of metaService sync failed.
+			klog.Errorf("timed out waiting for states informer caches to sync")
+			// Koordlet exit because of statesInformer sync failed.
 			os.Exit(1)
 			return
 		}
@@ -142,11 +142,11 @@ func (c *collector) Run(stopCh <-chan struct{}) error {
 
 	ic := NewPerformanceCollector(c.statesInformer, c.metricCache, c.config.CPICollectorTimeWindowSeconds)
 	util.RunFeature(func() {
-		// add sync metaService cache check before collect pod information
+		// add sync statesInformer cache check before collect pod information
 		// because collect function will get all pods.
 		if !cache.WaitForCacheSync(stopCh, c.statesInformer.HasSynced) {
-			// Koordlet exit because of metaService sync failed.
-			klog.Fatalf("timed out waiting for meta service caches to sync")
+			// Koordlet exit because of statesInformer sync failed.
+			klog.Fatalf("timed out waiting for states informer caches to sync")
 			return
 		}
 		ic.collectContainerCPI()
@@ -158,11 +158,11 @@ func (c *collector) Run(stopCh <-chan struct{}) error {
 			klog.Fatalf("collect psi fail, need anolis os")
 			return
 		}
-		// add sync metaService cache check before collect pod information
+		// add sync statesInformer cache check before collect pod information
 		// because collect function will get all pods.
 		if !cache.WaitForCacheSync(stopCh, c.statesInformer.HasSynced) {
-			// Koordlet exit because of metaService sync failed.
-			klog.Fatalf("timed out waiting for meta service caches to sync")
+			// Koordlet exit because of statesInformer sync failed.
+			klog.Fatalf("timed out waiting for states informer caches to sync")
 			return
 		}
 		ic.collectContainerPSI()
@@ -217,7 +217,7 @@ func (c *collector) collectNodeResUsed() {
 
 	// update collect time
 	c.state.RefreshTime(nodeResUsedUpdateTime)
-	metrics.RecordNodeUsedCPU(cpuUsageValue * 1000)
+	metrics.RecordNodeUsedCPU(cpuUsageValue) // in cpu cores
 
 	klog.Infof("collectNodeResUsed finished %+v", nodeMetric)
 }

--- a/pkg/koordlet/metricsadvisor/collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collector_test.go
@@ -35,9 +35,9 @@ import (
 
 func TestNewCollector(t *testing.T) {
 	type args struct {
-		cfg         *Config
-		metaService statesinformer.StatesInformer
-		metricCache metriccache.MetricCache
+		cfg            *Config
+		statesInformer statesinformer.StatesInformer
+		metricCache    metriccache.MetricCache
 	}
 	tests := []struct {
 		name string
@@ -46,15 +46,15 @@ func TestNewCollector(t *testing.T) {
 		{
 			name: "new-collector",
 			args: args{
-				cfg:         &Config{},
-				metaService: nil,
-				metricCache: nil,
+				cfg:            &Config{},
+				statesInformer: nil,
+				metricCache:    nil,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewCollector(tt.args.cfg, tt.args.metaService, tt.args.metricCache); got == nil {
+			if got := NewCollector(tt.args.cfg, tt.args.statesInformer, tt.args.metricCache); got == nil {
 				t.Errorf("NewCollector() = %v", got)
 			}
 		})

--- a/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/performance_collector_linux_test.go
@@ -37,10 +37,10 @@ import (
 
 func TestNewPerformanceCollector(t *testing.T) {
 	type args struct {
-		cfg         *Config
-		metaService statesinformer.StatesInformer
-		metricCache metriccache.MetricCache
-		timeWindow  int
+		cfg            *Config
+		statesInformer statesinformer.StatesInformer
+		metricCache    metriccache.MetricCache
+		timeWindow     int
 	}
 	tests := []struct {
 		name string
@@ -49,16 +49,16 @@ func TestNewPerformanceCollector(t *testing.T) {
 		{
 			name: "new-performance-collector",
 			args: args{
-				cfg:         &Config{},
-				metaService: nil,
-				metricCache: nil,
-				timeWindow:  10,
+				cfg:            &Config{},
+				statesInformer: nil,
+				metricCache:    nil,
+				timeWindow:     10,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewPerformanceCollector(tt.args.metaService, tt.args.metricCache, tt.args.timeWindow); got == nil {
+			if got := NewPerformanceCollector(tt.args.statesInformer, tt.args.metricCache, tt.args.timeWindow); got == nil {
 				t.Errorf("NewPerformanceCollector() = %v", got)
 			}
 		})

--- a/pkg/koordlet/resmanager/cpu_suppress.go
+++ b/pkg/koordlet/resmanager/cpu_suppress.go
@@ -153,7 +153,7 @@ func (r *CPUSuppress) calculateBESuppressCPU(node *corev1.Node, nodeMetric *metr
 		node.Status.Allocatable.Cpu().Format)
 	nodeBESuppressCPU.Sub(podLSUsedCPU)
 	nodeBESuppressCPU.Sub(systemUsedCPU)
-	metrics.RecordBESuppressLSUsedCPU(float64(podLSUsedCPU.Value()))
+	metrics.RecordBESuppressLSUsedCPU(float64(podLSUsedCPU.MilliValue()) / 1000)
 	klog.Infof("nodeSuppressBE[CPU(Core)]:%v = node.Total:%v * SLOPercent:%v%% - systemUsage:%v - podLSUsed:%v\n",
 		nodeBESuppressCPU.Value(), node.Status.Allocatable.Cpu().Value(), beCPUUsedThreshold, systemUsedCPU.Value(),
 		podLSUsedCPU.Value())

--- a/pkg/koordlet/resmanager/resmanager.go
+++ b/pkg/koordlet/resmanager/resmanager.go
@@ -124,7 +124,7 @@ func (r *resmanager) Run(stopCh <-chan struct{}) error {
 	go configextensions.RunQOSGreyCtrlPlugins(r.kubeClient, stopCh)
 
 	if !cache.WaitForCacheSync(stopCh, r.statesInformer.HasSynced) {
-		return fmt.Errorf("time out waiting for kubelet meta service caches to sync")
+		return fmt.Errorf("time out waiting for states informer caches to sync")
 	}
 
 	cgroupResourceReconcile := NewCgroupResourcesReconcile(r)

--- a/pkg/koordlet/statesinformer/config_test.go
+++ b/pkg/koordlet/statesinformer/config_test.go
@@ -18,10 +18,10 @@ package statesinformer
 
 import (
 	"flag"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -47,9 +47,8 @@ func TestNewDefaultConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewDefaultConfig(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewDefaultConfig() = %v, want %v", got, tt.want)
-			}
+			got := NewDefaultConfig()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -103,7 +102,6 @@ func TestConfig_InitFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			raw := &Config{
 				KubeletPreferredAddressType: tt.fields.KubeletPreferredAddressType,
 				KubeletSyncInterval:         tt.fields.KubeletSyncInterval,
@@ -111,15 +109,14 @@ func TestConfig_InitFlags(t *testing.T) {
 				InsecureKubeletTLS:          tt.fields.InsecureKubeletTLS,
 				KubeletReadOnlyPort:         tt.fields.KubeletReadOnlyPort,
 				NodeTopologySyncInterval:    tt.fields.NodeTopologySyncInterval,
-				DisableQueryKubeletConfig:   true,
-				EnableNodeMetricReport:      false,
+				DisableQueryKubeletConfig:   tt.fields.DisableQueryKubeletConfig,
+				EnableNodeMetricReport:      tt.fields.EnableNodeMetricReport,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)
-			tt.args.fs.Parse(cmdArgs[1:])
-			if !reflect.DeepEqual(raw, c) {
-				t.Fatalf("InitFlags got: \n%+v, \nwant: \n%+v", c, raw)
-			}
+			err := tt.args.fs.Parse(cmdArgs[1:])
+			assert.NoError(t, err)
+			assert.Equal(t, raw, c)
 		})
 	}
 }

--- a/pkg/koordlet/statesinformer/states_node_test.go
+++ b/pkg/koordlet/statesinformer/states_node_test.go
@@ -20,22 +20,62 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 )
 
 func Test_statesInformer_syncNode(t *testing.T) {
-	testingNode := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "test",
-			Labels: map[string]string{},
+	tests := []struct {
+		name string
+		arg  *corev1.Node
+	}{
+		{
+			name: "node is nil",
+			arg:  nil,
+		},
+		{
+			name: "node is incomplete",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test",
+					Labels: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "node is valid",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-node",
+					Labels: map[string]string{},
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100"),
+						corev1.ResourceMemory: resource.MustParse("200Gi"),
+						apiext.BatchCPU:       resource.MustParse("50000"),
+						apiext.BatchMemory:    resource.MustParse("80Gi"),
+					},
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100"),
+						corev1.ResourceMemory: resource.MustParse("200Gi"),
+						apiext.BatchCPU:       resource.MustParse("50000"),
+						apiext.BatchMemory:    resource.MustParse("80Gi"),
+					},
+				},
+			},
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &nodeInformer{}
+			metrics.Register(tt.arg)
+			defer metrics.Register(nil)
 
-	m := &nodeInformer{}
-	metrics.Register(testingNode)
-	defer metrics.Register(nil)
-
-	m.syncNode(testingNode)
+			m.syncNode(tt.arg)
+		})
+	}
 }

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -68,3 +68,7 @@ func IsResourceDiff(old, new corev1.ResourceList, resourceName corev1.ResourceNa
 
 	return newQuant >= oldQuant*(1+diffThreshold) || newQuant <= oldQuant*(1-diffThreshold)
 }
+
+func QuantityPtr(q resource.Quantity) *resource.Quantity {
+	return &q
+}

--- a/pkg/util/resource_test.go
+++ b/pkg/util/resource_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -89,6 +90,42 @@ func TestIsResourceDiff(t *testing.T) {
 			if got := IsResourceDiff(tt.args.old, tt.args.new, tt.args.resourceName, tt.args.diffThreshold); got != tt.want {
 				t.Errorf("IsResourceDiff() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestQuantityPtr(t *testing.T) {
+	testQuantity := resource.MustParse("1000")
+	testQuantityPtr := &testQuantity
+	testQuantity1 := resource.MustParse("20Gi")
+	testQuantityPtr1 := &testQuantity1
+	testQuantityPtr2 := resource.NewQuantity(1000, resource.DecimalSI)
+	testQuantity2 := *testQuantityPtr2
+	tests := []struct {
+		name string
+		arg  resource.Quantity
+		want *resource.Quantity
+	}{
+		{
+			name: "quantity 0",
+			arg:  testQuantity,
+			want: testQuantityPtr,
+		},
+		{
+			name: "quantity 1",
+			arg:  testQuantity1,
+			want: testQuantityPtr1,
+		},
+		{
+			name: "quantity 2",
+			arg:  testQuantity2,
+			want: testQuantityPtr2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := QuantityPtr(tt.arg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Add Prometheus metrics for node's and pod's batch resources, including metrics below:

```bash
koordlet_node_resource_allocatable{resource="kubernetes.io/batch-cpu|kubernetes.io/batch-memory", node=}
koordlet_pod_resource_request{resource="kubernetes.io/batch-cpu|kubernetes.io/batch-memory", node=, pod=, namespace=, container=}
koordlet_pod_resource_limit{resource="kubernetes.io/batch-cpu|kubernetes.io/batch-memory", node=, pod=, namespace=, container=}
```

Fix some spelling errors.

Fix metrics `koordlet_node_used_cpu_cores` and `koordlet_be_suppress_ls_used_cpu_cores`, and use *cores* instead of *milli-cores* as the unit.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
