### PR TITLE
koordlet: merge extensions in nodeslo and add general util methods

### DIFF
--- a/pkg/koordlet/statesinformer/states_nodeslo.go
+++ b/pkg/koordlet/statesinformer/states_nodeslo.go
@@ -159,6 +159,14 @@ func (s *nodeSLOInformer) mergeNodeSLOSpec(nodeSLO *slov1alpha1.NodeSLO) {
 	if mergedSystemStrategySpec != nil {
 		s.nodeSLO.Spec.SystemStrategy = mergedSystemStrategySpec
 	}
+
+	// merge Extensions
+	mergedExtensions := mergeSLOSpecExtensions(util.DefaultNodeSLOSpecConfig().Extensions,
+		nodeSLO.Spec.Extensions)
+	if mergedExtensions != nil {
+		s.nodeSLO.Spec.Extensions = mergedExtensions
+	}
+
 }
 
 func newNodeSLOInformer(client koordclientset.Interface, nodeName string) cache.SharedIndexInformer {
@@ -227,6 +235,20 @@ func mergeSLOSpecCPUBurstStrategy(defaultSpec,
 func mergeSLOSpecSystemStrategy(defaultSpec,
 	newSpec *slov1alpha1.SystemStrategy) *slov1alpha1.SystemStrategy {
 	spec := &slov1alpha1.SystemStrategy{}
+	if newSpec != nil {
+		spec = newSpec
+	}
+	// ignore err for serializing/deserializing the same struct type
+	data, _ := json.Marshal(spec)
+	// NOTE: use deepcopy to avoid a overwrite to the global default
+	out := defaultSpec.DeepCopy()
+	_ = json.Unmarshal(data, &out)
+	return out
+}
+
+func mergeSLOSpecExtensions(defaultSpec,
+	newSpec *slov1alpha1.ExtensionsMap) *slov1alpha1.ExtensionsMap {
+	spec := &slov1alpha1.ExtensionsMap{}
 	if newSpec != nil {
 		spec = newSpec
 	}

--- a/pkg/koordlet/statesinformer/states_nodeslo_test.go
+++ b/pkg/koordlet/statesinformer/states_nodeslo_test.go
@@ -57,6 +57,7 @@ func Test_mergeNodeSLOSpec(t *testing.T) {
 		SystemStrategy: &slov1alpha1.SystemStrategy{
 			WatermarkScaleFactor: pointer.Int64Ptr(200),
 		},
+		Extensions: &slov1alpha1.ExtensionsMap{},
 	}
 	testingMergedNodeSLOSpec := util.DefaultNodeSLOSpecConfig()
 	mergedInterface, err := util.MergeCfg(&testingMergedNodeSLOSpec, &testingCustomNodeSLOSpec)

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -146,6 +146,7 @@ const (
 	MemoryLimitName            = "memory.limit_in_bytes"
 	MemoryUsageName            = "memory.usage_in_bytes"
 	MemoryStatName             = "memory.stat"
+	MemoryNumaStatName         = "memory.numa_stat"
 	MemoryWmarkRatioName       = "memory.wmark_ratio"
 	MemoryWmarkScaleFactorName = "memory.wmark_scale_factor"
 	MemoryWmarkMinAdjName      = "memory.wmark_min_adj"
@@ -205,6 +206,7 @@ var (
 	MemoryLimit            = DefaultFactory.New(MemoryLimitName, CgroupMemDir)
 	MemoryUsage            = DefaultFactory.New(MemoryUsageName, CgroupMemDir)
 	MemoryStat             = DefaultFactory.New(MemoryStatName, CgroupMemDir)
+	MemoryNumaStat         = DefaultFactory.New(MemoryNumaStatName, CgroupMemDir)
 	MemoryWmarkRatio       = DefaultFactory.New(MemoryWmarkRatioName, CgroupMemDir).WithValidator(MemoryWmarkRatioValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkRatioName, CgroupMemDir))
 	MemoryWmarkScaleFactor = DefaultFactory.New(MemoryWmarkScaleFactorName, CgroupMemDir).WithValidator(MemoryWmarkScaleFactorFileNameValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkScaleFactorName, CgroupMemDir))
 	MemoryWmarkMinAdj      = DefaultFactory.New(MemoryWmarkMinAdjName, CgroupMemDir).WithValidator(MemoryWmarkMinAdjValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkMinAdjName, CgroupMemDir))
@@ -237,6 +239,7 @@ var (
 		MemoryLimit,
 		MemoryUsage,
 		MemoryStat,
+		MemoryNumaStat,
 		MemoryWmarkRatio,
 		MemoryWmarkScaleFactor,
 		MemoryWmarkMinAdj,
@@ -270,6 +273,7 @@ var (
 	MemoryLimitV2            = DefaultFactory.NewV2(MemoryLimitName, MemoryMaxName)
 	MemoryUsageV2            = DefaultFactory.NewV2(MemoryUsageName, MemoryCurrentName)
 	MemoryStatV2             = DefaultFactory.NewV2(MemoryStatName, MemoryStatName)
+	MemoryNumaStatV2         = DefaultFactory.NewV2(MemoryNumaStatName, MemoryNumaStatName)
 	MemoryMinV2              = DefaultFactory.NewV2(MemoryMinName, MemoryMinName).WithValidator(NaturalInt64Validator)
 	MemoryLowV2              = DefaultFactory.NewV2(MemoryLowName, MemoryLowName).WithValidator(NaturalInt64Validator)
 	MemoryHighV2             = DefaultFactory.NewV2(MemoryHighName, MemoryHighName).WithValidator(NaturalInt64Validator)
@@ -297,6 +301,7 @@ var (
 		MemoryLimitV2,
 		MemoryUsageV2,
 		MemoryStatV2,
+		MemoryNumaStatV2,
 		MemoryMinV2,
 		MemoryLowV2,
 		MemoryHighV2,

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -24,6 +24,19 @@ import (
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 )
 
+var defautExtensions = &slov1alpha1.ExtensionsMap{}
+
+func getDefaultExtensionsMap() *slov1alpha1.ExtensionsMap {
+	return defautExtensions.DeepCopy()
+}
+
+func RegisterDefaultExtensionsMap(extKey string, extCfg interface{}) {
+	if defautExtensions.Object == nil {
+		defautExtensions.Object = make(map[string]interface{})
+	}
+	defautExtensions.Object[extKey] = extCfg
+}
+
 // DefaultNodeSLOSpecConfig defines the default config of the nodeSLOSpec, which would be used by the resmgr
 func DefaultNodeSLOSpecConfig() slov1alpha1.NodeSLOSpec {
 	return slov1alpha1.NodeSLOSpec{
@@ -31,6 +44,7 @@ func DefaultNodeSLOSpecConfig() slov1alpha1.NodeSLOSpec {
 		ResourceQOSStrategy:         DefaultResourceQOSStrategy(),
 		CPUBurstStrategy:            DefaultCPUBurstStrategy(),
 		SystemStrategy:              DefaultSystemStrategy(),
+		Extensions:                  DefaultExtensions(),
 	}
 }
 
@@ -270,4 +284,8 @@ func DefaultSystemStrategy() *slov1alpha1.SystemStrategy {
 		MinFreeKbytesFactor:  pointer.Int64Ptr(100), // 1 means 1/10000
 		WatermarkScaleFactor: pointer.Int64Ptr(150), // 1 means 1/10000
 	}
+}
+
+func DefaultExtensions() *slov1alpha1.ExtensionsMap {
+	return getDefaultExtensionsMap()
 }

--- a/pkg/util/config_test.go
+++ b/pkg/util/config_test.go
@@ -31,6 +31,7 @@ func Test_DefaultNodeSLOSpecConfig(t *testing.T) {
 		ResourceQOSStrategy:         DefaultResourceQOSStrategy(),
 		CPUBurstStrategy:            DefaultCPUBurstStrategy(),
 		SystemStrategy:              DefaultSystemStrategy(),
+		Extensions:                  DefaultExtensions(),
 	}
 	got := DefaultNodeSLOSpecConfig()
 	assert.Equal(t, expect, got)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- merge NodeSLOSpec.Extensions when updating nodeSLO
- add general method in koordlet/util, which allows to read NumaStat info in cgroup
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
