### PR TITLE
koord-descheduler: support to configure eviction filter separately

### DIFF
--- a/pkg/descheduler/apis/config/types.go
+++ b/pkg/descheduler/apis/config/types.go
@@ -79,7 +79,8 @@ type DeschedulerProfile struct {
 type Plugins struct {
 	Deschedule PluginSet
 	Balance    PluginSet
-	Evictor    PluginSet
+	Evict      PluginSet
+	Filter     PluginSet
 }
 
 type PluginSet struct {

--- a/pkg/descheduler/apis/config/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/types_pluginargs.go
@@ -46,12 +46,22 @@ type MigrationControllerArgs struct {
 	// IgnorePVCPods prevents pods with PVCs from being evicted.
 	IgnorePvcPods bool
 
+	// PriorityThreshold filtering only pods under the threshold can be evicted
+	PriorityThreshold *PriorityThreshold
+
 	// LabelSelector sets whether to apply label filtering when evicting.
 	// Any pod matching the label selector is considered evictable.
 	LabelSelector *metav1.LabelSelector
 
 	// Namespaces carries a list of included/excluded namespaces
 	Namespaces *Namespaces
+
+	// NodeFit if enabled, it will check whether the candidate Pods have suitable nodes,
+	// including NodeAffinity, TaintTolerance, and whether resources are sufficient.
+	NodeFit bool
+
+	// NodeSelector for a set of nodes to operate over
+	NodeSelector string
 
 	// MaxMigratingPerNode represents he maximum number of pods that can be migrating during migrate per node.
 	MaxMigratingPerNode *int32

--- a/pkg/descheduler/apis/config/v1alpha2/default_plugins.go
+++ b/pkg/descheduler/apis/config/v1alpha2/default_plugins.go
@@ -31,7 +31,12 @@ func getDefaultPlugins() *Plugins {
 				// NOTE: add default deschedule plugins here.
 			},
 		},
-		Evictor: PluginSet{
+		Evict: PluginSet{
+			Enabled: []Plugin{
+				{Name: names.MigrationController},
+			},
+		},
+		Filter: PluginSet{
 			Enabled: []Plugin{
 				{Name: names.MigrationController},
 			},
@@ -48,7 +53,8 @@ func mergePlugins(defaultPlugins, customPlugins *Plugins) *Plugins {
 
 	defaultPlugins.Deschedule = mergePluginSet(defaultPlugins.Deschedule, customPlugins.Deschedule)
 	defaultPlugins.Balance = mergePluginSet(defaultPlugins.Balance, customPlugins.Balance)
-	defaultPlugins.Evictor = mergePluginSet(defaultPlugins.Evictor, customPlugins.Evictor)
+	defaultPlugins.Evict = mergePluginSet(defaultPlugins.Evict, customPlugins.Evict)
+	defaultPlugins.Filter = mergePluginSet(defaultPlugins.Filter, customPlugins.Filter)
 	return defaultPlugins
 }
 

--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -67,7 +67,8 @@ func pluginsNames(p *Plugins) []string {
 	extensions := []PluginSet{
 		p.Deschedule,
 		p.Balance,
-		p.Evictor,
+		p.Evict,
+		p.Filter,
 	}
 	n := sets.NewString()
 	for _, e := range extensions {

--- a/pkg/descheduler/apis/config/v1alpha2/types.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types.go
@@ -108,7 +108,8 @@ type DeschedulerProfile struct {
 type Plugins struct {
 	Deschedule PluginSet `json:"deschedule,omitempty"`
 	Balance    PluginSet `json:"balance,omitempty"`
-	Evictor    PluginSet `json:"evict,omitempty"`
+	Evict      PluginSet `json:"evict,omitempty"`
+	Filter     PluginSet `json:"filter,omitempty"`
 }
 
 type PluginSet struct {

--- a/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
@@ -48,12 +48,22 @@ type MigrationControllerArgs struct {
 	// IgnorePVCPods prevents pods with PVCs from being evicted.
 	IgnorePvcPods bool `json:"ignorePvcPods"`
 
+	// PriorityThreshold filtering only pods under the threshold can be evicted
+	PriorityThreshold *PriorityThreshold `json:"priorityThreshold,omitempty"`
+
 	// LabelSelector sets whether to apply label filtering when evicting.
 	// Any pod matching the label selector is considered evictable.
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	// Namespaces carries a list of included/excluded namespaces
 	Namespaces *Namespaces `json:"namespaces,omitempty"`
+
+	// NodeFit if enabled, it will check whether the candidate Pods have suitable nodes,
+	// including NodeAffinity, TaintTolerance, and whether resources are sufficient.
+	NodeFit bool `json:"nodeFit,omitempty"`
+
+	// NodeSelector for a set of nodes to operate over
+	NodeSelector string `json:"nodeSelector,omitempty"`
 
 	// MaxMigratingPerNode represents he maximum number of pods that can be migrating during migrate per node.
 	MaxMigratingPerNode *int32 `json:"maxMigratingPerNode,omitempty"`

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -419,8 +419,11 @@ func autoConvert_v1alpha2_MigrationControllerArgs_To_config_MigrationControllerA
 	out.EvictLocalStoragePods = in.EvictLocalStoragePods
 	out.EvictSystemCriticalPods = in.EvictSystemCriticalPods
 	out.IgnorePvcPods = in.IgnorePvcPods
+	out.PriorityThreshold = (*config.PriorityThreshold)(unsafe.Pointer(in.PriorityThreshold))
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
 	out.Namespaces = (*config.Namespaces)(unsafe.Pointer(in.Namespaces))
+	out.NodeFit = in.NodeFit
+	out.NodeSelector = in.NodeSelector
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))
 	out.MaxMigratingPerWorkload = (*intstr.IntOrString)(unsafe.Pointer(in.MaxMigratingPerWorkload))
@@ -453,8 +456,11 @@ func autoConvert_config_MigrationControllerArgs_To_v1alpha2_MigrationControllerA
 	out.EvictLocalStoragePods = in.EvictLocalStoragePods
 	out.EvictSystemCriticalPods = in.EvictSystemCriticalPods
 	out.IgnorePvcPods = in.IgnorePvcPods
+	out.PriorityThreshold = (*PriorityThreshold)(unsafe.Pointer(in.PriorityThreshold))
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
 	out.Namespaces = (*Namespaces)(unsafe.Pointer(in.Namespaces))
+	out.NodeFit = in.NodeFit
+	out.NodeSelector = in.NodeSelector
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))
 	out.MaxMigratingPerWorkload = (*intstr.IntOrString)(unsafe.Pointer(in.MaxMigratingPerWorkload))
@@ -597,7 +603,10 @@ func autoConvert_v1alpha2_Plugins_To_config_Plugins(in *Plugins, out *config.Plu
 	if err := Convert_v1alpha2_PluginSet_To_config_PluginSet(&in.Balance, &out.Balance, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha2_PluginSet_To_config_PluginSet(&in.Evictor, &out.Evictor, s); err != nil {
+	if err := Convert_v1alpha2_PluginSet_To_config_PluginSet(&in.Evict, &out.Evict, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha2_PluginSet_To_config_PluginSet(&in.Filter, &out.Filter, s); err != nil {
 		return err
 	}
 	return nil
@@ -615,7 +624,10 @@ func autoConvert_config_Plugins_To_v1alpha2_Plugins(in *config.Plugins, out *Plu
 	if err := Convert_config_PluginSet_To_v1alpha2_PluginSet(&in.Balance, &out.Balance, s); err != nil {
 		return err
 	}
-	if err := Convert_config_PluginSet_To_v1alpha2_PluginSet(&in.Evictor, &out.Evictor, s); err != nil {
+	if err := Convert_config_PluginSet_To_v1alpha2_PluginSet(&in.Evict, &out.Evict, s); err != nil {
+		return err
+	}
+	if err := Convert_config_PluginSet_To_v1alpha2_PluginSet(&in.Filter, &out.Filter, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -254,6 +254,11 @@ func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PriorityThreshold != nil {
+		in, out := &in.PriorityThreshold, &out.PriorityThreshold
+		*out = new(PriorityThreshold)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
 		*out = new(v1.LabelSelector)
@@ -466,7 +471,8 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	*out = *in
 	in.Deschedule.DeepCopyInto(&out.Deschedule)
 	in.Balance.DeepCopyInto(&out.Balance)
-	in.Evictor.DeepCopyInto(&out.Evictor)
+	in.Evict.DeepCopyInto(&out.Evict)
+	in.Filter.DeepCopyInto(&out.Filter)
 	return
 }
 

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -225,6 +225,11 @@ func (in *LowNodeLoadPodSelector) DeepCopy() *LowNodeLoadPodSelector {
 func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.PriorityThreshold != nil {
+		in, out := &in.PriorityThreshold, &out.PriorityThreshold
+		*out = new(PriorityThreshold)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
 		*out = new(v1.LabelSelector)
@@ -430,7 +435,8 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	*out = *in
 	in.Deschedule.DeepCopyInto(&out.Deschedule)
 	in.Balance.DeepCopyInto(&out.Balance)
-	in.Evictor.DeepCopyInto(&out.Evictor)
+	in.Evict.DeepCopyInto(&out.Evict)
+	in.Filter.DeepCopyInto(&out.Filter)
 	return
 }
 

--- a/pkg/descheduler/controllers/migration/evict.go
+++ b/pkg/descheduler/controllers/migration/evict.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	deschedulerconfig "github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/descheduler/controllers/migration/evictor"
+	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"
+)
+
+// Evict evicts a pod
+func (r *Reconciler) Evict(ctx context.Context, pod *corev1.Pod, evictOptions framework.EvictOptions) bool {
+	framework.FillEvictOptionsFromContext(ctx, &evictOptions)
+
+	if r.args.DryRun {
+		klog.Infof("%s tries to evict Pod %q via dryRun mode since %s", evictOptions.PluginName, klog.KObj(pod), evictOptions.Reason)
+		return true
+	}
+
+	if !r.Filter(pod) {
+		klog.Errorf("Pod %q cannot be evicted since failed to filter", klog.KObj(pod))
+		return false
+	}
+
+	err := CreatePodMigrationJob(ctx, pod, evictOptions, r.Client, r.args)
+	return err == nil
+}
+
+func CreatePodMigrationJob(ctx context.Context, pod *corev1.Pod, evictOptions framework.EvictOptions, client client.Client, args *deschedulerconfig.MigrationControllerArgs) error {
+	if evictOptions.DeleteOptions == nil {
+		evictOptions.DeleteOptions = args.DefaultDeleteOptions
+	}
+	job := &sev1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(UUIDGenerateFn()),
+			Annotations: map[string]string{
+				evictor.AnnotationEvictReason:  evictOptions.Reason,
+				evictor.AnnotationEvictTrigger: evictOptions.PluginName,
+			},
+		},
+		Spec: sev1alpha1.PodMigrationJobSpec{
+			PodRef: &corev1.ObjectReference{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+				UID:       pod.UID,
+			},
+			Mode:          sev1alpha1.PodMigrationJobMode(args.DefaultJobMode),
+			TTL:           args.DefaultJobTTL.DeepCopy(),
+			DeleteOptions: evictOptions.DeleteOptions,
+		},
+		Status: sev1alpha1.PodMigrationJobStatus{
+			Phase: sev1alpha1.PodMigrationJobPending,
+		},
+	}
+
+	jobCtx := FromContext(ctx)
+	if err := jobCtx.ApplyTo(job); err != nil {
+		klog.Errorf("Failed to apply JobContext to PodMigrationJob for Pod %s/%s, err: %v", pod.Namespace, pod.Name, err)
+		return err
+	}
+
+	err := client.Create(ctx, job)
+	if err != nil {
+		klog.Errorf("Failed to create PodMigrationJob for Pod %s/s, err: %v", pod.Namespace, pod.Name, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/descheduler/framework/plugins/kubernetes/defaultevictor/evictor.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/defaultevictor/evictor.go
@@ -46,7 +46,8 @@ type DefaultEvictor struct {
 	evictor       *evictions.PodEvictor
 }
 
-var _ framework.Evictor = &DefaultEvictor{}
+var _ framework.EvictPlugin = &DefaultEvictor{}
+var _ framework.FilterPlugin = &DefaultEvictor{}
 var _ k8sdeschedulerframework.EvictorPlugin = &DefaultEvictor{}
 
 func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {

--- a/pkg/descheduler/framework/plugins/kubernetes/plugin_test.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/plugin_test.go
@@ -100,7 +100,8 @@ func (pl *TestPlugin) Balance(ctx context.Context, nodes []*corev1.Node) *k8sdes
 	return &k8sdeschedulerframework.Status{Err: errors.New(pl.args.Err)}
 }
 
-var _ framework.Evictor = &TestEvictorPlugin{}
+var _ framework.EvictPlugin = &TestEvictorPlugin{}
+var _ framework.FilterPlugin = &TestEvictorPlugin{}
 
 type TestEvictorPlugin struct {
 	handle framework.Handle
@@ -117,6 +118,10 @@ func (pl *TestEvictorPlugin) Name() string {
 }
 
 func (pl *TestEvictorPlugin) Filter(pod *corev1.Pod) bool {
+	return true
+}
+
+func (pl *TestEvictorPlugin) PreEvictionFilter(pod *corev1.Pod) bool {
 	return true
 }
 
@@ -164,7 +169,8 @@ func TestPluginDescriptor(t *testing.T) {
 		[]frameworktesting.RegisterPluginFunc{
 			func(reg *frameworkruntime.Registry, profile *deschedulerconfig.DeschedulerProfile) {
 				reg.Register(testEvictorPluginName, newTestEvictorPlugin)
-				profile.Plugins.Evictor.Enabled = append(profile.Plugins.Evictor.Enabled, deschedulerconfig.Plugin{Name: testEvictorPluginName})
+				profile.Plugins.Evict.Enabled = append(profile.Plugins.Evict.Enabled, deschedulerconfig.Plugin{Name: testEvictorPluginName})
+				profile.Plugins.Filter.Enabled = append(profile.Plugins.Filter.Enabled, deschedulerconfig.Plugin{Name: testEvictorPluginName})
 			},
 			func(reg *frameworkruntime.Registry, profile *deschedulerconfig.DeschedulerProfile) {
 				reg.Register(testPluginName, descriptor.New)

--- a/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
@@ -1001,7 +1001,8 @@ func TestLowNodeLoad(t *testing.T) {
 				[]frameworktesting.RegisterPluginFunc{
 					func(reg *frameworkruntime.Registry, profile *deschedulerconfig.DeschedulerProfile) {
 						reg.Register(defaultevictor.PluginName, defaultevictor.New)
-						profile.Plugins.Evictor.Enabled = append(profile.Plugins.Evictor.Enabled, deschedulerconfig.Plugin{Name: defaultevictor.PluginName})
+						profile.Plugins.Evict.Enabled = append(profile.Plugins.Evict.Enabled, deschedulerconfig.Plugin{Name: defaultevictor.PluginName})
+						profile.Plugins.Filter.Enabled = append(profile.Plugins.Filter.Enabled, deschedulerconfig.Plugin{Name: defaultevictor.PluginName})
 						profile.PluginConfig = append(profile.PluginConfig, deschedulerconfig.PluginConfig{
 							Name: defaultevictor.PluginName,
 							Args: &defaultevictor.DefaultEvictorArgs{},

--- a/pkg/descheduler/framework/runtime/framework_test.go
+++ b/pkg/descheduler/framework/runtime/framework_test.go
@@ -48,7 +48,8 @@ type injectedResult struct {
 
 type evictFilterFn func(pod *corev1.Pod) bool
 
-var _ framework.Evictor = &TestEvictorPlugin{}
+var _ framework.EvictPlugin = &TestEvictorPlugin{}
+var _ framework.FilterPlugin = &TestEvictorPlugin{}
 var _ framework.DeschedulePlugin = &TestEvictorPlugin{}
 
 type TestEvictorPlugin struct {
@@ -76,6 +77,10 @@ func (pl *TestEvictorPlugin) Filter(pod *corev1.Pod) bool {
 		}
 	}
 	return true
+}
+
+func (pl *TestEvictorPlugin) PreEvictionFilter(pod *corev1.Pod) bool {
+	return pl.Filter(pod)
 }
 
 func (pl *TestEvictorPlugin) Evict(ctx context.Context, pod *corev1.Pod, evictOptions framework.EvictOptions) bool {
@@ -156,7 +161,12 @@ func TestNewFramework(t *testing.T) {
 			profile: &deschedulerconfig.DeschedulerProfile{
 				Name: testProfileName,
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
+						Enabled: []deschedulerconfig.Plugin{
+							{Name: evictorPluginName},
+						},
+					},
+					Filter: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -190,7 +200,7 @@ func TestNewFramework(t *testing.T) {
 			profile: &deschedulerconfig.DeschedulerProfile{
 				Name: testProfileName,
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 							{Name: evictorPluginName1},
@@ -205,7 +215,7 @@ func TestNewFramework(t *testing.T) {
 			profile: &deschedulerconfig.DeschedulerProfile{
 				Name: testProfileName,
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -310,7 +320,7 @@ func TestRunDeschedulePlugins(t *testing.T) {
 					},
 				},
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -350,7 +360,7 @@ func TestRunDeschedulePlugins(t *testing.T) {
 					},
 				},
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -370,7 +380,7 @@ func TestRunDeschedulePlugins(t *testing.T) {
 			profile: &deschedulerconfig.DeschedulerProfile{
 				Name: testProfileName,
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -438,7 +448,7 @@ func TestRunBalancePlugins(t *testing.T) {
 					},
 				},
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -478,7 +488,7 @@ func TestRunBalancePlugins(t *testing.T) {
 					},
 				},
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},
@@ -498,7 +508,7 @@ func TestRunBalancePlugins(t *testing.T) {
 			profile: &deschedulerconfig.DeschedulerProfile{
 				Name: testProfileName,
 				Plugins: &deschedulerconfig.Plugins{
-					Evictor: deschedulerconfig.PluginSet{
+					Evict: deschedulerconfig.PluginSet{
 						Enabled: []deschedulerconfig.Plugin{
 							{Name: evictorPluginName},
 						},

--- a/pkg/descheduler/framework/testing/framework_helpers.go
+++ b/pkg/descheduler/framework/testing/framework_helpers.go
@@ -51,8 +51,12 @@ func RegisterBalancePlugin(pluginName string, pluginNewFunc runtime.PluginFactor
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Balance")
 }
 
-func RegisterEvictorPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
-	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Evictor")
+func RegisterEvictPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Evict")
+}
+
+func RegisterFilterPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Filter")
 }
 
 // RegisterPluginAsExtensions returns a function to register a Plugin as given extensionPoints to a given registry.
@@ -89,8 +93,10 @@ func getPluginSetByExtension(plugins *deschedulerconfig.Plugins, extension strin
 		return &plugins.Deschedule
 	case "Balance":
 		return &plugins.Balance
-	case "Evictor":
-		return &plugins.Evictor
+	case "Evict":
+		return &plugins.Evict
+	case "Filter":
+		return &plugins.Filter
 	default:
 		return nil
 	}

--- a/pkg/descheduler/profile/profile_test.go
+++ b/pkg/descheduler/profile/profile_test.go
@@ -50,7 +50,7 @@ func TestNewMap(t *testing.T) {
 						Deschedule: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{},
 						},
-						Evictor: deschedulerconfig.PluginSet{
+						Evict: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{
 								{Name: names.MigrationController},
 							},
@@ -78,7 +78,7 @@ func TestNewMap(t *testing.T) {
 						Deschedule: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{},
 						},
-						Evictor: deschedulerconfig.PluginSet{
+						Evict: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{
 								{Name: names.MigrationController},
 							},
@@ -90,7 +90,7 @@ func TestNewMap(t *testing.T) {
 						Deschedule: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{},
 						},
-						Evictor: deschedulerconfig.PluginSet{
+						Evict: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{
 								{Name: names.MigrationController},
 							},
@@ -109,7 +109,7 @@ func TestNewMap(t *testing.T) {
 						Deschedule: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{},
 						},
-						Evictor: deschedulerconfig.PluginSet{
+						Evict: deschedulerconfig.PluginSet{
 							Enabled: []deschedulerconfig.Plugin{
 								{Name: names.MigrationController},
 							},
@@ -158,11 +158,15 @@ func (p *fakePlugin) Name() string {
 	return p.name
 }
 
+func (p *fakePlugin) Evict(_ context.Context, _ *corev1.Pod, _ framework.EvictOptions) bool {
+	return false
+}
+
 func (p *fakePlugin) Filter(_ *corev1.Pod) bool {
 	return false
 }
 
-func (p *fakePlugin) Evict(_ context.Context, _ *corev1.Pod, _ framework.EvictOptions) bool {
+func (p *fakePlugin) PreEvictionFilter(_ *corev1.Pod) bool {
 	return false
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In the original implementation of koor-descheduler, the `Evict` extension point is responsible for evicting Pods and providing the `Evicition Filter` function. But in fact, `Evict` and `Filter` are an **orthogonal relationship**. There can only be one evictor in a descheduler (to be precise, there can only be one evictor in a descheduler profile), but there can be multiple eviction filters. The evictor can use these eviction filters. The evictor plugin itself can also implement eviction filters, such as the current PodMigrationJob controller. The PodMigrationJob controller can also continue splitting, using the configured eviction filters.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

The original configuration as following:
```yaml
apiVersion: descheduler/v1alpha2
kind: DeschedulerConfiguration
deschedulingInterval: 10s
profiles:
  - name: koord-descheduler
    plugins:
      evict:
        enabled:
          - name: MigrationController
      deschedule:
        enabled:
          - name: PodLifeTime
          - name: RemoveFailedPods
      balance:
        enabled:
          - name: LowNodeLoad
    pluginConfig:
      ....
```

Now we can configure evictionFilter as following:
```yaml
apiVersion: descheduler/v1alpha2
kind: DeschedulerConfiguration
deschedulingInterval: 10s
profiles:
  - name: koord-descheduler
    plugins:
      evict:
        enabled:
          - name: MigrationController
      filter:   # here we can configure the eviction filters.
        enabled:
          - name: MigrationController
      deschedule:
        enabled:
          - name: PodLifeTime
          - name: RemoveFailedPods
      balance:
        enabled:
          - name: LowNodeLoad
    pluginConfig:
      ...
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
