### PR TITLE
koord-manager: fix not compatible with ElasticQuota associated by namespace

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/controller_test.go
+++ b/pkg/scheduler/plugins/elasticquota/controller_test.go
@@ -245,6 +245,13 @@ func (e *eqWrapper) Used(used v1.ResourceList) *eqWrapper {
 	return e
 }
 
+func (e *eqWrapper) Annotations(annotations map[string]string) *eqWrapper {
+	for k, v := range annotations {
+		e.ElasticQuota.Annotations[k] = v
+	}
+	return e
+}
+
 func (e *eqWrapper) Obj() *v1alpha1.ElasticQuota {
 	return e.ElasticQuota
 }

--- a/pkg/scheduler/plugins/elasticquota/plugin_helper_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_helper_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elasticquota
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schedulerv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+	schedulerclientsetfake "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/fake"
+	schedulerinformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+func TestGetQuotaName(t *testing.T) {
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		elasticQuotas   []*schedulerv1alpha1.ElasticQuota
+		expectQuotaName string
+	}{
+		{
+			name: "default quota",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				},
+			},
+			expectQuotaName: extension.DefaultQuotaName,
+		},
+		{
+			name: "quota name from label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-pod",
+					Labels: map[string]string{
+						extension.LabelQuotaName: "test",
+					},
+				},
+			},
+			expectQuotaName: "test",
+		},
+		{
+			name: "quota name from namespace",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				},
+			},
+			elasticQuotas: []*schedulerv1alpha1.ElasticQuota{
+				MakeEQ("test-ns", "parent-quota").Annotations(map[string]string{extension.LabelQuotaIsParent: "true"}).Obj(),
+				MakeEQ("test-ns", "test-ns").Obj(),
+			},
+			expectQuotaName: "test-ns",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := schedulerclientsetfake.NewSimpleClientset()
+			for _, eq := range tt.elasticQuotas {
+				_, err := fakeClient.SchedulingV1alpha1().ElasticQuotas(eq.Namespace).Create(context.TODO(), eq, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			informerFactory := schedulerinformers.NewSharedInformerFactory(fakeClient, 0)
+			lister := informerFactory.Scheduling().V1alpha1().ElasticQuotas().Lister()
+			informerFactory.Start(nil)
+			informerFactory.WaitForCacheSync(nil)
+			quotaName := GetQuotaName(tt.pod, lister)
+			assert.Equal(t, tt.expectQuotaName, quotaName)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When users create parent ElasticQuota in namespace and the pod in the namespace cannot be created.

As mentioned in the original [design proposal](https://github.com/koordinator-sh/koordinator/blob/main/docs/proposals/scheduling/20220722-multi-hierarchy-elastic-quota-management.md#compatibility) , if the Pod does not specify a QuotaName, use the Namespace as the QuotaName to find the ElasticQuota, and if there is none, use the default ElasticQuota.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1100 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

According to the reproduction method of issue #1100, the correct result expected by users can be achieved.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
