### PR TITLE
koordlet:move audit log to resource executor after resource update

### DIFF
--- a/pkg/koordlet/resmanager/cgroup_reconcile.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile.go
@@ -26,6 +26,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resmanager/configextensions"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
@@ -506,9 +507,11 @@ func makeCgroupResources(parentDir string, summary *cgroupResourceSummary) []res
 		var r resourceexecutor.ResourceUpdater
 		var err error
 		if t.isMergeable {
-			r, err = resourceexecutor.NewMergeableCgroupUpdaterIfValueLarger(t.resourceType, parentDir, valueStr)
+			eventHelper := audit.V(3).Reason("cgroup reconcile").Message("update calculated mergeable mem resources: %v to : %v", t.resourceType, valueStr)
+			r, err = resourceexecutor.NewMergeableCgroupUpdaterIfValueLarger(t.resourceType, parentDir, valueStr, eventHelper)
 		} else {
-			r, err = resourceexecutor.NewCommonCgroupUpdater(t.resourceType, parentDir, valueStr)
+			eventHelper := audit.V(3).Reason("cgroup reconcile").Message("update calculated mem resources: %v to : %v", t.resourceType, valueStr)
+			r, err = resourceexecutor.NewCommonCgroupUpdater(t.resourceType, parentDir, valueStr, eventHelper)
 		}
 
 		if err != nil {

--- a/pkg/koordlet/resmanager/cgroup_reconcile_test.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile_test.go
@@ -1386,9 +1386,9 @@ func createCgroupResourceUpdater(t *testing.T, resourceType system.ResourceType,
 	var u resourceexecutor.ResourceUpdater
 	var err error
 	if isMergeable {
-		u, err = resourceexecutor.NewMergeableCgroupUpdaterIfValueLarger(resourceType, parentDir, value)
+		u, err = resourceexecutor.NewMergeableCgroupUpdaterIfValueLarger(resourceType, parentDir, value, nil)
 	} else {
-		u, err = resourceexecutor.NewCommonCgroupUpdater(resourceType, parentDir, value)
+		u, err = resourceexecutor.NewCommonCgroupUpdater(resourceType, parentDir, value, nil)
 	}
 	assert.NoError(t, err)
 	return u
@@ -1408,6 +1408,8 @@ func assertCgroupResourceEqual(t *testing.T, expect, got []resourceexecutor.Reso
 		// assert not support func arguments
 		e.SetUpdateFunc(nil, nil)
 		g.SetUpdateFunc(nil, nil)
+		// set expect eventhelper like reality
+		e.SeteventHelper(g.GeteventHelper())
 		assert.Equal(t, e, g, fmt.Sprintf("check for index %v", i))
 	}
 }

--- a/pkg/koordlet/resmanager/cpu_suppress.go
+++ b/pkg/koordlet/resmanager/cpu_suppress.go
@@ -81,9 +81,10 @@ func (r *CPUSuppress) RunInit(stopCh <-chan struct{}) error {
 // writeBECgroupsCPUSet writes the be cgroups cpuset by order
 func (r *CPUSuppress) writeBECgroupsCPUSet(paths []string, cpusetStr string, isReversed bool) {
 	var updaters []resourceexecutor.ResourceUpdater
+	eventHelper := audit.V(3).Reason(resourceexecutor.AdjustBEByNodeCPUUsage).Message("update BE group to cpuset: %v", cpusetStr)
 	if isReversed {
 		for i := len(paths) - 1; i >= 0; i-- {
-			u, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUSetCPUSName, paths[i], cpusetStr)
+			u, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUSetCPUSName, paths[i], cpusetStr, eventHelper)
 			if err != nil {
 				klog.V(4).Infof("failed to get cpuset updater: path %s, err %s", paths[i], err)
 				continue
@@ -93,7 +94,7 @@ func (r *CPUSuppress) writeBECgroupsCPUSet(paths []string, cpusetStr string, isR
 		}
 	} else {
 		for i := range paths {
-			u, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUSetCPUSName, paths[i], cpusetStr)
+			u, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUSetCPUSName, paths[i], cpusetStr, eventHelper)
 			if err != nil {
 				klog.V(4).Infof("failed to get cpuset updater: path %s, err %s", paths[i], err)
 				continue
@@ -357,7 +358,6 @@ func (r *CPUSuppress) adjustByCPUSet(cpusetQuantity *resource.Quantity, nodeCPUI
 		klog.Warningf("suppressBECPU failed to apply be cpu suppress policy, err: %s", err)
 		return
 	}
-	_ = audit.V(1).Node().Reason(resourceexecutor.AdjustBEByNodeCPUUsage).Message("update BE group to cpuset: %v", beCPUSet).Do()
 	klog.Infof("suppressBECPU finished, suppress be cpu successfully: current cpuset %v", beCPUSet)
 }
 
@@ -435,7 +435,8 @@ func (r *CPUSuppress) adjustByCfsQuota(cpuQuantity *resource.Quantity, node *cor
 		newBeQuota = currentBeQuota + int64(beMaxIncreaseCPUQuota)
 	}
 
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUCFSQuotaName, beCgroupPath, strconv.FormatInt(newBeQuota, 10))
+	eventHelper := audit.V(3).Node().Reason(resourceexecutor.AdjustBEByNodeCPUUsage).Message("update BE group to cfs_quota: %v", newBeQuota)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUCFSQuotaName, beCgroupPath, strconv.FormatInt(newBeQuota, 10), eventHelper)
 	if err != nil {
 		klog.V(4).Infof("failed to get be cfs quota updater, err: %v", err)
 		return
@@ -457,7 +458,8 @@ func (r *CPUSuppress) recoverCFSQuotaIfNeed() {
 	}
 
 	beCgroupPath := koordletutil.GetPodQoSRelativePath(corev1.PodQOSBestEffort)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUCFSQuotaName, beCgroupPath, "-1")
+	eventHelper := audit.V(3).Reason("suppressBECPU").Message("recover bestEffort cfsQuota, isUpdated %v", "-1")
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUCFSQuotaName, beCgroupPath, "-1", eventHelper)
 	if err != nil {
 		klog.V(4).Infof("failed to get be cfs quota updater, err: %v", err)
 		return

--- a/pkg/koordlet/resmanager/system_config.go
+++ b/pkg/koordlet/resmanager/system_config.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
@@ -81,7 +82,8 @@ func caculateMemoryConfig(strategy *slov1alpha1.SystemStrategy, nodeMemory int64
 		if sysutil.ValidateResourceValue(&minFreeKbytes, "", sysutil.MinFreeKbytes) {
 			valueStr := strconv.FormatInt(minFreeKbytes, 10)
 			file := sysutil.MinFreeKbytes.Path("")
-			resource, err := resourceexecutor.NewCommonDefaultUpdater(file, file, valueStr)
+			eventHelper := audit.V(3).Node().Reason("systemConfig reconcile").Message("update calculated mem config min_free_kbytes to : %v", valueStr)
+			resource, err := resourceexecutor.NewCommonDefaultUpdater(file, file, valueStr, eventHelper)
 			if err != nil {
 				return resources
 			}
@@ -92,7 +94,8 @@ func caculateMemoryConfig(strategy *slov1alpha1.SystemStrategy, nodeMemory int64
 	if sysutil.ValidateResourceValue(strategy.WatermarkScaleFactor, "", sysutil.WatermarkScaleFactor) {
 		valueStr := strconv.FormatInt(*strategy.WatermarkScaleFactor, 10)
 		file := sysutil.WatermarkScaleFactor.Path("")
-		resource, err := resourceexecutor.NewCommonDefaultUpdater(file, file, valueStr)
+		eventHelper := audit.V(3).Node().Reason("systemConfig reconcile").Message("update calculated mem config watermark_scale_factor to : %v", valueStr)
+		resource, err := resourceexecutor.NewCommonDefaultUpdater(file, file, valueStr, eventHelper)
 		if err != nil {
 			return resources
 		}

--- a/pkg/koordlet/resourceexecutor/cgroup.go
+++ b/pkg/koordlet/resourceexecutor/cgroup.go
@@ -56,7 +56,7 @@ func cgroupFileWriteIfDifferent(cgroupTaskDir string, r sysutil.Resource, value 
 	if currentErr != nil {
 		return false, currentErr
 	}
-	if r.ResourceType() == sysutil.CPUSetCPUSName && IsEqualCpus(currentValue, value) {
+	if r.ResourceType() == sysutil.CPUSetCPUSName && cpuset.IsEqualStrCpus(currentValue, value) {
 		return false, nil
 	}
 	if value == currentValue || value == CgroupMaxValueStr && currentValue == CgroupMaxSymbolStr {
@@ -68,12 +68,6 @@ func cgroupFileWriteIfDifferent(cgroupTaskDir string, r sysutil.Resource, value 
 		return false, err
 	}
 	return true, nil
-}
-
-func IsEqualCpus(a, b string) bool {
-	cpus1, _ := cpuset.Parse(a)
-	cpus2, _ := cpuset.Parse(b)
-	return cpus1.Equals(cpus2)
 }
 
 // CgroupFileWrite writes the cgroup file with the given value.

--- a/pkg/koordlet/resourceexecutor/cgroup_test.go
+++ b/pkg/koordlet/resourceexecutor/cgroup_test.go
@@ -37,6 +37,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
+		want    bool
 		wantErr bool
 	}{
 		{
@@ -47,6 +48,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 				value:         "1024",
 				currentValue:  "1024",
 			},
+			want:    false,
 			wantErr: false,
 		},
 		{
@@ -57,6 +59,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 				value:         "1024",
 				currentValue:  "512",
 			},
+			want:    true,
 			wantErr: false,
 		},
 	}
@@ -65,10 +68,11 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 			helper := sysutil.NewFileTestUtil(t)
 			helper.CreateCgroupFile(taskDir, tt.args.resource)
 
-			err := cgroupFileWrite(taskDir, tt.args.resource, tt.args.currentValue)
+			err := cgroupFileWrite(taskDir, tt.args.resource, tt.args.value)
 			assert.NoError(t, err)
 
-			gotErr := cgroupFileWriteIfDifferent(taskDir, tt.args.resource, tt.args.currentValue)
+			got, gotErr := cgroupFileWriteIfDifferent(taskDir, tt.args.resource, tt.args.currentValue)
+			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantErr, gotErr != nil)
 		})
 	}

--- a/pkg/koordlet/resourceexecutor/executor_test.go
+++ b/pkg/koordlet/resourceexecutor/executor_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util/cache"
 )
@@ -48,9 +49,9 @@ func TestNewResourceUpdateExecutor_Run(t *testing.T) {
 }
 
 func TestResourceUpdateExecutor_Update(t *testing.T) {
-	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1")
+	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1", &audit.EventHelper{})
 	assert.NoError(t, err)
-	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576")
+	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576", &audit.EventHelper{})
 	assert.NoError(t, err)
 	type fields struct {
 		notStarted bool
@@ -139,9 +140,9 @@ func TestResourceUpdateExecutor_Update(t *testing.T) {
 }
 
 func TestResourceUpdateExecutor_UpdateBatch(t *testing.T) {
-	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1")
+	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1", &audit.EventHelper{})
 	assert.NoError(t, err)
-	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576")
+	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576", &audit.EventHelper{})
 	assert.NoError(t, err)
 	type fields struct {
 		notStarted bool

--- a/pkg/koordlet/resourceexecutor/updater_test.go
+++ b/pkg/koordlet/resourceexecutor/updater_test.go
@@ -89,7 +89,7 @@ func TestNewCommonCgroupUpdater(t *testing.T) {
 			defer helper.Cleanup()
 			helper.SetCgroupsV2(tt.fields.UseCgroupsV2)
 
-			got, gotErr := NewCommonCgroupUpdater(tt.args.resourceType, tt.args.parentDir, tt.args.value)
+			got, gotErr := NewCommonCgroupUpdater(tt.args.resourceType, tt.args.parentDir, tt.args.value, nil)
 			if !tt.wantErr {
 				assert.NotNil(t, got)
 				assert.Equal(t, tt.want.ResourceType(), got.ResourceType())
@@ -162,7 +162,7 @@ func TestCgroupResourceUpdater_Update(t *testing.T) {
 			defer helper.Cleanup()
 			helper.SetCgroupsV2(tt.fields.UseCgroupsV2)
 
-			u, gotErr := NewCommonCgroupUpdater(tt.args.resourceType, tt.args.parentDir, tt.args.value)
+			u, gotErr := NewCommonCgroupUpdater(tt.args.resourceType, tt.args.parentDir, tt.args.value, nil)
 			assert.NoError(t, gotErr)
 			c, ok := u.(*CgroupResourceUpdater)
 			assert.True(t, ok)
@@ -238,7 +238,7 @@ func TestDefaultResourceUpdater_Update(t *testing.T) {
 			defer helper.Cleanup()
 
 			file := filepath.Join(helper.TempDir, tt.args.subDir, tt.args.file)
-			u, gotErr := NewCommonDefaultUpdater(file, file, tt.args.value)
+			u, gotErr := NewCommonDefaultUpdater(file, file, tt.args.value, nil)
 			assert.NoError(t, gotErr)
 			_, ok := u.(*DefaultResourceUpdater)
 			assert.True(t, ok)

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
@@ -133,14 +133,13 @@ func (b *bvtPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		corev1.PodQOSGuaranteed, corev1.PodQOSBurstable, corev1.PodQOSBestEffort} {
 		bvtValue := r.getKubeQOSDirBvtValue(kubeQOS)
 		kubeQOSCgroupPath := koordletutil.GetPodQoSRelativePath(kubeQOS)
-		bvtUpdater, err := resourceexecutor.NewCommonCgroupUpdater(sysutil.CPUBVTWarpNsName, kubeQOSCgroupPath, strconv.FormatInt(bvtValue, 10))
+		e := audit.V(3).Group(string(kubeQOS)).Reason(name).Message("set bvt to %v", bvtValue)
+		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, kubeQOSCgroupPath, strconv.FormatInt(bvtValue, 10), e)
 		if err != nil {
-			klog.Infof("bvtupdater creat failed, dir %v, error %v", kubeQOSCgroupPath, err)
+			klog.Infof("bvtupdater create failed, dir %v, error %v", kubeQOSCgroupPath, err)
 		}
-		if _, err := b.executor.Update(false, bvtUpdater); err != nil {
+		if _, err := b.executor.Update(true, bvtUpdater); err != nil {
 			klog.Infof("update kube qos %v cpu bvt failed, dir %v, error %v", kubeQOS, kubeQOSCgroupPath, err)
-		} else {
-			audit.V(2).Group(string(kubeQOS)).Reason(name).Message("set bvt to %v", bvtValue)
 		}
 	}
 	for _, podMeta := range pods {
@@ -148,15 +147,14 @@ func (b *bvtPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		podKubeQOS := podMeta.Pod.Status.QOSClass
 		podBvt := r.getPodBvtValue(podQOS, podKubeQOS)
 		podCgroupPath := koordletutil.GetPodCgroupDirWithKube(podMeta.CgroupDir)
-		bvtUpdater, err := resourceexecutor.NewCommonCgroupUpdater(sysutil.CPUBVTWarpNsName, podCgroupPath, strconv.FormatInt(podBvt, 10))
+		e := audit.V(3).Pod(podMeta.Pod.Namespace, podMeta.Pod.Name).Reason(name).Message("set bvt to %v", podBvt)
+		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, podCgroupPath, strconv.FormatInt(podBvt, 10), e)
 		if err != nil {
 			klog.Infof("bvtupdater create failed, dir %v, error %v", podCgroupPath, err)
 		}
-		if _, err := b.executor.Update(false, bvtUpdater); err != nil {
+		if _, err := b.executor.Update(true, bvtUpdater); err != nil {
 			klog.Infof("update pod %s cpu bvt failed, dir %v, error %v",
 				util.GetPodKey(podMeta.Pod), podCgroupPath, err)
-		} else {
-			audit.V(2).Pod(podMeta.Pod.Namespace, podMeta.Pod.Name).Reason(name).Message("set bvt to %v", podBvt).Do()
 		}
 	}
 	return nil

--- a/pkg/koordlet/runtimehooks/protocol/container_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/container_context.go
@@ -172,7 +172,9 @@ func (c *ContainerContext) ReconcilerDone(executor resourceexecutor.ResourceUpda
 
 func (c *ContainerContext) injectForOrigin() {
 	if c.Response.Resources.CPUShares != nil {
-		if err := injectCPUShares(c.Request.CgroupParent, *c.Response.Resources.CPUShares, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container cpu share to %v", *c.Response.Resources.CPUShares)
+		if err := injectCPUShares(c.Request.CgroupParent, *c.Response.Resources.CPUShares, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v cpu share %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CPUShares, c.Request.CgroupParent, err)
 		} else {
@@ -184,7 +186,8 @@ func (c *ContainerContext) injectForOrigin() {
 		}
 	}
 	if c.Response.Resources.CPUSet != nil {
-		err := injectCPUSet(c.Request.CgroupParent, *c.Response.Resources.CPUSet, c.executor)
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message("set container cpuset to %v", *c.Response.Resources.CPUSet)
+		err := injectCPUSet(c.Request.CgroupParent, *c.Response.Resources.CPUSet, eventHelper, c.executor)
 		if err != nil && resourceexecutor.IsCgroupDirErr(err) {
 			klog.V(5).Infof("set container %v/%v/%v cpuset %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CPUSet, c.Request.CgroupParent, err)
@@ -195,32 +198,30 @@ func (c *ContainerContext) injectForOrigin() {
 			klog.V(5).Infof("set container %v/%v/%v cpuset %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.CPUSet, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container cpuset to %v", *c.Response.Resources.CPUSet).Do()
 		}
 	}
 	if c.Response.Resources.CFSQuota != nil {
-		if err := injectCPUQuota(c.Request.CgroupParent, *c.Response.Resources.CFSQuota, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container cfs quota to %v", *c.Response.Resources.CFSQuota)
+		if err := injectCPUQuota(c.Request.CgroupParent, *c.Response.Resources.CFSQuota, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v cfs quota %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CFSQuota, c.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set container %v/%v/%v cfs quota %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.CFSQuota, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container cfs quota to %v", *c.Response.Resources.CFSQuota).Do()
 		}
 	}
 	if c.Response.Resources.MemoryLimit != nil {
-		if err := injectMemoryLimit(c.Request.CgroupParent, *c.Response.Resources.MemoryLimit, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container memory limit to %v", *c.Response.Resources.MemoryLimit)
+		if err := injectMemoryLimit(c.Request.CgroupParent, *c.Response.Resources.MemoryLimit, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v memory limit %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.MemoryLimit, c.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set container %v/%v/%v memory limit %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.MemoryLimit, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container memory limit to %v", *c.Response.Resources.MemoryLimit).Do()
 		}
 	}
 	// TODO other fields

--- a/pkg/koordlet/runtimehooks/protocol/kubeqos_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/kubeqos_context.go
@@ -63,14 +63,14 @@ func (p *KubeQOSContext) injectForOrigin() {
 
 func (p *KubeQOSContext) injectForExt() {
 	if p.Response.Resources.CPUBvt != nil {
-		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, p.executor); err != nil {
+		eventHelper := audit.V(3).Group(string(p.Request.KubeQOSClass)).Reason("runtime-hooks").Message(
+			"set kubeqos bvt to %v", *p.Response.Resources.CPUBvt)
+		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, eventHelper, p.executor); err != nil {
 			klog.Infof("set kubeqos %v bvt %v on cgroup parent %v failed, error %v", p.Request.KubeQOSClass,
 				*p.Response.Resources.CPUBvt, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set kubeqos %v bvt %v on cgroup parent %v", p.Request.KubeQOSClass,
 				*p.Response.Resources.CPUBvt, p.Request.CgroupParent)
-			audit.V(2).Group(string(p.Request.KubeQOSClass)).Reason("runtime-hooks").Message(
-				"set kubeqos bvt to %v", *p.Response.Resources.CPUBvt).Do()
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -149,49 +149,49 @@ func (p *PodContext) injectForOrigin() {
 
 func (p *PodContext) injectForExt() {
 	if p.Response.Resources.CPUBvt != nil {
-		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod bvt to %v", *p.Response.Resources.CPUBvt)
+		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v bvt %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUBvt, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v bvt %v on cgroup parent %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUBvt, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod bvt to %v", *p.Response.Resources.CPUBvt).Do()
 		}
 	}
 	// some of pod-level cgroups are manually updated since pod-stage hooks do not support it;
 	// kubelet may set the cgroups when pod is created or restarted, so we need to update the cgroups repeatedly
 	if p.Response.Resources.CPUShares != nil {
-		if err := injectCPUShares(p.Request.CgroupParent, *p.Response.Resources.CPUShares, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod cpu shares to %v", *p.Response.Resources.CPUShares)
+		if err := injectCPUShares(p.Request.CgroupParent, *p.Response.Resources.CPUShares, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v cpu shares %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v cpu shares %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod cpu shares to %v", *p.Response.Resources.CPUShares).Do()
 		}
 	}
 	if p.Response.Resources.CFSQuota != nil {
-		if err := injectCPUQuota(p.Request.CgroupParent, *p.Response.Resources.CFSQuota, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod cfs quota to %v", *p.Response.Resources.CFSQuota)
+		if err := injectCPUQuota(p.Request.CgroupParent, *p.Response.Resources.CFSQuota, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v cfs quota %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v cfs quota %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod cfs quota to %v", *p.Response.Resources.CFSQuota).Do()
 		}
 	}
 	if p.Response.Resources.MemoryLimit != nil {
-		if err := injectMemoryLimit(p.Request.CgroupParent, *p.Response.Resources.MemoryLimit, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod memory limit to %v", *p.Response.Resources.MemoryLimit)
+		if err := injectMemoryLimit(p.Request.CgroupParent, *p.Response.Resources.MemoryLimit, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v memory limit %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v memory limit %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod memory limit to %v", *p.Response.Resources.MemoryLimit).Do()
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/protocol/protocol.go
+++ b/pkg/koordlet/runtimehooks/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
@@ -69,9 +70,9 @@ func (r *Resources) IsOriginResSet() bool {
 	return r.CPUShares != nil || r.CFSQuota != nil || r.CPUSet != nil || r.MemoryLimit != nil
 }
 
-func injectCPUShares(cgroupParent string, cpuShares int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUShares(cgroupParent string, cpuShares int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	cpuShareStr := strconv.FormatInt(cpuShares, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSharesName, cgroupParent, cpuShareStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSharesName, cgroupParent, cpuShareStr, a)
 	if err != nil {
 		return err
 	}
@@ -79,8 +80,8 @@ func injectCPUShares(cgroupParent string, cpuShares int64, e resourceexecutor.Re
 	return err
 }
 
-func injectCPUSet(cgroupParent string, cpuset string, e resourceexecutor.ResourceUpdateExecutor) error {
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSetCPUSName, cgroupParent, cpuset)
+func injectCPUSet(cgroupParent string, cpuset string, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSetCPUSName, cgroupParent, cpuset, a)
 	if err != nil {
 		return err
 	}
@@ -88,9 +89,9 @@ func injectCPUSet(cgroupParent string, cpuset string, e resourceexecutor.Resourc
 	return err
 }
 
-func injectCPUQuota(cgroupParent string, cpuQuota int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUQuota(cgroupParent string, cpuQuota int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	cpuQuotaStr := strconv.FormatInt(cpuQuota, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, cgroupParent, cpuQuotaStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, cgroupParent, cpuQuotaStr, a)
 	if err != nil {
 		return err
 	}
@@ -98,9 +99,9 @@ func injectCPUQuota(cgroupParent string, cpuQuota int64, e resourceexecutor.Reso
 	return err
 }
 
-func injectMemoryLimit(cgroupParent string, memoryLimit int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectMemoryLimit(cgroupParent string, memoryLimit int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	memoryLimitStr := strconv.FormatInt(memoryLimit, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, cgroupParent, memoryLimitStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, cgroupParent, memoryLimitStr, a)
 	if err != nil {
 		return err
 	}
@@ -108,9 +109,9 @@ func injectMemoryLimit(cgroupParent string, memoryLimit int64, e resourceexecuto
 	return err
 }
 
-func injectCPUBvt(cgroupParent string, bvtValue int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUBvt(cgroupParent string, bvtValue int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	bvtValueStr := strconv.FormatInt(bvtValue, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupParent, bvtValueStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupParent, bvtValueStr, a)
 	if err != nil {
 		return err
 	}

--- a/pkg/koordlet/util/system/common.go
+++ b/pkg/koordlet/util/system/common.go
@@ -36,16 +36,19 @@ func CommonFileRead(file string) (string, error) {
 	return strings.Trim(string(data), "\n"), err
 }
 
-func CommonFileWriteIfDifferent(file string, value string) error {
+func CommonFileWriteIfDifferent(file string, value string) (bool, error) {
 	currentValue, err := CommonFileRead(file)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if value == currentValue {
 		klog.Infof("resource currentValue equal newValue, skip update resource! file:%s, value %s", file, value)
-		return nil
+		return false, nil
 	}
-	return CommonFileWrite(file, value)
+	if err := CommonFileWrite(file, value); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func CommonFileWrite(file string, data string) error {

--- a/pkg/util/cpuset/cpuset.go
+++ b/pkg/util/cpuset/cpuset.go
@@ -364,3 +364,12 @@ func Parse(s string) (CPUSet, error) {
 	}
 	return b.Result(), nil
 }
+
+func IsEqualStrCpus(a, b string) bool {
+	cpus1, err1 := Parse(a)
+	cpus2, err2 := Parse(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return cpus1.Equals(cpus2)
+}

--- a/pkg/util/cpuset/cpuset_test.go
+++ b/pkg/util/cpuset/cpuset_test.go
@@ -334,6 +334,7 @@ func TestParse(t *testing.T) {
 		{"1,2,3,4,5", NewCPUSet(1, 2, 3, 4, 5), false},
 		{"1-5", NewCPUSet(1, 2, 3, 4, 5), false},
 		{"1-2,3-5", NewCPUSet(1, 2, 3, 4, 5), false},
+		{"3-5,1-2", NewCPUSet(1, 2, 3, 4, 5), false},
 		{"1-3-4", NewCPUSet(), true},
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
to solve the problem of duplicate audit logs by moving it to the executor module after resource update
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes #1018
The audit log redundancy issue has been addressed by leveraging the executor's built-in cache, which has changed the recording frequency from 10 seconds to 60 seconds. Meanwhile, the adjustbecpuset policy execution shows frequent CPU rebinding , both klog and audit log will print.

![截屏2023-03-10 10 15 44](https://user-images.githubusercontent.com/32286753/224206223-8edb915e-ec76-44a9-89b4-76e02ed14df7.png)

and klog shows here

![截屏2023-03-10 10 44 33](https://user-images.githubusercontent.com/32286753/224210101-817a20e1-8de6-4e37-b1eb-6cbeccdc6079.png)

and i will start a new issue since it looks like we need to modify the function applyCPUSetWithNonePolicy(beCPUSet, oldCPUSet) to improve the stability of CPUs for the BE Group's calculation policy.

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
