### PR TITLE
koord-scheduler: support Reservation reserve devices

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -150,9 +150,10 @@ var GetDeviceAllocations = func(podAnnotations map[string]string) (DeviceAllocat
 	return deviceAllocations, nil
 }
 
-func SetDeviceAllocations(pod *corev1.Pod, allocations DeviceAllocations) error {
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
+func SetDeviceAllocations(obj metav1.Object, allocations DeviceAllocations) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
 
 	data, err := json.Marshal(allocations)
@@ -160,7 +161,8 @@ func SetDeviceAllocations(pod *corev1.Pod, allocations DeviceAllocations) error 
 		return err
 	}
 
-	pod.Annotations[AnnotationDeviceAllocated] = string(data)
+	annotations[AnnotationDeviceAllocated] = string(data)
+	obj.SetAnnotations(annotations)
 	return nil
 }
 

--- a/pkg/descheduler/controllers/migration/evictor/evictor_soft.go
+++ b/pkg/descheduler/controllers/migration/evictor/evictor_soft.go
@@ -67,7 +67,7 @@ func (e *SoftEvictor) Evict(ctx context.Context, job *sev1alpha1.PodMigrationJob
 	newPod.Annotations[extension.AnnotationSoftEviction] = string(evictionSpecData)
 
 	return util.RetryOnConflictOrTooManyRequests(func() error {
-		_, err1 := util.NewPatch().WithClientset(e.client).AddAnnotations(newPod.Annotations).PatchPod(pod)
+		_, err1 := util.NewPatch().WithClientset(e.client).AddAnnotations(newPod.Annotations).PatchPod(ctx, pod)
 		return err1
 	})
 }

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -387,7 +387,7 @@ func (p *Plugin) PreBind(ctx context.Context, cycleState *framework.CycleState, 
 
 	// patch pod or reservation (if the pod is a reserve pod) with new annotations
 	err = util.RetryOnConflictOrTooManyRequests(func() error {
-		_, err1 := util.NewPatch().WithHandle(p.handle).AddAnnotations(pod.Annotations).PatchPodOrReservation(podOriginal)
+		_, err1 := util.NewPatch().WithHandle(p.handle).AddAnnotations(pod.Annotations).Patch(ctx, podOriginal)
 		return err1
 	})
 	if err != nil {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -346,7 +346,7 @@ func (pl *Plugin) PreBind(ctx context.Context, cycleState *framework.CycleState,
 	newPod := pod.DeepCopy()
 	apiext.SetReservationAllocated(newPod, reservation)
 	err := util.RetryOnConflictOrTooManyRequests(func() error {
-		_, err := util.NewPatch().WithClientset(pl.handle.ClientSet()).AddAnnotations(newPod.Annotations).PatchPod(pod)
+		_, err := util.NewPatch().WithClientset(pl.handle.ClientSet()).AddAnnotations(newPod.Annotations).PatchPod(ctx, pod)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Enhanced DeviceShare scheduling plugin:
- Support reserving device via Reservation.

There are some differences between Device Resource Reservation and other resource processing methods. Other resources, such as CPU/Memory or CPU Core, are continuous, single-dimensional resources. During Pod scheduling, resources reserved by Reservation and the remaining resources on the node can be allocated together. However, Devices such as GPUs are device instances. They are continuous within a single instance, and it is impossible to combine the Device resources reserved by Reservation with the remaining Device resources of the same type on the node. This may lead to fragmentation. However, the current device resource abstraction and resource protocol can only handle this for the time being.

For example, Reservation A reserves `koordiantor.sh/gpu-core:100`, and the scheduler allocates a GPU device instance for it. If an owner Pod A allocates `koordinator.sh/gpu-core:80` first, and then an owner Pod B applies for `koordinator.sh/gpu-core:50`, Pod B cannot reuse the resources reserved by this Reservation to be allocated from the node.

Additionally, the device resources specified when Reservation reserves resources need to correspond to the Requests of the owner Pod. For example, if Reservation A reserves `koordinator.sh/gpu-core:100`, the Pod must also write `koordinator.sh/gpu-core:100` instead of `nvidia.com/gpu:1`; otherwise, the Reservation cannot be reused.

I am exploring ways to optimize this issue in future upgrades, including upgrading to k8s version1.24 and introducing the informer transformer.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
