### PR TITLE
runtimeproxy: fix trap of nil interface{}

### DIFF
--- a/pkg/runtimeproxy/dispatcher/dispatcher.go
+++ b/pkg/runtimeproxy/dispatcher/dispatcher.go
@@ -86,6 +86,9 @@ func (rd *RuntimeHookDispatcher) Dispatch(ctx context.Context, runtimeRequestPat
 			// currently, only one hook be called during one runtime
 			// TODO: multi hook server to merge response
 			rsp, err := rd.dispatchInternal(ctx, hookType, client, request)
+			if err != nil {
+				return nil, err, hookServer.FailurePolicy
+			}
 			return rsp, err, hookServer.FailurePolicy
 		}
 	}

--- a/pkg/runtimeproxy/dispatcher/dispatcher_test.go
+++ b/pkg/runtimeproxy/dispatcher/dispatcher_test.go
@@ -121,8 +121,12 @@ func TestRuntimeHookDispatcher_Dispatch(t *testing.T) {
 			hookManager: configManager,
 			cm:          clientManager,
 		}
-		_, err, operation := runtimeHookDispatcher.Dispatch(context.TODO(), tt.requestPath, config.PreHook, tt.request)
+		rsp, err, operation := runtimeHookDispatcher.Dispatch(context.TODO(), tt.requestPath, config.PreHook, tt.request)
 		assert.Equal(t, operation, tt.expectedOperation, tt.name)
 		assert.Equal(t, err != nil, tt.expectReturnErr)
+		//if err != nil, the rsp need to be nil
+		if err != nil {
+			assert.Equal(t, rsp == nil, true)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: yuexian <694547990@qq.com>

### Ⅰ. fix bug,nil interface

 ref  https://cloud.tencent.com/developer/article/1911289

### Ⅱ. Does this pull request fix one issue? 
No

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
1. stop koordlet,before fix the  bug,it will be panic. because the hookResp which return from Dispatch is not nil,although the real value is nil
2. the return type is interface{}   https://github.com/koordinator-sh/koordinator/blob/ced52523f941978835950bf47b00062434b417d8/pkg/runtimeproxy/dispatcher/dispatcher.go#L68-L69
3. while rsp is nil, but if it return as interface{}, it will not be equal with nil  https://github.com/koordinator-sh/koordinator/blob/ced52523f941978835950bf47b00062434b417d8/pkg/runtimeproxy/dispatcher/dispatcher.go#L88-L89
4. after fix,it will be work fine


### Ⅳ. Special notes for reviews
#978 