### PR TITLE
koord-scheduler: compatible with lightweight-coscheduling

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -78,6 +78,13 @@ const (
 	GangModeNonStrict = "NonStrict"
 )
 
+const (
+	// Deprecated: kubernetes-sigs/scheduler-plugins/lightweight-coscheduling
+	LabelLightweightCoschedulingPodGroupName = "pod-group.scheduling.sigs.k8s.io/name"
+	// Deprecated: kubernetes-sigs/scheduler-plugins/lightweight-coscheduling
+	LabelLightweightCoschedulingPodGroupMinAvailable = "pod-group.scheduling.sigs.k8s.io/min-available"
+)
+
 // CustomUsageThresholds supports user-defined node resource utilization thresholds.
 type CustomUsageThresholds struct {
 	// UsageThresholds indicates the resource utilization threshold of the whole machine.

--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -104,7 +104,7 @@ func (gang *Gang) tryInitByPodConfig(pod *v1.Pod, args *config.CoschedulingArgs)
 	if gang.HasGangInit {
 		return false
 	}
-	minRequiredNumber, err := extension.GetMinNum(pod)
+	minRequiredNumber, err := util.GetGangMinNumFromPod(pod)
 	if err != nil {
 		klog.Errorf("pod's annotation MinRequiredNumber illegal, gangName: %v, value: %v",
 			gang.Name, pod.Annotations[extension.AnnotationGangMinNum])

--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
@@ -260,7 +260,9 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 						Namespace: "default",
 						Name:      "pod1",
 						Labels: map[string]string{
-							extension.LabelLightweightCoschedulingPodGroupName:         "ganga",
+							// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
+							extension.LabelLightweightCoschedulingPodGroupName: "ganga",
+							// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable is deprecated
 							extension.LabelLightweightCoschedulingPodGroupMinAvailable: "2",
 						},
 					},
@@ -275,7 +277,9 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 						Namespace: "default",
 						Name:      "pod2",
 						Labels: map[string]string{
-							extension.LabelLightweightCoschedulingPodGroupName:         "ganga",
+							// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
+							extension.LabelLightweightCoschedulingPodGroupName: "ganga",
+							// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable is deprecated
 							extension.LabelLightweightCoschedulingPodGroupMinAvailable: "2",
 						},
 					},
@@ -298,7 +302,9 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 								Namespace: "default",
 								Name:      "pod1",
 								Labels: map[string]string{
-									extension.LabelLightweightCoschedulingPodGroupName:         "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
+									extension.LabelLightweightCoschedulingPodGroupName: "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable is deprecated
 									extension.LabelLightweightCoschedulingPodGroupMinAvailable: "2",
 								},
 							},
@@ -311,7 +317,9 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 								Namespace: "default",
 								Name:      "pod2",
 								Labels: map[string]string{
-									extension.LabelLightweightCoschedulingPodGroupName:         "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
+									extension.LabelLightweightCoschedulingPodGroupName: "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable is deprecated
 									extension.LabelLightweightCoschedulingPodGroupMinAvailable: "2",
 								},
 							},
@@ -324,7 +332,9 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 								Namespace: "default",
 								Name:      "pod1",
 								Labels: map[string]string{
-									extension.LabelLightweightCoschedulingPodGroupName:         "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
+									extension.LabelLightweightCoschedulingPodGroupName: "ganga",
+									// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable
 									extension.LabelLightweightCoschedulingPodGroupMinAvailable: "2",
 								},
 							},

--- a/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
+++ b/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
@@ -47,6 +47,7 @@ func GetGangNameByPod(pod *v1.Pod) string {
 	}
 	var gangName string
 	if gangName = pod.Labels[v1alpha1.PodGroupLabel]; gangName == "" {
+		// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
 		if gangName = pod.Labels[extension.LabelLightweightCoschedulingPodGroupName]; gangName == "" {
 			gangName = extension.GetGangName(pod)
 		}
@@ -55,6 +56,7 @@ func GetGangNameByPod(pod *v1.Pod) string {
 }
 
 func GetGangMinNumFromPod(pod *v1.Pod) (minNum int, err error) {
+	// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupMinAvailable is deprecated
 	if s := pod.Labels[extension.LabelLightweightCoschedulingPodGroupMinAvailable]; s != "" {
 		val, err := strconv.ParseInt(pod.Labels[extension.LabelLightweightCoschedulingPodGroupMinAvailable], 10, 32)
 		return int(val), err
@@ -66,6 +68,7 @@ func GetGangMinNumFromPod(pod *v1.Pod) (minNum int, err error) {
 }
 
 func ShouldCreatePodGroup(pod *v1.Pod) bool {
+	// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
 	return pod.Labels[v1alpha1.PodGroupLabel] == "" &&
 		pod.Labels[extension.LabelLightweightCoschedulingPodGroupName] == "" &&
 		pod.Annotations[extension.AnnotationGangName] != ""

--- a/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
+++ b/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
+	"errors"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,8 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
-
-	"encoding/json"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 )
@@ -45,11 +46,33 @@ func GetGangNameByPod(pod *v1.Pod) string {
 		return ""
 	}
 	var gangName string
-	gangName = pod.Labels[v1alpha1.PodGroupLabel]
-	if gangName == "" {
-		gangName = extension.GetGangName(pod)
+	if gangName = pod.Labels[v1alpha1.PodGroupLabel]; gangName == "" {
+		if gangName = pod.Labels[extension.LabelLightweightCoschedulingPodGroupName]; gangName == "" {
+			gangName = extension.GetGangName(pod)
+		}
 	}
 	return gangName
+}
+
+func GetGangMinNumFromPod(pod *v1.Pod) (minNum int, err error) {
+	if s := pod.Labels[extension.LabelLightweightCoschedulingPodGroupMinAvailable]; s != "" {
+		val, err := strconv.ParseInt(pod.Labels[extension.LabelLightweightCoschedulingPodGroupMinAvailable], 10, 32)
+		return int(val), err
+	}
+	if _, ok := pod.Annotations[extension.AnnotationGangMinNum]; ok {
+		return extension.GetMinNum(pod)
+	}
+	return 0, errors.New("missing min available")
+}
+
+func ShouldCreatePodGroup(pod *v1.Pod) bool {
+	return pod.Labels[v1alpha1.PodGroupLabel] == "" &&
+		pod.Labels[extension.LabelLightweightCoschedulingPodGroupName] == "" &&
+		pod.Annotations[extension.AnnotationGangName] != ""
+}
+
+func ShouldDeletePodGroup(pod *v1.Pod) bool {
+	return ShouldCreatePodGroup(pod)
 }
 
 func IsPodNeedGang(pod *v1.Pod) bool {


### PR DESCRIPTION
Signed-off-by: Joseph <joseph.t.lee@outlook.com>

### Ⅰ. Describe what this PR does

Some users are still using [lightweight-coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/kep/2-lightweight-coscheduling/README.md), so require the coscheduling plugin to be compatible with lightweight-coscheduling. PodGroups are not created when the Pod uses the lightweight-coscheduling API.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
