### PR TITLE
koord-descheduler: dry-run evict pod to avoid unnecessary reservation creation

### DIFF
--- a/apis/scheduling/v1alpha1/pod_migration_job_types.go
+++ b/apis/scheduling/v1alpha1/pod_migration_job_types.go
@@ -169,6 +169,7 @@ const (
 
 // These are valid reasons of PodMigrationJob.
 const (
+	PodMigrationJobReasonDryRunEvictFailed         = "DryRunEvictFailed"
 	PodMigrationJobReasonTimeout                   = "Timeout"
 	PodMigrationJobReasonFailedCreateReservation   = "FailedCreateReservation"
 	PodMigrationJobReasonReservationExpired        = "ReservationExpired"

--- a/pkg/descheduler/controllers/migration/filter.go
+++ b/pkg/descheduler/controllers/migration/filter.go
@@ -149,6 +149,9 @@ func (r *Reconciler) filterMaxMigratingOrUnavailablePerWorkload(pod *corev1.Pod)
 	if err != nil {
 		return false
 	}
+	if expectedReplicas == 0 {
+		return true
+	}
 
 	maxMigrating, err := util.GetMaxMigrating(int(expectedReplicas), r.args.MaxMigratingPerWorkload)
 	if err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR provides a more practicable approach to avoid unnecessary reservation creation. PodMigrationJob will dry run evict pod before create reservation. If dry run failed, abort the job.

### Ⅱ. Does this pull request fix one issue?

Fix https://github.com/koordinator-sh/koordinator/issues/1034

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
