### PR TITLE
    koord-scheduler: support Reservation reserved CPU Cores

### DIFF
--- a/apis/extension/resource.go
+++ b/apis/extension/resource.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -155,18 +156,20 @@ func GetResourceStatus(annotations map[string]string) (*ResourceStatus, error) {
 	return resourceStatus, nil
 }
 
-func SetResourceStatus(pod *corev1.Pod, status *ResourceStatus) error {
-	if pod == nil {
+func SetResourceStatus(obj metav1.Object, status *ResourceStatus) error {
+	if obj == nil {
 		return nil
 	}
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
 	data, err := json.Marshal(status)
 	if err != nil {
 		return err
 	}
-	pod.Annotations[AnnotationResourceStatus] = string(data)
+	annotations[AnnotationResourceStatus] = string(data)
+	obj.SetAnnotations(annotations)
 	return nil
 }
 

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator.go
@@ -26,6 +26,29 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
+func takePreferredCPUs(
+	topology *CPUTopology,
+	maxRefCount int,
+	availableCPUs cpuset.CPUSet,
+	preferredCPUs cpuset.CPUSet,
+	allocatedCPUs CPUDetails,
+	numCPUsNeeded int,
+	cpuBindPolicy schedulingconfig.CPUBindPolicy,
+	cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy,
+	numaAllocatedStrategy schedulingconfig.NUMAAllocateStrategy,
+) (cpuset.CPUSet, error) {
+	preferredCPUs = availableCPUs.Intersection(preferredCPUs)
+	size := preferredCPUs.Size()
+	if size == 0 {
+		return cpuset.CPUSet{}, nil
+	}
+	if numCPUsNeeded > size {
+		numCPUsNeeded = size
+	}
+
+	return takeCPUs(topology, maxRefCount, preferredCPUs, allocatedCPUs, numCPUsNeeded, cpuBindPolicy, cpuExclusivePolicy, numaAllocatedStrategy)
+}
+
 func takeCPUs(
 	topology *CPUTopology,
 	maxRefCount int,

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_accumulator_test.go
@@ -569,7 +569,7 @@ func TestTakeCPUsWithMaxRefCount(t *testing.T) {
 
 	// first pod request 4 CPUs
 	podUID := uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err := takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		4, schedulingconfig.CPUBindPolicyFullPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -579,7 +579,7 @@ func TestTakeCPUsWithMaxRefCount(t *testing.T) {
 
 	// second pod request 5 CPUs
 	podUID = uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err = takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		5, schedulingconfig.CPUBindPolicyFullPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -589,7 +589,7 @@ func TestTakeCPUsWithMaxRefCount(t *testing.T) {
 
 	// third pod request 4 cpus
 	podUID = uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err = takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		4, schedulingconfig.CPUBindPolicyFullPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -610,7 +610,7 @@ func TestTakeCPUsSortByRefCount(t *testing.T) {
 
 	// first pod request 16 CPUs
 	podUID := uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err := takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		16, schedulingconfig.CPUBindPolicySpreadByPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -620,7 +620,7 @@ func TestTakeCPUsSortByRefCount(t *testing.T) {
 
 	// second pod request 16 CPUs
 	podUID = uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err = takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		16, schedulingconfig.CPUBindPolicyFullPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -630,7 +630,7 @@ func TestTakeCPUsSortByRefCount(t *testing.T) {
 
 	// third pod request 16 cpus
 	podUID = uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err = takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		16, schedulingconfig.CPUBindPolicySpreadByPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -640,7 +640,7 @@ func TestTakeCPUsSortByRefCount(t *testing.T) {
 
 	// forth pod request 16 cpus
 	podUID = uuid.NewUUID()
-	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, allocatedCPUsDetails = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	result, err = takeCPUs(
 		cpuTopology, 2, availableCPUs, allocatedCPUsDetails,
 		16, schedulingconfig.CPUBindPolicyFullPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
@@ -648,7 +648,7 @@ func TestTakeCPUsSortByRefCount(t *testing.T) {
 	assert.NoError(t, err)
 	allocationState.addCPUs(cpuTopology, podUID, result, schedulingconfig.CPUExclusivePolicyPCPULevel)
 
-	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	assert.Equal(t, cpuset.MustParse(""), availableCPUs)
 }
 
@@ -753,4 +753,21 @@ func BenchmarkTakeCPUsWithSpread(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestTakePreferredCPUs(t *testing.T) {
+	topology := buildCPUTopologyForTest(2, 1, 16, 2)
+	cpus := topology.CPUDetails.CPUs()
+	result, err := takeCPUs(topology, 1, cpus, nil, 2, schedulingconfig.CPUBindPolicySpreadByPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{0, 2}, result.ToSlice())
+
+	result, err = takePreferredCPUs(topology, 1, cpus, cpuset.NewCPUSet(), nil, 2, schedulingconfig.CPUBindPolicySpreadByPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
+	assert.NoError(t, err)
+	assert.Empty(t, result.ToSlice())
+
+	preferredCPUs := cpuset.NewCPUSet(11, 13, 15, 17)
+	result, err = takePreferredCPUs(topology, 1, cpus, preferredCPUs, nil, 2, schedulingconfig.CPUBindPolicySpreadByPCPUs, schedulingconfig.CPUExclusivePolicyNone, schedulingconfig.NUMAMostAllocated)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{11, 13}, result.ToSlice())
 }

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_allocation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_allocation.go
@@ -45,6 +45,11 @@ func (n *cpuAllocation) updateAllocatedCPUSet(cpuTopology *CPUTopology, podUID t
 	n.addCPUs(cpuTopology, podUID, cpuset, cpuExclusivePolicy)
 }
 
+func (n *cpuAllocation) getCPUs(podUID types.UID) (cpuset.CPUSet, bool) {
+	cpuset, ok := n.allocatedPods[podUID]
+	return cpuset, ok
+}
+
 func (n *cpuAllocation) addCPUs(cpuTopology *CPUTopology, podUID types.UID, cpuset cpuset.CPUSet, exclusivePolicy schedulingconfig.CPUExclusivePolicy) {
 	if _, ok := n.allocatedPods[podUID]; ok {
 		return
@@ -83,8 +88,21 @@ func (n *cpuAllocation) releaseCPUs(podUID types.UID) {
 	}
 }
 
-func (n *cpuAllocation) getAvailableCPUs(cpuTopology *CPUTopology, maxRefCount int, reservedCPUs cpuset.CPUSet) (availableCPUs cpuset.CPUSet, allocateInfo CPUDetails) {
+func (n *cpuAllocation) getAvailableCPUs(cpuTopology *CPUTopology, maxRefCount int, reservedCPUs, preferredCPUs cpuset.CPUSet) (availableCPUs cpuset.CPUSet, allocateInfo CPUDetails) {
 	allocateInfo = n.allocatedCPUs.Clone()
+	if !preferredCPUs.IsEmpty() {
+		for _, cpuID := range preferredCPUs.ToSliceNoSort() {
+			cpuInfo, ok := allocateInfo[cpuID]
+			if ok {
+				cpuInfo.RefCount--
+				if cpuInfo.RefCount == 0 {
+					delete(allocateInfo, cpuID)
+				} else {
+					allocateInfo[cpuID] = cpuInfo
+				}
+			}
+		}
+	}
 	allocated := allocateInfo.CPUs().Filter(func(cpuID int) bool {
 		return allocateInfo[cpuID].RefCount >= maxRefCount
 	})

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_allocation_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_allocation_test.go
@@ -54,7 +54,7 @@ func TestNodeAllocationStateAddCPUs(t *testing.T) {
 	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
 
-	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	expectAvailableCPUs := cpuset.MustParse("0-15")
 	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 
@@ -63,7 +63,7 @@ func TestNodeAllocationStateAddCPUs(t *testing.T) {
 	assert.Equal(t, expectAllocatedPods, allocationState.allocatedPods)
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
 
-	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	cpuset.MustParse("0-15")
 	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 
@@ -120,19 +120,39 @@ func Test_cpuAllocation_getAvailableCPUs(t *testing.T) {
 	podUID := uuid.NewUUID()
 	allocationState.addCPUs(cpuTopology, podUID, cpuset.MustParse("1-4"), schedulingconfig.CPUExclusivePolicyPCPULevel)
 
-	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	expectAvailableCPUs := cpuset.MustParse("0-15")
 	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 
 	// test with add already allocated cpu(refCount > 1 but less than maxRefCount) and another pod
 	anotherPodUID := uuid.NewUUID()
 	allocationState.addCPUs(cpuTopology, anotherPodUID, cpuset.MustParse("2-5"), schedulingconfig.CPUExclusivePolicyPCPULevel)
-	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet())
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 2, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	expectAvailableCPUs = cpuset.MustParse("0-1,5-15")
 	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 
 	allocationState.releaseCPUs(podUID)
-	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 1, cpuset.NewCPUSet())
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 1, cpuset.NewCPUSet(), cpuset.NewCPUSet())
 	expectAvailableCPUs = cpuset.MustParse("0-1,6-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+}
+
+func Test_cpuAllocation_getAvailableCPUs_with_preferred_cpus(t *testing.T) {
+	cpuTopology := buildCPUTopologyForTest(2, 1, 4, 2)
+	for _, v := range cpuTopology.CPUDetails {
+		v.CoreID = v.SocketID<<16 | v.CoreID
+		cpuTopology.CPUDetails[v.CPUID] = v
+	}
+
+	allocationState := newCPUAllocation("test-node-1")
+	assert.NotNil(t, allocationState)
+	podUID := uuid.NewUUID()
+	allocationState.addCPUs(cpuTopology, podUID, cpuset.MustParse("0-4"), schedulingconfig.CPUExclusivePolicyPCPULevel)
+	availableCPUs, _ := allocationState.getAvailableCPUs(cpuTopology, 1, cpuset.NewCPUSet(), cpuset.NewCPUSet())
+	expectAvailableCPUs := cpuset.MustParse("5-15")
+	assert.Equal(t, expectAvailableCPUs, availableCPUs)
+
+	availableCPUs, _ = allocationState.getAvailableCPUs(cpuTopology, 1, cpuset.NewCPUSet(), cpuset.NewCPUSet(1, 2))
+	expectAvailableCPUs = cpuset.MustParse("1-2,5-15")
 	assert.Equal(t, expectAvailableCPUs, availableCPUs)
 }

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_manager.go
@@ -37,9 +37,13 @@ type CPUManager interface {
 		node *corev1.Node,
 		numCPUsNeeded int,
 		cpuBindPolicy schedulingconfig.CPUBindPolicy,
-		cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy) (cpuset.CPUSet, error)
+		cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy,
+		preferredCPUs cpuset.CPUSet,
+	) (cpuset.CPUSet, error)
 
 	UpdateAllocatedCPUSet(nodeName string, podUID types.UID, cpuset cpuset.CPUSet, cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy)
+
+	GetAllocatedCPUSet(nodeName string, podUID types.UID) (cpuset.CPUSet, bool)
 
 	Free(nodeName string, podUID types.UID)
 
@@ -47,7 +51,9 @@ type CPUManager interface {
 		node *corev1.Node,
 		numCPUsNeeded int,
 		cpuBindPolicy schedulingconfig.CPUBindPolicy,
-		cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy) int64
+		cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy,
+		preferredCPUs cpuset.CPUSet,
+	) int64
 
 	GetAvailableCPUs(nodeName string) (availableCPUs cpuset.CPUSet, allocated CPUDetails, err error)
 }
@@ -112,6 +118,7 @@ func (c *cpuManagerImpl) Allocate(
 	numCPUsNeeded int,
 	cpuBindPolicy schedulingconfig.CPUBindPolicy,
 	cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy,
+	preferredCPUs cpuset.CPUSet,
 ) (cpuset.CPUSet, error) {
 	result := cpuset.CPUSet{}
 	// The Pod requires the CPU to be allocated according to CPUBindPolicy,
@@ -131,19 +138,47 @@ func (c *cpuManagerImpl) Allocate(
 	allocation.lock.Lock()
 	defer allocation.lock.Unlock()
 
-	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs)
+	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs, preferredCPUs)
 	numaAllocateStrategy := c.getNUMAAllocateStrategy(node)
-	result, err := takeCPUs(
-		cpuTopologyOptions.CPUTopology,
-		cpuTopologyOptions.MaxRefCount,
-		availableCPUs,
-		allocated,
-		numCPUsNeeded,
-		cpuBindPolicy,
-		cpuExclusivePolicy,
-		numaAllocateStrategy,
-	)
-	return result, err
+	if !preferredCPUs.IsEmpty() {
+		var err error
+		result, err = takePreferredCPUs(
+			cpuTopologyOptions.CPUTopology,
+			cpuTopologyOptions.MaxRefCount,
+			availableCPUs,
+			preferredCPUs,
+			allocated,
+			numCPUsNeeded,
+			cpuBindPolicy,
+			cpuExclusivePolicy,
+			numaAllocateStrategy)
+		if err != nil {
+			return result, err
+		}
+		numCPUsNeeded -= result.Size()
+		availableCPUs = availableCPUs.Difference(preferredCPUs)
+	}
+	if numCPUsNeeded > 0 {
+		cpus, err := takeCPUs(
+			cpuTopologyOptions.CPUTopology,
+			cpuTopologyOptions.MaxRefCount,
+			availableCPUs,
+			allocated,
+			numCPUsNeeded,
+			cpuBindPolicy,
+			cpuExclusivePolicy,
+			numaAllocateStrategy,
+		)
+		if err != nil {
+			return cpuset.CPUSet{}, err
+		}
+		if result.IsEmpty() {
+			result = cpus
+		} else {
+			result = result.Union(cpus)
+		}
+	}
+	return result, nil
 }
 
 func (c *cpuManagerImpl) UpdateAllocatedCPUSet(nodeName string, podUID types.UID, cpuset cpuset.CPUSet, cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy) {
@@ -159,6 +194,14 @@ func (c *cpuManagerImpl) UpdateAllocatedCPUSet(nodeName string, podUID types.UID
 	allocation.updateAllocatedCPUSet(cpuTopologyOptions.CPUTopology, podUID, cpuset, cpuExclusivePolicy)
 }
 
+func (c *cpuManagerImpl) GetAllocatedCPUSet(nodeName string, podUID types.UID) (cpuset.CPUSet, bool) {
+	allocation := c.getOrCreateAllocation(nodeName)
+	allocation.lock.Lock()
+	defer allocation.lock.Unlock()
+
+	return allocation.getCPUs(podUID)
+}
+
 func (c *cpuManagerImpl) Free(nodeName string, podUID types.UID) {
 	allocation := c.getOrCreateAllocation(nodeName)
 	allocation.lock.Lock()
@@ -166,12 +209,7 @@ func (c *cpuManagerImpl) Free(nodeName string, podUID types.UID) {
 	allocation.releaseCPUs(podUID)
 }
 
-func (c *cpuManagerImpl) Score(
-	node *corev1.Node,
-	numCPUsNeeded int,
-	cpuBindPolicy schedulingconfig.CPUBindPolicy,
-	cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy,
-) int64 {
+func (c *cpuManagerImpl) Score(node *corev1.Node, numCPUsNeeded int, cpuBindPolicy schedulingconfig.CPUBindPolicy, cpuExclusivePolicy schedulingconfig.CPUExclusivePolicy, preferredCPUs cpuset.CPUSet) int64 {
 	cpuTopologyOptions := c.topologyManager.GetCPUTopologyOptions(node.Name)
 	if cpuTopologyOptions.CPUTopology == nil || !cpuTopologyOptions.CPUTopology.IsValid() {
 		return 0
@@ -184,8 +222,10 @@ func (c *cpuManagerImpl) Score(
 	allocation.lock.Lock()
 	defer allocation.lock.Unlock()
 
+	// TODO(joseph): should support score with preferredCPUs.
+
 	cpuTopology := cpuTopologyOptions.CPUTopology
-	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs)
+	availableCPUs, allocated := allocation.getAvailableCPUs(cpuTopology, cpuTopologyOptions.MaxRefCount, reservedCPUs, preferredCPUs)
 	acc := newCPUAccumulator(
 		cpuTopology,
 		cpuTopologyOptions.MaxRefCount,
@@ -289,6 +329,7 @@ func (c *cpuManagerImpl) GetAvailableCPUs(nodeName string) (availableCPUs cpuset
 	allocation := c.getOrCreateAllocation(nodeName)
 	allocation.lock.Lock()
 	defer allocation.lock.Unlock()
-	availableCPUs, allocated = allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, cpuTopologyOptions.ReservedCPUs)
+	emptyCPUs := cpuset.NewCPUSet()
+	availableCPUs, allocated = allocation.getAvailableCPUs(cpuTopologyOptions.CPUTopology, cpuTopologyOptions.MaxRefCount, cpuTopologyOptions.ReservedCPUs, emptyCPUs)
 	return availableCPUs, allocated, nil
 }

--- a/pkg/scheduler/plugins/nodenumaresource/cpu_topology_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_topology_manager_test.go
@@ -88,8 +88,8 @@ func TestCPUTopologyManager(t *testing.T) {
 	assert.NotNil(t, topologyManager)
 
 	extendHandle := &frameworkHandleExtender{
-		Handle:    suit.Handle,
-		Clientset: suit.NRTClientset,
+		ExtendedHandle: suit.Extender,
+		Clientset:      suit.NRTClientset,
 	}
 	err = registerNodeResourceTopologyEventHandler(extendHandle, topologyManager)
 	assert.NoError(t, err)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Enhanced NodeNUMAResource scheduling plugin:
- Support reserving CPUSets through Reservation.  If there are reserved CPUSets through Reservation, the schedule Pod will allocate the reserved CPU Cores first, and then allocate from the remaining available CPU Cores on node.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #566

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Create a Reservation to reserve some CPU cores on a given node with 16 cores
```bash
$ cat << EOF | kubectl create -f -
apiVersion: scheduling.koordinator.sh/v1alpha1
kind: Reservation
metadata:
  generateName: test-
spec:
  allocateOnce: false
  owners:
  - labelSelector:
      matchLabels:
        app: test-app
  template:
    metadata:
      name: curlimage-55859d896f-8dx9c
      namespace: default
      labels:
        koordinator.sh/qosClass: LSR
    spec:
      containers:
      - resources:
          limits:
            cpu: "4"
          requests:
            cpu: "4"
      priority: 9000
      priorityClassName: koord-prod
      nodeSelector:
        kubernetes.io/hostname: cn-beijing.10.0.3.245
      restartPolicy: Always
      schedulerName: koord-scheduler
  ttl: 30m0s
EOF
reservation.scheduling.koordinator.sh/test-gfr29 created
```
2. Verify Reservation got CPU Cores
```bash
$ kubectl get reservation -o yaml | grep cpuset
      scheduling.koordinator.sh/resource-status: '{"cpuset":"0-3"}'
```
3. Create a deployment with 3 replicas, per replica requests 2 Cores
```bash
$ cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: test-app
  name: test-deploy
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 3
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: test-app
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        scheduling.koordinator.sh/resource-spec: '{"preferredCPUBindPolicy": "SpreadByPCPUs"}'
      creationTimestamp: null
      labels:
        app: test-app
        koordinator.sh/qosClass: LSR
    spec:
      containers:
      - args:
        - "3600"
        command:
        - sleep
        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
        imagePullPolicy: IfNotPresent
        name: test
        resources:
          limits:
            cpu: "2"
            memory: 100Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      priorityClassName: koord-prod
      restartPolicy: Always
      schedulerName: koord-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
deployment/test-deploy created
```
4. Watch Pod status
```bash
$ kubectl get pod
NAME                           READY   STATUS    RESTARTS   AGE   IP          NODE                    NOMINATED NODE   READINESS GATES
test-deploy-7f9ddf4844-4qf6c   1/1     Running   0          35s   10.0.3.7    cn-beijing.10.0.3.245   <none>           <none>
test-deploy-7f9ddf4844-k4nws   1/1     Running   0          35s   10.0.3.10   cn-beijing.10.0.3.245   <none>           <none>
test-deploy-7f9ddf4844-ljfw4   1/1     Running   0          35s   10.0.3.6    cn-beijing.10.0.3.245   <none>           <none>
```

5. Get Reservation information from Pods, expect two Pods allocate CPU Core from Reservation
```bash
$ kubectl get pod -o yaml | grep reserva
      scheduling.koordinator.sh/reservation-allocated: '{"name":"test-gfr29","uid":"7da25eb5-8873-4e72-8451-0740aa247572"}'
      scheduling.koordinator.sh/reservation-allocated: '{"name":"test-gfr29","uid":"7da25eb5-8873-4e72-8451-0740aa247572"}'
```
6.  Verify Pods got CPU Cores, expect two Pod allocated from Reservation
```bash
 $ kubectl get pod -o yaml | grep cpuset
      scheduling.koordinator.sh/resource-status: '{"cpuset":"0,2"}'
      scheduling.koordinator.sh/resource-status: '{"cpuset":"4,6"}'
      scheduling.koordinator.sh/resource-status: '{"cpuset":"1,3"}'
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
