### PR TITLE
koordlet: clean up log format

### DIFF
--- a/pkg/koordlet/statesinformer/states_pods.go
+++ b/pkg/koordlet/statesinformer/states_pods.go
@@ -271,7 +271,7 @@ func recordPodResourceMetrics(podMeta *PodMeta) {
 		recordContainerResourceMetrics(c, containerStatus, pod)
 	}
 
-	klog.V(6).Infof("record pod prometheus metrics successfully, pod %s", pod.Namespace, pod.Name)
+	klog.V(6).Infof("record pod prometheus metrics successfully, pod %s/%s", pod.Namespace, pod.Name)
 }
 
 func recordContainerResourceMetrics(container *corev1.Container, containerStatus *corev1.ContainerStatus, pod *corev1.Pod) {


### PR DESCRIPTION
Signed-off-by: Wang Xiaoqiang <wangxiaoqiang@qiyi.com>

### Ⅰ. Describe what this PR does

Clean up one invalid log format:

```
I0118 10:17:58.329530  111031 states_pods.go:274] record pod prometheus metrics successfully, pod koordinator-system%!(EXTRA string=koord-manager-6f579679ff-4m7nj)
```

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
