### PR TITLE
koord-scheduler: additionally check parent's Quota if configured

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -175,6 +175,9 @@ type ElasticQuotaArgs struct {
 
 	// MonitorAllQuotas monitor the quotaGroups' used and runtime Quota to revoke pods
 	MonitorAllQuotas *bool `json:"monitorAllQuotas,omitempty"`
+
+	// EnableCheckParentQuota check parentQuotaGroups' used and runtime Quota in PreFilter
+	EnableCheckParentQuota *bool `json:"enableCheckParentQuota,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -73,7 +73,8 @@ var (
 
 	defaultQuotaGroupNamespace = "koordinator-system"
 
-	defaultMonitorAllQuotas = pointer.Bool(false)
+	defaultMonitorAllQuotas       = pointer.Bool(false)
+	defaultEnableCheckParentQuota = pointer.Bool(false)
 
 	defaultTimeout           = 600 * time.Second
 	defaultControllerWorkers = 1
@@ -136,6 +137,9 @@ func SetDefaults_ElasticQuotaArgs(obj *ElasticQuotaArgs) {
 	}
 	if obj.MonitorAllQuotas == nil {
 		obj.MonitorAllQuotas = defaultMonitorAllQuotas
+	}
+	if obj.EnableCheckParentQuota == nil {
+		obj.EnableCheckParentQuota = defaultEnableCheckParentQuota
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -171,6 +171,9 @@ type ElasticQuotaArgs struct {
 
 	// MonitorAllQuotas monitor the quotaGroups' used and runtime Quota to revoke pods
 	MonitorAllQuotas *bool `json:"monitorAllQuotas,omitempty"`
+
+	// EnableCheckParentQuota check parentQuotaGroups' used and runtime Quota in PreFilter
+	EnableCheckParentQuota *bool `json:"enableCheckParentQuota,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -143,6 +143,7 @@ func autoConvert_v1beta2_ElasticQuotaArgs_To_config_ElasticQuotaArgs(in *Elastic
 	out.SystemQuotaGroupMax = *(*corev1.ResourceList)(unsafe.Pointer(&in.SystemQuotaGroupMax))
 	out.QuotaGroupNamespace = in.QuotaGroupNamespace
 	out.MonitorAllQuotas = (*bool)(unsafe.Pointer(in.MonitorAllQuotas))
+	out.EnableCheckParentQuota = (*bool)(unsafe.Pointer(in.EnableCheckParentQuota))
 	return nil
 }
 
@@ -158,6 +159,7 @@ func autoConvert_config_ElasticQuotaArgs_To_v1beta2_ElasticQuotaArgs(in *config.
 	out.SystemQuotaGroupMax = *(*corev1.ResourceList)(unsafe.Pointer(&in.SystemQuotaGroupMax))
 	out.QuotaGroupNamespace = in.QuotaGroupNamespace
 	out.MonitorAllQuotas = (*bool)(unsafe.Pointer(in.MonitorAllQuotas))
+	out.EnableCheckParentQuota = (*bool)(unsafe.Pointer(in.EnableCheckParentQuota))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -96,6 +96,11 @@ func (in *ElasticQuotaArgs) DeepCopyInto(out *ElasticQuotaArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableCheckParentQuota != nil {
+		in, out := &in.EnableCheckParentQuota, &out.EnableCheckParentQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -96,6 +96,11 @@ func (in *ElasticQuotaArgs) DeepCopyInto(out *ElasticQuotaArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableCheckParentQuota != nil {
+		in, out := &in.EnableCheckParentQuota, &out.EnableCheckParentQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: xulinfei.xlf <xulinfei.xlf@alibaba-inc.com>

### Ⅰ. Describe what this PR does
ElasticQuotaPlugin
1、PreFilter will addtionally check the parent's usedQuota + pod's Request >  parent's runtimeQuota if configured
2、The output of the PreFilter Result just print the map, which is unfriendly for users to read.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
