### PR TITLE
koord-descheduler: support pod deletion cost and eviction cost

### DIFF
--- a/apis/extension/descheduling.go
+++ b/apis/extension/descheduling.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	// AnnotationEvictionCost indicates the eviction cost. It can be used to set to an int32.
+	// Although the K8s community has [Pod Deletion Cost #2255](https://github.com/kubernetes/enhancements/issues/2255),
+	// it is not a general mechanism. To avoid conflicts with components that use `Pod Deletion Cost`,
+	// users can individually mark the eviction cost for Pods.
+	// The implicit eviction cost for pods that don't set the annotation is 0, negative values are permitted.
+	// If set the cost with `math.MaxInt32`, it means the Pod will not be evicted.
+	// Pods with lower eviction cost are preferred to be evicted before pods with higher eviction cost.
+	// If a batch of Pods to be evicted have the same priority, they will be sorted by cost,
+	// and the Pod with the smallest cost will be evicted.
+	AnnotationEvictionCost = SchedulingDomainPrefix + "/eviction-cost"
+)
+
+func GetEvictionCost(annotations map[string]string) (int32, error) {
+	if value, exist := annotations[AnnotationEvictionCost]; exist {
+		// values that start with plus sign (e.g, "+10") or leading zeros (e.g., "008") are not valid.
+		if !validFirstDigit(value) {
+			return 0, fmt.Errorf("invalid value %q", value)
+		}
+
+		i, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			// make sure we default to 0 on error.
+			return 0, err
+		}
+		return int32(i), nil
+	}
+	return 0, nil
+}
+
+func validFirstDigit(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	return str[0] == '-' || (str[0] == '0' && str == "0") || (str[0] >= '1' && str[0] <= '9')
+}

--- a/pkg/descheduler/controllers/migration/controller.go
+++ b/pkg/descheduler/controllers/migration/controller.go
@@ -157,8 +157,9 @@ func newReconciler(args *deschedulerconfig.MigrationControllerArgs, handle frame
 		excludedNamespaces = sets.NewString(args.Namespaces.Exclude...)
 	}
 
+	wrapFilterFuncs := podutil.WrapFilterFuncs(util.FilterPodWithMaxEvictionCost, evictorFilter.Filter)
 	podFilter, err := podutil.NewOptions().
-		WithFilter(evictorFilter.Filter).
+		WithFilter(wrapFilterFuncs).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		BuildFilterFunc()

--- a/pkg/descheduler/controllers/migration/util/util.go
+++ b/pkg/descheduler/controllers/migration/util/util.go
@@ -17,9 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/controllers/migration/reservation"
 )
@@ -91,4 +95,10 @@ func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, err
 
 func GetMaxMigrating(replicas int, intOrPercent *intstr.IntOrString) (int, error) {
 	return GetMaxUnavailable(replicas, intOrPercent)
+}
+
+// FilterPodWithMaxEvictionCost rejects if pod's eviction cost is math.MaxInt32
+func FilterPodWithMaxEvictionCost(pod *corev1.Pod) bool {
+	cost, _ := extension.GetEvictionCost(pod.Annotations)
+	return !(cost == math.MaxInt32)
 }


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

1. Migration Controller supports filtered Pod that has max eviction cost.
2. PodSorter supports pod deletion cost and eviction cost.

### Ⅱ. Does this pull request fix one issue?

fix #938 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
