### PR TITLE
koord-scheduler: allow Reservation to reserve a subset of resources requested by Pod

### DIFF
--- a/pkg/scheduler/plugins/reservation/garbage_collection.go
+++ b/pkg/scheduler/plugins/reservation/garbage_collection.go
@@ -154,6 +154,7 @@ func (p *Plugin) syncActiveReservation(r *schedulingv1alpha1.Reservation) {
 
 	// fix the incorrect owner status
 	newR := r.DeepCopy()
+	actualAllocated = quotav1.Mask(actualAllocated, quotav1.ResourceNames(r.Status.Allocatable))
 	newR.Status.Allocated = actualAllocated
 	newR.Status.CurrentOwners = actualOwners
 	// if failed to update, abort and let the next event reconcile


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Allows users to use Reservation to reserve a subset of resources requested by a Pod.

For example, Reservation only reserves 4000m CPU for Pod A, but Pod A applies for 4C and 4Gi memory. Currently, we do not support scenes. This opportunity will cause inconvenience to users and waste reserved resources.

With this PR, users can easily use Reservations to reserve a subset of resources requested by Pods, and Reservations can be used to inject other resources into Pods through webhooks, resources that would otherwise be wasted.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1111 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

```bash
$ cat << EOF | kubectl create -f -
apiVersion: scheduling.koordinator.sh/v1alpha1
kind: Reservation
metadata:
  generateName: test-
spec:
  allocateOnce: true
  owners:
  - labelSelector:
      matchLabels:
        app: curlimage
  template:
    metadata:
      name: curlimage-55859d896f-8dx9c
      namespace: default
    spec:
      containers:
      - resources:
          limits:
            cpu: "1"
            #memory: "1Gi"
          requests:
            cpu: "1"
            #memory: "1Gi"
      restartPolicy: Always
      schedulerName: koord-scheduler
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 300
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 300
  ttl: 30m0s
EOF
reservation.scheduling.koordinator.sh/test-ng86p created
$ kubectl get reservation
NAME            PHASE       AGE     NODE                           TTL     EXPIRES
test-ng86p   Available    2m       cn-beijing.10.0.0.51    30m0s
$ cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pod-demo
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: curlimage
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: curlimage
      name: stress
    spec:
      containers:
      - args:
        - -c
        - "1"
        command:
        - stress
        image: polinux/stress
        imagePullPolicy: Always
        name: stress
        resources:
          limits:
            cpu: 1
            memory: 4Gi
          requests:
            cpu: 1
            memory: 400Mi
      restartPolicy: Always
      schedulerName: test-scheduler
EOF
deployment.apps/pod-demo created
$ kubectl get pod 
NAME                                              READY   STATUS    RESTARTS   AGE
pod-demo-589968796b-mlr28   1/1          Running    0                   44s
$ kubectl get reservation
NAME         PHASE       AGE     NODE                    TTL     EXPIRES
test-ng86p   Succeeded   4m18s   cn-beijing.10.0.0.51    30m0s
$ kubectl get reservation test-ng86p -o yaml
apiVersion: scheduling.koordinator.sh/v1alpha1
kind: Reservation
metadata:
  creationTimestamp: "2023-03-13T07:11:08Z"
  generateName: test-
  generation: 1
  name: test-ng86p
  resourceVersion: "28997529"
  uid: a923eba8-a2d0-4d8b-b04c-85ee94ea435b
spec:
  allocateOnce: true
  owners:
  - labelSelector:
      matchLabels:
        app: curlimage
  template:
    metadata:
      name: curlimage-55859d896f-8dx9c
      namespace: default
    spec:
      containers:
      - resources:
          limits:
            cpu: "1"
          requests:
            cpu: "1"
      priority: 9000
      priorityClassName: koord-prod
      restartPolicy: Always
      schedulerName: test-scheduler
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 300
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 300
  ttl: 30m0s
status:
  allocatable:
    cpu: "1"
  allocated:
    cpu: "1"
  conditions:
  - lastProbeTime: "2023-03-13T07:11:08Z"
    lastTransitionTime: "2023-03-13T07:11:08Z"
    reason: Scheduled
    status: "True"
    type: Scheduled
  - lastProbeTime: "2023-03-13T07:14:17Z"
    lastTransitionTime: "2023-03-13T07:11:08Z"
    reason: Succeeded
    status: "False"
    type: Ready
  currentOwners:
  - name: pod-demo-589968796b-mlr28
    namespace: default
    uid: 46cbb148-b585-4605-9302-39ceff82a7a3
  nodeName: cn-beijing.10.0.0.51
  phase: Succeeded
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
