### PR TITLE
koordlet: use libcontainer check cgroupfsv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ KOORD_DESCHEDULER_IMG ?= "${REG}/${REG_NS}/koord-descheduler:${GIT_BRANCH}-${GIT
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 
+AGENT_MODE ?= hostMode
 # Set license header files.
 LICENSE_HEADER_GO ?= hack/boilerplate/boilerplate.go.txt
 
@@ -89,11 +90,11 @@ lint-license:
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(PACKAGES) -race -covermode atomic -coverprofile cover.out
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" agent_mode=$(AGENT_MODE) go test $(PACKAGES) -race -covermode atomic -coverprofile cover.out
 
 .PHONY: fast-test
 fast-test: envtest ## Run tests fast.
-	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(PACKAGES) -race -covermode atomic -coverprofile cover.out
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" agent_mode=$(AGENT_MODE) go test $(PACKAGES) -race -covermode atomic -coverprofile cover.out
 
 ##@ Build
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
+	github.com/opencontainers/runc v1.0.2
 	github.com/openkruise/kruise-api v1.3.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prashantv/gostub v1.1.0
@@ -156,7 +157,6 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/opencontainers/runc v1.0.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.8.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect

--- a/pkg/koordlet/metricsadvisor/collectors/beresource/be_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/beresource/be_resource_collector_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func Test_collectBECPUResourceMetric(t *testing.T) {
+	system.UseCgroupsV2 = false
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/koordlet/util/container_test.go
+++ b/pkg/koordlet/util/container_test.go
@@ -292,6 +292,7 @@ func Test_GetContainerCurTasks(t *testing.T) {
 }
 
 func Test_GetContainerCgroupXXXPath(t *testing.T) {
+	system.UseCgroupsV2 = false
 	system.SetupCgroupPathFormatter(system.Systemd)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	type args struct {

--- a/pkg/koordlet/util/pod_test.go
+++ b/pkg/koordlet/util/pod_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func Test_GetRootCgroupCPUSetDirWithSystemdDriver(t *testing.T) {
+	system.UseCgroupsV2 = false
 	system.SetupCgroupPathFormatter(system.Systemd)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	tests := []struct {
@@ -71,6 +72,7 @@ func Test_GetRootCgroupCPUSetDirWithSystemdDriver(t *testing.T) {
 }
 
 func Test_GetRootCgroupCPUSetDirWithCgroupfsDriver(t *testing.T) {
+	system.UseCgroupsV2 = false
 	system.SetupCgroupPathFormatter(system.Cgroupfs)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	tests := []struct {
@@ -134,6 +136,7 @@ func Test_GetRootCgroupCurCPUSet(t *testing.T) {
 
 	wantCPUSet := []int32{1, 2}
 
+	system.UseCgroupsV2 = false
 	gotCPUSet, err := GetRootCgroupCurCPUSet(corev1.PodQOSGuaranteed)
 	if err != nil {
 		t.Errorf("failed to GetRootCgroupCurCPUSet, err: %v", err)

--- a/pkg/koordlet/util/system/cgroup2.go
+++ b/pkg/koordlet/util/system/cgroup2.go
@@ -18,16 +18,8 @@ package system
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
-
-	"k8s.io/klog/v2"
-)
-
-const (
-	CgroupControllersName    = "cgroup.controllers"
-	CgroupSubtreeControlName = "cgroup.subtree_control"
 )
 
 type CPUStatV2Raw struct {
@@ -42,28 +34,6 @@ type CPUStatV2Raw struct {
 
 func initCgroupsVersion() {
 	UseCgroupsV2 = IsUsingCgroupsV2()
-}
-
-func IsUsingCgroupsV2() bool {
-	// currently we only check the absences of `cgroup.controllers` and `cgroup.subtree_control`
-	// TBD: check if the filesystem type of the cgroup root.
-	// link: https://kubernetes.io/docs/concepts/architecture/cgroups/#check-cgroup-version
-	cgroupControllersPath := filepath.Join(Conf.CgroupRootDir, CgroupControllersName)
-	exists, err := PathExists(cgroupControllersPath)
-	klog.V(2).Infof("[%v] PathExists exists %v, err: %v", cgroupControllersPath, exists, err)
-	if err != nil || !exists {
-		return false
-	}
-
-	cgroupSubtreeControlPath := filepath.Join(Conf.CgroupRootDir, CgroupSubtreeControlName)
-	exists, err = PathExists(cgroupSubtreeControlPath)
-	klog.V(2).Infof("[%v] PathExists exists %v, err: %v", cgroupSubtreeControlPath, exists, err)
-	if err != nil && !exists {
-		return false
-	}
-
-	klog.V(5).Infof("check cgroups v2 successfully")
-	return true
 }
 
 func ParseCPUCFSQuotaV2(content string) (int64, error) {

--- a/pkg/koordlet/util/system/cgroup_driver_unsupported.go
+++ b/pkg/koordlet/util/system/cgroup_driver_unsupported.go
@@ -26,3 +26,7 @@ func GuessCgroupDriverFromCgroupName() CgroupDriverType {
 func GuessCgroupDriverFromKubeletPort(int) (CgroupDriverType, error) {
 	return kubeletDefaultCgroupDriver, nil
 }
+
+func IsUsingCgroupsV2() bool {
+	return false
+}

--- a/pkg/koordlet/util/system/util_test_tool.go
+++ b/pkg/koordlet/util/system/util_test_tool.go
@@ -19,6 +19,7 @@ package system
 import (
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -177,6 +178,9 @@ func (c *FileTestUtil) ReadProcSubFileContents(relativeFilePath string) string {
 }
 
 func (c *FileTestUtil) CreateCgroupFile(taskDir string, r Resource) {
+
+	c.SetCgroupsV2(IsCgroupV2Resource(r))
+
 	filePath := GetCgroupFilePath(taskDir, r)
 	dir, _ := path.Split(filePath)
 	if err := os.MkdirAll(dir, 0777); err != nil {
@@ -188,6 +192,9 @@ func (c *FileTestUtil) CreateCgroupFile(taskDir string, r Resource) {
 }
 
 func (c *FileTestUtil) WriteCgroupFileContents(taskDir string, r Resource, contents string) {
+
+	c.SetCgroupsV2(IsCgroupV2Resource(r))
+
 	filePath := GetCgroupFilePath(taskDir, r)
 	if !FileExists(filePath) {
 		c.CreateCgroupFile(taskDir, r)
@@ -198,7 +205,27 @@ func (c *FileTestUtil) WriteCgroupFileContents(taskDir string, r Resource, conte
 	}
 }
 
+func (c *FileTestUtil) ReadCgroupFileContentsInt(taskDir string, r Resource) *int64 {
+
+	c.SetCgroupsV2(IsCgroupV2Resource(r))
+
+	contents, err := CgroupFileRead(taskDir, r)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+
+	data, err := strconv.ParseInt(strings.TrimSpace(contents), 10, 64)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+
+	return &data
+}
+
 func (c *FileTestUtil) ReadCgroupFileContents(taskDir string, r Resource) string {
+
+	c.SetCgroupsV2(IsCgroupV2Resource(r))
+
 	contents, err := CgroupFileRead(taskDir, r)
 	if err != nil {
 		c.t.Fatal(err)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Use libcontainer check if the os support cgroupfsv2, and the default value for `system.UseCgroupsV2` maybe change to 
true.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
