### PR TITLE
koordlet: fix batch resource plugin for empty label pods

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
@@ -360,8 +360,5 @@ func (p *plugin) SetContainerMemoryLimit(proto protocol.HooksProtocol) error {
 }
 
 func isPodQoSBEByAttr(labels map[string]string, annotations map[string]string) bool {
-	if labels == nil || annotations == nil {
-		return false
-	}
 	return apiext.GetQoSClassByAttrs(labels, annotations) == apiext.QoSBE
 }

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource_test.go
@@ -595,3 +595,37 @@ func Test_plugin_SetContainerResources(t *testing.T) {
 		})
 	}
 }
+
+func Test_isPodQoSBEByAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  map[string]string
+		arg1 map[string]string
+		want bool
+	}{
+		{
+			name: "qos is BE",
+			arg: map[string]string{
+				apiext.LabelPodQoS: string(apiext.QoSBE),
+			},
+			want: true,
+		},
+		{
+			name: "qos is not BE",
+			arg: map[string]string{
+				apiext.LabelPodQoS: string(apiext.QoSLS),
+			},
+			want: false,
+		},
+		{
+			name: "qos is not BE 1",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPodQoSBEByAttr(tt.arg, tt.arg1)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -158,7 +158,7 @@ func (p *PodContext) injectForExt() {
 			klog.Infof("set pod %v/%v cpu shares %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent, err)
 		} else {
-			klog.V(5).Infof("set pod %v/%v/%v cpu shares %v on cgroup parent %v",
+			klog.V(5).Infof("set pod %v/%v cpu shares %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent)
 			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
 				"set pod cpu shares to %v", *p.Response.Resources.CPUShares).Do()
@@ -169,7 +169,7 @@ func (p *PodContext) injectForExt() {
 			klog.Infof("set pod %v/%v cfs quota %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent, err)
 		} else {
-			klog.V(5).Infof("set pod %v/%v/%v cfs quota %v on cgroup parent %v",
+			klog.V(5).Infof("set pod %v/%v cfs quota %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent)
 			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
 				"set pod cfs quota to %v", *p.Response.Resources.CFSQuota).Do()
@@ -180,7 +180,7 @@ func (p *PodContext) injectForExt() {
 			klog.Infof("set pod %v/%v memory limit %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent, err)
 		} else {
-			klog.V(5).Infof("set pod %v/%v/%v memory limit %v on cgroup parent %v",
+			klog.V(5).Infof("set pod %v/%v memory limit %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent)
 			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
 				"set pod memory limit to %v", *p.Response.Resources.MemoryLimit).Do()


### PR DESCRIPTION
Signed-off-by: saintube <saintube@foxmail.com>

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the batch resource plugin when the BE pod has no label or annotation.

Also, fix some log format errors.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Currently, the batch resource plugin aborts set cgroup resources when a BE pod has no label or annotation since it checks if both of them are non-nil.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
