### PR TITLE
koord-descheduler: optimize the migration defense strategies

### DIFF
--- a/pkg/descheduler/controllers/migration/controllerfinder/controller_finder.go
+++ b/pkg/descheduler/controllers/migration/controllerfinder/controller_finder.go
@@ -68,6 +68,10 @@ type ControllerReference struct {
 // controllers and their scale.
 type PodControllerFinder func(ref ControllerReference, namespace string) (*ScaleAndSelector, error)
 
+type Interface interface {
+	GetPodsForRef(apiVersion, kind, name, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, int32, error)
+}
+
 type ControllerFinder struct {
 	client.Client
 

--- a/pkg/descheduler/controllers/migration/util/util.go
+++ b/pkg/descheduler/controllers/migration/util/util.go
@@ -90,7 +90,14 @@ func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, err
 			intOrPercent = &s
 		}
 	}
-	return intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, true)
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
+	if err != nil {
+		return 0, err
+	}
+	if maxUnavailable > replicas {
+		maxUnavailable = replicas
+	}
+	return maxUnavailable, nil
 }
 
 func GetMaxMigrating(replicas int, intOrPercent *intstr.IntOrString) (int, error) {


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

1. Support k8s descheduler Pod annotation `descheduler.alpha.kubernetes.io/evict` to skip migration defense strategies.
2. Fix MigrationJob cannot execute when `maxMigratingPerNode=1` and `maxMigratingPerNamespace=1`.
3. Fix not checking `maxUnavailablePerWorkload` when a workload has many unavailable Pods but no migrating Pods
4. Fix did not correctly determine whether the Pod is available, e.g. the Pod is in the Pending state or not Ready
5. Limit some special configuration scenarios for `maxMigratingPerWorkload` and `maxUnavailablePerWorkload`. Reject eviction when `maxMigratingPerWorkload` or `maxUnavailablePerWorkload` equals the expected number of replicas of the workload.
6. When calculating the number of unavailable replicas, round down to avoid risks as much as possible

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
