### PR TITLE
koord-descheduler: support soft eviction takeover eviction behavior

### DIFF
--- a/apis/extension/descheduling.go
+++ b/apis/extension/descheduling.go
@@ -17,8 +17,11 @@ limitations under the License.
 package extension
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,6 +36,35 @@ const (
 	// and the Pod with the smallest cost will be evicted.
 	AnnotationEvictionCost = SchedulingDomainPrefix + "/eviction-cost"
 )
+
+const (
+	// AnnotationSoftEviction indicates custom eviction. It can be used to set to an "true".
+	AnnotationSoftEviction = SchedulingDomainPrefix + "/soft-eviction"
+)
+
+type SoftEvictionSpec struct {
+	// Timestamp indicates time when custom eviction occurs . It can be used to set a second timestamp.
+	Timestamp *metav1.Time `json:"timestamp,omitempty"`
+	// DeleteOptions indicates the options to delete the pod.
+	DeleteOptions *metav1.DeleteOptions `json:"deleteOptions,omitempty"`
+	// Initiator indicates the initiator of the eviction.
+	Initiator string `json:"initiator,omitempty"`
+	// Reason indicates reason for eviction.
+	Reason string `json:"reason,omitempty"`
+}
+
+func GetSoftEvictionSpec(annotations map[string]string) (*SoftEvictionSpec, error) {
+	evictionSpec := &SoftEvictionSpec{}
+	data, ok := annotations[AnnotationSoftEviction]
+	if !ok {
+		return evictionSpec, nil
+	}
+	err := json.Unmarshal([]byte(data), evictionSpec)
+	if err != nil {
+		return evictionSpec, err
+	}
+	return evictionSpec, err
+}
 
 func GetEvictionCost(annotations map[string]string) (int32, error) {
 	if value, exist := annotations[AnnotationEvictionCost]; exist {

--- a/pkg/descheduler/apis/config/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/types_pluginargs.go
@@ -96,7 +96,7 @@ type MigrationControllerArgs struct {
 	EvictQPS *Float64OrString
 	// EvictBurst is the maximum number of tokens
 	EvictBurst int32
-	// EvictionPolicy represents how to delete Pod, support "Delete" and "Eviction", default value is "Eviction"
+	// EvictionPolicy represents how to delete Pod, support "Delete" and "Eviction" and "SoftEviction", default value is "Eviction"
 	EvictionPolicy string
 	// DefaultDeleteOptions defines options when deleting migrated pods and preempted pods through the method specified by EvictionPolicy
 	DefaultDeleteOptions *metav1.DeleteOptions

--- a/pkg/descheduler/controllers/migration/evictor/evictor_soft.go
+++ b/pkg/descheduler/controllers/migration/evictor/evictor_soft.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evictor
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+func init() {
+	RegisterEvictor(SoftEvictorName, NewSoftEvictor)
+}
+
+const (
+	SoftEvictorName = "SoftEviction"
+)
+
+type SoftEvictor struct {
+	client kubernetes.Interface
+}
+
+func NewSoftEvictor(client kubernetes.Interface) (Interface, error) {
+	return &SoftEvictor{
+		client: client,
+	}, nil
+}
+
+func (e *SoftEvictor) Evict(ctx context.Context, job *sev1alpha1.PodMigrationJob, pod *corev1.Pod) error {
+	trigger, reason := GetEvictionTriggerAndReason(job.Annotations)
+	evictionSpec := extension.SoftEvictionSpec{
+		Timestamp:     &metav1.Time{Time: time.Now()},
+		DeleteOptions: job.Spec.DeleteOptions,
+		Initiator:     trigger,
+		Reason:        reason,
+	}
+	evictionSpecData, err := json.Marshal(evictionSpec)
+	if err != nil {
+		return err
+	}
+	newPod := pod.DeepCopy()
+	if newPod.Annotations == nil {
+		newPod.Annotations = make(map[string]string)
+	}
+	newPod.Annotations[extension.AnnotationSoftEviction] = string(evictionSpecData)
+
+	return util.RetryOnConflictOrTooManyRequests(func() error {
+		_, err1 := util.NewPatch().WithClientset(e.client).AddAnnotations(newPod.Annotations).PatchPod(pod)
+		return err1
+	})
+}

--- a/pkg/descheduler/controllers/migration/evictor/evictor_soft_test.go
+++ b/pkg/descheduler/controllers/migration/evictor/evictor_soft_test.go
@@ -1,0 +1,56 @@
+package evictor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestPodEvictorMark(t *testing.T) {
+	ctx := context.Background()
+	fakeClient := fake.NewSimpleClientset()
+	softEvictor, err := NewSoftEvictor(fakeClient)
+	assert.NoError(t, err)
+	initiator := "test-initiator"
+	reason := "test-reason"
+	pod := &corev1.Pod{
+
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node-1",
+		},
+	}
+	job := &sev1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				AnnotationEvictReason:  reason,
+				AnnotationEvictTrigger: initiator,
+			},
+		},
+		Spec: sev1alpha1.PodMigrationJobSpec{
+			DeleteOptions: &metav1.DeleteOptions{},
+		},
+	}
+	pod, err = fakeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.NoError(t, softEvictor.Evict(ctx, job, pod))
+	newPo, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	softEvictionSpec, err := extension.GetSoftEvictionSpec(newPo.Annotations)
+	assert.NoError(t, err)
+	assert.NotNil(t, softEvictionSpec.Timestamp)
+
+	assert.Equal(t, initiator, softEvictionSpec.Initiator)
+	assert.Equal(t, reason, softEvictionSpec.Reason)
+
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
By tagging, the user takes over the eviction.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fixes  https://github.com/koordinator-sh/koordinator/issues/1102

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Enable this feature in koord-descheduler-config
```yaml
pluginConfig:
- name: MigrationController
  args:
    apiVersion: descheduler/v1alpha2
    kind: MigrationControllerArgs
    evictionPolicy: SoftEviction
    evictLocalStoragePods: true
    ignorePvcPods: true
    namespaces:
      include:
          - qa
    evictQPS: "10"
    evictBurst: 1
```

2. A annotation will be written on Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
   scheduling.koordinator.sh/soft-eviction: |-
          {
            "timestamp": 1679970640,
            "deleteOptions": {},
            "initiator": "xxx",
            "reason": "xxx"
          }
```


### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
