### PR TITLE
koordlet: cleanup cgroup path utils

### DIFF
--- a/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux_test.go
@@ -18,7 +18,7 @@ package gpu
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -286,20 +286,22 @@ func Test_gpuUsageDetailRecord_GetPIDsTotalGPUUsage(t *testing.T) {
 }
 
 func Test_gpuDeviceManager_getPodGPUUsage(t *testing.T) {
-
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+	helper.SetCgroupsV2(false)
 	system.SetupCgroupPathFormatter(system.Systemd)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	dir := t.TempDir()
 	system.Conf.CgroupRootDir = dir
 
 	p1 := "/cpu/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope/cgroup.procs"
-	p1CgroupPath := path.Join(dir, p1)
+	p1CgroupPath := filepath.Join(dir, p1)
 	if err := writeCgroupContent(p1CgroupPath, []byte("122\n222")); err != nil {
 		t.Fatal(err)
 	}
 
 	p2 := "/cpu/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4acff.scope/cgroup.procs"
-	p2CgroupPath := path.Join(dir, p2)
+	p2CgroupPath := filepath.Join(dir, p2)
 	if err := writeCgroupContent(p2CgroupPath, []byte("45\n67")); err != nil {
 		t.Fatal(err)
 	}
@@ -490,20 +492,22 @@ func Test_gpuDeviceManager_getPodGPUUsage(t *testing.T) {
 	}
 }
 func Test_gpuDeviceManager_getContainerGPUUsage(t *testing.T) {
-
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+	helper.SetCgroupsV2(false)
 	system.SetupCgroupPathFormatter(system.Systemd)
 	defer system.SetupCgroupPathFormatter(system.Systemd)
 	dir := t.TempDir()
 	system.Conf.CgroupRootDir = dir
 
 	p1 := "/cpu/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope/cgroup.procs"
-	p1CgroupPath := path.Join(dir, p1)
+	p1CgroupPath := filepath.Join(dir, p1)
 	if err := writeCgroupContent(p1CgroupPath, []byte("122\n222")); err != nil {
 		t.Fatal(err)
 	}
 
 	p2 := "/cpu/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4acff.scope/cgroup.procs"
-	p2CgroupPath := path.Join(dir, p2)
+	p2CgroupPath := filepath.Join(dir, p2)
 	if err := writeCgroupContent(p2CgroupPath, []byte("122")); err != nil {
 		t.Fatal(err)
 	}
@@ -626,7 +630,7 @@ func Test_gpuDeviceManager_getContainerGPUUsage(t *testing.T) {
 }
 
 func writeCgroupContent(filePath string, content []byte) error {
-	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/koordlet/util/cgroup_parent_utils.go
+++ b/pkg/koordlet/util/cgroup_parent_utils.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+// NOTE: functions in this file can be overwritten for extension
+
+// GetPodCgroupDirWithKube gets the full pod cgroup parent dir with the podParentDir (excluding kubepods dir).
+// @podKubeRelativeDir kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+// @return kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+func GetPodCgroupDirWithKube(podParentDir string) string {
+	return filepath.Join(system.CgroupPathFormatter.ParentDir, podParentDir)
+}
+
+// GetPodKubeRelativePath gets the full pod cgroup parent with the pod info.
+// @return like kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+func GetPodKubeRelativePath(pod *corev1.Pod) string {
+	qosClass := util.GetKubeQosClass(pod)
+	return filepath.Join(
+		system.CgroupPathFormatter.QOSDirFn(qosClass),
+		system.CgroupPathFormatter.PodDirFn(qosClass, string(pod.UID)),
+	)
+}
+
+func GetKubeQoSByCgroupParent(cgroupDir string) corev1.PodQOSClass {
+	if strings.Contains(cgroupDir, "besteffort") {
+		return corev1.PodQOSBestEffort
+	} else if strings.Contains(cgroupDir, "burstable") {
+		return corev1.PodQOSBurstable
+	}
+	return corev1.PodQOSGuaranteed
+}
+
+// @return like kubepods.slice/kubepods-burstable.slice/
+func GetPodQoSRelativePath(qosClass corev1.PodQOSClass) string {
+	return filepath.Join(
+		system.CgroupPathFormatter.ParentDir,
+		system.CgroupPathFormatter.QOSDirFn(qosClass),
+	)
+}
+
+// GetContainerCgroupPathWithKube gets the full container cgroup parent dir with the podKubeRelativeDir and the
+// containerStatus.
+// @parentDir kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+// @return kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/****.scope
+func GetContainerCgroupPathWithKube(podParentDir string, c *corev1.ContainerStatus) (string, error) {
+	return GetContainerCgroupPathWithKubeByID(podParentDir, c.ContainerID)
+}
+
+// GetContainerCgroupPathWithKubeByID gets the full container cgroup parent dir with the podKubeRelativeDir and the
+// container ID.
+// @parentDir kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+// @return kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/****.scope
+func GetContainerCgroupPathWithKubeByID(podParentDir string, containerID string) (string, error) {
+	containerDir, err := system.CgroupPathFormatter.ContainerDirFn(containerID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(
+		GetPodCgroupDirWithKube(podParentDir),
+		containerDir,
+	), nil
+}

--- a/pkg/koordlet/util/cgroup_parent_utils_test.go
+++ b/pkg/koordlet/util/cgroup_parent_utils_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func Test_GetPodKubeRelativePath(t *testing.T) {
+	system.SetupCgroupPathFormatter(system.Systemd)
+	system.Conf = system.NewDsModeConfig()
+
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name string
+		pod  *corev1.Pod
+		path string
+	}{
+		{
+			name: "guaranteed",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid1"),
+				},
+				Status: corev1.PodStatus{
+					QOSClass: corev1.PodQOSGuaranteed,
+				},
+			},
+			path: "/kubepods-poduid1.slice",
+		},
+		{
+			name: "burstable",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid1"),
+				},
+				Status: corev1.PodStatus{
+					QOSClass: corev1.PodQOSBurstable,
+				},
+			},
+			path: "kubepods-burstable.slice/kubepods-burstable-poduid1.slice",
+		},
+		{
+			name: "besteffort",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid1"),
+				},
+				Status: corev1.PodStatus{
+					QOSClass: corev1.PodQOSBestEffort,
+				},
+			},
+			path: "kubepods-besteffort.slice/kubepods-besteffort-poduid1.slice",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := GetPodKubeRelativePath(tc.pod)
+			assert.Equal(tc.path, path)
+		})
+	}
+}
+
+func Test_GetPodCgroupPath(t *testing.T) {
+	system.SetupCgroupPathFormatter(system.Systemd)
+
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name         string
+		relativePath string
+		path         string
+		cgroup       system.Resource
+	}{
+		{
+			name:         "cpuacct",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/cpuacct.usage",
+			cgroup:       system.CPUAcctUsage,
+		},
+		{
+			name:         "cpushare",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpu/kubepods.slice/pod1/cpu.shares",
+			cgroup:       system.CPUShares,
+		},
+		{
+			name:         "cfsperiod",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpu/kubepods.slice/pod1/cpu.cfs_period_us",
+			cgroup:       system.CPUCFSPeriod,
+		},
+		{
+			name:         "cfsperiod",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpu/kubepods.slice/pod1/cpu.cfs_quota_us",
+			cgroup:       system.CPUCFSQuota,
+		},
+		{
+			name:         "memorystat",
+			relativePath: "pod1",
+			path:         "/host-cgroup/memory/kubepods.slice/pod1/memory.stat",
+			cgroup:       system.MemoryStat,
+		},
+		{
+			name:         "memorylimit",
+			relativePath: "pod1",
+			path:         "/host-cgroup/memory/kubepods.slice/pod1/memory.limit_in_bytes",
+			cgroup:       system.MemoryLimit,
+		},
+		{
+			name:         "cpustat",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpu/kubepods.slice/pod1/cpu.stat",
+			cgroup:       system.CPUStat,
+		},
+		{
+			name:         "cpupressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/cpu.pressure",
+			cgroup:       system.CPUAcctCPUPressure,
+		},
+		{
+			name:         "mempressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/memory.pressure",
+			cgroup:       system.CPUAcctMemoryPressure,
+		},
+		{
+			name:         "iopressure",
+			relativePath: "pod1",
+			path:         "/host-cgroup/cpuacct/kubepods.slice/pod1/io.pressure",
+			cgroup:       system.CPUAcctIOPressure,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podPath := GetPodCgroupDirWithKube(tc.relativePath)
+			path := system.GetCgroupFilePath(podPath, tc.cgroup)
+			assert.Equal(tc.path, path)
+		})
+	}
+}
+
+func Test_GetKubeQoSByCgroupParent(t *testing.T) {
+	system.SetupCgroupPathFormatter(system.Systemd)
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name              string
+		path              string
+		wantPriorityClass corev1.PodQOSClass
+	}{
+		{
+			name:              "burstable",
+			path:              "kubepods-burstable.slice/kubepods-poduid1.slice",
+			wantPriorityClass: corev1.PodQOSBurstable,
+		},
+		{
+			name:              "besteffort",
+			path:              "kubepods-besteffort.slice/kubepods-poduid1.slice",
+			wantPriorityClass: corev1.PodQOSBestEffort,
+		},
+		{
+			name:              "guaranteed",
+			path:              "kubepods-poduid1.slice",
+			wantPriorityClass: corev1.PodQOSGuaranteed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(tc.wantPriorityClass, GetKubeQoSByCgroupParent(tc.path))
+		})
+	}
+}
+
+func TestGetContainerCgroupPathWithKube_SystemdDriver(t *testing.T) {
+	system.SetupCgroupPathFormatter(system.Systemd)
+	defer system.SetupCgroupPathFormatter(system.Systemd)
+	type args struct {
+		podParentDir string
+		c            *corev1.ContainerStatus
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "docker-container",
+			args: args{
+				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				c: &corev1.ContainerStatus{
+					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+				},
+			},
+			want:    "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope",
+			wantErr: false,
+		},
+		{
+			name: "containerd-container",
+			args: args{
+				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				c: &corev1.ContainerStatus{
+					ContainerID: "containerd://413715dc061efe71c16ef989f2f2ff5cf999a7dc905bb7078eda82cbb38210ec",
+				},
+			},
+			want:    "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/cri-containerd-413715dc061efe71c16ef989f2f2ff5cf999a7dc905bb7078eda82cbb38210ec.scope",
+			wantErr: false,
+		},
+		{
+			name: "invalid-container",
+			args: args{
+				podParentDir: "",
+				c: &corev1.ContainerStatus{
+					ContainerID: "invalid",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "unsupported-container",
+			args: args{
+				podParentDir: "",
+				c: &corev1.ContainerStatus{
+					ContainerID: "crio://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		system.Conf = system.NewDsModeConfig()
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetContainerCgroupPathWithKube(tt.args.podParentDir, tt.args.c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getContainerCgroupPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getContainerCgroupPath() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetContainerCgroupPathWithKube_CgroupfsDriver(t *testing.T) {
+	system.SetupCgroupPathFormatter(system.Cgroupfs)
+	defer system.SetupCgroupPathFormatter(system.Systemd)
+	type args struct {
+		podParentDir string
+		c            *corev1.ContainerStatus
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "docker-container",
+			args: args{
+				podParentDir: "besteffort/pod6553a60b-2b97-442a-b6da-a5704d81dd98/",
+				c: &corev1.ContainerStatus{
+					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+				},
+			},
+			want:    "kubepods/besteffort/pod6553a60b-2b97-442a-b6da-a5704d81dd98/703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+			wantErr: false,
+		},
+		{
+			name: "containerd-container",
+			args: args{
+				podParentDir: "besteffort/pod6553a60b-2b97-442a-b6da-a5704d81dd98/",
+				c: &corev1.ContainerStatus{
+					ContainerID: "containerd://413715dc061efe71c16ef989f2f2ff5cf999a7dc905bb7078eda82cbb38210ec",
+				},
+			},
+			want:    "kubepods/besteffort/pod6553a60b-2b97-442a-b6da-a5704d81dd98/413715dc061efe71c16ef989f2f2ff5cf999a7dc905bb7078eda82cbb38210ec",
+			wantErr: false,
+		},
+		{
+			name: "invalid-container",
+			args: args{
+				podParentDir: "",
+				c: &corev1.ContainerStatus{
+					ContainerID: "invalid",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "unsupported-container",
+			args: args{
+				podParentDir: "",
+				c: &corev1.ContainerStatus{
+					ContainerID: "crio://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		system.Conf = system.NewDsModeConfig()
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetContainerCgroupPathWithKube(tt.args.podParentDir, tt.args.c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getContainerCgroupPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getContainerCgroupPath() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/util/meminfo_test.go
+++ b/pkg/koordlet/util/meminfo_test.go
@@ -19,51 +19,116 @@ package util
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
 func Test_readMemInfo(t *testing.T) {
 	tempDir := t.TempDir()
 	tempInvalidMemInfoPath := filepath.Join(tempDir, "no_meminfo")
 	tempMemInfoPath := filepath.Join(tempDir, "meminfo")
-	memInfoContentStr := "MemTotal:       263432804 kB\nMemFree:        254391744 kB\nMemAvailable:   256703236 kB\n" +
-		"Buffers:          958096 kB\nCached:          3763224 kB\nSwapCached:            0 kB\n" +
-		"Active:          2786012 kB\nInactive:        2223752 kB\nActive(anon):     289488 kB\n" +
-		"Inactive(anon):     1300 kB\nActive(file):    2496524 kB\nInactive(file):  2222452 kB\n" +
-		"Unevictable:           0 kB\nMlocked:               0 kB\nSwapTotal:             0 kB\n" +
-		"SwapFree:              0 kB\nDirty:               624 kB\nWriteback:             0 kB\n" +
-		"AnonPages:        281748 kB\nMapped:           495936 kB\nShmem:              2340 kB\n" +
-		"Slab:            1097040 kB\nSReclaimable:     445164 kB\nSUnreclaim:       651876 kB\n" +
-		"KernelStack:       20944 kB\nPageTables:         7896 kB\nNFS_Unstable:          0 kB\n" +
-		"Bounce:                0 kB\nWritebackTmp:          0 kB\nCommitLimit:    131716400 kB\n" +
-		"Committed_AS:    3825364 kB\nVmallocTotal:   34359738367 kB\nVmallocUsed:           0 kB\n" +
-		"VmallocChunk:          0 kB\nHardwareCorrupted:     0 kB\nAnonHugePages:     38912 kB\n" +
-		"ShmemHugePages:        0 kB\nShmemPmdMapped:        0 kB\nCmaTotal:              0 kB\n" +
-		"CmaFree:               0 kB\nHugePages_Total:       0\nHugePages_Free:        0\n" +
-		"HugePages_Rsvd:        0\nHugePages_Surp:        0\nHugepagesize:       2048 kB\n" +
-		"DirectMap4k:      414760 kB\nDirectMap2M:     8876032 kB\nDirectMap1G:    261095424 kB\n"
+	memInfoContentStr := `MemTotal:       263432804 kB
+MemFree:        254391744 kB
+MemAvailable:   256703236 kB
+Buffers:          958096 kB
+Cached:          3763224 kB
+SwapCached:            0 kB
+Active:          2786012 kB
+Inactive:        2223752 kB
+Active(anon):     289488 kB
+Inactive(anon):     1300 kB
+Active(file):    2496524 kB
+Inactive(file):  2222452 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:               624 kB
+Writeback:             0 kB
+AnonPages:        281748 kB
+Mapped:           495936 kB
+Shmem:              2340 kB
+Slab:            1097040 kB
+SReclaimable:     445164 kB
+SUnreclaim:       651876 kB
+KernelStack:       20944 kB
+PageTables:         7896 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    131716400 kB
+Committed_AS:    3825364 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:     38912 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      414760 kB
+DirectMap2M:     8876032 kB
+DirectMap1G:    261095424 kB`
 	err := os.WriteFile(tempMemInfoPath, []byte(memInfoContentStr), 0666)
 	assert.NoError(t, err)
 	tempMemInfoPath1 := filepath.Join(tempDir, "meminfo1")
-	memInfoContentStr1 := "MemTotal:       263432804 kB\nMemFree:        254391744 kB\nMemAvailable:   256703236 kB\n" +
-		"Buffers:          958096 kB\nCached:          invalidField kB\nSwapCached:            0 kB\n" +
-		"Active:          2786012 kB\nInactive:        2223752 kB\nActive(anon):     289488 kB\n" +
-		"Inactive(anon):     1300 kB\nActive(file):    2496524 kB\nInactive(file):  2222452 kB\n" +
-		"Unevictable:           0 kB\nMlocked:               0 kB\nSwapTotal:             0 kB\n" +
-		"SwapFree:              0 kB\nDirty:               624 kB\nWriteback:             0 kB\n" +
-		"AnonPages:        281748 kB\nMapped:           495936 kB\nShmem:              2340 kB\n" +
-		"Slab:            1097040 kB\nSReclaimable:     445164 kB\nSUnreclaim:       651876 kB\n" +
-		"KernelStack:       20944 kB\nPageTables:         7896 kB\nNFS_Unstable:          0 kB\n" +
-		"Bounce:                0 kB\nWritebackTmp:          0 kB\nCommitLimit:    131716400 kB\n" +
-		"Committed_AS:    3825364 kB\nVmallocTotal:   34359738367 kB\nVmallocUsed:           0 kB\n" +
-		"VmallocChunk:          0 kB\nHardwareCorrupted:     0 kB\nAnonHugePages:     38912 kB\n" +
-		"ShmemHugePages:        0 kB\nShmemPmdMapped:        0 kB\nCmaTotal:              0 kB\n" +
-		"CmaFree:               0 kB\nHugePages_Total:       0\nHugePages_Free:        0\n" +
-		"HugePages_Rsvd:        0\nHugePages_Surp:        0\nHugepagesize:       2048 kB\n" +
-		"DirectMap4k:      414760 kB\nDirectMap2M:     8876032 kB\nDirectMap1G:    261095424 kB\n"
+	memInfoContentStr1 := `MemTotal:       263432804 kB
+MemFree:        254391744 kB
+MemAvailable:   256703236 kB
+Buffers:          958096 kB
+Cached:                0 kB
+SwapCached:            0 kB
+Active:          2786012 kB
+Inactive:        2223752 kB
+Active(anon):     289488 kB
+Inactive(anon):     1300 kB
+Active(file):    2496524 kB
+Inactive(file):  2222452 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:               624 kB
+Writeback:             0 kB
+AnonPages:        281748 kB
+Mapped:           495936 kB
+Shmem:              2340 kB
+Slab:            1097040 kB
+SReclaimable:     445164 kB
+SUnreclaim:       651876 kB
+KernelStack:       20944 kB
+PageTables:         7896 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    131716400 kB
+Committed_AS:    3825364 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:     38912 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      414760 kB
+DirectMap2M:     8876032 kB
+DirectMap1G:    261095424 kB`
 	err = os.WriteFile(tempMemInfoPath1, []byte(memInfoContentStr1), 0666)
 	assert.NoError(t, err)
 	type args struct {
@@ -150,25 +215,68 @@ func Test_readMemInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readMemInfo(tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("readMemInfo wantErr %v but got err %s", tt.wantErr, err)
-			}
-			if !tt.wantErr {
-				assert.Equal(t, tt.want, got)
-			}
+			got, gotErr := readMemInfo(tt.args.path)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func Test_GetMemInfoUsageKB(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Log("Ignore non-Linux environment")
-		return
-	}
+	testMemInfo := `MemTotal:       263432804 kB
+MemFree:        254391744 kB
+MemAvailable:   256703236 kB
+Buffers:          958096 kB
+Cached:          3763224 kB
+SwapCached:            0 kB
+Active:          2786012 kB
+Inactive:        2223752 kB
+Active(anon):     289488 kB
+Inactive(anon):     1300 kB
+Active(file):    2496524 kB
+Inactive(file):  2222452 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:               624 kB
+Writeback:             0 kB
+AnonPages:        281748 kB
+Mapped:           495936 kB
+Shmem:              2340 kB
+Slab:            1097040 kB
+SReclaimable:     445164 kB
+SUnreclaim:       651876 kB
+KernelStack:       20944 kB
+PageTables:         7896 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    131716400 kB
+Committed_AS:    3825364 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:     38912 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      414760 kB
+DirectMap2M:     8876032 kB
+DirectMap1G:    261095424 kB`
+
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+	helper.WriteProcSubFileContents(system.ProcMemInfoName, testMemInfo)
+
 	memInfoUsage, err := GetMemInfoUsageKB()
-	if err != nil {
-		t.Error("failed to get MemInfo usage: ", err)
-	}
-	t.Log("meminfo: ", memInfoUsage)
+	assert.NoError(t, err)
+	assert.NotNil(t, memInfoUsage)
 }

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -236,6 +236,7 @@ var (
 		CPUAcctCPUPressure,
 		CPUAcctMemoryPressure,
 		CPUAcctIOPressure,
+		CPUProcs,
 		MemoryLimit,
 		MemoryUsage,
 		MemoryStat,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. Cleanup useless utility functions in the koordlet.
2. Move out the functions for cgroup parent generating for extensions.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
