### PR TITLE
koord-descheduler: LowNodeLoad eliminates abnormal states based on consecutiveNormalities

### DIFF
--- a/pkg/descheduler/apis/config/types_loadaware.go
+++ b/pkg/descheduler/apis/config/types_loadaware.go
@@ -83,4 +83,6 @@ type LoadAnomalyCondition struct {
 	Timeout metav1.Duration
 	// ConsecutiveAbnormalities indicates the number of consecutive abnormalities
 	ConsecutiveAbnormalities uint32
+	// ConsecutiveNormalities indicates the number of consecutive normalities
+	ConsecutiveNormalities uint32
 }

--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -53,6 +53,7 @@ var (
 	defaultLoadAnomalyCondition = &LoadAnomalyCondition{
 		Timeout:                  &metav1.Duration{Duration: 1 * time.Minute},
 		ConsecutiveAbnormalities: 5,
+		ConsecutiveNormalities:   3,
 	}
 )
 
@@ -239,7 +240,9 @@ func SetDefaults_LowNodeLoadArgs(obj *LowNodeLoadArgs) {
 	if obj.NodeFit == nil {
 		obj.NodeFit = pointer.Bool(true)
 	}
-	if obj.AnomalyCondition == nil || obj.AnomalyCondition.ConsecutiveAbnormalities == 0 {
+	if obj.AnomalyCondition == nil {
 		obj.AnomalyCondition = defaultLoadAnomalyCondition
+	} else if obj.AnomalyCondition.ConsecutiveAbnormalities == 0 {
+		obj.AnomalyCondition.ConsecutiveAbnormalities = defaultLoadAnomalyCondition.ConsecutiveAbnormalities
 	}
 }

--- a/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
@@ -82,4 +82,6 @@ type LoadAnomalyCondition struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// ConsecutiveAbnormalities indicates the number of consecutive abnormalities
 	ConsecutiveAbnormalities uint32 `json:"consecutiveAbnormalities,omitempty"`
+	// ConsecutiveNormalities indicates the number of consecutive normalities
+	ConsecutiveNormalities uint32 `json:"consecutiveNormalities,omitempty"`
 }

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -291,6 +291,7 @@ func autoConvert_v1alpha2_LoadAnomalyCondition_To_config_LoadAnomalyCondition(in
 		return err
 	}
 	out.ConsecutiveAbnormalities = in.ConsecutiveAbnormalities
+	out.ConsecutiveNormalities = in.ConsecutiveNormalities
 	return nil
 }
 
@@ -304,6 +305,7 @@ func autoConvert_config_LoadAnomalyCondition_To_v1alpha2_LoadAnomalyCondition(in
 		return err
 	}
 	out.ConsecutiveAbnormalities = in.ConsecutiveAbnormalities
+	out.ConsecutiveNormalities = in.ConsecutiveNormalities
 	return nil
 }
 

--- a/pkg/descheduler/utils/anomaly/types.go
+++ b/pkg/descheduler/utils/anomaly/types.go
@@ -45,4 +45,5 @@ type Detector interface {
 	Name() string
 	Mark(normality bool) (State, error)
 	State() State
+	Reset()
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

LowNodeLoad improves the anomaly condition mechanism and supports the elimination of abnormal states based on consecutiveNormalities. The original mechanism for eliminating abnormal states based on timeout parameters remains unchanged.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1002 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

```yaml
apiVersion: descheduler/v1alpha2
kind: DeschedulerConfiguration
deschedulingInterval: 10s
dryRun: true
profiles:
  - name: koord-descheduler
    plugins:
      evict:
        enabled:
          - name: MigrationController
      balance:
        enabled:
          - name: LowNodeLoad
    pluginConfig:
      - name: LowNodeLoad
        args:
          apiVersion: descheduler/v1alpha2
          kind: LowNodeLoadArgs
          lowThresholds:
            cpu: 20
            memory: 30
          highThresholds:
            cpu: 50
            memory: 60
          evictableNamespaces:
            include:
              - default
          anomalyCondition:
            consecutiveAbnormalities: 5
            consecutiveNormalities: 3
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
