### PR TITLE
koord-scheduler: set Reservation indexer before informer start to avoid error

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -338,11 +338,14 @@ func Setup(ctx context.Context, opts *options.Options, schedulingHooks []framewo
 
 	// NOTE(joseph): K8s scheduling framework does not provide extension point for initialization.
 	// Currently, only by copying the initialization code and implementing custom initialization.
-	extendedHandle := frameworkext.NewExtendedHandle(
+	extendedHandle, err := frameworkext.NewExtendedHandle(
 		frameworkext.WithServicesEngine(cc.ServicesEngine),
 		frameworkext.WithKoordinatorClientSet(cc.KoordinatorClient),
 		frameworkext.WithKoordinatorSharedInformerFactory(cc.KoordinatorSharedInformerFactory),
 	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
 	outOfTreeRegistry := make(runtime.Registry)
 	for _, option := range outOfTreeRegistryOptions {

--- a/pkg/scheduler/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/eventhandlers/reservation_handler_test.go
@@ -83,7 +83,7 @@ func TestAddReservationErrorHandler(t *testing.T) {
 		internalHandler := &fakeSchedulerInternalHandler{}
 		koordClientSet := koordfake.NewSimpleClientset(testR)
 		koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-		extendHandle := frameworkext.NewExtendedHandle(
+		extendHandle, _ := frameworkext.NewExtendedHandle(
 			frameworkext.WithKoordinatorClientSet(koordClientSet),
 			frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 		)
@@ -127,7 +127,7 @@ func TestAddScheduleEventHandler(t *testing.T) {
 		internalHandler := &fakeSchedulerInternalHandler{}
 		koordClientSet := koordfake.NewSimpleClientset()
 		koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-		extendHandle := frameworkext.NewExtendedHandle(
+		extendHandle, _ := frameworkext.NewExtendedHandle(
 			frameworkext.WithKoordinatorClientSet(koordClientSet),
 			frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 		)

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -28,6 +28,7 @@ import (
 
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/indexer"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
 )
 
@@ -86,10 +87,14 @@ type frameworkExtendedHandleImpl struct {
 	controllerMaps                   *ControllersMap
 }
 
-func NewExtendedHandle(options ...Option) ExtendedHandle {
+func NewExtendedHandle(options ...Option) (ExtendedHandle, error) {
 	handleOptions := &extendedHandleOptions{}
 	for _, opt := range options {
 		opt(handleOptions)
+	}
+
+	if err := indexer.AddIndexers(handleOptions.koordinatorSharedInformerFactory); err != nil {
+		return nil, err
 	}
 
 	return &frameworkExtendedHandleImpl{
@@ -98,7 +103,7 @@ func NewExtendedHandle(options ...Option) ExtendedHandle {
 		koordinatorSharedInformerFactory: handleOptions.koordinatorSharedInformerFactory,
 		sharedListerAdapter:              handleOptions.sharedListerAdapter,
 		controllerMaps:                   NewControllersMap(),
-	}
+	}, nil
 }
 
 func (ext *frameworkExtendedHandleImpl) Run() {

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -92,7 +92,7 @@ func Test_frameworkExtenderImpl_RunPreFilterPlugins(t *testing.T) {
 				&TestHook{index: 1},
 				&TestHook{index: 2},
 			}
-			extendedHandle := NewExtendedHandle()
+			extendedHandle, _ := NewExtendedHandle()
 			extendedFrameworkFactory := NewFrameworkExtenderFactory(extendedHandle, schedulingHooks...)
 			registeredPlugins := []schedulertesting.RegisterPluginFunc{
 				schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -141,7 +141,7 @@ func Test_frameworkExtenderImpl_RunFilterPluginsWithNominatedPods(t *testing.T) 
 				&TestHook{index: 1},
 				&TestHook{index: 2},
 			}
-			extendedHandle := NewExtendedHandle()
+			extendedHandle, _ := NewExtendedHandle()
 			extendedFrameworkFactory := NewFrameworkExtenderFactory(extendedHandle, schedulingHooks...)
 			registeredPlugins := []schedulertesting.RegisterPluginFunc{
 				schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -200,7 +200,7 @@ func Test_frameworkExtenderImpl_RunScorePlugins(t *testing.T) {
 				&TestHook{index: 1},
 				&TestHook{index: 2},
 			}
-			extendedHandle := NewExtendedHandle()
+			extendedHandle, _ := NewExtendedHandle()
 			extendedFrameworkFactory := NewFrameworkExtenderFactory(extendedHandle, schedulingHooks...)
 			registeredPlugins := []schedulertesting.RegisterPluginFunc{
 				schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),

--- a/pkg/scheduler/frameworkext/indexer/add_indexer.go
+++ b/pkg/scheduler/frameworkext/indexer/add_indexer.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+)
+
+type addIndexerFunc func(koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory) error
+
+var addIndexerFuncList = []addIndexerFunc{}
+
+// AddIndexers add indexers to koordinator informer
+func AddIndexers(koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory) error {
+	if koordinatorSharedInformerFactory == nil {
+		return nil
+	}
+	for _, f := range addIndexerFuncList {
+		if err := f(koordinatorSharedInformerFactory); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/scheduler/frameworkext/indexer/reservation.go
+++ b/pkg/scheduler/frameworkext/indexer/reservation.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/cache"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+)
+
+const (
+	// ReservationStatusNodeNameIndex is the lookup name for the index function, which is to index by the status.nodeName field.
+	ReservationStatusNodeNameIndex string = "status.nodeName"
+)
+
+func init() {
+	addIndexerFuncList = append(addIndexerFuncList, addReservationIndexer)
+}
+
+// reservationStatusNodeNameIndexFunc is an index function that indexes based on a reservation's status.nodeName
+func reservationStatusNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	r, ok := obj.(*schedulingv1alpha1.Reservation)
+	if !ok {
+		return []string{}, nil
+	}
+	if len(r.Status.NodeName) <= 0 {
+		return []string{}, nil
+	}
+	return []string{r.Status.NodeName}, nil
+}
+
+func addReservationIndexer(koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory) error {
+	reservationInterface := koordinatorSharedInformerFactory.Scheduling().V1alpha1().Reservations()
+	reservationInformer := reservationInterface.Informer()
+	// index reservation with status.nodeName; avoid duplicate add
+	if reservationInformer.GetIndexer().GetIndexers()[ReservationStatusNodeNameIndex] == nil {
+		err := reservationInformer.AddIndexers(cache.Indexers{ReservationStatusNodeNameIndex: reservationStatusNodeNameIndexFunc})
+		if err != nil {
+			return fmt.Errorf("failed to add indexer, err: %s", err)
+		}
+	}
+	return nil
+}

--- a/pkg/scheduler/frameworkext/indexer/reservation_test.go
+++ b/pkg/scheduler/frameworkext/indexer/reservation_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestReservationStatusNodeNameIndexFunc(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		got, err := reservationStatusNodeNameIndexFunc(pod)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{}, got)
+
+		rPending := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "reserve-pod-0",
+			},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template: &corev1.PodTemplateSpec{},
+			},
+		}
+		got, err = reservationStatusNodeNameIndexFunc(rPending)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{}, got)
+
+		rActive := rPending.DeepCopy()
+		rActive.Status = schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: "test-node-0",
+		}
+		got, err = reservationStatusNodeNameIndexFunc(rActive)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"test-node-0"}, got)
+	})
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -137,7 +137,7 @@ func proxyPluginFactory(extendHandle *fakeExtendedHandle, factory runtime.Plugin
 func newPluginTestSuit(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-	extendHandle := frameworkext.NewExtendedHandle(
+	extendHandle, _ := frameworkext.NewExtendedHandle(
 		frameworkext.WithKoordinatorClientSet(koordClientSet),
 		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 	)
@@ -186,7 +186,7 @@ func newPluginTestSuit(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
 func Test_New(t *testing.T) {
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-	extendHandle := frameworkext.NewExtendedHandle(
+	extendHandle, _ := frameworkext.NewExtendedHandle(
 		frameworkext.WithKoordinatorClientSet(koordClientSet),
 		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 	)
@@ -1980,7 +1980,7 @@ func TestAllocator(t *testing.T) {
 
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-	extendHandle := frameworkext.NewExtendedHandle(
+	extendHandle, _ := frameworkext.NewExtendedHandle(
 		frameworkext.WithKoordinatorClientSet(koordClientSet),
 		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 	)

--- a/pkg/scheduler/plugins/loadaware/load_aware_test.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware_test.go
@@ -112,7 +112,7 @@ func TestNew(t *testing.T) {
 
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-	extendHandle := frameworkext.NewExtendedHandle(
+	extendHandle, _ := frameworkext.NewExtendedHandle(
 		frameworkext.WithKoordinatorClientSet(koordClientSet),
 		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 	)
@@ -206,7 +206,7 @@ func TestFilterExpiredNodeMetric(t *testing.T) {
 
 			koordClientSet := koordfake.NewSimpleClientset()
 			koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-			extendHandle := frameworkext.NewExtendedHandle(
+			extendHandle, _ := frameworkext.NewExtendedHandle(
 				frameworkext.WithKoordinatorClientSet(koordClientSet),
 				frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 			)
@@ -791,7 +791,7 @@ func TestFilterUsage(t *testing.T) {
 
 			koordClientSet := koordfake.NewSimpleClientset()
 			koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-			extendHandle := frameworkext.NewExtendedHandle(
+			extendHandle, _ := frameworkext.NewExtendedHandle(
 				frameworkext.WithKoordinatorClientSet(koordClientSet),
 				frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 			)
@@ -1735,7 +1735,7 @@ func TestScore(t *testing.T) {
 
 			koordClientSet := koordfake.NewSimpleClientset()
 			koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-			extendHandle := frameworkext.NewExtendedHandle(
+			extendHandle, _ := frameworkext.NewExtendedHandle(
 				frameworkext.WithKoordinatorClientSet(koordClientSet),
 				frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 			)

--- a/pkg/scheduler/plugins/reservation/garbage_collection.go
+++ b/pkg/scheduler/plugins/reservation/garbage_collection.go
@@ -29,6 +29,7 @@ import (
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/indexer"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -76,7 +77,7 @@ func (p *Plugin) gcReservations() {
 
 func (p *Plugin) expireReservationOnNode(node *corev1.Node) {
 	// assert node != nil
-	rOnNode, err := p.informer.GetIndexer().ByIndex(NodeNameIndex, node.Name)
+	rOnNode, err := p.informer.GetIndexer().ByIndex(indexer.ReservationStatusNodeNameIndex, node.Name)
 	if err != nil {
 		klog.V(4).InfoS("failed to list reservations for node deletion from indexer",
 			"node", node.Name, "err", err)

--- a/pkg/scheduler/plugins/reservation/hook.go
+++ b/pkg/scheduler/plugins/reservation/hook.go
@@ -31,6 +31,7 @@ import (
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	index "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/indexer"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -153,10 +154,10 @@ func (h *Hook) prepareMatchReservationState(handle frameworkext.ExtendedHandle, 
 		}
 
 		// list reservations on the current node
-		rOnNode, err := indexer.ByIndex(NodeNameIndex, node.Name)
+		rOnNode, err := indexer.ByIndex(index.ReservationStatusNodeNameIndex, node.Name)
 		if err != nil {
 			klog.V(3).InfoS("PreFilterHook failed to list reservations",
-				"node", node.Name, "index", NodeNameIndex, "err", err)
+				"node", node.Name, "index", index.ReservationStatusNodeNameIndex, "err", err)
 			return
 		}
 		klog.V(6).InfoS("PreFilterHook indexer list reservation on node",

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -100,15 +100,6 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	koordSharedInformerFactory := extendedHandle.KoordinatorSharedInformerFactory()
 	reservationInterface := koordSharedInformerFactory.Scheduling().V1alpha1().Reservations()
 	reservationInformer := reservationInterface.Informer()
-	// index reservation with status.nodeName; avoid duplicate add
-	if reservationInformer.GetIndexer().GetIndexers()[NodeNameIndex] == nil {
-		err := reservationInformer.AddIndexers(cache.Indexers{NodeNameIndex: StatusNodeNameIndexFunc})
-		if err != nil {
-			return nil, fmt.Errorf("failed to add indexer, err: %s", err)
-		}
-	} else {
-		klog.V(3).InfoS("indexer has been added", "index", NodeNameIndex)
-	}
 
 	p := &Plugin{
 		handle:           extendedHandle,

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -297,7 +297,7 @@ func TestNew(t *testing.T) {
 
 		koordClientSet := koordfake.NewSimpleClientset()
 		koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-		extendHandle := frameworkext.NewExtendedHandle(
+		extendHandle, _ := frameworkext.NewExtendedHandle(
 			frameworkext.WithKoordinatorClientSet(koordClientSet),
 			frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
 		)

--- a/pkg/scheduler/plugins/reservation/utils.go
+++ b/pkg/scheduler/plugins/reservation/utils.go
@@ -33,23 +33,6 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
-const (
-	// NodeNameIndex is the lookup name for the index function, which is to index by the status.nodeName field.
-	NodeNameIndex string = "status.nodeName"
-)
-
-// StatusNodeNameIndexFunc is an index function that indexes based on a reservation's status.nodeName
-func StatusNodeNameIndexFunc(obj interface{}) ([]string, error) {
-	r, ok := obj.(*schedulingv1alpha1.Reservation)
-	if !ok {
-		return []string{}, nil
-	}
-	if len(r.Status.NodeName) <= 0 {
-		return []string{}, nil
-	}
-	return []string{r.Status.NodeName}, nil
-}
-
 func isReservationNeedExpiration(r *schedulingv1alpha1.Reservation) bool {
 	// 1. failed or succeeded reservations does not need to expire
 	if r.Status.Phase == schedulingv1alpha1.ReservationFailed || r.Status.Phase == schedulingv1alpha1.ReservationSucceeded {

--- a/pkg/scheduler/plugins/reservation/utils_test.go
+++ b/pkg/scheduler/plugins/reservation/utils_test.go
@@ -28,36 +28,6 @@ import (
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
 
-func TestStatusNodeNameIndexFunc(t *testing.T) {
-	t.Run("test not panic", func(t *testing.T) {
-		pod := &corev1.Pod{}
-		got, err := StatusNodeNameIndexFunc(pod)
-		assert.NoError(t, err)
-		assert.Equal(t, []string{}, got)
-
-		rPending := &schedulingv1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "reserve-pod-0",
-			},
-			Spec: schedulingv1alpha1.ReservationSpec{
-				Template: &corev1.PodTemplateSpec{},
-			},
-		}
-		got, err = StatusNodeNameIndexFunc(rPending)
-		assert.NoError(t, err)
-		assert.Equal(t, []string{}, got)
-
-		rActive := rPending.DeepCopy()
-		rActive.Status = schedulingv1alpha1.ReservationStatus{
-			Phase:    schedulingv1alpha1.ReservationAvailable,
-			NodeName: "test-node-0",
-		}
-		got, err = StatusNodeNameIndexFunc(rActive)
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"test-node-0"}, got)
-	})
-}
-
 func Test_matchReservationPorts(t *testing.T) {
 	type args struct {
 		pod *corev1.Pod


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

If there is a new plugin that also starts the reservation informer during initialization, it will cause the reservation plugin to fail to register the indexer internally. The reason is that the k8s scheduling framework does not guarantee that the plugins are initialized in the order of configuration, even if the reservation plugin is configured first.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
