### PR TITLE
apis: Reservation enables AllocateOnce by default

### DIFF
--- a/apis/scheduling/v1alpha1/reservation_types.go
+++ b/apis/scheduling/v1alpha1/reservation_types.go
@@ -57,9 +57,9 @@ type ReservationSpec struct {
 	// reservation would be waiting to be available until free resources are sufficient.
 	// +optional
 	PreAllocation bool `json:"preAllocation,omitempty"`
-	// By default, reserved resources are always allocatable as long as the reservation phase is Available. When
-	// `AllocateOnce` is set, the reserved resources are only available for the first owner who allocates successfully
-	// and are not allocatable to other owners anymore.
+	// When `AllocateOnce` is set, the reserved resources are only available for the first owner who allocates successfully
+	// and are not allocatable to other owners anymore. Defaults to true.
+	// +kubebuilder:default=true
 	// +optional
 	AllocateOnce bool `json:"allocateOnce,omitempty"`
 }

--- a/config/crd/bases/scheduling.koordinator.sh_reservations.yaml
+++ b/config/crd/bases/scheduling.koordinator.sh_reservations.yaml
@@ -54,11 +54,10 @@ spec:
           spec:
             properties:
               allocateOnce:
-                description: By default, reserved resources are always allocatable
-                  as long as the reservation phase is Available. When `AllocateOnce`
-                  is set, the reserved resources are only available for the first
-                  owner who allocates successfully and are not allocatable to other
-                  owners anymore.
+                default: true
+                description: When `AllocateOnce` is set, the reserved resources are
+                  only available for the first owner who allocates successfully and
+                  are not allocatable to other owners anymore. Defaults to true.
                 type: boolean
               expires:
                 description: Expired timestamp when the reservation is expected to


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Scenarios where the Reservation is released immediately after being used are more common. And using AllocateOnce can also avoid many resource allocation problems. So the default value of AllocateOnce is changed to true

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #934 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
