### PR TITLE
koord-descheduler: enhanced support for Deployment

### DIFF
--- a/pkg/descheduler/controllers/migration/controller_test.go
+++ b/pkg/descheduler/controllers/migration/controller_test.go
@@ -98,7 +98,11 @@ type fakeControllerFinder struct {
 	err      error
 }
 
-func (f *fakeControllerFinder) GetPodsForRef(apiVersion, kind, name, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, int32, error) {
+func (f *fakeControllerFinder) ListPodsByWorkloads(workloadUIDs []types.UID, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, error) {
+	return f.pods, f.err
+}
+
+func (f *fakeControllerFinder) GetPodsForRef(ownerReference *metav1.OwnerReference, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, int32, error) {
 	return f.pods, f.replicas, f.err
 }
 

--- a/pkg/descheduler/controllers/migration/controllerfinder/controller_finder.go
+++ b/pkg/descheduler/controllers/migration/controllerfinder/controller_finder.go
@@ -69,8 +69,9 @@ type ControllerReference struct {
 type PodControllerFinder func(ref ControllerReference, namespace string) (*ScaleAndSelector, error)
 
 type Interface interface {
-	GetPodsForRef(apiVersion, kind, name, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, int32, error)
+	GetPodsForRef(ownerReference *metav1.OwnerReference, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, int32, error)
 	GetExpectedScaleForPod(pods *corev1.Pod) (int32, error)
+	ListPodsByWorkloads(workloadUIDs []types.UID, ns string, labelSelector *metav1.LabelSelector, active bool) ([]*corev1.Pod, error)
 }
 
 type ControllerFinder struct {

--- a/pkg/descheduler/controllers/migration/controllerfinder/pods_finder_test.go
+++ b/pkg/descheduler/controllers/migration/controllerfinder/pods_finder_test.go
@@ -1,0 +1,144 @@
+package controllerfinder
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise-api/apps/v1beta1"
+	kruisepolicyv1alpha1 "github.com/openkruise/kruise-api/policy/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestControllerFinder_GetPodsForRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		ownerReference *metav1.OwnerReference
+		ns             string
+	}{
+		{
+			name: "replicaset",
+			ownerReference: &metav1.OwnerReference{
+				APIVersion: ControllerKindRS.Group + "/" + ControllerKindRS.Version,
+				Kind:       ControllerKindRS.Kind,
+				Name:       "test",
+			},
+			ns: "default",
+		},
+		{
+			name: "deployment",
+			ownerReference: &metav1.OwnerReference{
+				APIVersion: ControllerKindDep.Group + "/" + ControllerKindDep.Version,
+				Kind:       ControllerKindDep.Kind,
+				Name:       "test",
+			},
+			ns: "default",
+		},
+		{
+			name: "Others",
+			ownerReference: &metav1.OwnerReference{
+				APIVersion: ControllerKruiseKindCS.Group + "/" + ControllerKruiseKindCS.Version,
+				Kind:       ControllerKruiseKindCS.Kind,
+				Name:       "test",
+			},
+			ns: "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = sev1alpha1.AddToScheme(scheme)
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = appsv1alpha1.AddToScheme(scheme)
+			_ = appsv1beta1.AddToScheme(scheme)
+			_ = kruisepolicyv1alpha1.AddToScheme(scheme)
+			runtimeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			deployment := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ControllerKindDep.Kind,
+					APIVersion: ControllerKindDep.Group + "/" + ControllerKindDep.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+					Selector: nil,
+				},
+			}
+			assert.NoError(t, runtimeClient.Create(context.Background(), deployment))
+			replicaSet := &appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ControllerKindRS.Kind,
+					APIVersion: ControllerKindRS.Group + "/" + ControllerKindRS.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: ControllerKindDep.Group + "/" + ControllerKindDep.Version,
+						Kind:       ControllerKindDep.Kind,
+						Name:       "test",
+						Controller: pointer.Bool(true),
+					}},
+				},
+			}
+			assert.NoError(t, runtimeClient.Create(context.Background(), replicaSet))
+			cloneSet := &appsv1alpha1.CloneSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ControllerKruiseKindCS.Kind,
+					APIVersion: ControllerKruiseKindCS.Group + "/" + ControllerKruiseKindCS.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.CloneSetSpec{
+					Replicas: pointer.Int32(3),
+					Selector: nil,
+				},
+			}
+			assert.NoError(t, runtimeClient.Create(context.Background(), cloneSet))
+			var pods []*corev1.Pod
+			for i := 0; i < 3; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("test-%d", i),
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: tt.ownerReference.APIVersion,
+							Kind:       tt.ownerReference.Kind,
+							Name:       tt.ownerReference.Name,
+						}},
+					},
+				}
+				assert.NoError(t, runtimeClient.Create(context.Background(), pod))
+				pods = append(pods, pod)
+			}
+			r := &ControllerFinder{
+				Client: runtimeClient,
+				mapper: runtimeClient.RESTMapper(),
+			}
+			gotPods, gotReplicas, err := r.GetPodsForRef(tt.ownerReference, tt.ns, nil, false)
+			assert.NoError(t, err)
+			if !reflect.DeepEqual(gotPods, pods) {
+				t.Errorf("GetPodsForRef() gotPods = %v, wantPods %v", gotPods, pods)
+			}
+			if gotReplicas != 3 {
+				t.Errorf("GetPodsForRef() gotReplicas = %v, wantReplicas %v", gotReplicas, 3)
+			}
+		})
+	}
+}

--- a/pkg/descheduler/controllers/migration/filter.go
+++ b/pkg/descheduler/controllers/migration/filter.go
@@ -221,7 +221,7 @@ func (r *Reconciler) filterMaxMigratingOrUnavailablePerWorkload(pod *corev1.Pod)
 	if ownerRef == nil {
 		return true
 	}
-	pods, expectedReplicas, err := r.controllerFinder.GetPodsForRef(ownerRef.APIVersion, ownerRef.Kind, ownerRef.Name, pod.Namespace, nil, false)
+	pods, expectedReplicas, err := r.controllerFinder.GetPodsForRef(ownerRef, pod.Namespace, nil, false)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Currently, koord-descheduler only consider replicaset's directly owned pods when filterMaxUnavailableByWorkload. However, replicaset owns to deployment. Koord-descheduler should consider in Deployment Level.
 
### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
