### PR TITLE
koordlet: use cgroup parent path straightforward

### DIFF
--- a/pkg/koordlet/common/utils/pod.go
+++ b/pkg/koordlet/common/utils/pod.go
@@ -27,7 +27,7 @@ func GetPodMetas(pods []*corev1.Pod) []*statesinformer.PodMeta {
 	podMetas := make([]*statesinformer.PodMeta, len(pods))
 
 	for index, pod := range pods {
-		cgroupDir := util.GetPodKubeRelativePath(pod)
+		cgroupDir := util.GetPodCgroupParentDir(pod)
 		podMeta := &statesinformer.PodMeta{CgroupDir: cgroupDir, Pod: pod.DeepCopy()}
 		podMetas[index] = podMeta
 	}

--- a/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux.go
+++ b/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux.go
@@ -234,7 +234,7 @@ func (p *performanceCollector) collectContainerPSI() {
 
 func (p *performanceCollector) collectSingleContainerPSI(podParentCgroupDir string, containerStatus *corev1.ContainerStatus, pod *corev1.Pod) {
 	collectTime := time.Now()
-	containerPath, err := util.GetContainerCgroupPathWithKube(podParentCgroupDir, containerStatus)
+	containerPath, err := util.GetContainerCgroupParentDir(podParentCgroupDir, containerStatus)
 	if err != nil {
 		klog.Errorf("failed to get container path for container %v/%v/%v cgroup path failed, error: %v", pod.Namespace, pod.Name, containerStatus.Name, err)
 		return
@@ -288,8 +288,7 @@ func (p *performanceCollector) collectPodPSI() {
 
 func (p *performanceCollector) collectSinglePodPSI(pod *corev1.Pod, podCgroupDir string) {
 	collectTime := time.Now()
-	paths := util.GetPodCgroupDirWithKube(podCgroupDir)
-	podPSI, err := p.cgroupReader.ReadPSI(paths)
+	podPSI, err := p.cgroupReader.ReadPSI(podCgroupDir)
 	if err != nil {
 		klog.Errorf("collect pod %v/%v psi err: %v", pod.Namespace, pod.Name, err)
 		return

--- a/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux_test.go
@@ -259,7 +259,7 @@ func Test_collectContainerPSI(t *testing.T) {
 	testPodMeta := mockInterferencePodMeta(t.TempDir())
 	mockStatesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{testPodMeta}).AnyTimes()
 
-	paths := util.GetPodCgroupCPUAcctPSIPath(cgroupDir)
+	paths := getPodCgroupCPUAcctPSIPath(cgroupDir)
 	errCreateCPU := createTestPSIFile(paths.CPU, FullCorrectPSIContents)
 	if errCreateCPU != nil {
 		t.Fatalf("got error when create psi files: %v", errCreateCPU)
@@ -297,7 +297,7 @@ func Test_collectPodPSI(t *testing.T) {
 	testPodMeta := mockInterferencePodMeta(t.TempDir())
 	mockStatesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{testPodMeta}).AnyTimes()
 
-	paths := util.GetPodCgroupCPUAcctPSIPath(cgroupDir)
+	paths := getPodCgroupCPUAcctPSIPath(cgroupDir)
 	errCreateCPU := createTestPSIFile(paths.CPU, FullCorrectPSIContents)
 	if errCreateCPU != nil {
 		t.Fatalf("got error when create psi files: %v", errCreateCPU)
@@ -374,5 +374,19 @@ func mockLSPod() *corev1.Pod {
 				},
 			},
 		},
+	}
+}
+
+// @podParentDir kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
+// @return {
+//    CPU: /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/cpu.pressure
+//    Mem: /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/memory.pressure
+//    IO:  /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/io.pressure
+//  }
+func getPodCgroupCPUAcctPSIPath(podParentDir string) resourceexecutor.PSIPath {
+	return resourceexecutor.PSIPath{
+		CPU: system.GetCgroupFilePath(podParentDir, system.CPUAcctCPUPressure),
+		Mem: system.GetCgroupFilePath(podParentDir, system.CPUAcctMemoryPressure),
+		IO:  system.GetCgroupFilePath(podParentDir, system.CPUAcctIOPressure),
 	}
 }

--- a/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector.go
@@ -93,7 +93,7 @@ func (p *podResourceCollector) collectPodResUsed() {
 		pod := meta.Pod
 		uid := string(pod.UID) // types.UID
 		collectTime := time.Now()
-		podCgroupDir := koordletutil.GetPodCgroupDirWithKube(meta.CgroupDir)
+		podCgroupDir := meta.CgroupDir
 
 		currentCPUUsage, err0 := p.cgroupReader.ReadCPUAcctUsage(podCgroupDir)
 		memStat, err1 := p.cgroupReader.ReadMemoryStat(podCgroupDir)
@@ -137,7 +137,7 @@ func (p *podResourceCollector) collectPodResUsed() {
 			},
 		}
 		for deviceName, deviceCollector := range p.deviceCollectors {
-			if err := deviceCollector.FillPodMetric(&podMetric, meta.CgroupDir, meta.Pod.Status.ContainerStatuses); err != nil {
+			if err := deviceCollector.FillPodMetric(&podMetric, meta.CgroupDir, pod.Status.ContainerStatuses); err != nil {
 				klog.Warningf("fill pod %s/%s/%s device usage failed for %v, error: %v",
 					pod.Namespace, pod.Name, deviceName, err)
 			}
@@ -170,7 +170,7 @@ func (p *podResourceCollector) collectContainerResUsed(meta *statesinformer.PodM
 			continue
 		}
 
-		containerCgroupDir, err := koordletutil.GetContainerCgroupPathWithKube(meta.CgroupDir, containerStat)
+		containerCgroupDir, err := koordletutil.GetContainerCgroupParentDir(meta.CgroupDir, containerStat)
 		if err != nil {
 			klog.V(4).Infof("failed to collect container usage for %s/%s/%s, cannot get container cgroup, err: %s",
 				pod.Namespace, pod.Name, containerStat.Name, err)

--- a/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
@@ -39,7 +39,7 @@ import (
 func Test_collector_collectPodResUsed(t *testing.T) {
 	testNow := time.Now()
 	testContainerID := "containerd://123abc"
-	testPodMetaDir := "/kubepods-podxxxxxxxx.slice"
+	testPodMetaDir := "kubepods.slice/kubepods-podxxxxxxxx.slice"
 	testPodParentDir := "/kubepods.slice/kubepods-podxxxxxxxx.slice"
 	testContainerParentDir := "/kubepods.slice/kubepods-podxxxxxxxx.slice/cri-containerd-123abc.scope"
 	testPod := &corev1.Pod{

--- a/pkg/koordlet/metricsadvisor/collectors/podthrottled/pod_throttled_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podthrottled/pod_throttled_collector.go
@@ -88,7 +88,7 @@ func (c *podThrottledCollector) collectPodThrottledInfo() {
 		pod := meta.Pod
 		uid := string(pod.UID) // types.UID
 		collectTime := time.Now()
-		podCgroupDir := koordletutil.GetPodCgroupDirWithKube(meta.CgroupDir)
+		podCgroupDir := meta.CgroupDir
 		currentCPUStat, err := c.cgroupReader.ReadCPUStat(podCgroupDir)
 		if err != nil || currentCPUStat == nil {
 			if pod.Status.Phase == corev1.PodRunning {
@@ -139,7 +139,7 @@ func (c *podThrottledCollector) collectContainerThrottledInfo(podMeta *statesinf
 			continue
 		}
 
-		containerCgroupDir, err := koordletutil.GetContainerCgroupPathWithKube(podMeta.CgroupDir, containerStat)
+		containerCgroupDir, err := koordletutil.GetContainerCgroupParentDir(podMeta.CgroupDir, containerStat)
 		if err != nil {
 			klog.V(4).Infof("collect container %s/%s/%s cpu throttled failed, cannot get container cgroup, err: %s",
 				pod.Namespace, pod.Name, containerStat.Name, err)

--- a/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu.go
+++ b/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu.go
@@ -104,7 +104,7 @@ type GPUDeviceManager interface {
 
 type dummyDeviceManager struct{}
 
-func (g *dummyDeviceManager) started() bool {
+func (d *dummyDeviceManager) started() bool {
 	return true
 }
 

--- a/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux_test.go
@@ -336,7 +336,7 @@ func Test_gpuDeviceManager_getPodGPUUsage(t *testing.T) {
 				},
 			},
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				cs: []corev1.ContainerStatus{
 					{
 						ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
@@ -390,7 +390,7 @@ func Test_gpuDeviceManager_getPodGPUUsage(t *testing.T) {
 				},
 			},
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				cs: []corev1.ContainerStatus{
 					{
 						ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
@@ -445,7 +445,7 @@ func Test_gpuDeviceManager_getPodGPUUsage(t *testing.T) {
 				},
 			},
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				cs: []corev1.ContainerStatus{
 					{
 						ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
@@ -542,7 +542,7 @@ func Test_gpuDeviceManager_getContainerGPUUsage(t *testing.T) {
 				},
 			},
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				c: &corev1.ContainerStatus{
 					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 					State: corev1.ContainerState{
@@ -585,7 +585,7 @@ func Test_gpuDeviceManager_getContainerGPUUsage(t *testing.T) {
 				},
 			},
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				c: &corev1.ContainerStatus{
 					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4acff",
 					State: corev1.ContainerState{

--- a/pkg/koordlet/resmanager/cgroup_reconcile.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile.go
@@ -187,7 +187,7 @@ func (m *CgroupResourcesReconcile) calculateQoSResources(summary *cgroupResource
 func (m *CgroupResourcesReconcile) calculatePodAndContainerResources(podMeta *statesinformer.PodMeta, node *corev1.Node,
 	podCfg *slov1alpha1.ResourceQOS) (podResources, containerResources []resourceexecutor.ResourceUpdater) {
 	pod := podMeta.Pod
-	podDir := koordletutil.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+	podDir := podMeta.CgroupDir
 
 	podResources = m.calculatePodResources(pod, podDir, podCfg)
 
@@ -198,7 +198,7 @@ func (m *CgroupResourcesReconcile) calculatePodAndContainerResources(podMeta *st
 				util.GetPodKey(pod), container.Name, err)
 			continue
 		}
-		containerDir, err := koordletutil.GetContainerCgroupPathWithKube(podMeta.CgroupDir, containerStatus)
+		containerDir, err := koordletutil.GetContainerCgroupParentDir(podMeta.CgroupDir, containerStatus)
 		if err != nil {
 			klog.Warningf("parse containerDir error! msg: %v", err)
 			continue

--- a/pkg/koordlet/resmanager/cgroup_reconcile_test.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile_test.go
@@ -452,9 +452,9 @@ func Test_calculateAndUpdateResources(t *testing.T) {
 
 func TestCgroupResourceReconcile_calculateResources(t *testing.T) {
 	testingPodLS := createPod(corev1.PodQOSBurstable, apiext.QoSLS)
-	podParentDirLS := koordletutil.GetPodCgroupDirWithKube(testingPodLS.CgroupDir)
-	containerDirLS, _ := koordletutil.GetContainerCgroupPathWithKube(testingPodLS.CgroupDir, &testingPodLS.Pod.Status.ContainerStatuses[0])
-	containerDirLS1, _ := koordletutil.GetContainerCgroupPathWithKube(testingPodLS.CgroupDir, &testingPodLS.Pod.Status.ContainerStatuses[1])
+	podParentDirLS := testingPodLS.CgroupDir
+	containerDirLS, _ := koordletutil.GetContainerCgroupParentDir(testingPodLS.CgroupDir, &testingPodLS.Pod.Status.ContainerStatuses[0])
+	containerDirLS1, _ := koordletutil.GetContainerCgroupParentDir(testingPodLS.CgroupDir, &testingPodLS.Pod.Status.ContainerStatuses[1])
 	testingPodBEWithMemQOS := createPodWithMemoryQOS(corev1.PodQOSBestEffort, apiext.QoSBE, &slov1alpha1.PodMemoryQOSConfig{
 		Policy: slov1alpha1.PodMemoryQOSPolicyAuto,
 		MemoryQOS: slov1alpha1.MemoryQOS{
@@ -477,9 +477,9 @@ func TestCgroupResourceReconcile_calculateResources(t *testing.T) {
 			WmarkMinAdj:       pointer.Int64Ptr(50),
 		},
 	})
-	podParentDirBE := koordletutil.GetPodCgroupDirWithKube(testingPodBEWithMemQOS.CgroupDir)
-	containerDirBE, _ := koordletutil.GetContainerCgroupPathWithKube(testingPodBEWithMemQOS.CgroupDir, &testingPodBEWithMemQOS.Pod.Status.ContainerStatuses[0])
-	containerDirBE1, _ := koordletutil.GetContainerCgroupPathWithKube(testingPodBEWithMemQOS.CgroupDir, &testingPodBEWithMemQOS.Pod.Status.ContainerStatuses[1])
+	podParentDirBE := testingPodBEWithMemQOS.CgroupDir
+	containerDirBE, _ := koordletutil.GetContainerCgroupParentDir(testingPodBEWithMemQOS.CgroupDir, &testingPodBEWithMemQOS.Pod.Status.ContainerStatuses[0])
+	containerDirBE1, _ := koordletutil.GetContainerCgroupParentDir(testingPodBEWithMemQOS.CgroupDir, &testingPodBEWithMemQOS.Pod.Status.ContainerStatuses[1])
 	type fields struct {
 		resmanager *resmanager
 	}
@@ -1357,7 +1357,7 @@ func createPod(kubeQosClass corev1.PodQOSClass, qosClass apiext.QoSClass) *state
 	}
 
 	return &statesinformer.PodMeta{
-		CgroupDir: koordletutil.GetPodKubeRelativePath(pod),
+		CgroupDir: koordletutil.GetPodCgroupParentDir(pod),
 		Pod:       pod,
 	}
 }

--- a/pkg/koordlet/resmanager/cpu_suppress_test.go
+++ b/pkg/koordlet/resmanager/cpu_suppress_test.go
@@ -614,8 +614,8 @@ func Test_cpuSuppress_suppressBECPU(t *testing.T) {
 			helper.WriteCgroupFileContents(koordletutil.GetPodQoSRelativePath(corev1.PodQOSBestEffort), system.CPUCFSQuota, strconv.FormatInt(tt.args.preBECFSQuota, 10))
 			helper.WriteCgroupFileContents(koordletutil.GetPodQoSRelativePath(corev1.PodQOSBestEffort), system.CPUCFSPeriod, strconv.FormatInt(system.DefaultCPUCFSPeriod, 10))
 			for _, podMeta := range tt.args.podMetas {
-				podMeta.CgroupDir = koordletutil.GetPodKubeRelativePath(podMeta.Pod)
-				helper.WriteCgroupFileContents(filepath.Join(koordletutil.GetPodQoSRelativePath(corev1.PodQOSGuaranteed), podMeta.CgroupDir), system.CPUSet, tt.args.preBECPUSet)
+				podMeta.CgroupDir = koordletutil.GetPodCgroupParentDir(podMeta.Pod)
+				helper.WriteCgroupFileContents(podMeta.CgroupDir, system.CPUSet, tt.args.preBECPUSet)
 			}
 
 			r := &resmanager{
@@ -650,8 +650,8 @@ func Test_cpuSuppress_suppressBECPU(t *testing.T) {
 			assert.Equal(t, tt.wantBECPUSet, gotCPUSetBECgroup, "checkBECPUSet")
 			for _, podMeta := range tt.args.podMetas {
 				if util.GetKubeQosClass(podMeta.Pod) == corev1.PodQOSBestEffort {
-					gotPodCPUSet := helper.ReadCgroupFileContents(filepath.Join(koordletutil.GetPodQoSRelativePath(corev1.PodQOSGuaranteed), podMeta.CgroupDir), system.CPUSet)
-					assert.Equal(t, tt.wantBECPUSet, gotPodCPUSet, "checkPodCPUSet", filepath.Join(koordletutil.GetPodQoSRelativePath(corev1.PodQOSGuaranteed), podMeta.CgroupDir))
+					gotPodCPUSet := helper.ReadCgroupFileContents(podMeta.CgroupDir, system.CPUSet)
+					assert.Equal(t, tt.wantBECPUSet, gotPodCPUSet, "checkPodCPUSet", podMeta.CgroupDir)
 				}
 			}
 		})

--- a/pkg/koordlet/resmanager/resctrl_reconcile.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile.go
@@ -170,7 +170,7 @@ func (r *ResctrlReconcile) getPodCgroupNewTaskIds(podMeta *statesinformer.PodMet
 			continue
 		}
 
-		containerDir, err := koordletutil.GetContainerCgroupPathWithKube(podMeta.CgroupDir, &containerStat)
+		containerDir, err := koordletutil.GetContainerCgroupParentDir(podMeta.CgroupDir, &containerStat)
 		if err != nil {
 			klog.V(4).Infof("failed to get pod container cgroup path for container %s/%s/%s, err: %s",
 				pod.Namespace, pod.Name, container.Name, err)

--- a/pkg/koordlet/resmanager/resctrl_reconcile_test.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile_test.go
@@ -335,7 +335,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 							},
 						},
 					},
-					CgroupDir: "p0",
+					CgroupDir: "kubepods.slice/p0",
 				},
 				tasksMap: map[int32]struct{}{
 					122450: {},
@@ -373,7 +373,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 							},
 						},
 					},
-					CgroupDir: "p0",
+					CgroupDir: "kubepods.slice/p0",
 				},
 				tasksMap: map[int32]struct{}{
 					122450: {},
@@ -407,7 +407,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 							ContainerStatuses: []corev1.ContainerStatus{},
 						},
 					},
-					CgroupDir: "p0",
+					CgroupDir: "kubepods.slice/p0",
 				},
 				tasksMap: map[int32]struct{}{
 					122450: {},
@@ -445,7 +445,7 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 							},
 						},
 					},
-					CgroupDir: "p0",
+					CgroupDir: "kubepods.slice/p0",
 				},
 				tasksMap: map[int32]struct{}{
 					122450: {},
@@ -1122,7 +1122,7 @@ func TestResctrlReconcile_reconcileResctrlGroups(t *testing.T) {
 				},
 			},
 		},
-		CgroupDir: "p0",
+		CgroupDir: "kubepods.slice/p0",
 	}
 	testQOSStrategy := util.DefaultResourceQOSStrategy()
 	testQOSStrategy.BEClass.ResctrlQOS.Enable = pointer.BoolPtr(true)

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
@@ -356,10 +356,10 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 			helper := sysutil.NewFileTestUtil(t)
 			// init cgroups cpuset file
 			for _, podMeta := range tt.args.pods {
-				cgroupDir := util.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+				cgroupDir := podMeta.CgroupDir
 				helper.WriteCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota, "-1")
 				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
-					cgroupDir, err := util.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					cgroupDir, err := util.GetContainerCgroupParentDirByID(podMeta.CgroupDir, containerStat.ContainerID)
 					assert.NoError(t, err, "container "+containerStat.Name)
 					helper.WriteCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota, "-1")
 				}
@@ -378,10 +378,10 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 			// init cgroups cpuset file
 			for i, podMeta := range tt.args.pods {
 				w := tt.want[i]
-				cgroupDir := util.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+				cgroupDir := podMeta.CgroupDir
 				assert.Equal(t, w.cfsQuota, helper.ReadCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota))
 				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
-					cgroupDir, err := util.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					cgroupDir, err := util.GetContainerCgroupParentDirByID(podMeta.CgroupDir, containerStat.ContainerID)
 					assert.NoError(t, err, "container "+containerStat.Name)
 					assert.Equal(t, w.cfsQuota, helper.ReadCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota))
 				}

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
@@ -604,7 +604,7 @@ func Test_cpusetPlugin_ruleUpdateCb(t *testing.T) {
 			// init cgroups cpuset file
 			for _, podMeta := range tt.args.pods {
 				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
-					containerPath, err := koordletutil.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					containerPath, err := koordletutil.GetContainerCgroupParentDirByID(podMeta.CgroupDir, containerStat.ContainerID)
 					assert.NoError(t, err, "get contaienr cgorup path during init container cpuset")
 					initCPUSet(containerPath, "", testHelper)
 				}
@@ -634,7 +634,7 @@ func Test_cpusetPlugin_ruleUpdateCb(t *testing.T) {
 
 			for _, podMeta := range tt.args.pods {
 				for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
-					containerPath, err := koordletutil.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, containerStat.ContainerID)
+					containerPath, err := koordletutil.GetContainerCgroupParentDirByID(podMeta.CgroupDir, containerStat.ContainerID)
 					assert.NoError(t, err, "get contaienr cgorup path during check container cpuset")
 					gotCPUSEt := getCPUSet(containerPath, testHelper)
 					assert.Equal(t, tt.wants.containersCPUSet[containerStat.Name], gotCPUSEt,

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
@@ -146,7 +146,7 @@ func (b *bvtPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		podQOS := ext.GetPodQoSClass(podMeta.Pod)
 		podKubeQOS := podMeta.Pod.Status.QOSClass
 		podBvt := r.getPodBvtValue(podQOS, podKubeQOS)
-		podCgroupPath := koordletutil.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+		podCgroupPath := podMeta.CgroupDir
 		e := audit.V(3).Pod(podMeta.Pod.Namespace, podMeta.Pod.Name).Reason(name).Message("set bvt to %v", podBvt)
 		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, podCgroupPath, strconv.FormatInt(podBvt, 10), e)
 		if err != nil {

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule_test.go
@@ -564,7 +564,7 @@ func Test_bvtPlugin_ruleUpdateCb(t *testing.T) {
 		}
 		podList := make([]*statesinformer.PodMeta, 0, len(tt.args.pods))
 		for _, pod := range tt.args.pods {
-			initCPUBvt(util.GetPodCgroupDirWithKube(pod.CgroupDir), 0, testHelper)
+			initCPUBvt(pod.CgroupDir, 0, testHelper)
 			podList = append(podList, pod)
 		}
 		t.Run(tt.name, func(t *testing.T) {
@@ -585,7 +585,7 @@ func Test_bvtPlugin_ruleUpdateCb(t *testing.T) {
 				assert.Equal(t, gotBvt, wantBvt, "qos %s bvt value not equal", kubeQoS)
 			}
 			for podName, pod := range tt.args.pods {
-				gotBvtStr := testHelper.ReadCgroupFileContents(util.GetPodCgroupDirWithKube(pod.CgroupDir), system.CPUBVTWarpNs)
+				gotBvtStr := testHelper.ReadCgroupFileContents(pod.CgroupDir, system.CPUBVTWarpNs)
 				gotBvt, _ := strconv.ParseInt(gotBvtStr, 10, 64)
 				wantBvt := tt.wantPodVal[podName]
 				assert.Equal(t, gotBvt, wantBvt, "pod %s bvt value not equal", podName)

--- a/pkg/koordlet/runtimehooks/protocol/container_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/container_context.go
@@ -56,7 +56,7 @@ func (c *ContainerRequest) FromProxy(req *runtimeapi.ContainerResourceHookReques
 	c.ContainerMeta.FromProxy(req.ContainerMeta, req.PodAnnotations)
 	c.PodLabels = req.GetPodLabels()
 	c.PodAnnotations = req.GetPodAnnotations()
-	c.CgroupParent, _ = koordletutil.GetContainerCgroupPathWithKubeByID(req.GetPodCgroupParent(), c.ContainerMeta.ID)
+	c.CgroupParent, _ = koordletutil.GetContainerCgroupParentDirByID(req.GetPodCgroupParent(), c.ContainerMeta.ID)
 	c.ContainerEnvs = req.GetContainerEnvs()
 	// retrieve ExtendedResources from pod annotations
 	spec, err := apiext.GetExtendedResourceSpec(req.GetPodAnnotations())
@@ -95,7 +95,7 @@ func (c *ContainerRequest) FromReconciler(podMeta *statesinformer.PodMeta, conta
 	}
 	c.PodLabels = podMeta.Pod.Labels
 	c.PodAnnotations = podMeta.Pod.Annotations
-	c.CgroupParent, _ = koordletutil.GetContainerCgroupPathWithKubeByID(podMeta.CgroupDir, c.ContainerMeta.ID)
+	c.CgroupParent, _ = koordletutil.GetContainerCgroupParentDirByID(podMeta.CgroupDir, c.ContainerMeta.ID)
 	// retrieve ExtendedResources from container spec and pod annotations (prefer container spec)
 	specFromAnnotations, err := apiext.GetExtendedResourceSpec(podMeta.Pod.Annotations)
 	if err != nil {

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -25,7 +25,6 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
-	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -75,7 +74,7 @@ func (p *PodRequest) FromReconciler(podMeta *statesinformer.PodMeta) {
 	p.PodMeta.FromReconciler(podMeta.Pod.ObjectMeta)
 	p.Labels = podMeta.Pod.Labels
 	p.Annotations = podMeta.Pod.Annotations
-	p.CgroupParent = koordletutil.GetPodCgroupDirWithKube(podMeta.CgroupDir)
+	p.CgroupParent = podMeta.CgroupDir
 	// retrieve ExtendedResources from pod spec and pod annotations (prefer pod spec)
 	specFromAnnotations, err := apiext.GetExtendedResourceSpec(podMeta.Pod.Annotations)
 	if err != nil {

--- a/pkg/koordlet/statesinformer/states_pods.go
+++ b/pkg/koordlet/statesinformer/states_pods.go
@@ -238,8 +238,8 @@ func newKubeletStubFromConfig(node *corev1.Node, cfg *Config) (KubeletStub, erro
 
 func genPodCgroupParentDir(pod *corev1.Pod) string {
 	// todo use cri interface to get pod cgroup dir
-	// e.g. kubepods-burstable.slice/kubepods-burstable-pod9dba1d9e_67ba_4db6_8a73_fb3ea297c363.slice/
-	return koordletutil.GetPodKubeRelativePath(pod)
+	// e.g. kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod9dba1d9e_67ba_4db6_8a73_fb3ea297c363.slice/
+	return koordletutil.GetPodCgroupParentDir(pod)
 }
 
 func resetPodMetrics() {

--- a/pkg/koordlet/statesinformer/states_pods_test.go
+++ b/pkg/koordlet/statesinformer/states_pods_test.go
@@ -57,7 +57,7 @@ func Test_genPodCgroupParentDirWithCgroupfsDriver(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			},
-			want: "/pod111-222-333",
+			want: "/kubepods/pod111-222-333",
 		},
 		{
 			name: "BestEffort",
@@ -69,7 +69,7 @@ func Test_genPodCgroupParentDirWithCgroupfsDriver(t *testing.T) {
 					QOSClass: corev1.PodQOSBestEffort,
 				},
 			},
-			want: "/besteffort/pod111-222-333",
+			want: "/kubepods/besteffort/pod111-222-333",
 		},
 		{
 			name: "Burstable",
@@ -81,7 +81,7 @@ func Test_genPodCgroupParentDirWithCgroupfsDriver(t *testing.T) {
 					QOSClass: corev1.PodQOSBurstable,
 				},
 			},
-			want: "/burstable/pod111-222-333",
+			want: "/kubepods/burstable/pod111-222-333",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/koordlet/util/container.go
+++ b/pkg/koordlet/util/container.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
@@ -38,7 +37,7 @@ func GetContainerCgroupPath(podParentDir string, c *corev1.ContainerStatus, reso
 	if err != nil {
 		return "", fmt.Errorf("failed to get resource type %v, err: %w", resourceType, err)
 	}
-	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
+	containerPath, err := GetContainerCgroupParentDir(podParentDir, c)
 	if err != nil {
 		return "", fmt.Errorf("failed to get container cgroup path, err: %w", err)
 	}
@@ -52,7 +51,7 @@ func GetContainerCgroupCPUProcsPath(podParentDir string, c *corev1.ContainerStat
 }
 
 func GetContainerCgroupPerfPath(podParentDir string, c *corev1.ContainerStatus) (string, error) {
-	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
+	containerPath, err := GetContainerCgroupParentDir(podParentDir, c)
 	if err != nil {
 		return "", err
 	}
@@ -60,19 +59,6 @@ func GetContainerCgroupPerfPath(podParentDir string, c *corev1.ContainerStatus) 
 		return filepath.Join(system.Conf.CgroupRootDir, containerPath), nil
 	}
 	return filepath.Join(system.Conf.CgroupRootDir, "perf_event/", containerPath), nil
-}
-
-func GetContainerCgroupCPUAcctPSIPath(podParentDir string, c *corev1.ContainerStatus) (resourceexecutor.PSIPath, error) {
-	containerPath, err := GetContainerCgroupPathWithKube(podParentDir, c)
-	if err != nil {
-		return resourceexecutor.PSIPath{}, err
-	}
-	// psi file saved in cpuacct for cgroup v1 file system
-	return resourceexecutor.PSIPath{
-		CPU: system.GetCgroupFilePath(containerPath, system.CPUAcctCPUPressure),
-		Mem: system.GetCgroupFilePath(containerPath, system.CPUAcctMemoryPressure),
-		IO:  system.GetCgroupFilePath(containerPath, system.CPUAcctIOPressure),
-	}, nil
 }
 
 func GetContainerBaseCFSQuota(container *corev1.Container) int64 {

--- a/pkg/koordlet/util/container_test.go
+++ b/pkg/koordlet/util/container_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
@@ -48,7 +47,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_resource_not_found",
 			resourceType: "unknown_resource",
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -57,7 +56,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpuacct_usage_path",
 			resourceType: system.CPUAcctUsageName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -67,7 +66,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpuacct_usage_path_invalid",
 			resourceType: system.CPUAcctUsageName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -77,7 +76,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_memory_stat_path",
 			resourceType: system.MemoryStatName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -87,7 +86,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_memory_stat_path",
 			resourceType: system.MemoryStatName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -97,7 +96,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_stat_path",
 			resourceType: system.CPUStatName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -107,7 +106,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_stat_path_invalid",
 			resourceType: system.CPUStatName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -117,7 +116,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_memory_limit_path",
 			resourceType: system.MemoryLimitName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -127,7 +126,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_memory_limit_path_invalid",
 			resourceType: system.MemoryLimitName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -137,7 +136,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_share_path",
 			resourceType: system.CPUSharesName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -147,7 +146,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_share_path_invalid",
 			resourceType: system.CPUSharesName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -157,7 +156,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_cfs_period_path",
 			resourceType: system.CPUCFSPeriodName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -167,7 +166,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_cfs_period_path",
 			resourceType: system.CPUCFSPeriodName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -177,7 +176,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_cfs_quota_path",
 			resourceType: system.CPUCFSQuotaName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -187,7 +186,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_cfs_quota_path_invalid",
 			resourceType: system.CPUCFSQuotaName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -197,7 +196,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_current_task_path",
 			resourceType: system.CPUTasksName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -207,7 +206,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_current_task_path_invalid",
 			resourceType: system.CPUTasksName,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -217,7 +216,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_procs_path",
 			fn:           GetContainerCgroupCPUProcsPath,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -227,7 +226,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_cpu_procs_path_invalid",
 			fn:           GetContainerCgroupCPUProcsPath,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -237,7 +236,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_perf_path",
 			fn:           GetContainerCgroupPerfPath,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -247,7 +246,7 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 		{
 			name:         "test_perf_path_invalid",
 			fn:           GetContainerCgroupPerfPath,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+			podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 			containerStatus: &corev1.ContainerStatus{
 				ContainerID: "703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 			},
@@ -268,50 +267,6 @@ func Test_GetContainerCgroupPath(t *testing.T) {
 			}
 			assert.Equal(t, tt.expectPath, gotPath, "checkPath")
 			assert.Equal(t, tt.expectErr, gotErr != nil, fmt.Sprintf("checkErr: %v", gotErr))
-		})
-	}
-}
-
-func Test_GetContainerPSIPath(t *testing.T) {
-	helper := system.NewFileTestUtil(t)
-	defer helper.Cleanup()
-	helper.SetCgroupsV2(false)
-	system.SetupCgroupPathFormatter(system.Systemd)
-	defer system.SetupCgroupPathFormatter(system.Systemd)
-	type args struct {
-		name            string
-		fn              func(podParentDir string, c *corev1.ContainerStatus) (resourceexecutor.PSIPath, error)
-		containerStatus *corev1.ContainerStatus
-		podParentDir    string
-		expectPath      resourceexecutor.PSIPath
-		expectErr       bool
-	}
-
-	tests := []args{
-		{
-			name:         "test_psi_path",
-			fn:           GetContainerCgroupCPUAcctPSIPath,
-			podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
-			containerStatus: &corev1.ContainerStatus{
-				ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
-			},
-			expectPath: resourceexecutor.PSIPath{
-				CPU: "/host-cgroup/cpuacct/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope/cpu.pressure",
-				Mem: "/host-cgroup/cpuacct/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope/memory.pressure",
-				IO:  "/host-cgroup/cpuacct/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/docker-703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf.scope/io.pressure",
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		system.Conf = system.NewDsModeConfig()
-		t.Run(tt.name, func(t *testing.T) {
-			gotPath, gotErr := tt.fn(tt.podParentDir, tt.containerStatus)
-			assert.Equal(t, tt.expectPath.CPU, gotPath.CPU, "checkPathCPU")
-			assert.Equal(t, tt.expectPath.Mem, gotPath.Mem, "checkPathMem")
-			assert.Equal(t, tt.expectPath.IO, gotPath.IO, "checkPathIO")
-			assert.Equal(t, tt.expectErr, gotErr == nil, "checkError")
 		})
 	}
 }
@@ -344,7 +299,7 @@ func TestGetPIDsInContainer(t *testing.T) {
 		{
 			name: "cgroup",
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				c: &corev1.ContainerStatus{
 					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",
 				},
@@ -354,7 +309,7 @@ func TestGetPIDsInContainer(t *testing.T) {
 		{
 			name: "not exist",
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				c: &corev1.ContainerStatus{
 					ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4assf",
 				},

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -19,24 +19,8 @@ package util
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
-
-// @podParentDir kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
-// @return {
-//    CPU: /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/cpu.pressure
-//    Mem: /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/memory.pressure
-//    IO:  /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/io.pressure
-//  }
-func GetPodCgroupCPUAcctPSIPath(podParentDir string) resourceexecutor.PSIPath {
-	podPath := GetPodCgroupDirWithKube(podParentDir)
-	return resourceexecutor.PSIPath{
-		CPU: system.GetCgroupFilePath(podPath, system.CPUAcctCPUPressure),
-		Mem: system.GetCgroupFilePath(podPath, system.CPUAcctMemoryPressure),
-		IO:  system.GetCgroupFilePath(podPath, system.CPUAcctIOPressure),
-	}
-}
 
 // ParsePodID parse pod ID from the pod base path.
 // e.g. 7712555c_ce62_454a_9e18_9ff0217b8941 from kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice

--- a/pkg/koordlet/util/pod_test.go
+++ b/pkg/koordlet/util/pod_test.go
@@ -146,7 +146,7 @@ func TestGetPIDsInPod(t *testing.T) {
 		{
 			name: "cgroup",
 			args: args{
-				podParentDir: "kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
+				podParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod6553a60b_2b97_442a_b6da_a5704d81dd98.slice/",
 				cs: []corev1.ContainerStatus{
 					{
 						ContainerID: "docker://703b1b4e811f56673d68f9531204e5dd4963e734e2929a7056fd5f33fde4abaf",

--- a/pkg/koordlet/util/system/cgroup.go
+++ b/pkg/koordlet/util/system/cgroup.go
@@ -68,6 +68,7 @@ func (m *MemoryStatRaw) Usage() int64 {
 	return m.InactiveAnon + m.ActiveAnon + m.Unevictable
 }
 
+// GetCgroupFilePath gets the full path of the given cgroup dir and resource.
 // @cgroupTaskDir kubepods.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/
 // @return /sys/fs/cgroup/cpu/kubepods.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/cpu.shares
 func GetCgroupFilePath(cgroupTaskDir string, r Resource) string {

--- a/pkg/koordlet/util/system/util_test_tool.go
+++ b/pkg/koordlet/util/system/util_test_tool.go
@@ -195,9 +195,9 @@ func (c *FileTestUtil) CreateCgroupFile(taskDir string, r Resource) {
 	}
 }
 
-//This function is only intended for test functions. For specific read/write functionalities, please refer to the executor package.
+// WriteCgroupFileContents is only intended for test functions. For specific read/write functionalities, please refer
+// to the executor package.
 func (c *FileTestUtil) WriteCgroupFileContents(taskDir string, r Resource, contents string) {
-
 	c.SetCgroupsV2(IsCgroupV2Resource(r))
 
 	filePath := GetCgroupFilePath(taskDir, r)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Directly store the cgroup parent path with the kubepods directory in the pod meta. No longer do concatenation while generating the full cgroup file path. It is also helpful when the pod cgroup path is moved from the upstream pattern.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
