### PR TITLE
koordlet: move audit log to resource executor after resource update

### DIFF
--- a/pkg/koordlet/resourceexecutor/cgroup.go
+++ b/pkg/koordlet/resourceexecutor/cgroup.go
@@ -40,27 +40,30 @@ const EmptyValueError string = "EmptyValueError"
 const ErrCgroupDir = "cgroup path or file not exist"
 
 // CgroupFileWriteIfDifferent writes the cgroup file if current value is different from the given value.
-func cgroupFileWriteIfDifferent(cgroupTaskDir string, r sysutil.Resource, value string) error {
+func cgroupFileWriteIfDifferent(cgroupTaskDir string, r sysutil.Resource, value string) (bool, error) {
 	if supported, msg := r.IsSupported(cgroupTaskDir); !supported {
-		return sysutil.ResourceUnsupportedErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
+		return false, sysutil.ResourceUnsupportedErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
 	}
 	if valid, msg := r.IsValid(value); !valid {
-		return fmt.Errorf("write cgroup %s failed, value[%v] not valid, msg: %s", r.ResourceType(), value, msg)
+		return false, fmt.Errorf("write cgroup %s failed, value[%v] not valid, msg: %s", r.ResourceType(), value, msg)
 	}
 	if exist, msg := IsCgroupPathExist(cgroupTaskDir, r); !exist {
-		return ResourceCgroupDirErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
+		return false, ResourceCgroupDirErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
 	}
 
 	currentValue, currentErr := cgroupFileRead(cgroupTaskDir, r)
 	if currentErr != nil {
-		return currentErr
+		return false, currentErr
 	}
-	if value == currentValue || value == CgroupMaxValueStr && currentValue == CgroupMaxSymbolStr {
+	if value == currentValue || value == sysutil.CgroupMaxValueStr && currentValue == sysutil.CgroupMaxSymbolStr {
 		// compatible with cgroup valued "max"
 		klog.V(6).Infof("read before write %s and got str value, considered as MaxInt64", r.Path(cgroupTaskDir))
-		return nil
+		return false, nil
 	}
-	return cgroupFileWrite(cgroupTaskDir, r, value)
+	if err := cgroupFileWrite(cgroupTaskDir, r, value); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // CgroupFileWrite writes the cgroup file with the given value.

--- a/pkg/koordlet/resourceexecutor/cgroup_test.go
+++ b/pkg/koordlet/resourceexecutor/cgroup_test.go
@@ -37,6 +37,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
+		want    bool
 		wantErr bool
 	}{
 		{
@@ -47,6 +48,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 				value:         "1024",
 				currentValue:  "1024",
 			},
+			want:    false,
 			wantErr: false,
 		},
 		{
@@ -57,6 +59,7 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 				value:         "1024",
 				currentValue:  "512",
 			},
+			want:    true,
 			wantErr: false,
 		},
 	}
@@ -65,10 +68,11 @@ func TestCgroupFileWriteIfDifferent(t *testing.T) {
 			helper := sysutil.NewFileTestUtil(t)
 			helper.CreateCgroupFile(taskDir, tt.args.resource)
 
-			err := cgroupFileWrite(taskDir, tt.args.resource, tt.args.currentValue)
+			err := cgroupFileWrite(taskDir, tt.args.resource, tt.args.value)
 			assert.NoError(t, err)
 
-			gotErr := cgroupFileWriteIfDifferent(taskDir, tt.args.resource, tt.args.currentValue)
+			got, gotErr := cgroupFileWriteIfDifferent(taskDir, tt.args.resource, tt.args.currentValue)
+			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantErr, gotErr != nil)
 		})
 	}

--- a/pkg/koordlet/resourceexecutor/executor_test.go
+++ b/pkg/koordlet/resourceexecutor/executor_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util/cache"
 )
@@ -139,9 +140,10 @@ func TestResourceUpdateExecutor_Update(t *testing.T) {
 }
 
 func TestResourceUpdateExecutor_UpdateBatch(t *testing.T) {
-	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1")
+	e := &audit.EventHelper{}
+	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1", e)
 	assert.NoError(t, err)
-	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576")
+	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576", e)
 	assert.NoError(t, err)
 	type fields struct {
 		notStarted bool

--- a/pkg/koordlet/resourceexecutor/executor_test.go
+++ b/pkg/koordlet/resourceexecutor/executor_test.go
@@ -140,10 +140,9 @@ func TestResourceUpdateExecutor_Update(t *testing.T) {
 }
 
 func TestResourceUpdateExecutor_UpdateBatch(t *testing.T) {
-	e := &audit.EventHelper{}
-	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1", e)
+	testUpdater, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, "test", "-1", &audit.EventHelper{})
 	assert.NoError(t, err)
-	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576", e)
+	testUpdater1, err := DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, "test", "1048576", &audit.EventHelper{})
 	assert.NoError(t, err)
 	type fields struct {
 		notStarted bool

--- a/pkg/koordlet/resourceexecutor/resctrl_updater.go
+++ b/pkg/koordlet/resourceexecutor/resctrl_updater.go
@@ -135,7 +135,7 @@ func UpdateResctrlSchemataFunc(u ResourceUpdater) error {
 	// $ cat /sys/fs/resctrl/BE/schemata
 	// L3:0=03f;1=03f
 	// MB:0=100;1=100
-	_ = audit.V(5).Reason(ReasonUpdateResctrl).Message("update %v to %v", u.Key(), u.Value()).Do()
+	_ = audit.V(3).Reason(ReasonUpdateResctrl).Message("update %v to %v", u.Key(), u.Value()).Do()
 	return sysutil.CommonFileWrite(u.Path(), u.Value())
 }
 

--- a/pkg/koordlet/runtimehooks/protocol/container_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/container_context.go
@@ -172,19 +172,20 @@ func (c *ContainerContext) ReconcilerDone(executor resourceexecutor.ResourceUpda
 
 func (c *ContainerContext) injectForOrigin() {
 	if c.Response.Resources.CPUShares != nil {
-		if err := injectCPUShares(c.Request.CgroupParent, *c.Response.Resources.CPUShares, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container cpu share to %v", *c.Response.Resources.CPUShares)
+		if err := injectCPUShares(c.Request.CgroupParent, *c.Response.Resources.CPUShares, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v cpu share %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CPUShares, c.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set container %v/%v/%v cpu share %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.CPUShares, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container cpu share to %v", *c.Response.Resources.CPUShares).Do()
 		}
 	}
 	if c.Response.Resources.CPUSet != nil {
-		err := injectCPUSet(c.Request.CgroupParent, *c.Response.Resources.CPUSet, c.executor)
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message("set container cpuset to %v", *c.Response.Resources.CPUSet)
+		err := injectCPUSet(c.Request.CgroupParent, *c.Response.Resources.CPUSet, eventHelper, c.executor)
 		if err != nil && resourceexecutor.IsCgroupDirErr(err) {
 			klog.V(5).Infof("set container %v/%v/%v cpuset %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CPUSet, c.Request.CgroupParent, err)
@@ -195,32 +196,30 @@ func (c *ContainerContext) injectForOrigin() {
 			klog.V(5).Infof("set container %v/%v/%v cpuset %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.CPUSet, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container cpuset to %v", *c.Response.Resources.CPUSet).Do()
 		}
 	}
 	if c.Response.Resources.CFSQuota != nil {
-		if err := injectCPUQuota(c.Request.CgroupParent, *c.Response.Resources.CFSQuota, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container cfs quota to %v", *c.Response.Resources.CFSQuota)
+		if err := injectCPUQuota(c.Request.CgroupParent, *c.Response.Resources.CFSQuota, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v cfs quota %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.CFSQuota, c.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set container %v/%v/%v cfs quota %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.CFSQuota, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container cfs quota to %v", *c.Response.Resources.CFSQuota).Do()
 		}
 	}
 	if c.Response.Resources.MemoryLimit != nil {
-		if err := injectMemoryLimit(c.Request.CgroupParent, *c.Response.Resources.MemoryLimit, c.executor); err != nil {
+		eventHelper := audit.V(3).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
+			"set container memory limit to %v", *c.Response.Resources.MemoryLimit)
+		if err := injectMemoryLimit(c.Request.CgroupParent, *c.Response.Resources.MemoryLimit, eventHelper, c.executor); err != nil {
 			klog.Infof("set container %v/%v/%v memory limit %v on cgroup parent %v failed, error %v", c.Request.PodMeta.Namespace,
 				c.Request.PodMeta.Name, c.Request.ContainerMeta.Name, *c.Response.Resources.MemoryLimit, c.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set container %v/%v/%v memory limit %v on cgroup parent %v",
 				c.Request.PodMeta.Namespace, c.Request.PodMeta.Name, c.Request.ContainerMeta.Name,
 				*c.Response.Resources.MemoryLimit, c.Request.CgroupParent)
-			audit.V(2).Container(c.Request.ContainerMeta.ID).Reason("runtime-hooks").Message(
-				"set container memory limit to %v", *c.Response.Resources.MemoryLimit).Do()
 		}
 	}
 	// TODO other fields

--- a/pkg/koordlet/runtimehooks/protocol/kubeqos_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/kubeqos_context.go
@@ -63,14 +63,14 @@ func (p *KubeQOSContext) injectForOrigin() {
 
 func (p *KubeQOSContext) injectForExt() {
 	if p.Response.Resources.CPUBvt != nil {
-		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, p.executor); err != nil {
+		eventHelper := audit.V(3).Group(string(p.Request.KubeQOSClass)).Reason("runtime-hooks").Message(
+			"set kubeqos bvt to %v", *p.Response.Resources.CPUBvt)
+		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, eventHelper, p.executor); err != nil {
 			klog.Infof("set kubeqos %v bvt %v on cgroup parent %v failed, error %v", p.Request.KubeQOSClass,
 				*p.Response.Resources.CPUBvt, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set kubeqos %v bvt %v on cgroup parent %v", p.Request.KubeQOSClass,
 				*p.Response.Resources.CPUBvt, p.Request.CgroupParent)
-			audit.V(2).Group(string(p.Request.KubeQOSClass)).Reason("runtime-hooks").Message(
-				"set kubeqos bvt to %v", *p.Response.Resources.CPUBvt).Do()
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -149,49 +149,49 @@ func (p *PodContext) injectForOrigin() {
 
 func (p *PodContext) injectForExt() {
 	if p.Response.Resources.CPUBvt != nil {
-		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod bvt to %v", *p.Response.Resources.CPUBvt)
+		if err := injectCPUBvt(p.Request.CgroupParent, *p.Response.Resources.CPUBvt, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v bvt %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUBvt, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v bvt %v on cgroup parent %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUBvt, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod bvt to %v", *p.Response.Resources.CPUBvt).Do()
 		}
 	}
 	// some of pod-level cgroups are manually updated since pod-stage hooks do not support it;
 	// kubelet may set the cgroups when pod is created or restarted, so we need to update the cgroups repeatedly
 	if p.Response.Resources.CPUShares != nil {
-		if err := injectCPUShares(p.Request.CgroupParent, *p.Response.Resources.CPUShares, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod cpu shares to %v", *p.Response.Resources.CPUShares)
+		if err := injectCPUShares(p.Request.CgroupParent, *p.Response.Resources.CPUShares, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v cpu shares %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v cpu shares %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CPUShares, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod cpu shares to %v", *p.Response.Resources.CPUShares).Do()
 		}
 	}
 	if p.Response.Resources.CFSQuota != nil {
-		if err := injectCPUQuota(p.Request.CgroupParent, *p.Response.Resources.CFSQuota, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod cfs quota to %v", *p.Response.Resources.CFSQuota)
+		if err := injectCPUQuota(p.Request.CgroupParent, *p.Response.Resources.CFSQuota, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v cfs quota %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v cfs quota %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.CFSQuota, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod cfs quota to %v", *p.Response.Resources.CFSQuota).Do()
 		}
 	}
 	if p.Response.Resources.MemoryLimit != nil {
-		if err := injectMemoryLimit(p.Request.CgroupParent, *p.Response.Resources.MemoryLimit, p.executor); err != nil {
+		eventHelper := audit.V(3).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
+			"set pod memory limit to %v", *p.Response.Resources.MemoryLimit)
+		if err := injectMemoryLimit(p.Request.CgroupParent, *p.Response.Resources.MemoryLimit, eventHelper, p.executor); err != nil {
 			klog.Infof("set pod %v/%v memory limit %v on cgroup parent %v failed, error %v", p.Request.PodMeta.Namespace,
 				p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent, err)
 		} else {
 			klog.V(5).Infof("set pod %v/%v memory limit %v on cgroup parent %v",
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent)
-			audit.V(2).Pod(p.Request.PodMeta.Namespace, p.Request.PodMeta.Name).Reason("runtime-hooks").Message(
-				"set pod memory limit to %v", *p.Response.Resources.MemoryLimit).Do()
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/protocol/protocol.go
+++ b/pkg/koordlet/runtimehooks/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
@@ -69,9 +70,9 @@ func (r *Resources) IsOriginResSet() bool {
 	return r.CPUShares != nil || r.CFSQuota != nil || r.CPUSet != nil || r.MemoryLimit != nil
 }
 
-func injectCPUShares(cgroupParent string, cpuShares int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUShares(cgroupParent string, cpuShares int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	cpuShareStr := strconv.FormatInt(cpuShares, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSharesName, cgroupParent, cpuShareStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSharesName, cgroupParent, cpuShareStr, a)
 	if err != nil {
 		return err
 	}
@@ -79,8 +80,8 @@ func injectCPUShares(cgroupParent string, cpuShares int64, e resourceexecutor.Re
 	return err
 }
 
-func injectCPUSet(cgroupParent string, cpuset string, e resourceexecutor.ResourceUpdateExecutor) error {
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSetCPUSName, cgroupParent, cpuset)
+func injectCPUSet(cgroupParent string, cpuset string, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSetCPUSName, cgroupParent, cpuset, a)
 	if err != nil {
 		return err
 	}
@@ -88,9 +89,9 @@ func injectCPUSet(cgroupParent string, cpuset string, e resourceexecutor.Resourc
 	return err
 }
 
-func injectCPUQuota(cgroupParent string, cpuQuota int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUQuota(cgroupParent string, cpuQuota int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	cpuQuotaStr := strconv.FormatInt(cpuQuota, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, cgroupParent, cpuQuotaStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, cgroupParent, cpuQuotaStr, a)
 	if err != nil {
 		return err
 	}
@@ -98,9 +99,9 @@ func injectCPUQuota(cgroupParent string, cpuQuota int64, e resourceexecutor.Reso
 	return err
 }
 
-func injectMemoryLimit(cgroupParent string, memoryLimit int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectMemoryLimit(cgroupParent string, memoryLimit int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	memoryLimitStr := strconv.FormatInt(memoryLimit, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, cgroupParent, memoryLimitStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, cgroupParent, memoryLimitStr, a)
 	if err != nil {
 		return err
 	}
@@ -108,9 +109,9 @@ func injectMemoryLimit(cgroupParent string, memoryLimit int64, e resourceexecuto
 	return err
 }
 
-func injectCPUBvt(cgroupParent string, bvtValue int64, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUBvt(cgroupParent string, bvtValue int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
 	bvtValueStr := strconv.FormatInt(bvtValue, 10)
-	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupParent, bvtValueStr)
+	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupParent, bvtValueStr, a)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
 solve the problem of duplicate audit logs by moving it to the executor module after resource update
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/koordinator-sh/koordinator/issues/1018
![截屏2023-03-08 15 39 44](https://user-images.githubusercontent.com/32286753/223670348-58020a2f-bff7-4079-ada3-b873875ce2f1.png)

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
