### PR TITLE
⚡  add new method GetPodIsAssigned to QuotaInfo

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/quota_info.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info.go
@@ -344,6 +344,19 @@ func (qi *QuotaInfo) GetPodIsAssigned(pod *v1.Pod) bool {
 	return false
 }
 
+func (qi *QuotaInfo) GetPodThatIsAssigned() []*v1.Pod {
+	qi.lock.Lock()
+	defer qi.lock.Unlock()
+
+	pods := make([]*v1.Pod, 0)
+	for _, podInfo := range qi.PodCache {
+		if podInfo.isAssigned {
+			pods = append(pods, podInfo.pod)
+		}
+	}
+	return pods
+}
+
 func (qi *QuotaInfo) Lock() {
 	qi.lock.Lock()
 }

--- a/pkg/scheduler/plugins/elasticquota/core/quota_info_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info_test.go
@@ -28,15 +28,17 @@ func TestQuotaInfo_AddPodIfNotPresent_RemovePodIfPresent_GetPodCache(t *testing.
 	pod := schetesting.MakePod().Name("test").Obj()
 	qi.addPodIfNotPresent(pod)
 	assert.Equal(t, 1, len(qi.GetPodCache()))
+	assert.Equal(t, 0, len(qi.GetPodThatIsAssigned()))
 	qi.addPodIfNotPresent(pod)
 	assert.False(t, qi.GetPodIsAssigned(pod))
-	err := qi.UpdatePodIsAssigned(pod, false)
+	err := qi.UpdatePodIsAssigned(pod.Name, false)
 	assert.NotNil(t, err)
-	err = qi.UpdatePodIsAssigned(pod, true)
+	err = qi.UpdatePodIsAssigned(pod.Name, true)
 	assert.Nil(t, err)
 	assert.True(t, qi.GetPodIsAssigned(pod))
+	assert.Equal(t, 1, len(qi.GetPodThatIsAssigned()))
 
-	qi.removePodIfPresent(pod)
+	qi.removePodIfPresent(pod.Name)
 	assert.Equal(t, 0, len(qi.GetPodCache()))
 }
 

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke.go
@@ -99,12 +99,7 @@ func (monitor *QuotaOverUsedGroupMonitor) getToRevokePodList(quotaName string) [
 	oriUsed := used.DeepCopy()
 
 	// order pod from low priority -> high priority
-	priPodCache := make([]*v1.Pod, 0)
-	for _, pod := range quotaInfo.GetPodCache() {
-		if quotaInfo.GetPodIsAssigned(pod) {
-			priPodCache = append(priPodCache, pod)
-		}
-	}
+	priPodCache := quotaInfo.GetPodThatIsAssigned()
 
 	sort.Slice(priPodCache, func(i, j int) bool { return !util.MoreImportantPod(priPodCache[i], priPodCache[j]) })
 


### PR DESCRIPTION
Signed-off-by: kingeasternsun <kingeasternsun@gmail.com>

### Ⅰ. Describe what this PR does

when we get pods that is assigned from quota, we could just return them directly with lock once , instead of lock twice that with first lock we get all pods, with second lock we judge each pod and collect assigned pods.

### Ⅱ. Does this pull request fix one issue?

no 
### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
