### PR TITLE
koord-scheduler: PodGroups are no longer created if pods use Gang annotations

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -35,9 +35,8 @@ var (
 )
 
 const (
-	GangFromPodGroupCrd       string = "GangFromPodGroupCrd"
-	GangFromPodAnnotation     string = "GangFromPodAnnotation"
-	PodGroupFromPodAnnotation string = "PodGroupFromPodAnnotation"
+	GangFromPodGroupCrd   string = "GangFromPodGroupCrd"
+	GangFromPodAnnotation string = "GangFromPodAnnotation"
 )
 
 // Gang  basic podGroup info recorded in gangCache:

--- a/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
+++ b/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
@@ -67,17 +67,6 @@ func GetGangMinNumFromPod(pod *v1.Pod) (minNum int, err error) {
 	return 0, errors.New("missing min available")
 }
 
-func ShouldCreatePodGroup(pod *v1.Pod) bool {
-	// nolint:staticcheck // SA1019: extension.LabelLightweightCoschedulingPodGroupName is deprecated
-	return pod.Labels[v1alpha1.PodGroupLabel] == "" &&
-		pod.Labels[extension.LabelLightweightCoschedulingPodGroupName] == "" &&
-		pod.Annotations[extension.AnnotationGangName] != ""
-}
-
-func ShouldDeletePodGroup(pod *v1.Pod) bool {
-	return ShouldCreatePodGroup(pod)
-}
-
 func IsPodNeedGang(pod *v1.Pod) bool {
 	return GetGangNameByPod(pod) != ""
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1.  Remove the verification of the Gang name defined in the pod.
2. PodGroups are no longer created if pods use Gang annotations.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1099 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
