### PR TITLE
koord-scheudler: fix ElasticQuota PreFilterExtension error with missing Pod

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -204,12 +204,11 @@ func (g *Plugin) AddPod(ctx context.Context, state *framework.CycleState, podToS
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	quotaInfo := postFilterState.quotaInfo
-	if err = quotaInfo.UpdatePodIsAssigned(podInfoToAdd.Pod, true); err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+	if err = quotaInfo.UpdatePodIsAssigned(podInfoToAdd.Pod, true); err == nil {
+		pod := core.RunDecoratePod(podInfoToAdd.Pod)
+		podReq, _ := resource.PodRequestsAndLimits(pod)
+		quotaInfo.CalculateInfo.Used = quotav1.Add(quotaInfo.CalculateInfo.Used, podReq)
 	}
-	pod := core.RunDecoratePod(podInfoToAdd.Pod)
-	podReq, _ := resource.PodRequestsAndLimits(pod)
-	quotaInfo.CalculateInfo.Used = quotav1.Add(quotaInfo.CalculateInfo.Used, podReq)
 	return framework.NewStatus(framework.Success, "")
 }
 
@@ -226,12 +225,11 @@ func (g *Plugin) RemovePod(ctx context.Context, state *framework.CycleState, pod
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	quotaInfo := postFilterState.quotaInfo
-	if err = quotaInfo.UpdatePodIsAssigned(podInfoToRemove.Pod, false); err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+	if err = quotaInfo.UpdatePodIsAssigned(podInfoToRemove.Pod, false); err == nil {
+		pod := core.RunDecoratePod(podInfoToRemove.Pod)
+		podReq, _ := resource.PodRequestsAndLimits(pod)
+		quotaInfo.CalculateInfo.Used = quotav1.SubtractWithNonNegativeResult(quotaInfo.CalculateInfo.Used, podReq)
 	}
-	pod := core.RunDecoratePod(podInfoToRemove.Pod)
-	podReq, _ := resource.PodRequestsAndLimits(pod)
-	quotaInfo.CalculateInfo.Used = quotav1.SubtractWithNonNegativeResult(quotaInfo.CalculateInfo.Used, podReq)
 	return framework.NewStatus(framework.Success, "")
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The PreFilterExtension.AddPod/Remove implemented by ElasticQuota will conflict with the scheduler framework snapshot mechanism. When the framework calls these two methods, it is possible that the Pod corresponding to these two parameters has been deleted. ElasticQuota senses this change through cache.EventHandler and clears the relevant data from its internal state. At this time, AddPod/RemovePod will Check whether the corresponding Pod is still there, and report an error if it is not. This stage actually expects a best effort, so try not to report errors here. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1131 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
