### PR TITLE
e2e: fix e2e BatchResource for custom namespace

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -188,6 +188,11 @@ type TestContextType struct {
 
 	// SnapshotControllerHTTPPort the port used for communicating with the snapshot controller HTTP endpoint.
 	SnapshotControllerHTTPPort int
+
+	// KoordinatorComponentNamespace is the namespace of the koordinator components deployed to.
+	KoordinatorComponentNamespace string
+	// SLOCtrlConfigMap is the name of the slo-controller configmap.
+	SLOCtrlConfigMap string
 }
 
 // NodeKillerConfig describes configuration of NodeKiller -- a utility to
@@ -326,6 +331,10 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 
 	flags.StringVar(&TestContext.SnapshotControllerPodName, "snapshot-controller-pod-name", "", "The pod name to use for identifying the snapshot controller in the kube-system namespace.")
 	flags.IntVar(&TestContext.SnapshotControllerHTTPPort, "snapshot-controller-http-port", 0, "The port to use for snapshot controller HTTP communication.")
+
+	// koordinator configs
+	flags.StringVar(&TestContext.KoordinatorComponentNamespace, "koordinator-component-namespace", "koordinator-system", "The namespace of the koordinator components deployed to.")
+	flags.StringVar(&TestContext.SLOCtrlConfigMap, "slo-config-name", "slo-controller-config", "The name of the slo-controller configmap.")
 }
 
 // RegisterClusterFlags registers flags specific to the cluster e2e test suite.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the e2e case BatchResource when the namespace and name of the slo-controller-config is customized.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
