### PR TITLE
apis: deprecated device resource names with prefix kuberenetes.io

### DIFF
--- a/apis/extension/deprecated.go
+++ b/apis/extension/deprecated.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// Deprecated: because of the limitation of extended resource naming
+	KoordBatchCPU corev1.ResourceName = DomainPrefix + "batch-cpu"
+	// Deprecated: because of the limitation of extended resource naming
+	KoordBatchMemory corev1.ResourceName = DomainPrefix + "batch-memory"
+
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedKoordRDMA corev1.ResourceName = ResourceDomainPrefix + "rdma"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedKoordFPGA corev1.ResourceName = ResourceDomainPrefix + "fpga"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedKoordGPU corev1.ResourceName = ResourceDomainPrefix + "gpu"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedGPUCore corev1.ResourceName = ResourceDomainPrefix + "gpu-core"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedGPUMemory corev1.ResourceName = ResourceDomainPrefix + "gpu-memory"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedGPUMemoryRatio corev1.ResourceName = ResourceDomainPrefix + "gpu-memory-ratio"
+)
+
+const (
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedGPUDriver string = ResourceDomainPrefix + "gpu-driver"
+	// Deprecated: Device extension resource names should use the prefix `koordinator.sh`
+	DeprecatedGPUModel string = ResourceDomainPrefix + "gpu-model"
+)
+
+var deprecatedDeviceResourceNameMapper = map[corev1.ResourceName]corev1.ResourceName{
+	DeprecatedKoordRDMA:      ResourceRDMA,
+	DeprecatedKoordFPGA:      ResourceFPGA,
+	DeprecatedKoordGPU:       ResourceGPU,
+	DeprecatedGPUCore:        ResourceGPUCore,
+	DeprecatedGPUMemory:      ResourceGPUMemory,
+	DeprecatedGPUMemoryRatio: ResourceGPUMemoryRatio,
+}
+
+func TransformDeprecatedDeviceResources(resList corev1.ResourceList) corev1.ResourceList {
+	r := make(corev1.ResourceList, len(resList))
+	for k, v := range resList {
+		newResName := deprecatedDeviceResourceNameMapper[k]
+		if newResName != "" {
+			r[newResName] = v
+		} else {
+			r[k] = v
+		}
+	}
+	return r
+}

--- a/apis/extension/resource.go
+++ b/apis/extension/resource.go
@@ -23,26 +23,21 @@ import (
 )
 
 const (
-	// Deprecated: because of the limitation of extended resource naming
-	KoordBatchCPU corev1.ResourceName = DomainPrefix + "batch-cpu"
-	// Deprecated: because of the limitation of extended resource naming
-	KoordBatchMemory corev1.ResourceName = DomainPrefix + "batch-memory"
-
 	BatchCPU    corev1.ResourceName = ResourceDomainPrefix + "batch-cpu"
 	BatchMemory corev1.ResourceName = ResourceDomainPrefix + "batch-memory"
 
-	KoordRDMA corev1.ResourceName = ResourceDomainPrefix + "rdma"
-	KoordFPGA corev1.ResourceName = ResourceDomainPrefix + "fpga"
+	ResourceNvidiaGPU      corev1.ResourceName = "nvidia.com/gpu"
+	ResourceRDMA           corev1.ResourceName = DomainPrefix + "rdma"
+	ResourceFPGA           corev1.ResourceName = DomainPrefix + "fpga"
+	ResourceGPU            corev1.ResourceName = DomainPrefix + "gpu"
+	ResourceGPUCore        corev1.ResourceName = DomainPrefix + "gpu-core"
+	ResourceGPUMemory      corev1.ResourceName = DomainPrefix + "gpu-memory"
+	ResourceGPUMemoryRatio corev1.ResourceName = DomainPrefix + "gpu-memory-ratio"
+)
 
-	KoordGPU  corev1.ResourceName = ResourceDomainPrefix + "gpu"
-	NvidiaGPU corev1.ResourceName = "nvidia.com/gpu"
-
-	GPUCore        corev1.ResourceName = ResourceDomainPrefix + "gpu-core"
-	GPUMemory      corev1.ResourceName = ResourceDomainPrefix + "gpu-memory"
-	GPUMemoryRatio corev1.ResourceName = ResourceDomainPrefix + "gpu-memory-ratio"
-
-	GPUDriver string = ResourceDomainPrefix + "gpu-driver"
-	GPUModel  string = ResourceDomainPrefix + "gpu-model"
+const (
+	LabelGPUModel         string = NodeDomainPrefix + "gpu-model"
+	LabelGPUDriverVersion string = NodeDomainPrefix + "gpu-driver-version"
 )
 
 const (

--- a/apis/extension/scheduling_test.go
+++ b/apis/extension/scheduling_test.go
@@ -66,7 +66,7 @@ func Test_GetDeviceAllocations(t *testing.T) {
 					Namespace: "default",
 					Name:      "test",
 					Annotations: map[string]string{
-						AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"kubernetes.io/gpu-core":"100","kubernetes.io/gpu-memory":"16Gi","kubernetes.io/gpu-memory-ratio":"100"}}]}`,
+						AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"}}]}`,
 					},
 				},
 			},
@@ -75,9 +75,9 @@ func Test_GetDeviceAllocations(t *testing.T) {
 					{
 						Minor: 1,
 						Resources: corev1.ResourceList{
-							GPUCore:        resource.MustParse("100"),
-							GPUMemoryRatio: resource.MustParse("100"),
-							GPUMemory:      resource.MustParse("16Gi"),
+							ResourceGPUCore:        resource.MustParse("100"),
+							ResourceGPUMemoryRatio: resource.MustParse("100"),
+							ResourceGPUMemory:      resource.MustParse("16Gi"),
 						},
 					},
 				},
@@ -118,14 +118,14 @@ func Test_SetDeviceAllocations(t *testing.T) {
 					{
 						Minor: 1,
 						Resources: corev1.ResourceList{
-							GPUCore:        resource.MustParse("100"),
-							GPUMemoryRatio: resource.MustParse("100"),
-							GPUMemory:      resource.MustParse("16Gi"),
+							ResourceGPUCore:        resource.MustParse("100"),
+							ResourceGPUMemoryRatio: resource.MustParse("100"),
+							ResourceGPUMemory:      resource.MustParse("16Gi"),
 						},
 					},
 				},
 			},
-			wantAnnotation: `{"gpu":[{"minor":1,"resources":{"kubernetes.io/gpu-core":"100","kubernetes.io/gpu-memory":"16Gi","kubernetes.io/gpu-memory-ratio":"100"}}]}`,
+			wantAnnotation: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"}}]}`,
 		},
 	}
 	for _, tt := range tests {

--- a/docs/proposals/scheduling/20220629-fine-grained-device-scheduling.md
+++ b/docs/proposals/scheduling/20220629-fine-grained-device-scheduling.md
@@ -33,8 +33,8 @@ status: provisional
             - [User apply device resources scenarios](#user-apply-device-resources-scenarios)
                 - [Compatible with nvidia.com/gpu](#compatible-with-nvidiacomgpu)
                 - [Apply whole resources of GPU or part resources of GPU](#apply-whole-resources-of-gpu-or-part-resources-of-gpu)
-                - [Apply kubernetes.io/gpu-core and kubernetes.io/gpu-memory-ratio separately](#apply-kubernetesiogpu-core-and-kubernetesiogpu-memory-ratio-separately)
-                - [Apply kubernetes.io/gpu-core and kubernetes.io/gpu-memory separately](#apply-kubernetesiogpu-core-and-kubernetesiogpu-memory-separately)
+                - [Apply koordinator.sh/gpu-core and koordinator.sh/gpu-memory-ratio separately](#apply-koordinatorshgpu-core-and-koordinatorshgpu-memory-ratio-separately)
+                - [Apply koordinator.sh/gpu-core and koordinator.sh/gpu-memory separately](#apply-koordinatorshgpu-core-and-koordinatorshgpu-memory-separately)
                 - [Apply RDMA](#apply-rdma)
         - [Implementation Details](#implementation-details)
             - [Scheduling](#scheduling)
@@ -87,46 +87,46 @@ Due to GPU is complicated, we will introduce GPU first. As we all know there is 
 
 We abstract GPU resources into different dimensions:
 
-- `kubernetes.io/gpu-core` represents the computing capacity of the GPU. Similar to K8s MilliCPU, we abstract the total computing power of GPU into one hundred, and users can apply for the corresponding amount of GPU computing power according to their needs.
-- `kubernetes.io/gpu-memory` represents the memory capacity of the GPU in bytes.
-- `kubernetes.io/gpu-memory-ratio` represents the percentage of the GPU's memory.
+- `koordinator.sh/gpu-core` represents the computing capacity of the GPU. Similar to K8s MilliCPU, we abstract the total computing power of GPU into one hundred, and users can apply for the corresponding amount of GPU computing power according to their needs.
+- `koordinator.sh/gpu-memory` represents the memory capacity of the GPU in bytes.
+- `koordinator.sh/gpu-memory-ratio` represents the percentage of the GPU's memory.
 
 Assuming that node A has 4 GPU instances, and the total memory of each instance is 8GB, when device reporter reports GPU capacity information to `Node.Status.Allocatable`, it no longer reports nvidia.com/gpu=4, but reports the following information:
 
 ```yaml
 status:
   capacity:
-    kubernetes.io/gpu-core: 400
-    kubernetes.io/gpu-memory: "32GB"
-    kubernetes.io/gpu-memory-ratio: 400
+    koordinator.sh/gpu-core: 400
+    koordinator.sh/gpu-memory: "32GB"
+    koordinator.sh/gpu-memory-ratio: 400
   allocatable:
-    kubernetes.io/gpu-core: 400
-    kubernetes.io/gpu-memory: "32GB"
-    kubernetes.io/gpu-memory-ratio: 400
+    koordinator.sh/gpu-core: 400
+    koordinator.sh/gpu-memory: "32GB"
+    koordinator.sh/gpu-memory-ratio: 400
 ```
 
-For the convenience of users, an independent resource name `kubernetes.io/gpu` is defined. For example, when a user wants to use half of the computing resources and memory resources of a GPU instance, the user can directly declare `kubernetes.io/gpu: 50`, and the scheduler will convert it to `kubernetes.io/gpu-core: 50, kubernetes.io/gpu-memory-ratio: 50`
+For the convenience of users, an independent resource name `koordinator.sh/gpu` is defined. For example, when a user wants to use half of the computing resources and memory resources of a GPU instance, the user can directly declare `koordinator.sh/gpu: 50`, and the scheduler will convert it to `koordinator.sh/gpu-core: 50, koordinator.sh/gpu-memory-ratio: 50`
 
 For other devices like RDMA and FPGA, the node has 1 RDMA and 1 FGPA, will report the following information:
 
 ```yaml
 status:
   capacity:
-    kubernetes.io/rdma: 100
-    kubernetes.io/fpga: 100
+    koordinator.sh/rdma: 100
+    koordinator.sh/fpga: 100
   allocatable:
-    kubernetes.io/rdma: 100
-    kubernetes.io/fpga: 100
+    koordinator.sh/rdma: 100
+    koordinator.sh/fpga: 100
 ```
 
-Why do we need `kubernetes.io/gpu-memory-ratio` and `kubernetes.io/gpu-memory` ? 
+Why do we need `koordinator.sh/gpu-memory-ratio` and `koordinator.sh/gpu-memory` ? 
 When user apply 0.5/0.25 GPU, the user don't know the exact memory total bytes per GPU, only wants to use 
-half or quarter percentage of memory, so user can request the GPU memory with `kubernetes.io/gpu-memory-ratio`. 
-When scheduler assigned Pod on concrete node, scheduler will translate the `kubernetes.io/gpu-memory-ratio` to `kubernetes.io/gpu-memory` by the formulas:  ***allocatedMemory = totalMemoryOf(GPU)  * `kubernetes.io/gpu-memory-ratio`***, so that the GPU isolation can work.
+half or quarter percentage of memory, so user can request the GPU memory with `koordinator.sh/gpu-memory-ratio`. 
+When scheduler assigned Pod on concrete node, scheduler will translate the `koordinator.sh/gpu-memory-ratio` to `koordinator.sh/gpu-memory` by the formulas:  ***allocatedMemory = totalMemoryOf(GPU)  * `koordinator.sh/gpu-memory-ratio`***, so that the GPU isolation can work.
 
-During the scheduling filter phase, the scheduler will do special processing for `kubernetes.io/gpu-memory` and `kubernetes.io/gpu-memory-ratio`. When a Pod specifies `kubernetes.io/gpu-memory-ratio`, the scheduler checks each GPU instance on each node for unallocated or remaining resources to ensure that the remaining memory on each GPU instance meets the ratio requirement.
+During the scheduling filter phase, the scheduler will do special processing for `koordinator.sh/gpu-memory` and `koordinator.sh/gpu-memory-ratio`. When a Pod specifies `koordinator.sh/gpu-memory-ratio`, the scheduler checks each GPU instance on each node for unallocated or remaining resources to ensure that the remaining memory on each GPU instance meets the ratio requirement.
 
-If the user knows exactly or can roughly estimate the specific memory consumption of the workload, he can apply for GPU memory through `kubernetes.io/gpu-memory`. All details can be seen below.
+If the user knows exactly or can roughly estimate the specific memory consumption of the workload, he can apply for GPU memory through `koordinator.sh/gpu-memory`. All details can be seen below.
 
 Besides, when dimension's value > 100, means Pod need multi-devices. now only allow the value can be divided by 100.
 
@@ -147,9 +147,9 @@ The scheduler translates the `nvida.com/gpu: 2` to the following spec:
 ```yaml
 resources:
   requests:
-    kubernetes.io/gpu-core: "200"
-    kubernetes.io/gpu-memory-ratio: "200"
-    kubernetes.io/gpu-memory: "16Gi" # assume 8G memory in bytes per GPU
+    koordinator.sh/gpu-core: "200"
+    koordinator.sh/gpu-memory-ratio: "200"
+    koordinator.sh/gpu-memory: "16Gi" # assume 8G memory in bytes per GPU
     cpu: "4"
     memory: "8Gi"
 ```
@@ -159,41 +159,41 @@ resources:
 ```yaml
 resources:
    requests:
-    kubernetes.io/gpu: "50"
+    koordinator.sh/gpu: "50"
     cpu: "4"
     memory: "8Gi"
 ```
 
-The scheduler translates the `kubernetes.io/gpu: "50"` to the following spec:
+The scheduler translates the `koordinator.sh/gpu: "50"` to the following spec:
 
 ```yaml
 resources:
   requests:
-    kubernetes.io/gpu-core: "50"
-    kubernetes.io/gpu-memory-ratio: "50"
-    kubernetes.io/gpu-memory: "4Gi" # assume 8G memory in bytes for the GPU
+    koordinator.sh/gpu-core: "50"
+    koordinator.sh/gpu-memory-ratio: "50"
+    koordinator.sh/gpu-memory: "4Gi" # assume 8G memory in bytes for the GPU
     cpu: "4"
     memory: "8Gi"
 ```
 
-##### Apply `kubernetes.io/gpu-core` and `kubernetes.io/gpu-memory-ratio` separately
+##### Apply `koordinator.sh/gpu-core` and `koordinator.sh/gpu-memory-ratio` separately
 
 ```yaml
 resources:
   requests:
-    kubernetes.io/gpu-core: "50"
-    kubernetes.io/gpu-memory-ratio: "60"
+    koordinator.sh/gpu-core: "50"
+    koordinator.sh/gpu-memory-ratio: "60"
     cpu: "4"
     memory: "8Gi"
 ```
 
-##### Apply `kubernetes.io/gpu-core` and `kubernetes.io/gpu-memory` separately
+##### Apply `koordinator.sh/gpu-core` and `koordinator.sh/gpu-memory` separately
 
 ```yaml
 resources:
   requests:
-    kubernetes.io/gpu-core: "60"
-    kubernetes.io/gpu-memory: "4Gi"
+    koordinator.sh/gpu-core: "60"
+    koordinator.sh/gpu-memory: "4Gi"
     cpu: "4"
     memory: "8Gi"
 ```
@@ -203,7 +203,7 @@ resources:
 ```yaml
 resources:
   requests:
-    kubernetes.io/rdma: "100"
+    koordinator.sh/rdma: "100"
     cpu: "4"
     memory: "8Gi"
 ```
@@ -227,17 +227,17 @@ In the PreBind stage, the scheduler will update the device (including GPU) alloc
     {
       "minor": 0,
       "resouurces": {
-        "kubernetes.io/gpu-core": 100,
-        "kubernetes.io/gpu-mem-ratio": 100,
-        "kubernetes.io/gpu-mem": "16Gi"
+        "koordinator.sh/gpu-core": 100,
+        "koordinator.sh/gpu-mem-ratio": 100,
+        "koordinator.sh/gpu-mem": "16Gi"
       }
     },
     {
       "minor": 1,
       "resouurces": {
-        "kubernetes.io/gpu-core": 100,
-        "kubernetes.io/gpu-mem-ratio": 100,
-        "kubernetes.io/gpu-mem": "16Gi"
+        "koordinator.sh/gpu-core": 100,
+        "koordinator.sh/gpu-mem-ratio": 100,
+        "koordinator.sh/gpu-mem": "16Gi"
       }
     }
   ]
@@ -280,8 +280,8 @@ type nodeDevice struct {
 }
 
 // We use `deviceResource` to present resources per device.
-// "0": {kubernetes.io/gpu-core:100, kubernetes.io/gpu-memory-ratio:100, kubernetes.io/gpu-memory: 16GB}
-// "1": {kubernetes.io/gpu-core:100, kubernetes.io/gpu-memory-ratio:100, kubernetes.io/gpu-memory: 16GB}
+// "0": {koordinator.sh/gpu-core:100, koordinator.sh/gpu-memory-ratio:100, koordinator.sh/gpu-memory: 16GB}
+// "1": {koordinator.sh/gpu-core:100, koordinator.sh/gpu-memory-ratio:100, koordinator.sh/gpu-memory: 16GB}
 type deviceResources map[int]corev1.ResourceList
 
 ```
@@ -380,17 +380,17 @@ spec:
     id: GPU-98583a5c-c155-9cf6-f955-03c189d3dbfb
     minor: 0
     resources:
-      kubernetes.io/gpu-core: "100"
-      kubernetes.io/gpu-memory: 15472384Ki
-      kubernetes.io/gpu-memory-ratio: "100"
+      koordinator.sh/gpu-core: "100"
+      koordinator.sh/gpu-memory: 15472384Ki
+      koordinator.sh/gpu-memory-ratio: "100"
     type: gpu
   - health: true
     id: GPU-7f6410b9-bdf7-f9a5-de09-aa5ec31a7124
     minor: 1
     resources:
-      kubernetes.io/gpu-core: "100"
-      kubernetes.io/gpu-memory: 15472384Ki
-      kubernetes.io/gpu-memory-ratio: "100"
+      koordinator.sh/gpu-core: "100"
+      koordinator.sh/gpu-memory: 15472384Ki
+      koordinator.sh/gpu-memory-ratio: "100"
     type: gpu
 status: {}
 ```
@@ -469,6 +469,6 @@ In the future Koordinator will provide a webhook to solve the upgrade existing c
 - 2022-08-18: Add PreFilter step and update cache structure
 - 2022-09-01: Update details about compatible existing GPU Pods
 - 2022-09-02: Simplify the definition of DeviceStatus and Supplementary upgrade strategy
-- 2022-09-21: Update resource names
+- 2022-09-21: Update resource names 
 
 ## References

--- a/pkg/koordlet/statesinformer/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/states_device_linux.go
@@ -106,10 +106,10 @@ func (s *statesInformer) fillGPUDevice(device *schedulingv1alpha1.Device,
 		device.Labels = make(map[string]string)
 	}
 	if gpuModel != "" {
-		device.Labels[extension.GPUModel] = gpuModel
+		device.Labels[extension.LabelGPUModel] = gpuModel
 	}
 	if gpuDriverVer != "" {
-		device.Labels[extension.GPUDriver] = gpuDriverVer
+		device.Labels[extension.LabelGPUDriverVersion] = gpuDriverVer
 	}
 }
 
@@ -170,9 +170,9 @@ func (s *statesInformer) buildGPUDevice() []schedulingv1alpha1.DeviceInfo {
 			Type:   schedulingv1alpha1.GPU,
 			Health: health,
 			Resources: map[corev1.ResourceName]resource.Quantity{
-				extension.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-				extension.GPUMemory:      gpu.MemoryTotal,
-				extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUMemory:      gpu.MemoryTotal,
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 		})
 	}

--- a/pkg/koordlet/statesinformer/states_device_linux_test.go
+++ b/pkg/koordlet/statesinformer/states_device_linux_test.go
@@ -86,9 +86,9 @@ func Test_reportGPUDevice(t *testing.T) {
 			Type:   schedulingv1alpha1.GPU,
 			Health: true,
 			Resources: map[corev1.ResourceName]resource.Quantity{
-				extension.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-				extension.GPUMemory:      *resource.NewQuantity(8000, resource.BinarySI),
-				extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUMemory:      *resource.NewQuantity(8000, resource.BinarySI),
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 		},
 		{
@@ -97,9 +97,9 @@ func Test_reportGPUDevice(t *testing.T) {
 			Type:   schedulingv1alpha1.GPU,
 			Health: true,
 			Resources: map[corev1.ResourceName]resource.Quantity{
-				extension.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-				extension.GPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
-				extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceGPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 		},
 	}
@@ -123,14 +123,14 @@ func Test_reportGPUDevice(t *testing.T) {
 		Type:   schedulingv1alpha1.GPU,
 		Health: true,
 		Resources: map[corev1.ResourceName]resource.Quantity{
-			extension.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-			extension.GPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
-			extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+			extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+			extension.ResourceGPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
+			extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 		},
 	})
 	device, err = fakeClient.Get(context.TODO(), "test", metav1.GetOptions{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, device.Spec.Devices, expectedDevices)
-	assert.Equal(t, device.Labels[extension.GPUModel], "A100")
-	assert.Equal(t, device.Labels[extension.GPUDriver], "470")
+	assert.Equal(t, device.Labels[extension.LabelGPUModel], "A100")
+	assert.Equal(t, device.Labels[extension.LabelGPUDriverVersion], "470")
 }

--- a/pkg/koordlet/statesinformer/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/states_nodemetric.go
@@ -460,9 +460,9 @@ func convertNodeMetricToResourceMap(nodeMetric *metriccache.NodeResourceMetric) 
 				Type:  schedulingv1alpha1.GPU,
 				// TODO: how to check the health status of GPU
 				Resources: map[corev1.ResourceName]resource.Quantity{
-					apiext.GPUCore:        *resource.NewQuantity(int64(gpu.SMUtil), resource.BinarySI),
-					apiext.GPUMemory:      gpu.MemoryUsed,
-					apiext.GPUMemoryRatio: *resource.NewQuantity(int64(memoryRatioRaw), resource.BinarySI),
+					apiext.ResourceGPUCore:        *resource.NewQuantity(int64(gpu.SMUtil), resource.BinarySI),
+					apiext.ResourceGPUMemory:      gpu.MemoryUsed,
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(int64(memoryRatioRaw), resource.BinarySI),
 				},
 			}
 			deviceInfos = append(deviceInfos, gpuInfo)
@@ -488,9 +488,9 @@ func convertPodMetricToResourceMap(podMetric *metriccache.PodResourceMetric) *sl
 				Type:  schedulingv1alpha1.GPU,
 				// TODO: how to check the health status of GPU
 				Resources: map[corev1.ResourceName]resource.Quantity{
-					apiext.GPUCore:        *resource.NewQuantity(int64(gpu.SMUtil), resource.DecimalSI),
-					apiext.GPUMemory:      gpu.MemoryUsed,
-					apiext.GPUMemoryRatio: *resource.NewQuantity(int64(memoryRatioRaw), resource.DecimalSI),
+					apiext.ResourceGPUCore:        *resource.NewQuantity(int64(gpu.SMUtil), resource.DecimalSI),
+					apiext.ResourceGPUMemory:      gpu.MemoryUsed,
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(int64(memoryRatioRaw), resource.DecimalSI),
 				},
 			}
 			deviceInfos = append(deviceInfos, gpuInfo)

--- a/pkg/scheduler/plugins/deviceshare/device_handler_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_handler_test.go
@@ -63,18 +63,18 @@ func Test_nodeDeviceCache_onDeviceAdd(t *testing.T) {
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -94,18 +94,18 @@ func Test_nodeDeviceCache_onDeviceAdd(t *testing.T) {
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
@@ -119,28 +119,28 @@ func Test_nodeDeviceCache_onDeviceAdd(t *testing.T) {
 					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							0: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
 					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							0: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
@@ -148,6 +148,37 @@ func Test_nodeDeviceCache_onDeviceAdd(t *testing.T) {
 					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList{},
 				},
 			},
+		},
+		{
+			name:   "deprecated resource names",
+			device: generateFakeDeviceWithDeprecatedResourceNames(),
+			deviceCache: &nodeDeviceCache{
+				nodeDeviceInfos: map[string]*nodeDevice{
+					"test-node-1": {
+						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								0: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								0: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceUsed:  map[schedulingv1alpha1.DeviceType]deviceResources{},
+						allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList{},
+					},
+				},
+			},
+			wantCache: generateFakeNodeDeviceInfos(),
 		},
 	}
 	for _, tt := range tests {
@@ -190,9 +221,9 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 							Health: true,
 							Type:   schedulingv1alpha1.GPU,
 							Resources: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("32Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 							},
 						},
 					},
@@ -206,18 +237,18 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("32Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 							},
 						},
 					},
 					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("32Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 							},
 						},
 					},
@@ -266,9 +297,9 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 							Minor: pointer.Int32Ptr(1),
 							Type:  schedulingv1alpha1.GPU,
 							Resources: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 						{
@@ -276,7 +307,7 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 							Minor: pointer.Int32Ptr(1),
 							Type:  schedulingv1alpha1.FPGA,
 							Resources: corev1.ResourceList{
-								apiext.KoordFPGA: resource.MustParse("100"),
+								apiext.ResourceFPGA: resource.MustParse("100"),
 							},
 						},
 					},
@@ -289,28 +320,28 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
@@ -324,9 +355,9 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 						schedulingv1alpha1.FPGA: {},
@@ -334,12 +365,69 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 						schedulingv1alpha1.FPGA: {},
+					},
+					deviceUsed:  map[schedulingv1alpha1.DeviceType]deviceResources{},
+					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList{},
+				},
+			},
+		},
+		{
+			name:      "deprecated resource names",
+			oldDevice: generateFakeDeviceWithDeprecatedResourceNames(),
+			newDevice: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-1",
+				},
+				Spec: schedulingv1alpha1.DeviceSpec{
+					Devices: []schedulingv1alpha1.DeviceInfo{
+						{
+							UUID:   string(uuid.NewUUID()),
+							Minor:  pointer.Int32Ptr(1),
+							Health: true,
+							Type:   schedulingv1alpha1.GPU,
+							Resources: corev1.ResourceList{
+								//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+								//nolint: staticcheck
+								apiext.DeprecatedGPUCore: resource.MustParse("100"),
+								//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+								//nolint: staticcheck
+								apiext.DeprecatedGPUMemoryRatio: resource.MustParse("100"),
+								//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+								//nolint: staticcheck
+								apiext.DeprecatedGPUMemory: resource.MustParse("32Gi"),
+							},
+						},
+					},
+				},
+			},
+			deviceCache: &nodeDeviceCache{
+				nodeDeviceInfos: generateFakeNodeDeviceInfos(),
+			},
+			wantCache: map[string]*nodeDevice{
+				"test-node-1": {
+					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
+							},
+						},
+					},
+					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
+							},
+						},
 					},
 					deviceUsed:  map[schedulingv1alpha1.DeviceType]deviceResources{},
 					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList{},
@@ -420,9 +508,38 @@ func generateFakeDevice() *schedulingv1alpha1.Device {
 					Health: true,
 					Type:   schedulingv1alpha1.GPU,
 					Resources: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("16Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateFakeDeviceWithDeprecatedResourceNames() *schedulingv1alpha1.Device {
+	return &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-1",
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{
+				{
+					UUID:   string(uuid.NewUUID()),
+					Minor:  pointer.Int32Ptr(1),
+					Health: true,
+					Type:   schedulingv1alpha1.GPU,
+					Resources: corev1.ResourceList{
+						//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+						//nolint: staticcheck
+						apiext.DeprecatedGPUCore: resource.MustParse("100"),
+						//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+						//nolint: staticcheck
+						apiext.DeprecatedGPUMemoryRatio: resource.MustParse("100"),
+						//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+						//nolint: staticcheck
+						apiext.DeprecatedGPUMemory: resource.MustParse("16Gi"),
 					},
 				},
 			},
@@ -443,9 +560,9 @@ func generateMultipleFakeDevice() *schedulingv1alpha1.Device {
 					Health: true,
 					Type:   schedulingv1alpha1.GPU,
 					Resources: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("16Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 					},
 				},
 				{
@@ -454,9 +571,9 @@ func generateMultipleFakeDevice() *schedulingv1alpha1.Device {
 					Health: true,
 					Type:   schedulingv1alpha1.GPU,
 					Resources: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("16Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 					},
 				},
 			},
@@ -470,18 +587,18 @@ func generateFakeNodeDeviceInfos() map[string]*nodeDevice {
 			deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 				schedulingv1alpha1.GPU: {
 					1: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("16Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 					},
 				},
 			},
 			deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 				schedulingv1alpha1.GPU: {
 					1: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("16Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 					},
 				},
 			},

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -84,6 +84,7 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 	}
 
 	podRequest, _ := resource.PodRequestsAndLimits(pod)
+	podRequest = apiext.TransformDeprecatedDeviceResources(podRequest)
 
 	for deviceType := range DeviceResourceNames {
 		switch deviceType {

--- a/pkg/scheduler/plugins/deviceshare/plugin_service_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_service_test.go
@@ -54,23 +54,23 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	deviceInfo0.Health = true
 	deviceInfo0.Type = schedulingv1alpha1.GPU
 	deviceInfo0.Resources = corev1.ResourceList{
-		apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-		apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 	}
 	deviceInfo1 := schedulingv1alpha1.DeviceInfo{}
 	deviceInfo1.Minor = pointer.Int32Ptr(1)
 	deviceInfo1.Health = true
 	deviceInfo1.Type = schedulingv1alpha1.GPU
 	deviceInfo1.Resources = corev1.ResourceList{
-		apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-		apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 	}
 	deviceInfo2 := schedulingv1alpha1.DeviceInfo{}
 	deviceInfo2.Minor = pointer.Int32Ptr(2)
 	deviceInfo2.Health = true
 	deviceInfo2.Type = schedulingv1alpha1.FPGA
 	deviceInfo2.Resources = corev1.ResourceList{
-		apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 	}
 	device.Spec.Devices = append(device.Spec.Devices, deviceInfo0)
 	device.Spec.Devices = append(device.Spec.Devices, deviceInfo1)
@@ -87,7 +87,7 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 				{
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							apiext.NvidiaGPU: *resource.NewQuantity(1, resource.DecimalSI),
+							apiext.ResourceNvidiaGPU: *resource.NewQuantity(1, resource.DecimalSI),
 						},
 					},
 				},
@@ -99,23 +99,23 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	deviceAllocation := &extension.DeviceAllocation{
 		Minor: 0,
 		Resources: corev1.ResourceList{
-			apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-			apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+			apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+			apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 		},
 	}
 	allocResult[schedulingv1alpha1.GPU] = append(allocResult[schedulingv1alpha1.GPU], deviceAllocation)
 	deviceAllocation = &extension.DeviceAllocation{
 		Minor: 1,
 		Resources: corev1.ResourceList{
-			apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-			apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+			apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+			apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 		},
 	}
 	allocResult[schedulingv1alpha1.GPU] = append(allocResult[schedulingv1alpha1.GPU], deviceAllocation)
 	deviceAllocation = &extension.DeviceAllocation{
 		Minor: 2,
 		Resources: corev1.ResourceList{
-			apiext.KoordFPGA: *resource.NewQuantity(51, resource.DecimalSI),
+			apiext.ResourceFPGA: *resource.NewQuantity(51, resource.DecimalSI),
 		},
 	}
 	allocResult[schedulingv1alpha1.FPGA] = append(allocResult[schedulingv1alpha1.FPGA], deviceAllocation)
@@ -135,40 +135,40 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	nodeDeviceSummaryExpect := make(map[string]*NodeDeviceSummary)
 	nodeDeviceSummaryExpect["node1"] = NewNodeDeviceSummary()
 	nodeDeviceSummaryExpect["node1"].DeviceTotal = map[corev1.ResourceName]*resource.Quantity{
-		apiext.GPUCore:        resource.NewQuantity(200, resource.DecimalSI),
-		apiext.GPUMemoryRatio: resource.NewQuantity(200, resource.DecimalSI),
-		apiext.KoordFPGA:      resource.NewQuantity(100, resource.DecimalSI),
+		apiext.ResourceGPUCore:        resource.NewQuantity(200, resource.DecimalSI),
+		apiext.ResourceGPUMemoryRatio: resource.NewQuantity(200, resource.DecimalSI),
+		apiext.ResourceFPGA:           resource.NewQuantity(100, resource.DecimalSI),
 	}
 	assert.True(t, apiequality.Semantic.DeepEqual(nodeDeviceSummary["node1"].DeviceTotal, nodeDeviceSummaryExpect["node1"].DeviceTotal))
 
 	nodeDeviceSummaryExpect["node1"].DeviceFree = map[corev1.ResourceName]*resource.Quantity{
-		apiext.GPUCore:        resource.NewQuantity(102, resource.DecimalSI),
-		apiext.GPUMemoryRatio: resource.NewQuantity(102, resource.DecimalSI),
-		apiext.KoordFPGA:      resource.NewQuantity(49, resource.DecimalSI),
+		apiext.ResourceGPUCore:        resource.NewQuantity(102, resource.DecimalSI),
+		apiext.ResourceGPUMemoryRatio: resource.NewQuantity(102, resource.DecimalSI),
+		apiext.ResourceFPGA:           resource.NewQuantity(49, resource.DecimalSI),
 	}
 	assert.True(t, apiequality.Semantic.DeepEqual(nodeDeviceSummary["node1"].DeviceFree, nodeDeviceSummaryExpect["node1"].DeviceFree))
 
 	nodeDeviceSummaryExpect["node1"].DeviceUsed = map[corev1.ResourceName]*resource.Quantity{
-		apiext.GPUCore:        resource.NewQuantity(98, resource.DecimalSI),
-		apiext.GPUMemoryRatio: resource.NewQuantity(98, resource.DecimalSI),
-		apiext.KoordFPGA:      resource.NewQuantity(51, resource.DecimalSI),
+		apiext.ResourceGPUCore:        resource.NewQuantity(98, resource.DecimalSI),
+		apiext.ResourceGPUMemoryRatio: resource.NewQuantity(98, resource.DecimalSI),
+		apiext.ResourceFPGA:           resource.NewQuantity(51, resource.DecimalSI),
 	}
 	assert.True(t, apiequality.Semantic.DeepEqual(nodeDeviceSummary["node1"].DeviceUsed, nodeDeviceSummaryExpect["node1"].DeviceUsed))
 
 	nodeDeviceSummaryExpect["node1"].DeviceTotalDetail = map[schedulingv1alpha1.DeviceType]deviceResources{
 		schedulingv1alpha1.GPU: map[int]corev1.ResourceList{
 			0: {
-				apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 			1: {
-				apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 		},
 		schedulingv1alpha1.FPGA: map[int]corev1.ResourceList{
 			2: {
-				apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 			},
 		},
 	}
@@ -177,17 +177,17 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	nodeDeviceSummaryExpect["node1"].DeviceFreeDetail = map[schedulingv1alpha1.DeviceType]deviceResources{
 		schedulingv1alpha1.GPU: map[int]corev1.ResourceList{
 			0: {
-				apiext.GPUCore:        *resource.NewQuantity(51, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(51, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(51, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(51, resource.DecimalSI),
 			},
 			1: {
-				apiext.GPUCore:        *resource.NewQuantity(51, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(51, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(51, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(51, resource.DecimalSI),
 			},
 		},
 		schedulingv1alpha1.FPGA: map[int]corev1.ResourceList{
 			2: {
-				apiext.KoordFPGA: *resource.NewQuantity(49, resource.DecimalSI),
+				apiext.ResourceFPGA: *resource.NewQuantity(49, resource.DecimalSI),
 			},
 		},
 	}
@@ -196,17 +196,17 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	nodeDeviceSummaryExpect["node1"].DeviceUsedDetail = map[schedulingv1alpha1.DeviceType]deviceResources{
 		schedulingv1alpha1.GPU: map[int]corev1.ResourceList{
 			0: {
-				apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 			},
 			1: {
-				apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 			},
 		},
 		schedulingv1alpha1.FPGA: map[int]corev1.ResourceList{
 			2: {
-				apiext.KoordFPGA: *resource.NewQuantity(51, resource.DecimalSI),
+				apiext.ResourceFPGA: *resource.NewQuantity(51, resource.DecimalSI),
 			},
 		},
 	}
@@ -216,19 +216,19 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 		schedulingv1alpha1.GPU: {
 			"ns/pod1": {
 				0: {
-					apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-					apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+					apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 				},
 				1: {
-					apiext.GPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
-					apiext.GPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
+					apiext.ResourceGPUCore:        *resource.NewQuantity(49, resource.DecimalSI),
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(49, resource.DecimalSI),
 				},
 			},
 		},
 		schedulingv1alpha1.FPGA: {
 			"ns/pod1": {
 				2: {
-					apiext.KoordFPGA: *resource.NewQuantity(51, resource.DecimalSI),
+					apiext.ResourceFPGA: *resource.NewQuantity(51, resource.DecimalSI),
 				},
 			},
 		},

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -269,14 +269,14 @@ func Test_Plugin_PreFilter(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.KoordGPU: resource.MustParse("101"),
+									apiext.ResourceGPU: resource.MustParse("101"),
 								},
 							},
 						},
 					},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Error, fmt.Sprintf("failed to validate %v: 101", apiext.KoordGPU)),
+			wantStatus: framework.NewStatus(framework.Error, fmt.Sprintf("failed to validate %v: 101", apiext.ResourceGPU)),
 		},
 		{
 			name: "pod has invalid fpga request",
@@ -293,14 +293,14 @@ func Test_Plugin_PreFilter(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("101"),
+									apiext.ResourceFPGA: resource.MustParse("101"),
 								},
 							},
 						},
 					},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.Error, fmt.Sprintf("failed to validate %v: 101", apiext.KoordFPGA)),
+			wantStatus: framework.NewStatus(framework.Error, fmt.Sprintf("failed to validate %v: 101", apiext.ResourceFPGA)),
 		},
 		{
 			name: "pod has valid gpu request",
@@ -317,7 +317,7 @@ func Test_Plugin_PreFilter(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.KoordGPU: resource.MustParse("100"),
+									apiext.ResourceGPU: resource.MustParse("100"),
 								},
 							},
 						},
@@ -327,8 +327,8 @@ func Test_Plugin_PreFilter(t *testing.T) {
 			wantState: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 		},
@@ -347,7 +347,7 @@ func Test_Plugin_PreFilter(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
@@ -357,7 +357,7 @@ func Test_Plugin_PreFilter(t *testing.T) {
 			wantState: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("100"),
+					apiext.ResourceFPGA: resource.MustParse("100"),
 				},
 			},
 		},
@@ -376,8 +376,8 @@ func Test_Plugin_PreFilter(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.KoordGPU:  resource.MustParse("100"),
-									apiext.KoordRDMA: resource.MustParse("100"),
+									apiext.ResourceGPU:  resource.MustParse("100"),
+									apiext.ResourceRDMA: resource.MustParse("100"),
 								},
 							},
 						},
@@ -387,9 +387,9 @@ func Test_Plugin_PreFilter(t *testing.T) {
 			wantState: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
-					apiext.KoordRDMA:      resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceRDMA:           resource.MustParse("100"),
 				},
 			},
 		},
@@ -453,8 +453,8 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -471,8 +471,8 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -482,27 +482,27 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("75"),
-									apiext.GPUMemoryRatio: resource.MustParse("75"),
-									apiext.GPUMemory:      resource.MustParse("12Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("75"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+									apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("25"),
-									apiext.GPUMemoryRatio: resource.MustParse("25"),
-									apiext.GPUMemory:      resource.MustParse("4Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("25"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+									apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 								},
 							},
 						},
@@ -517,9 +517,9 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.KoordFPGA:      resource.MustParse("100"),
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceFPGA:           resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -529,37 +529,37 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("75"),
-									apiext.GPUMemoryRatio: resource.MustParse("75"),
-									apiext.GPUMemory:      resource.MustParse("12Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("75"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+									apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("25"),
-									apiext.GPUMemoryRatio: resource.MustParse("25"),
-									apiext.GPUMemory:      resource.MustParse("4Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("25"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+									apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 								},
 							},
 						},
@@ -574,9 +574,9 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.KoordFPGA:      resource.MustParse("100"),
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceFPGA:           resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -586,42 +586,42 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("75"),
-									apiext.GPUMemoryRatio: resource.MustParse("75"),
-									apiext.GPUMemory:      resource.MustParse("12Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("75"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+									apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("50"),
+									apiext.ResourceFPGA: resource.MustParse("50"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("25"),
-									apiext.GPUMemoryRatio: resource.MustParse("25"),
-									apiext.GPUMemory:      resource.MustParse("4Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("25"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+									apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("50"),
+									apiext.ResourceFPGA: resource.MustParse("50"),
 								},
 							},
 						},
@@ -636,7 +636,7 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("100"),
+					apiext.ResourceFPGA: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -646,14 +646,14 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
@@ -669,7 +669,7 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("100"),
+					apiext.ResourceFPGA: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -679,27 +679,27 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("75"),
+									apiext.ResourceFPGA: resource.MustParse("75"),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("25"),
+									apiext.ResourceFPGA: resource.MustParse("25"),
 								},
 							},
 						},
@@ -714,8 +714,8 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -725,28 +725,28 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -762,8 +762,8 @@ func Test_Plugin_Filter(t *testing.T) {
 			state: &preFilterState{
 				skip: false,
 				convertedDeviceResource: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("100"),
-					apiext.GPUMemoryRatio: resource.MustParse("100"),
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 				},
 			},
 			pod: &corev1.Pod{},
@@ -773,37 +773,37 @@ func Test_Plugin_Filter(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("25"),
-									apiext.GPUMemoryRatio: resource.MustParse("25"),
-									apiext.GPUMemory:      resource.MustParse("4Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("25"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+									apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 								},
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("75"),
-									apiext.GPUMemoryRatio: resource.MustParse("75"),
-									apiext.GPUMemory:      resource.MustParse("12Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("75"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+									apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 								},
 							},
 						},
@@ -885,27 +885,27 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("25"),
-										apiext.GPUMemoryRatio: resource.MustParse("25"),
-										apiext.GPUMemory:      resource.MustParse("4Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("25"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+										apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("75"),
-										apiext.GPUMemoryRatio: resource.MustParse("75"),
-										apiext.GPUMemory:      resource.MustParse("12Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("75"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+										apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 									},
 								},
 							},
@@ -916,8 +916,8 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 					},
 				},
 				nodeName: "test-node",
@@ -935,27 +935,27 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("25"),
-										apiext.GPUMemoryRatio: resource.MustParse("25"),
-										apiext.GPUMemory:      resource.MustParse("4Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("25"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("25"),
+										apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("75"),
-										apiext.GPUMemoryRatio: resource.MustParse("75"),
-										apiext.GPUMemory:      resource.MustParse("12Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("75"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("75"),
+										apiext.ResourceGPUMemory:      resource.MustParse("12Gi"),
 									},
 								},
 							},
@@ -966,8 +966,8 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("200"),
-						apiext.GPUMemoryRatio: resource.MustParse("200"),
+						apiext.ResourceGPUCore:        resource.MustParse("200"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 					},
 				},
 				nodeName: "test-node",
@@ -985,18 +985,18 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1008,8 +1008,8 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("200"),
-						apiext.GPUMemoryRatio: resource.MustParse("200"),
+						apiext.ResourceGPUCore:        resource.MustParse("200"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 					},
 				},
 				nodeName: "test-node",
@@ -1027,21 +1027,21 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("50"),
+										apiext.ResourceRDMA: resource.MustParse("50"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("50"),
+										apiext.ResourceRDMA: resource.MustParse("50"),
 									},
 								},
 							},
@@ -1052,7 +1052,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.KoordRDMA: resource.MustParse("100"),
+						apiext.ResourceRDMA: resource.MustParse("100"),
 					},
 				},
 				nodeName: "test-node",
@@ -1070,24 +1070,24 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 							},
@@ -1099,8 +1099,8 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.KoordRDMA: resource.MustParse("200"),
-						apiext.KoordFPGA: resource.MustParse("200"),
+						apiext.ResourceRDMA: resource.MustParse("200"),
+						apiext.ResourceFPGA: resource.MustParse("200"),
 					},
 				},
 				nodeName: "test-node",
@@ -1118,38 +1118,38 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1162,10 +1162,10 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.KoordRDMA:      resource.MustParse("100"),
-						apiext.KoordFPGA:      resource.MustParse("100"),
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceRDMA:           resource.MustParse("100"),
+						apiext.ResourceFPGA:           resource.MustParse("100"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 					},
 				},
 				nodeName: "test-node",
@@ -1177,57 +1177,57 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("0"),
+										apiext.ResourceRDMA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("0"),
+										apiext.ResourceFPGA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("0"),
-										apiext.GPUMemoryRatio: resource.MustParse("0"),
-										apiext.GPUMemory:      resource.MustParse("0"),
+										apiext.ResourceGPUCore:        resource.MustParse("0"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("0"),
+										apiext.ResourceGPUMemory:      resource.MustParse("0"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1239,9 +1239,9 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
@@ -1249,7 +1249,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.KoordFPGA: resource.MustParse("100"),
+								apiext.ResourceFPGA: resource.MustParse("100"),
 							},
 						},
 					},
@@ -1257,7 +1257,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.KoordRDMA: resource.MustParse("100"),
+								apiext.ResourceRDMA: resource.MustParse("100"),
 							},
 						},
 					},
@@ -1273,60 +1273,60 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1339,10 +1339,10 @@ func Test_Plugin_Reserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.KoordRDMA:      resource.MustParse("200"),
-						apiext.KoordFPGA:      resource.MustParse("200"),
-						apiext.GPUCore:        resource.MustParse("200"),
-						apiext.GPUMemoryRatio: resource.MustParse("200"),
+						apiext.ResourceRDMA:           resource.MustParse("200"),
+						apiext.ResourceFPGA:           resource.MustParse("200"),
+						apiext.ResourceGPUCore:        resource.MustParse("200"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 					},
 				},
 				nodeName: "test-node",
@@ -1354,90 +1354,90 @@ func Test_Plugin_Reserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("0"),
+										apiext.ResourceRDMA: resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("0"),
+										apiext.ResourceRDMA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("0"),
+										apiext.ResourceFPGA: resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("0"),
+										apiext.ResourceFPGA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("0"),
-										apiext.GPUMemoryRatio: resource.MustParse("0"),
-										apiext.GPUMemory:      resource.MustParse("0"),
+										apiext.ResourceGPUCore:        resource.MustParse("0"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("0"),
+										apiext.ResourceGPUMemory:      resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("0"),
-										apiext.GPUMemoryRatio: resource.MustParse("0"),
-										apiext.GPUMemory:      resource.MustParse("0"),
+										apiext.ResourceGPUCore:        resource.MustParse("0"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("0"),
+										apiext.ResourceGPUMemory:      resource.MustParse("0"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1449,17 +1449,17 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 						{
 							Minor: 1,
 							Resources: corev1.ResourceList{
-								apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
@@ -1467,13 +1467,13 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 							},
 						},
 						{
 							Minor: 1,
 							Resources: corev1.ResourceList{
-								apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 							},
 						},
 					},
@@ -1481,13 +1481,13 @@ func Test_Plugin_Reserve(t *testing.T) {
 						{
 							Minor: 0,
 							Resources: corev1.ResourceList{
-								apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 							},
 						},
 						{
 							Minor: 1,
 							Resources: corev1.ResourceList{
-								apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 							},
 						},
 					},
@@ -1580,17 +1580,17 @@ func Test_Plugin_Unreserve(t *testing.T) {
 							{
 								Minor: 0,
 								Resources: corev1.ResourceList{
-									apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							{
 								Minor: 1,
 								Resources: corev1.ResourceList{
-									apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -1598,13 +1598,13 @@ func Test_Plugin_Unreserve(t *testing.T) {
 							{
 								Minor: 0,
 								Resources: corev1.ResourceList{
-									apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 							{
 								Minor: 1,
 								Resources: corev1.ResourceList{
-									apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
@@ -1612,13 +1612,13 @@ func Test_Plugin_Unreserve(t *testing.T) {
 							{
 								Minor: 0,
 								Resources: corev1.ResourceList{
-									apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 							{
 								Minor: 1,
 								Resources: corev1.ResourceList{
-									apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
@@ -1630,90 +1630,90 @@ func Test_Plugin_Unreserve(t *testing.T) {
 							deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("0"),
+										apiext.ResourceRDMA: resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("0"),
+										apiext.ResourceRDMA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("0"),
+										apiext.ResourceFPGA: resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("0"),
+										apiext.ResourceFPGA: resource.MustParse("0"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("0"),
-										apiext.GPUMemoryRatio: resource.MustParse("0"),
-										apiext.GPUMemory:      resource.MustParse("0"),
+										apiext.ResourceGPUCore:        resource.MustParse("0"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("0"),
+										apiext.ResourceGPUMemory:      resource.MustParse("0"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("0"),
-										apiext.GPUMemoryRatio: resource.MustParse("0"),
-										apiext.GPUMemory:      resource.MustParse("0"),
+										apiext.ResourceGPUCore:        resource.MustParse("0"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("0"),
+										apiext.ResourceGPUMemory:      resource.MustParse("0"),
 									},
 								},
 							},
 							deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
 							deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 								schedulingv1alpha1.RDMA: {
 									0: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordRDMA: resource.MustParse("100"),
+										apiext.ResourceRDMA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									0: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 									1: corev1.ResourceList{
-										apiext.KoordFPGA: resource.MustParse("100"),
+										apiext.ResourceFPGA: resource.MustParse("100"),
 									},
 								},
 								schedulingv1alpha1.GPU: {
 									0: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 									1: corev1.ResourceList{
-										apiext.GPUCore:        resource.MustParse("100"),
-										apiext.GPUMemoryRatio: resource.MustParse("100"),
-										apiext.GPUMemory:      resource.MustParse("16Gi"),
+										apiext.ResourceGPUCore:        resource.MustParse("100"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+										apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 									},
 								},
 							},
@@ -1721,34 +1721,34 @@ func Test_Plugin_Unreserve(t *testing.T) {
 								schedulingv1alpha1.GPU: {
 									namespacedName: {
 										0: corev1.ResourceList{
-											apiext.GPUCore:        resource.MustParse("100"),
-											apiext.GPUMemoryRatio: resource.MustParse("100"),
-											apiext.GPUMemory:      resource.MustParse("16Gi"),
+											apiext.ResourceGPUCore:        resource.MustParse("100"),
+											apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+											apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 										},
 										1: corev1.ResourceList{
-											apiext.GPUCore:        resource.MustParse("100"),
-											apiext.GPUMemoryRatio: resource.MustParse("100"),
-											apiext.GPUMemory:      resource.MustParse("16Gi"),
+											apiext.ResourceGPUCore:        resource.MustParse("100"),
+											apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+											apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 										},
 									},
 								},
 								schedulingv1alpha1.FPGA: {
 									namespacedName: {
 										0: corev1.ResourceList{
-											apiext.KoordFPGA: resource.MustParse("100"),
+											apiext.ResourceFPGA: resource.MustParse("100"),
 										},
 										1: corev1.ResourceList{
-											apiext.KoordFPGA: resource.MustParse("100"),
+											apiext.ResourceFPGA: resource.MustParse("100"),
 										},
 									},
 								},
 								schedulingv1alpha1.RDMA: {
 									namespacedName: {
 										0: corev1.ResourceList{
-											apiext.KoordRDMA: resource.MustParse("100"),
+											apiext.ResourceRDMA: resource.MustParse("100"),
 										},
 										1: corev1.ResourceList{
-											apiext.KoordRDMA: resource.MustParse("100"),
+											apiext.ResourceRDMA: resource.MustParse("100"),
 										},
 									},
 								},
@@ -1765,60 +1765,60 @@ func Test_Plugin_Unreserve(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.RDMA: {
 								0: corev1.ResourceList{
-									apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceFPGA: *resource.NewQuantity(100, resource.DecimalSI),
 								},
 							},
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 								1: corev1.ResourceList{
-									apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.RDMA: {
 								0: corev1.ResourceList{
-									apiext.KoordRDMA: resource.MustParse("100"),
+									apiext.ResourceRDMA: resource.MustParse("100"),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordRDMA: resource.MustParse("100"),
+									apiext.ResourceRDMA: resource.MustParse("100"),
 								},
 							},
 							schedulingv1alpha1.FPGA: {
 								0: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 								1: corev1.ResourceList{
-									apiext.KoordFPGA: resource.MustParse("100"),
+									apiext.ResourceFPGA: resource.MustParse("100"),
 								},
 							},
 							schedulingv1alpha1.GPU: {
 								0: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -1871,7 +1871,7 @@ func Test_Plugin_PreBind(t *testing.T) {
 					Name: "test-container-a",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							apiext.KoordGPU: resource.MustParse("2"),
+							apiext.ResourceGPU: resource.MustParse("2"),
 						},
 					},
 				},
@@ -1915,25 +1915,25 @@ func Test_Plugin_PreBind(t *testing.T) {
 							{
 								Minor: 0,
 								Resources: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 							{
 								Minor: 1,
 								Resources: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 					},
 					convertedDeviceResource: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("200"),
-						apiext.GPUMemoryRatio: resource.MustParse("200"),
-						apiext.GPUMemory:      resource.MustParse("32Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("200"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+						apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 					},
 				},
 			},

--- a/pkg/scheduler/plugins/deviceshare/pod_handler.go
+++ b/pkg/scheduler/plugins/deviceshare/pod_handler.go
@@ -54,6 +54,7 @@ func (n *nodeDeviceCache) onPodAdd(obj interface{}) {
 	if len(devicesAllocation) == 0 {
 		return
 	}
+	transformDeviceAllocations(devicesAllocation)
 
 	info := n.getNodeDevice(pod.Spec.NodeName)
 	if info == nil {
@@ -96,6 +97,7 @@ func (n *nodeDeviceCache) onPodDelete(obj interface{}) {
 	if len(devicesAllocation) == 0 {
 		return
 	}
+	transformDeviceAllocations(devicesAllocation)
 
 	info := n.getNodeDevice(pod.Spec.NodeName)
 	if info == nil {
@@ -108,4 +110,12 @@ func (n *nodeDeviceCache) onPodDelete(obj interface{}) {
 
 	info.updateCacheUsed(devicesAllocation, pod, false)
 	klog.V(5).InfoS("pod cache deleted", "pod", klog.KObj(pod))
+}
+
+func transformDeviceAllocations(deviceAllocations apiext.DeviceAllocations) {
+	for _, allocations := range deviceAllocations {
+		for _, v := range allocations {
+			v.Resources = apiext.TransformDeprecatedDeviceResources(v.Resources)
+		}
+	}
 }

--- a/pkg/scheduler/plugins/deviceshare/pod_handler_test.go
+++ b/pkg/scheduler/plugins/deviceshare/pod_handler_test.go
@@ -118,9 +118,9 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -147,7 +147,7 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 					Namespace: "default",
 					Name:      "test",
 					Annotations: map[string]string{
-						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"kubernetes.io/gpu-core":"60","kubernetes.io/gpu-memory":"8Gi","kubernetes.io/gpu-memory-ratio":"50"}}]}`,
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -157,9 +157,9 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("60"),
-									apiext.GPUMemoryRatio: resource.MustParse("50"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
@@ -175,18 +175,18 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -202,27 +202,27 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        *resource.NewQuantity(40, resource.DecimalSI),
-								apiext.GPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
-								apiext.GPUMemory:      resource.MustParse("8Gi"),
+								apiext.ResourceGPUCore:        *resource.NewQuantity(40, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 							},
 						},
 					},
 					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
 					deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("60"),
-								apiext.GPUMemoryRatio: resource.MustParse("50"),
-								apiext.GPUMemory:      resource.MustParse("8Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("60"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 							},
 						},
 					},
@@ -230,9 +230,116 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 						schedulingv1alpha1.GPU: {
 							podNamespacedName: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("60"),
-									apiext.GPUMemoryRatio: resource.MustParse("50"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "device allocation annotation with deprecated resource names",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "123456789",
+					Namespace: "default",
+					Name:      "test",
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"kubernetes.io/gpu-core":"60","kubernetes.io/gpu-memory":"8Gi","kubernetes.io/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+									//nolint: staticcheck
+									apiext.DeprecatedGPUCore: resource.MustParse("60"),
+									//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+									//nolint: staticcheck
+									apiext.DeprecatedGPUMemoryRatio: resource.MustParse("50"),
+									//lint:ignore SA1019 Device extension resource names should use the prefix `koordinator.sh`
+									//nolint: staticcheck
+									apiext.DeprecatedGPUMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			deviceCache: &nodeDeviceCache{
+				nodeDeviceInfos: map[string]*nodeDevice{
+					"test-node": {
+						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {},
+						},
+						allocateSet: make(map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList),
+					},
+				},
+			},
+			wantCache: map[string]*nodeDevice{
+				"test-node": {
+					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        *resource.NewQuantity(40, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+							},
+						},
+					},
+					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+							},
+						},
+					},
+					deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("60"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+							},
+						},
+					},
+					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]map[int]corev1.ResourceList{
+						schedulingv1alpha1.GPU: {
+							podNamespacedName: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
@@ -368,9 +475,9 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
@@ -397,7 +504,7 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 					Namespace: "default",
 					Name:      "test",
 					Annotations: map[string]string{
-						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"kubernetes.io/gpu-core":"60","kubernetes.io/gpu-memory":"8Gi","kubernetes.io/gpu-memory-ratio":"50"}}]}`,
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -407,9 +514,9 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("60"),
-									apiext.GPUMemoryRatio: resource.MustParse("50"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
@@ -425,27 +532,27 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("40"),
-									apiext.GPUMemoryRatio: resource.MustParse("50"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("40"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
 						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("100"),
-									apiext.GPUMemoryRatio: resource.MustParse("100"),
-									apiext.GPUMemory:      resource.MustParse("16Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 								},
 							},
 						},
 						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
 							schedulingv1alpha1.GPU: {
 								1: corev1.ResourceList{
-									apiext.GPUCore:        resource.MustParse("60"),
-									apiext.GPUMemoryRatio: resource.MustParse("50"),
-									apiext.GPUMemory:      resource.MustParse("8Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
 								},
 							},
 						},
@@ -462,18 +569,18 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},
 					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
 						schedulingv1alpha1.GPU: {
 							1: corev1.ResourceList{
-								apiext.GPUCore:        resource.MustParse("100"),
-								apiext.GPUMemoryRatio: resource.MustParse("100"),
-								apiext.GPUMemory:      resource.MustParse("16Gi"),
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 							},
 						},
 					},

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -36,9 +36,9 @@ const (
 )
 
 var DeviceResourceNames = map[schedulingv1alpha1.DeviceType][]corev1.ResourceName{
-	schedulingv1alpha1.GPU:  {apiext.NvidiaGPU, apiext.KoordGPU, apiext.GPUCore, apiext.GPUMemory, apiext.GPUMemoryRatio},
-	schedulingv1alpha1.RDMA: {apiext.KoordRDMA},
-	schedulingv1alpha1.FPGA: {apiext.KoordFPGA},
+	schedulingv1alpha1.GPU:  {apiext.ResourceNvidiaGPU, apiext.ResourceGPU, apiext.ResourceGPUCore, apiext.ResourceGPUMemory, apiext.ResourceGPUMemoryRatio},
+	schedulingv1alpha1.RDMA: {apiext.ResourceRDMA},
+	schedulingv1alpha1.FPGA: {apiext.ResourceFPGA},
 }
 
 func hasDeviceResource(podRequest corev1.ResourceList, deviceType schedulingv1alpha1.DeviceType) bool {
@@ -62,14 +62,14 @@ func validateCommonDeviceRequest(podRequest corev1.ResourceList, deviceType sche
 	var commonDevice resource.Quantity
 	switch deviceType {
 	case schedulingv1alpha1.FPGA:
-		commonDevice = podRequest[apiext.KoordFPGA]
+		commonDevice = podRequest[apiext.ResourceFPGA]
 	case schedulingv1alpha1.RDMA:
-		commonDevice = podRequest[apiext.KoordRDMA]
+		commonDevice = podRequest[apiext.ResourceRDMA]
 	default:
 		return fmt.Errorf("device type %v is not supported yet", deviceType)
 	}
 	if commonDevice.Value() > 100 && commonDevice.Value()%100 != 0 {
-		return fmt.Errorf("failed to validate %v%v: %v", apiext.ResourceDomainPrefix, deviceType, commonDevice.Value())
+		return fmt.Errorf("failed to validate %v%v: %v", apiext.DomainPrefix, deviceType, commonDevice.Value())
 	}
 	return nil
 }
@@ -84,28 +84,28 @@ var ValidateGPURequest = func(podRequest corev1.ResourceList) (uint, error) {
 		return gpuCombination, fmt.Errorf("pod request should not be empty")
 	}
 
-	if _, exist := podRequest[apiext.NvidiaGPU]; exist {
+	if _, exist := podRequest[apiext.ResourceNvidiaGPU]; exist {
 		gpuCombination |= NvidiaGPUExist
 	}
-	if koordGPU, exist := podRequest[apiext.KoordGPU]; exist {
+	if koordGPU, exist := podRequest[apiext.ResourceGPU]; exist {
 		if koordGPU.Value() > 100 && koordGPU.Value()%100 != 0 {
-			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.KoordGPU, koordGPU.Value())
+			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.ResourceGPU, koordGPU.Value())
 		}
 		gpuCombination |= KoordGPUExist
 	}
-	if gpuCore, exist := podRequest[apiext.GPUCore]; exist {
+	if gpuCore, exist := podRequest[apiext.ResourceGPUCore]; exist {
 		// koordinator.sh/gpu-core should be something like: 25, 50, 75, 100, 200, 300
 		if gpuCore.Value() > 100 && gpuCore.Value()%100 != 0 {
-			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.GPUCore, gpuCore.Value())
+			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.ResourceGPUCore, gpuCore.Value())
 		}
 		gpuCombination |= GPUCoreExist
 	}
-	if _, exist := podRequest[apiext.GPUMemory]; exist {
+	if _, exist := podRequest[apiext.ResourceGPUMemory]; exist {
 		gpuCombination |= GPUMemoryExist
 	}
-	if gpuMemRatio, exist := podRequest[apiext.GPUMemoryRatio]; exist {
+	if gpuMemRatio, exist := podRequest[apiext.ResourceGPUMemoryRatio]; exist {
 		if gpuMemRatio.Value() > 100 && gpuMemRatio.Value()%100 != 0 {
-			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.GPUMemoryRatio, gpuMemRatio.Value())
+			return gpuCombination, fmt.Errorf("failed to validate %v: %v", apiext.ResourceGPUMemoryRatio, gpuMemRatio.Value())
 		}
 		gpuCombination |= GPUMemoryRatioExist
 	}
@@ -128,15 +128,15 @@ func convertCommonDeviceResource(podRequest corev1.ResourceList, deviceType sche
 	var resources corev1.ResourceList
 	switch deviceType {
 	case schedulingv1alpha1.RDMA:
-		if value, ok := podRequest[apiext.KoordRDMA]; ok {
+		if value, ok := podRequest[apiext.ResourceRDMA]; ok {
 			resources = corev1.ResourceList{
-				apiext.KoordRDMA: value,
+				apiext.ResourceRDMA: value,
 			}
 		}
 	case schedulingv1alpha1.FPGA:
-		if value, ok := podRequest[apiext.KoordFPGA]; ok {
+		if value, ok := podRequest[apiext.ResourceFPGA]; ok {
 			resources = corev1.ResourceList{
-				apiext.KoordFPGA: value,
+				apiext.ResourceFPGA: value,
 			}
 		}
 	default:
@@ -146,9 +146,9 @@ func convertCommonDeviceResource(podRequest corev1.ResourceList, deviceType sche
 	return resources
 }
 
+// ConvertGPUResource will convert either nvidia.com/gpu or koordinator.sh/gpu to koordinator.sh/gpu-core and koordinator.sh/gpu-memory-ratio
 // nvidia.com/gpu means applying for full-card
 // koordinator.sh/gpu means applying for cards in percentile
-// ConvertGPUResource will convert either nvidia.com/gpu or koordinator.sh/gpu to koordinator.sh/gpu-core and koordinator.sh/gpu-memory-ratio
 var ConvertGPUResource = func(podRequest corev1.ResourceList, combination uint) corev1.ResourceList {
 	if podRequest == nil || len(podRequest) == 0 {
 		klog.Warningf("pod request should not be empty")
@@ -157,24 +157,24 @@ var ConvertGPUResource = func(podRequest corev1.ResourceList, combination uint) 
 	switch combination {
 	case GPUCoreExist | GPUMemoryExist:
 		return corev1.ResourceList{
-			apiext.GPUCore:   podRequest[apiext.GPUCore],
-			apiext.GPUMemory: podRequest[apiext.GPUMemory],
+			apiext.ResourceGPUCore:   podRequest[apiext.ResourceGPUCore],
+			apiext.ResourceGPUMemory: podRequest[apiext.ResourceGPUMemory],
 		}
 	case GPUCoreExist | GPUMemoryRatioExist:
 		return corev1.ResourceList{
-			apiext.GPUCore:        podRequest[apiext.GPUCore],
-			apiext.GPUMemoryRatio: podRequest[apiext.GPUMemoryRatio],
+			apiext.ResourceGPUCore:        podRequest[apiext.ResourceGPUCore],
+			apiext.ResourceGPUMemoryRatio: podRequest[apiext.ResourceGPUMemoryRatio],
 		}
 	case KoordGPUExist:
 		return corev1.ResourceList{
-			apiext.GPUCore:        podRequest[apiext.KoordGPU],
-			apiext.GPUMemoryRatio: podRequest[apiext.KoordGPU],
+			apiext.ResourceGPUCore:        podRequest[apiext.ResourceGPU],
+			apiext.ResourceGPUMemoryRatio: podRequest[apiext.ResourceGPU],
 		}
 	case NvidiaGPUExist:
-		nvidiaGpu := podRequest[apiext.NvidiaGPU]
+		nvidiaGpu := podRequest[apiext.ResourceNvidiaGPU]
 		return corev1.ResourceList{
-			apiext.GPUCore:        *resource.NewQuantity(nvidiaGpu.Value()*100, resource.DecimalSI),
-			apiext.GPUMemoryRatio: *resource.NewQuantity(nvidiaGpu.Value()*100, resource.DecimalSI),
+			apiext.ResourceGPUCore:        *resource.NewQuantity(nvidiaGpu.Value()*100, resource.DecimalSI),
+			apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(nvidiaGpu.Value()*100, resource.DecimalSI),
 		}
 	}
 	return nil
@@ -187,10 +187,10 @@ func isMultipleCommonDevicePod(podRequest corev1.ResourceList, deviceType schedu
 	}
 	switch deviceType {
 	case schedulingv1alpha1.RDMA:
-		rdma := podRequest[apiext.KoordRDMA]
+		rdma := podRequest[apiext.ResourceRDMA]
 		return rdma.Value() > 100 && rdma.Value()%100 == 0
 	case schedulingv1alpha1.FPGA:
-		fpga := podRequest[apiext.KoordFPGA]
+		fpga := podRequest[apiext.ResourceFPGA]
 		return fpga.Value() > 100 && fpga.Value()%100 == 0
 	default:
 		return false
@@ -202,7 +202,7 @@ func isMultipleGPUPod(podRequest corev1.ResourceList) bool {
 		klog.Warningf("pod request should not be empty")
 		return false
 	}
-	gpuCore := podRequest[apiext.GPUCore]
+	gpuCore := podRequest[apiext.ResourceGPUCore]
 	return gpuCore.Value() > 100 && gpuCore.Value()%100 == 0
 }
 
@@ -229,7 +229,7 @@ func patchContainerGPUResource(pod *corev1.Pod, podRequest corev1.ResourceList) 
 			}
 		}
 		if needPatch {
-			for _, v := range []corev1.ResourceName{apiext.GPUCore, apiext.GPUMemory, apiext.GPUMemoryRatio} {
+			for _, v := range []corev1.ResourceName{apiext.ResourceGPUCore, apiext.ResourceGPUMemory, apiext.ResourceGPUMemoryRatio} {
 				reqs[v] = podRequest[v]
 			}
 			break
@@ -247,10 +247,10 @@ func fillGPUTotalMem(nodeDeviceTotal deviceResources, podRequest corev1.Resource
 	}
 
 	// a node can only contain one type of GPU, so each of them has the same total memory.
-	if gpuMem, ok := podRequest[apiext.GPUMemory]; ok {
-		podRequest[apiext.GPUMemoryRatio] = memBytesToRatio(gpuMem, nodeDeviceTotal[activeMinor][apiext.GPUMemory])
+	if gpuMem, ok := podRequest[apiext.ResourceGPUMemory]; ok {
+		podRequest[apiext.ResourceGPUMemoryRatio] = memBytesToRatio(gpuMem, nodeDeviceTotal[activeMinor][apiext.ResourceGPUMemory])
 	} else {
-		gpuMemRatio := podRequest[apiext.GPUMemoryRatio]
-		podRequest[apiext.GPUMemory] = memRatioToBytes(gpuMemRatio, nodeDeviceTotal[activeMinor][apiext.GPUMemory])
+		gpuMemRatio := podRequest[apiext.ResourceGPUMemoryRatio]
+		podRequest[apiext.ResourceGPUMemory] = memRatioToBytes(gpuMemRatio, nodeDeviceTotal[activeMinor][apiext.ResourceGPUMemory])
 	}
 }

--- a/pkg/scheduler/plugins/deviceshare/utils_test.go
+++ b/pkg/scheduler/plugins/deviceshare/utils_test.go
@@ -61,9 +61,9 @@ func Test_hasDeviceResource(t *testing.T) {
 			name: "no match device resource",
 			args: args{
 				podRequest: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10"),
-					corev1.ResourceMemory: resource.MustParse("200"),
-					apiext.GPUCore:        resource.MustParse("50"),
+					corev1.ResourceCPU:     resource.MustParse("10"),
+					corev1.ResourceMemory:  resource.MustParse("200"),
+					apiext.ResourceGPUCore: resource.MustParse("50"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
@@ -75,7 +75,7 @@ func Test_hasDeviceResource(t *testing.T) {
 				podRequest: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10"),
 					corev1.ResourceMemory: resource.MustParse("200"),
-					apiext.KoordRDMA:      resource.MustParse("50"),
+					apiext.ResourceRDMA:   resource.MustParse("50"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
@@ -112,7 +112,7 @@ func Test_validateCommonDeviceRequest(t *testing.T) {
 			name: "invalid fpga request",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("201"),
+					apiext.ResourceFPGA: resource.MustParse("201"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
@@ -122,7 +122,7 @@ func Test_validateCommonDeviceRequest(t *testing.T) {
 			name: "valid fpga request",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("50"),
+					apiext.ResourceFPGA: resource.MustParse("50"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
@@ -132,7 +132,7 @@ func Test_validateCommonDeviceRequest(t *testing.T) {
 			name: "invalid rdma request",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordRDMA: resource.MustParse("201"),
+					apiext.ResourceRDMA: resource.MustParse("201"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
@@ -142,7 +142,7 @@ func Test_validateCommonDeviceRequest(t *testing.T) {
 			name: "valid rdma request",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordRDMA: resource.MustParse("50"),
+					apiext.ResourceRDMA: resource.MustParse("50"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
@@ -152,7 +152,7 @@ func Test_validateCommonDeviceRequest(t *testing.T) {
 			name: "not common device type",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.NvidiaGPU: resource.MustParse("2"),
+					apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 				},
 				deviceType: schedulingv1alpha1.GPU,
 			},
@@ -183,7 +183,7 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "invalid gpu request 1",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore: resource.MustParse("101"),
+				apiext.ResourceGPUCore: resource.MustParse("101"),
 			},
 			want:    0,
 			wantErr: true,
@@ -191,11 +191,11 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "invalid gpu request 2",
 			podRequest: corev1.ResourceList{
-				apiext.NvidiaGPU:      resource.MustParse("2"),
-				apiext.KoordGPU:       resource.MustParse("200"),
-				apiext.GPUCore:        resource.MustParse("200"),
-				apiext.GPUMemory:      resource.MustParse("32Gi"),
-				apiext.GPUMemoryRatio: resource.MustParse("200"),
+				apiext.ResourceNvidiaGPU:      resource.MustParse("2"),
+				apiext.ResourceGPU:            resource.MustParse("200"),
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 			},
 			want:    0,
 			wantErr: true,
@@ -203,7 +203,7 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "invalid gpu request 3",
 			podRequest: corev1.ResourceList{
-				apiext.KoordGPU: resource.MustParse("101"),
+				apiext.ResourceGPU: resource.MustParse("101"),
 			},
 			want:    0,
 			wantErr: true,
@@ -211,8 +211,8 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "invalid gpu request 4",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore:        resource.MustParse("100"),
-				apiext.GPUMemoryRatio: resource.MustParse("101"),
+				apiext.ResourceGPUCore:        resource.MustParse("100"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("101"),
 			},
 			want:    0,
 			wantErr: true,
@@ -220,7 +220,7 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "valid gpu request 1",
 			podRequest: corev1.ResourceList{
-				apiext.NvidiaGPU: resource.MustParse("2"),
+				apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 			},
 			want:    NvidiaGPUExist,
 			wantErr: false,
@@ -228,7 +228,7 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "valid gpu request 2",
 			podRequest: corev1.ResourceList{
-				apiext.KoordGPU: resource.MustParse("200"),
+				apiext.ResourceGPU: resource.MustParse("200"),
 			},
 			want:    KoordGPUExist,
 			wantErr: false,
@@ -236,8 +236,8 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "valid gpu request 3",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore:   resource.MustParse("200"),
-				apiext.GPUMemory: resource.MustParse("64Gi"),
+				apiext.ResourceGPUCore:   resource.MustParse("200"),
+				apiext.ResourceGPUMemory: resource.MustParse("64Gi"),
 			},
 			want:    GPUCoreExist | GPUMemoryExist,
 			wantErr: false,
@@ -245,8 +245,8 @@ func Test_validateGPURequest(t *testing.T) {
 		{
 			name: "valid gpu request 4",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore:        resource.MustParse("200"),
-				apiext.GPUMemoryRatio: resource.MustParse("200"),
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 			},
 			want:    GPUCoreExist | GPUMemoryRatioExist,
 			wantErr: false,
@@ -285,7 +285,7 @@ func Test_convertCommonDeviceResource(t *testing.T) {
 			name: "non common device",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.NvidiaGPU: resource.MustParse("2"),
+					apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 				},
 				deviceType: schedulingv1alpha1.GPU,
 			},
@@ -295,24 +295,24 @@ func Test_convertCommonDeviceResource(t *testing.T) {
 			name: "rdma",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordRDMA: resource.MustParse("80"),
+					apiext.ResourceRDMA: resource.MustParse("80"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
 			want: corev1.ResourceList{
-				apiext.KoordRDMA: resource.MustParse("80"),
+				apiext.ResourceRDMA: resource.MustParse("80"),
 			},
 		},
 		{
 			name: "fpga",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("80"),
+					apiext.ResourceFPGA: resource.MustParse("80"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
 			want: corev1.ResourceList{
-				apiext.KoordFPGA: resource.MustParse("80"),
+				apiext.ResourceFPGA: resource.MustParse("80"),
 			},
 		},
 	}
@@ -346,7 +346,7 @@ func Test_convertGPUResource(t *testing.T) {
 			name: "invalid combination",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.NvidiaGPU: resource.MustParse("2"),
+					apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 				},
 				gpuCombination: GPUCoreExist | GPUMemoryExist | GPUMemoryRatioExist,
 			},
@@ -356,54 +356,54 @@ func Test_convertGPUResource(t *testing.T) {
 			name: "nvidiaGpuExist",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.NvidiaGPU: resource.MustParse("2"),
+					apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 				},
 				gpuCombination: NvidiaGPUExist,
 			},
 			want: corev1.ResourceList{
-				apiext.GPUCore:        *resource.NewQuantity(200, resource.DecimalSI),
-				apiext.GPUMemoryRatio: *resource.NewQuantity(200, resource.DecimalSI),
+				apiext.ResourceGPUCore:        *resource.NewQuantity(200, resource.DecimalSI),
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(200, resource.DecimalSI),
 			},
 		},
 		{
 			name: "koordGpuExist",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordGPU: resource.MustParse("50"),
+					apiext.ResourceGPU: resource.MustParse("50"),
 				},
 				gpuCombination: KoordGPUExist,
 			},
 			want: corev1.ResourceList{
-				apiext.GPUCore:        resource.MustParse("50"),
-				apiext.GPUMemoryRatio: resource.MustParse("50"),
+				apiext.ResourceGPUCore:        resource.MustParse("50"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
 			},
 		},
 		{
 			name: "gpuCoreExist | gpuMemoryRatioExist",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("50"),
-					apiext.GPUMemoryRatio: resource.MustParse("50"),
+					apiext.ResourceGPUCore:        resource.MustParse("50"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
 				},
 				gpuCombination: GPUCoreExist | GPUMemoryRatioExist,
 			},
 			want: corev1.ResourceList{
-				apiext.GPUCore:        resource.MustParse("50"),
-				apiext.GPUMemoryRatio: resource.MustParse("50"),
+				apiext.ResourceGPUCore:        resource.MustParse("50"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
 			},
 		},
 		{
 			name: "gpuCoreExist | gpuMemoryExist",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:   resource.MustParse("50"),
-					apiext.GPUMemory: resource.MustParse("32Gi"),
+					apiext.ResourceGPUCore:   resource.MustParse("50"),
+					apiext.ResourceGPUMemory: resource.MustParse("32Gi"),
 				},
 				gpuCombination: GPUCoreExist | GPUMemoryExist,
 			},
 			want: corev1.ResourceList{
-				apiext.GPUCore:   resource.MustParse("50"),
-				apiext.GPUMemory: resource.MustParse("32Gi"),
+				apiext.ResourceGPUCore:   resource.MustParse("50"),
+				apiext.ResourceGPUMemory: resource.MustParse("32Gi"),
 			},
 		},
 	}
@@ -437,7 +437,7 @@ func Test_isMultipleCommonDevicePod(t *testing.T) {
 			name: "non common device",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore: resource.MustParse("100"),
+					apiext.ResourceGPUCore: resource.MustParse("100"),
 				},
 				deviceType: schedulingv1alpha1.GPU,
 			},
@@ -447,7 +447,7 @@ func Test_isMultipleCommonDevicePod(t *testing.T) {
 			name: "multiple fpga",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("300"),
+					apiext.ResourceFPGA: resource.MustParse("300"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
@@ -457,7 +457,7 @@ func Test_isMultipleCommonDevicePod(t *testing.T) {
 			name: "single fpga",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordFPGA: resource.MustParse("30"),
+					apiext.ResourceFPGA: resource.MustParse("30"),
 				},
 				deviceType: schedulingv1alpha1.FPGA,
 			},
@@ -467,7 +467,7 @@ func Test_isMultipleCommonDevicePod(t *testing.T) {
 			name: "multiple rdma",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordRDMA: resource.MustParse("300"),
+					apiext.ResourceRDMA: resource.MustParse("300"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
@@ -477,7 +477,7 @@ func Test_isMultipleCommonDevicePod(t *testing.T) {
 			name: "single rdma",
 			args: args{
 				podRequest: corev1.ResourceList{
-					apiext.KoordRDMA: resource.MustParse("30"),
+					apiext.ResourceRDMA: resource.MustParse("30"),
 				},
 				deviceType: schedulingv1alpha1.RDMA,
 			},
@@ -506,14 +506,14 @@ func Test_isMultipleGPUPod(t *testing.T) {
 		{
 			name: "single gpu",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore: resource.MustParse("80"),
+				apiext.ResourceGPUCore: resource.MustParse("80"),
 			},
 			want: false,
 		},
 		{
 			name: "multiple gpu",
 			podRequest: corev1.ResourceList{
-				apiext.GPUCore: resource.MustParse("200"),
+				apiext.ResourceGPUCore: resource.MustParse("200"),
 			},
 			want: true,
 		},
@@ -564,7 +564,7 @@ func Test_patchContainerGPUResource(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.NvidiaGPU: resource.MustParse("2"),
+									apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 								},
 							},
 						},
@@ -576,10 +576,10 @@ func Test_patchContainerGPUResource(t *testing.T) {
 			},
 			gpuContainerNum: 0,
 			podRequest: corev1.ResourceList{
-				apiext.NvidiaGPU:      resource.MustParse("2"),
-				apiext.GPUCore:        resource.MustParse("200"),
-				apiext.GPUMemoryRatio: resource.MustParse("200"),
-				apiext.GPUMemory:      resource.MustParse("64Gi"),
+				apiext.ResourceNvidiaGPU:      resource.MustParse("2"),
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+				apiext.ResourceGPUMemory:      resource.MustParse("64Gi"),
 			},
 		},
 		{
@@ -600,7 +600,7 @@ func Test_patchContainerGPUResource(t *testing.T) {
 							Name: "test-container-b",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.NvidiaGPU: resource.MustParse("2"),
+									apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 								},
 							},
 						},
@@ -612,10 +612,10 @@ func Test_patchContainerGPUResource(t *testing.T) {
 			},
 			gpuContainerNum: 1,
 			podRequest: corev1.ResourceList{
-				apiext.NvidiaGPU:      resource.MustParse("2"),
-				apiext.GPUCore:        resource.MustParse("200"),
-				apiext.GPUMemoryRatio: resource.MustParse("200"),
-				apiext.GPUMemory:      resource.MustParse("64Gi"),
+				apiext.ResourceNvidiaGPU:      resource.MustParse("2"),
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+				apiext.ResourceGPUMemory:      resource.MustParse("64Gi"),
 			},
 		},
 		{
@@ -633,7 +633,7 @@ func Test_patchContainerGPUResource(t *testing.T) {
 							Name: "test-container-a",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									apiext.NvidiaGPU: resource.MustParse("2"),
+									apiext.ResourceNvidiaGPU: resource.MustParse("2"),
 								},
 							},
 						},
@@ -648,10 +648,10 @@ func Test_patchContainerGPUResource(t *testing.T) {
 			},
 			gpuContainerNum: 0,
 			podRequest: corev1.ResourceList{
-				apiext.NvidiaGPU:      resource.MustParse("2"),
-				apiext.GPUCore:        resource.MustParse("200"),
-				apiext.GPUMemoryRatio: resource.MustParse("200"),
-				apiext.GPUMemory:      resource.MustParse("64Gi"),
+				apiext.ResourceNvidiaGPU:      resource.MustParse("2"),
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+				apiext.ResourceGPUMemory:      resource.MustParse("64Gi"),
 			},
 		},
 	}
@@ -681,21 +681,21 @@ func Test_fillGPUTotalMem(t *testing.T) {
 			args: args{
 				gpuTotal: deviceResources{
 					0: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("32Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 					},
 				},
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("50"),
-					apiext.GPUMemoryRatio: resource.MustParse("50"),
+					apiext.ResourceGPUCore:        resource.MustParse("50"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
 				},
 			},
 			wants: wants{
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("50"),
-					apiext.GPUMemoryRatio: resource.MustParse("50"),
-					apiext.GPUMemory:      resource.MustParse("16Gi"),
+					apiext.ResourceGPUCore:        resource.MustParse("50"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+					apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 				},
 			},
 		},
@@ -704,21 +704,21 @@ func Test_fillGPUTotalMem(t *testing.T) {
 			args: args{
 				gpuTotal: deviceResources{
 					0: corev1.ResourceList{
-						apiext.GPUCore:        resource.MustParse("100"),
-						apiext.GPUMemoryRatio: resource.MustParse("100"),
-						apiext.GPUMemory:      resource.MustParse("32Gi"),
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("32Gi"),
 					},
 				},
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:   resource.MustParse("50"),
-					apiext.GPUMemory: resource.MustParse("16Gi"),
+					apiext.ResourceGPUCore:   resource.MustParse("50"),
+					apiext.ResourceGPUMemory: resource.MustParse("16Gi"),
 				},
 			},
 			wants: wants{
 				podRequest: corev1.ResourceList{
-					apiext.GPUCore:        resource.MustParse("50"),
-					apiext.GPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
-					apiext.GPUMemory:      resource.MustParse("16Gi"),
+					apiext.ResourceGPUCore:        resource.MustParse("50"),
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
+					apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
 				},
 			},
 		},

--- a/pkg/slo-controller/noderesource/noderesource_test.go
+++ b/pkg/slo-controller/noderesource/noderesource_test.go
@@ -243,8 +243,8 @@ func Test_updateNodeGPUResource_updateGPUDriverAndModel(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNode.Name,
 			Labels: map[string]string{
-				extension.GPUModel:  "A100",
-				extension.GPUDriver: "480",
+				extension.LabelGPUModel:         "A100",
+				extension.LabelGPUDriverVersion: "480",
 			},
 		},
 		Spec: schedulingv1alpha1.DeviceSpec{
@@ -255,9 +255,9 @@ func Test_updateNodeGPUResource_updateGPUDriverAndModel(t *testing.T) {
 					Health: true,
 					Type:   schedulingv1alpha1.GPU,
 					Resources: map[corev1.ResourceName]resource.Quantity{
-						extension.GPUCore:        *resource.NewQuantity(100, resource.BinarySI),
-						extension.GPUMemory:      *resource.NewQuantity(8000, resource.BinarySI),
-						extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.BinarySI),
+						extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.BinarySI),
+						extension.ResourceGPUMemory:      *resource.NewQuantity(8000, resource.BinarySI),
+						extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.BinarySI),
 					},
 				},
 				{
@@ -266,9 +266,9 @@ func Test_updateNodeGPUResource_updateGPUDriverAndModel(t *testing.T) {
 					Health: true,
 					Type:   schedulingv1alpha1.GPU,
 					Resources: map[corev1.ResourceName]resource.Quantity{
-						extension.GPUCore:        *resource.NewQuantity(100, resource.BinarySI),
-						extension.GPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
-						extension.GPUMemoryRatio: *resource.NewQuantity(100, resource.BinarySI),
+						extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.BinarySI),
+						extension.ResourceGPUMemory:      *resource.NewQuantity(10000, resource.BinarySI),
+						extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.BinarySI),
 					},
 				},
 			},
@@ -278,9 +278,9 @@ func Test_updateNodeGPUResource_updateGPUDriverAndModel(t *testing.T) {
 	r.updateGPUNodeResource(testNode, fakeDevice)
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: testNode.Name}, testNode)
 	assert.Equal(t, nil, err)
-	actualMemoryRatio := testNode.Status.Allocatable[extension.GPUMemoryRatio]
-	actualMemory := testNode.Status.Allocatable[extension.GPUMemory]
-	actualCore := testNode.Status.Allocatable[extension.GPUCore]
+	actualMemoryRatio := testNode.Status.Allocatable[extension.ResourceGPUMemoryRatio]
+	actualMemory := testNode.Status.Allocatable[extension.ResourceGPUMemory]
+	actualCore := testNode.Status.Allocatable[extension.ResourceGPUCore]
 	assert.Equal(t, actualMemoryRatio.Value(), resource.NewQuantity(200, resource.DecimalSI).Value())
 	assert.Equal(t, actualMemory.Value(), resource.NewQuantity(18000, resource.BinarySI).Value())
 	assert.Equal(t, actualCore.Value(), resource.NewQuantity(200, resource.BinarySI).Value())
@@ -288,8 +288,8 @@ func Test_updateNodeGPUResource_updateGPUDriverAndModel(t *testing.T) {
 	r.updateGPUDriverAndModel(testNode, fakeDevice)
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: testNode.Name}, testNode)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, testNode.Labels[extension.GPUModel], "A100")
-	assert.Equal(t, testNode.Labels[extension.GPUDriver], "480")
+	assert.Equal(t, testNode.Labels[extension.LabelGPUModel], "A100")
+	assert.Equal(t, testNode.Labels[extension.LabelGPUDriverVersion], "480")
 }
 
 func Test_isGPUResourceNeedSync(t *testing.T) {
@@ -306,9 +306,9 @@ func Test_isGPUResourceNeedSync(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("20"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("20"),
+						extension.ResourceGPUCore:        resource.MustParse("20"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("20"),
 					},
 				},
 			},
@@ -318,39 +318,9 @@ func Test_isGPUResourceNeedSync(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("20"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("20"),
-					},
-				},
-			},
-			&SyncContext{
-				contextMap: map[string]time.Time{"/test-node0": time.Now()},
-			},
-			false,
-		},
-		{
-			&corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node0",
-				},
-				Status: corev1.NodeStatus{
-					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("20"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("21"),
-					},
-				},
-			},
-			&corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node0",
-				},
-				Status: corev1.NodeStatus{
-					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("21"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("20"),
+						extension.ResourceGPUCore:        resource.MustParse("20"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("20"),
 					},
 				},
 			},
@@ -366,9 +336,9 @@ func Test_isGPUResourceNeedSync(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("20"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("20"),
+						extension.ResourceGPUCore:        resource.MustParse("20"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("21"),
 					},
 				},
 			},
@@ -378,9 +348,39 @@ func Test_isGPUResourceNeedSync(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
-						extension.GPUCore:        resource.MustParse("20"),
-						extension.GPUMemory:      resource.MustParse("40G"),
-						extension.GPUMemoryRatio: resource.MustParse("20"),
+						extension.ResourceGPUCore:        resource.MustParse("21"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("20"),
+					},
+				},
+			},
+			&SyncContext{
+				contextMap: map[string]time.Time{"/test-node0": time.Now()},
+			},
+			false,
+		},
+		{
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node0",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						extension.ResourceGPUCore:        resource.MustParse("20"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("20"),
+					},
+				},
+			},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node0",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						extension.ResourceGPUCore:        resource.MustParse("20"),
+						extension.ResourceGPUMemory:      resource.MustParse("40G"),
+						extension.ResourceGPUMemoryRatio: resource.MustParse("20"),
 					},
 				},
 			},
@@ -422,8 +422,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "A100",
-						extension.GPUDriver: "480",
+						extension.LabelGPUModel:         "A100",
+						extension.LabelGPUDriverVersion: "480",
 					},
 				},
 			},
@@ -431,8 +431,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "A100",
-						extension.GPUDriver: "480",
+						extension.LabelGPUModel:         "A100",
+						extension.LabelGPUDriverVersion: "480",
 					},
 				},
 			},
@@ -443,8 +443,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "P40",
-						extension.GPUDriver: "480",
+						extension.LabelGPUModel:         "P40",
+						extension.LabelGPUDriverVersion: "480",
 					},
 				},
 			},
@@ -452,8 +452,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "A100",
-						extension.GPUDriver: "480",
+						extension.LabelGPUModel:         "A100",
+						extension.LabelGPUDriverVersion: "480",
 					},
 				},
 			},
@@ -464,8 +464,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "A100",
-						extension.GPUDriver: "470",
+						extension.LabelGPUModel:         "A100",
+						extension.LabelGPUDriverVersion: "470",
 					},
 				},
 			},
@@ -473,8 +473,8 @@ func Test_isGPULabelNeedSync(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node0",
 					Labels: map[string]string{
-						extension.GPUModel:  "A100",
-						extension.GPUDriver: "480",
+						extension.LabelGPUModel:         "A100",
+						extension.LabelGPUDriverVersion: "480",
 					},
 				},
 			},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The resource names starting with the prefix `kubernetes.io` in k8s are native resource types, and device plugins cannot use these resource names, otherwise the kubelet will reject them.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
