### PR TITLE
koordlet: support cpu eviction in cpuset supress mode with cpu static policy

### DIFF
--- a/pkg/koordlet/metricsadvisor/be_collector.go
+++ b/pkg/koordlet/metricsadvisor/be_collector.go
@@ -69,7 +69,7 @@ func (c *collector) collectBECPUResourceMetric() {
 func getBECPURealMilliLimit() (int, error) {
 	limit := 0
 
-	cpuSet, err := koordletutil.GetRootCgroupCurCPUSet(corev1.PodQOSBestEffort)
+	cpuSet, err := koordletutil.GetBECgroupCurCPUSet()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/koordlet/resmanager/cpu_suppress_test.go
+++ b/pkg/koordlet/resmanager/cpu_suppress_test.go
@@ -970,7 +970,7 @@ func Test_cpuSuppress_recoverCPUSetIfNeed(t *testing.T) {
 			if tt.args.currentPolicyStatus != nil {
 				cpuSuppress.suppressPolicyStatuses[string(slov1alpha1.CPUSetPolicy)] = *tt.args.currentPolicyStatus
 			}
-			cpuSuppress.recoverCPUSetIfNeed(containerCgroupPathRelativeDepth)
+			cpuSuppress.recoverCPUSetIfNeed(koordletutil.ContainerCgroupPathRelativeDepth)
 			gotPolicyStatus := cpuSuppress.suppressPolicyStatuses[string(slov1alpha1.CPUSetPolicy)]
 			assert.Equal(t, *tt.wantPolicyStatus, gotPolicyStatus, "checkStatus")
 			gotCPUSetBECgroup := helper.ReadCgroupFileContents(koordletutil.GetKubeQosRelativePath(corev1.PodQOSBestEffort), system.CPUSet)
@@ -1197,7 +1197,7 @@ func Test_cpuSuppress_applyCPUSetWithNonePolicy(t *testing.T) {
 	cpuset := []int32{3, 2, 1}
 	wantCPUSetStr := "1-3"
 
-	oldCPUSet, err := koordletutil.GetRootCgroupCurCPUSet(corev1.PodQOSBestEffort)
+	oldCPUSet, err := koordletutil.GetBECgroupCurCPUSet()
 	assert.NoError(t, err)
 
 	r := newTestCPUSuppress(nil)
@@ -1226,7 +1226,7 @@ func Test_getBECgroupCPUSetPathsRecursive(t *testing.T) {
 		wantPaths = append(wantPaths, filepath.Join(koordletutil.GetRootCgroupCPUSetDir(corev1.PodQOSBestEffort), podDir))
 	}
 
-	paths, err := getBECPUSetPathsByMaxDepth(containerCgroupPathRelativeDepth)
+	paths, err := koordletutil.GetBECPUSetPathsByMaxDepth(koordletutil.ContainerCgroupPathRelativeDepth)
 	assert.NoError(t, err)
 	assert.Equal(t, len(wantPaths), len(paths))
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Cpu eviction does not work for cpuset suppress mode with cpu manager static policy, this pr fix it.

### Ⅱ. Does this pull request fix one issue?

fix #871

### Ⅲ. Describe how to verify it

- Configure kubelet with cpuManagerPolicy: static

- Configure koordinator's resource-threshold-config with:

```
  resource-threshold-config: |
    {
      "clusterStrategy": {
        "enable": true,
        "cpuSuppressThresholdPercent": 40,
        "memoryEvictThresholdPercent": 70,
        "cpuEvictBESatisfactionUpperPercent": 80,
        "cpuEvictBESatisfactionLowerPercent": 60,
        "cpuEvictBEUsageThresholdPercent": 40,
        "cpuEvictTimeWindowSeconds": 1
      },
    }
```

- Create a be pod: pod1 on a K8s node: node1

- Increase the node1's cpu usage until pod1 is evicted

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
