### PR TITLE
koord-descheduler: allow annotated migrationJob pass filter

### DIFF
--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -351,8 +351,8 @@ func (ef *EvictorFilter) Filter(pod *corev1.Pod) bool {
 }
 
 // HaveEvictAnnotation checks if the pod have evict annotation
-func HaveEvictAnnotation(pod *corev1.Pod) bool {
-	_, found := pod.ObjectMeta.Annotations[evictPodAnnotationKey]
+func HaveEvictAnnotation(obj metav1.Object) bool {
+	_, found := obj.GetAnnotations()[evictPodAnnotationKey]
 	return found
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Sometimes I create a PodMigrationJob to migrate one Pod but cannot pass the internal filters, but I known the risk about the migration.

K8s descheduler supports passing filters with Pod which has annotation descheduler.alpha.kubernetes.io/evict,
and koord-descheduler also supports this annotation but unsupports the job. So we should support it.

### Ⅱ. Does this pull request fix one issue?

fixes #1084

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
