### PR TITLE
koord-scheduler: LoadAware supports custom estimator

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -48,6 +48,8 @@ type LoadAwareSchedulingArgs struct {
 	ProdUsageThresholds map[corev1.ResourceName]int64 `json:"prodUsageThresholds,omitempty"`
 	// ScoreAccordingProdUsage controls whether to score according to the utilization of Prod Pod
 	ScoreAccordingProdUsage bool `json:"scoreAccordingProdUsage,omitempty"`
+	// Estimator indicates the expected Estimator to use
+	Estimator string `json:"estimator,omitempty"`
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -18,7 +18,6 @@ package v1beta2
 
 import (
 	"math"
-
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -94,8 +93,14 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 	if len(obj.UsageThresholds) == 0 {
 		obj.UsageThresholds = defaultUsageThresholds
 	}
-	if len(obj.EstimatedScalingFactors) == 0 {
+	if obj.EstimatedScalingFactors == nil {
 		obj.EstimatedScalingFactors = defaultEstimatedScalingFactors
+	} else {
+		for k, v := range defaultEstimatedScalingFactors {
+			if _, ok := obj.EstimatedScalingFactors[k]; !ok {
+				obj.EstimatedScalingFactors[k] = v
+			}
+		}
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -48,6 +48,8 @@ type LoadAwareSchedulingArgs struct {
 	ProdUsageThresholds map[corev1.ResourceName]int64 `json:"prodUsageThresholds,omitempty"`
 	// ScoreAccordingProdUsage controls whether to score according to the utilization of Prod Pod
 	ScoreAccordingProdUsage *bool `json:"scoreAccordingProdUsage,omitempty"`
+	// Estimator indicates the expected Estimator to use
+	Estimator string `json:"estimator,omitempty"`
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -243,6 +243,7 @@ func autoConvert_v1beta2_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	if err := v1.Convert_Pointer_bool_To_bool(&in.ScoreAccordingProdUsage, &out.ScoreAccordingProdUsage, s); err != nil {
 		return err
 	}
+	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
@@ -270,6 +271,7 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta2_LoadAwareSchedulingAr
 	if err := v1.Convert_bool_To_Pointer_bool(&in.ScoreAccordingProdUsage, &out.ScoreAccordingProdUsage, s); err != nil {
 		return err
 	}
+	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+)
+
+const (
+	defaultEstimatorName = "defaultEstimator"
+
+	// DefaultMilliCPURequest defines default milli cpu request number.
+	DefaultMilliCPURequest int64 = 250 // 0.25 core
+	// DefaultMemoryRequest defines default memory request size.
+	DefaultMemoryRequest int64 = 200 * 1024 * 1024 // 200 MB
+)
+
+type DefaultEstimator struct {
+	resourceWeights map[corev1.ResourceName]int64
+	scalingFactors  map[corev1.ResourceName]int64
+}
+
+func NewDefaultEstimator(args *config.LoadAwareSchedulingArgs, handle framework.Handle) (Estimator, error) {
+	return &DefaultEstimator{
+		resourceWeights: args.ResourceWeights,
+		scalingFactors:  args.EstimatedScalingFactors,
+	}, nil
+}
+
+func (e *DefaultEstimator) Name() string {
+	return defaultEstimatorName
+}
+
+func (e *DefaultEstimator) Estimate(pod *corev1.Pod) (map[corev1.ResourceName]int64, error) {
+	return estimatedPodUsed(pod, e.resourceWeights, e.scalingFactors), nil
+}
+
+func estimatedPodUsed(pod *corev1.Pod, resourceWeights map[corev1.ResourceName]int64, scalingFactors map[corev1.ResourceName]int64) map[corev1.ResourceName]int64 {
+	requests, limits := resourceapi.PodRequestsAndLimits(pod)
+	estimatedUsed := make(map[corev1.ResourceName]int64)
+	priorityClass := extension.GetPriorityClass(pod)
+	for resourceName := range resourceWeights {
+		realResourceName := extension.TranslateResourceNameByPriorityClass(priorityClass, resourceName)
+		estimatedUsed[resourceName] = estimatedUsedByResource(requests, limits, realResourceName, scalingFactors[resourceName])
+	}
+	return estimatedUsed
+}
+
+// TODO(joseph): Do we need to differentiate scalingFactor according to Koordinator Priority type?
+func estimatedUsedByResource(requests, limits corev1.ResourceList, resourceName corev1.ResourceName, scalingFactor int64) int64 {
+	limitQuantity := limits[resourceName]
+	requestQuantity := requests[resourceName]
+	var quantity resource.Quantity
+	if limitQuantity.Cmp(requestQuantity) > 0 {
+		scalingFactor = 100
+		quantity = limitQuantity
+	} else {
+		quantity = requestQuantity
+	}
+
+	if quantity.IsZero() {
+		switch resourceName {
+		case corev1.ResourceCPU, extension.BatchCPU:
+			return DefaultMilliCPURequest
+		case corev1.ResourceMemory, extension.BatchMemory:
+			return DefaultMemoryRequest
+		}
+		return 0
+	}
+
+	var estimatedUsed int64
+	switch resourceName {
+	case corev1.ResourceCPU:
+		estimatedUsed = int64(math.Round(float64(quantity.MilliValue()) * float64(scalingFactor) / 100))
+		if estimatedUsed > limitQuantity.MilliValue() {
+			estimatedUsed = limitQuantity.MilliValue()
+		}
+	default:
+		estimatedUsed = int64(math.Round(float64(quantity.Value()) * float64(scalingFactor) / 100))
+		if estimatedUsed > limitQuantity.Value() {
+			estimatedUsed = limitQuantity.Value()
+		}
+	}
+	return estimatedUsed
+}

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1beta2"
+)
+
+func TestDefaultEstimator(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		scalarFactors map[corev1.ResourceName]int64
+		want          map[corev1.ResourceName]int64
+	}{
+		{
+			name: "estimate empty pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:      "main",
+							Resources: corev1.ResourceRequirements{},
+						},
+					},
+				},
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    DefaultMilliCPURequest,
+				corev1.ResourceMemory: DefaultMemoryRequest,
+			},
+		},
+		{
+			name: "estimate guaranteed pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    3400,
+				corev1.ResourceMemory: 6012954214, // 5.6Gi
+			},
+		},
+		{
+			name: "estimate burstable pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("8"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    8000,
+				corev1.ResourceMemory: 6012954214, // 5.6Gi
+			},
+		},
+		{
+			name: "estimate guaranteed pod and zoomed cpu factors",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			scalarFactors: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU: 110,
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    4000,
+				corev1.ResourceMemory: 6012954214, // 5.6Gi
+			},
+		},
+		{
+			name: "estimate guaranteed pod and zoomed memory factors",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			scalarFactors: map[corev1.ResourceName]int64{
+				corev1.ResourceMemory: 110,
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    3400,
+				corev1.ResourceMemory: 8589934592, // 5.6Gi
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v1beta2args v1beta2.LoadAwareSchedulingArgs
+			v1beta2args.EstimatedScalingFactors = tt.scalarFactors
+			v1beta2.SetDefaults_LoadAwareSchedulingArgs(&v1beta2args)
+			var loadAwareSchedulingArgs config.LoadAwareSchedulingArgs
+			err := v1beta2.Convert_v1beta2_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(&v1beta2args, &loadAwareSchedulingArgs, nil)
+			assert.NoError(t, err)
+			estimator, err := NewDefaultEstimator(&loadAwareSchedulingArgs, nil)
+			assert.NoError(t, err)
+			assert.NotNil(t, estimator)
+			assert.Equal(t, defaultEstimatorName, estimator.Name())
+
+			got, err := estimator.Estimate(tt.pod)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/loadaware/estimator/types.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/types.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+)
+
+type FactoryFn func(args *config.LoadAwareSchedulingArgs, handle framework.Handle) (Estimator, error)
+
+var Estimators = map[string]FactoryFn{
+	defaultEstimatorName: NewDefaultEstimator,
+}
+
+type Estimator interface {
+	Name() string
+	Estimate(pod *corev1.Pod) (map[corev1.ResourceName]int64, error)
+}
+
+func NewEstimator(args *config.LoadAwareSchedulingArgs, handle framework.Handle) (Estimator, error) {
+	factoryFn := Estimators[args.Estimator]
+	if factoryFn == nil {
+		factoryFn = NewDefaultEstimator
+	}
+	return factoryFn(args, handle)
+}


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

LoadAware scheduling plugin is based on the factor estimation algorithm to resolve the problem of scheduling a large number of Pods in cold node scenarios. This algorithm is relatively simple, and needs to be able to customize the estimator to achieve a more accurate estimation mechanism.

Now move the factor estimation algorithm to estimator package as default estimator.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
