### PR TITLE
apis: move qos utils for extensions

### DIFF
--- a/apis/extension/priority.go
+++ b/apis/extension/priority.go
@@ -24,6 +24,7 @@ import (
 
 type PriorityClass string
 
+// https://koordinator.sh/docs/architecture/priority/
 const (
 	PriorityProd  PriorityClass = "koord-prod"
 	PriorityMid   PriorityClass = "koord-mid"

--- a/apis/extension/qos.go
+++ b/apis/extension/qos.go
@@ -16,10 +16,9 @@ limitations under the License.
 
 package extension
 
-import corev1 "k8s.io/api/core/v1"
-
 type QoSClass string
 
+// https://koordinator.sh/docs/architecture/qos/
 const (
 	QoSLSE    QoSClass = "LSE"
 	QoSLSR    QoSClass = "LSR"
@@ -28,21 +27,6 @@ const (
 	QoSSystem QoSClass = "SYSTEM"
 	QoSNone   QoSClass = ""
 )
-
-func GetPodQoSClass(pod *corev1.Pod) QoSClass {
-	if pod == nil || pod.Labels == nil {
-		return QoSNone
-	}
-	return GetQoSClassByAttrs(pod.Labels, pod.Annotations)
-}
-
-func GetQoSClassByAttrs(labels, annotations map[string]string) QoSClass {
-	// annotations are for old format adaption reason
-	if q, exist := labels[LabelPodQoS]; exist {
-		return GetPodQoSClassByName(q)
-	}
-	return QoSNone
-}
 
 func GetPodQoSClassByName(qos string) QoSClass {
 	q := QoSClass(qos)

--- a/apis/extension/qos_utils.go
+++ b/apis/extension/qos_utils.go
@@ -18,17 +18,19 @@ package extension
 
 import corev1 "k8s.io/api/core/v1"
 
-const (
-	DomainPrefix = "koordinator.sh/"
-	// ResourceDomainPrefix is a prefix "kubernetes.io/" used by particular extend resources (e.g. batch resources)
-	ResourceDomainPrefix = corev1.ResourceDefaultNamespacePrefix
-	// SchedulingDomainPrefix represents the scheduling domain prefix
-	SchedulingDomainPrefix = "scheduling.koordinator.sh"
-	// NodeDomainPrefix represents the node domain prefix
-	NodeDomainPrefix = "node.koordinator.sh"
+// NOTE: functions in this file can be overwritten for extension
 
-	LabelPodQoS      = DomainPrefix + "qosClass"
-	LabelPodPriority = DomainPrefix + "priority"
+func GetPodQoSClass(pod *corev1.Pod) QoSClass {
+	if pod == nil || pod.Labels == nil {
+		return QoSNone
+	}
+	return GetQoSClassByAttrs(pod.Labels, pod.Annotations)
+}
 
-	LabelManagedBy = "app.kubernetes.io/managed-by"
-)
+func GetQoSClassByAttrs(labels, annotations map[string]string) QoSClass {
+	// annotations are for old format adaption reason
+	if q, exist := labels[LabelPodQoS]; exist {
+		return GetPodQoSClassByName(q)
+	}
+	return QoSNone
+}

--- a/apis/extension/qos_utils_test.go
+++ b/apis/extension/qos_utils_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPodQoSClass(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *corev1.Pod
+		want QoSClass
+	}{
+		{
+			name: "koord qos class not specified",
+			arg:  &corev1.Pod{},
+			want: QoSNone,
+		},
+		{
+			name: "koord qos class not specified 1",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			want: QoSNone,
+		},
+		{
+			name: "qos LS",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodQoS: string(QoSLS),
+					},
+				},
+			},
+			want: QoSLS,
+		},
+		{
+			name: "qos BE",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodQoS: string(QoSBE),
+					},
+				},
+			},
+			want: QoSBE,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodQoSClass(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetQoSClassByAttrs(t *testing.T) {
+	type args struct {
+		labels      map[string]string
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want QoSClass
+	}{
+		{
+			name: "koord qos class not specified",
+			args: args{
+				labels: map[string]string{},
+			},
+			want: QoSNone,
+		},
+		{
+			name: "qos BE",
+			args: args{
+				labels: map[string]string{
+					LabelPodQoS: string(QoSBE),
+				},
+			},
+			want: QoSBE,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetQoSClassByAttrs(tt.args.labels, tt.args.annotations)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. Move QoS utility functions into another file for extensions. (e.g. customize the annotation of pod QoS)
2. Revise some comments in the API package.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
