### PR TITLE
koordlet: fix not support cpu without L3 cache

### DIFF
--- a/pkg/koordlet/util/cpuinfo_test.go
+++ b/pkg/koordlet/util/cpuinfo_test.go
@@ -351,6 +351,32 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
 			},
 			wantErr: false,
 		},
+		{
+			name: "read lsCPUStr successfully without l3 cache",
+			args: args{
+				lsCPUStr: `
+CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
+0   0    0      0    0:0:0         yes
+1   0    0      1    1:1:1         yes
+2   0    0      2    2:2:2         yes
+3   0    0      3    3:3:3         yes
+4   0    0      4    4:4:4         yes
+5   0    0      5    5:5:5         yes
+6   0    0      6    6:6:6         yes
+7   0    0      7    7:7:7        yes
+`},
+			want: []ProcessorInfo{
+				{CPUID: 0, CoreID: 0, SocketID: 0, NodeID: 0, L1dl1il2: "0", L3: 0, Online: "yes"},
+				{CPUID: 1, CoreID: 1, SocketID: 0, NodeID: 0, L1dl1il2: "1", L3: 0, Online: "yes"},
+				{CPUID: 2, CoreID: 2, SocketID: 0, NodeID: 0, L1dl1il2: "2", L3: 0, Online: "yes"},
+				{CPUID: 3, CoreID: 3, SocketID: 0, NodeID: 0, L1dl1il2: "3", L3: 0, Online: "yes"},
+				{CPUID: 4, CoreID: 4, SocketID: 0, NodeID: 0, L1dl1il2: "4", L3: 0, Online: "yes"},
+				{CPUID: 5, CoreID: 5, SocketID: 0, NodeID: 0, L1dl1il2: "5", L3: 0, Online: "yes"},
+				{CPUID: 6, CoreID: 6, SocketID: 0, NodeID: 0, L1dl1il2: "6", L3: 0, Online: "yes"},
+				{CPUID: 7, CoreID: 7, SocketID: 0, NodeID: 0, L1dl1il2: "7", L3: 0, Online: "yes"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/koordlet/util/system/lscpu.go
+++ b/pkg/koordlet/util/system/lscpu.go
@@ -38,11 +38,15 @@ func GetCacheInfo(str string) (string, int32, error) {
 	//  2    0      0    1 1:1:1:0          yes
 	//  3    0      0    1 1:1:1:0          yes
 	infos := strings.Split(strings.TrimSpace(str), ":")
-	// assert l1, l2 are private cache, so they has the same id with the core
-	if len(infos) != 4 {
+	// assert l1, l2 are private cache, so they have the same id with the core
+	// L3 cache maybe not available, when the host is qemu-kvm. detail: https://bugzilla.redhat.com/show_bug.cgi?id=1434537
+	if len(infos) < 3 {
 		return "", 0, fmt.Errorf("invalid cache info %s", str)
 	}
 	l1l2 := infos[0]
+	if len(infos) == 3 {
+		return l1l2, 0, nil
+	}
 	l3, err := strconv.ParseInt(infos[3], 10, 32)
 	if err != nil {
 		return "", 0, err


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fix `lscpu`  get cache info failed  when the cpu has no L3 cache. 

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
