### PR TITLE
koord-scheduler: DeviceShare supports preempting devices

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/allocator.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/informers"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 )
 
@@ -39,7 +40,7 @@ type AllocatorFactoryFn func(options AllocatorOptions) Allocator
 
 type Allocator interface {
 	Name() string
-	Allocate(nodeName string, pod *corev1.Pod, podRequest corev1.ResourceList, nodeDevice *nodeDevice) (apiext.DeviceAllocations, error)
+	Allocate(nodeName string, pod *corev1.Pod, podRequest corev1.ResourceList, nodeDevice *nodeDevice, preemptibleFreeDevices map[schedulingv1alpha1.DeviceType]deviceResources) (apiext.DeviceAllocations, error)
 	Reserve(pod *corev1.Pod, nodeDevice *nodeDevice, allocations apiext.DeviceAllocations)
 	Unreserve(pod *corev1.Pod, nodeDevice *nodeDevice, allocations apiext.DeviceAllocations)
 }
@@ -68,8 +69,8 @@ func (a *defaultAllocator) Name() string {
 	return defaultAllocatorName
 }
 
-func (a *defaultAllocator) Allocate(nodeName string, pod *corev1.Pod, podRequest corev1.ResourceList, nodeDevice *nodeDevice) (apiext.DeviceAllocations, error) {
-	return nodeDevice.tryAllocateDevice(podRequest)
+func (a *defaultAllocator) Allocate(nodeName string, pod *corev1.Pod, podRequest corev1.ResourceList, nodeDevice *nodeDevice, preemptibleFreeDevices map[schedulingv1alpha1.DeviceType]deviceResources) (apiext.DeviceAllocations, error) {
+	return nodeDevice.tryAllocateDevice(podRequest, preemptibleFreeDevices)
 }
 
 func (a *defaultAllocator) Reserve(pod *corev1.Pod, nodeDevice *nodeDevice, allocations apiext.DeviceAllocations) {

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -29,6 +29,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 // deviceResources is used to present resources per device.
@@ -152,6 +153,26 @@ func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations,
 	}
 }
 
+func (n *nodeDevice) getUsed(pod *corev1.Pod) map[schedulingv1alpha1.DeviceType]deviceResources {
+	podNamespacedName := types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+	}
+	allocations := map[schedulingv1alpha1.DeviceType]deviceResources{}
+	for deviceType, podAllocated := range n.allocateSet {
+		resources := podAllocated[podNamespacedName]
+		if len(resources) == 0 {
+			continue
+		}
+		resourcesCopy := make(map[int]corev1.ResourceList, len(resources))
+		for minor, res := range resources {
+			resourcesCopy[minor] = res.DeepCopy()
+		}
+		allocations[deviceType] = resourcesCopy
+	}
+	return allocations
+}
+
 func (n *nodeDevice) resetDeviceFree(deviceType schedulingv1alpha1.DeviceType) {
 	if n.deviceFree[deviceType] == nil {
 		n.deviceFree[deviceType] = make(deviceResources)
@@ -167,9 +188,7 @@ func (n *nodeDevice) resetDeviceFree(deviceType schedulingv1alpha1.DeviceType) {
 		if n.deviceTotal[deviceType][minor] == nil {
 			n.deviceTotal[deviceType][minor] = make(corev1.ResourceList)
 		}
-		n.deviceFree[deviceType][minor] = quotav1.SubtractWithNonNegativeResult(
-			n.deviceTotal[deviceType][minor],
-			usedResource)
+		n.deviceFree[deviceType][minor] = quotav1.SubtractWithNonNegativeResult(n.deviceTotal[deviceType][minor], usedResource)
 	}
 }
 
@@ -221,8 +240,7 @@ func (n *nodeDevice) isValid(deviceType schedulingv1alpha1.DeviceType, pod *core
 	return true
 }
 
-func (n *nodeDevice) updateAllocateSet(deviceType schedulingv1alpha1.DeviceType,
-	allocations []*apiext.DeviceAllocation, pod *corev1.Pod, add bool) {
+func (n *nodeDevice) updateAllocateSet(deviceType schedulingv1alpha1.DeviceType, allocations []*apiext.DeviceAllocation, pod *corev1.Pod, add bool) {
 	podNamespacedName := types.NamespacedName{
 		Namespace: pod.Namespace,
 		Name:      pod.Name,
@@ -241,7 +259,7 @@ func (n *nodeDevice) updateAllocateSet(deviceType schedulingv1alpha1.DeviceType,
 	}
 }
 
-func (n *nodeDevice) tryAllocateDevice(podRequest corev1.ResourceList) (apiext.DeviceAllocations, error) {
+func (n *nodeDevice) tryAllocateDevice(podRequest corev1.ResourceList, preemptibleDevices map[schedulingv1alpha1.DeviceType]deviceResources) (apiext.DeviceAllocations, error) {
 	allocateResult := make(apiext.DeviceAllocations)
 
 	for deviceType := range DeviceResourceNames {
@@ -250,14 +268,14 @@ func (n *nodeDevice) tryAllocateDevice(podRequest corev1.ResourceList) (apiext.D
 			if !hasDeviceResource(podRequest, deviceType) {
 				break
 			}
-			if err := n.tryAllocateCommonDevice(podRequest, deviceType, allocateResult); err != nil {
+			if err := n.tryAllocateCommonDevice(podRequest, deviceType, allocateResult, preemptibleDevices); err != nil {
 				return nil, err
 			}
 		case schedulingv1alpha1.GPU:
 			if !hasDeviceResource(podRequest, deviceType) {
 				break
 			}
-			if err := n.tryAllocateGPU(podRequest, allocateResult); err != nil {
+			if err := n.tryAllocateGPU(podRequest, allocateResult, preemptibleDevices); err != nil {
 				return nil, err
 			}
 		default:
@@ -268,12 +286,28 @@ func (n *nodeDevice) tryAllocateDevice(podRequest corev1.ResourceList) (apiext.D
 	return allocateResult, nil
 }
 
-func (n *nodeDevice) tryAllocateCommonDevice(podRequest corev1.ResourceList, deviceType schedulingv1alpha1.DeviceType, allocateResult apiext.DeviceAllocations) error {
+func (n *nodeDevice) tryAllocateCommonDevice(podRequest corev1.ResourceList, deviceType schedulingv1alpha1.DeviceType, allocateResult apiext.DeviceAllocations, preemptibleDevices map[schedulingv1alpha1.DeviceType]deviceResources) error {
 	podRequest = quotav1.Mask(podRequest, DeviceResourceNames[deviceType])
 	nodeDeviceTotal := n.deviceTotal[deviceType]
 	if len(nodeDeviceTotal) <= 0 {
 		return fmt.Errorf("node does not have enough %v", deviceType)
 	}
+
+	freeDevices := n.deviceFree[deviceType]
+	preemptible := preemptibleDevices[deviceType]
+	mergedFreeDevices := deviceResources{}
+	for minor, v := range preemptible {
+		mergedFreeDevices[minor] = v.DeepCopy()
+	}
+	for minor, v := range freeDevices {
+		res := mergedFreeDevices[minor]
+		if res == nil {
+			mergedFreeDevices[minor] = v.DeepCopy()
+		} else {
+			util.AddResourceList(res, v)
+		}
+	}
+	freeDevices = mergedFreeDevices
 
 	var deviceAllocations []*apiext.DeviceAllocation
 
@@ -295,7 +329,7 @@ func (n *nodeDevice) tryAllocateCommonDevice(podRequest corev1.ResourceList, dev
 			}
 		}
 		satisfiedDeviceCount := 0
-		orderedDeviceResources := sortDeviceResourcesByMinor(n.deviceFree[deviceType])
+		orderedDeviceResources := sortDeviceResourcesByMinor(freeDevices)
 		for _, deviceResource := range orderedDeviceResources {
 			if satisfied, _ := quotav1.LessThanOrEqual(podRequestPerCard, deviceResource.resources); satisfied {
 				satisfiedDeviceCount++
@@ -313,7 +347,7 @@ func (n *nodeDevice) tryAllocateCommonDevice(podRequest corev1.ResourceList, dev
 		return fmt.Errorf("node does not have enough %v", deviceType)
 	}
 
-	orderedDeviceResources := sortDeviceResourcesByMinor(n.deviceFree[deviceType])
+	orderedDeviceResources := sortDeviceResourcesByMinor(freeDevices)
 	for _, deviceResource := range orderedDeviceResources {
 		if satisfied, _ := quotav1.LessThanOrEqual(podRequest, deviceResource.resources); satisfied {
 			deviceAllocations = append(deviceAllocations, &apiext.DeviceAllocation{
@@ -328,12 +362,29 @@ func (n *nodeDevice) tryAllocateCommonDevice(podRequest corev1.ResourceList, dev
 	return fmt.Errorf("node does not have enough %v", deviceType)
 }
 
-func (n *nodeDevice) tryAllocateGPU(podRequest corev1.ResourceList, allocateResult apiext.DeviceAllocations) error {
+func (n *nodeDevice) tryAllocateGPU(podRequest corev1.ResourceList, allocateResult apiext.DeviceAllocations, preemptibleDevices map[schedulingv1alpha1.DeviceType]deviceResources) error {
 	podRequest = quotav1.Mask(podRequest, DeviceResourceNames[schedulingv1alpha1.GPU])
 	nodeDeviceTotal := n.deviceTotal[schedulingv1alpha1.GPU]
 	if len(nodeDeviceTotal) <= 0 {
 		return fmt.Errorf("node does not have enough GPU")
 	}
+
+	// freeGPUs is the rest of the whole machine, or is the rest of the reservation
+	freeGPUs := n.deviceFree[schedulingv1alpha1.GPU]
+	preemptibleGPUs := preemptibleDevices[schedulingv1alpha1.GPU]
+	mergedFreeGPUs := deviceResources{}
+	for minor, v := range preemptibleGPUs {
+		mergedFreeGPUs[minor] = v.DeepCopy()
+	}
+	for minor, v := range freeGPUs {
+		res := mergedFreeGPUs[minor]
+		if res == nil {
+			mergedFreeGPUs[minor] = v.DeepCopy()
+		} else {
+			util.AddResourceList(res, v)
+		}
+	}
+	freeGPUs = mergedFreeGPUs
 
 	fillGPUTotalMem(nodeDeviceTotal, podRequest)
 
@@ -347,7 +398,7 @@ func (n *nodeDevice) tryAllocateGPU(podRequest corev1.ResourceList, allocateResu
 			apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(gpuMemRatio.Value()/gpuWanted, resource.DecimalSI),
 		}
 		satisfiedDeviceCount := 0
-		orderedDeviceResources := sortDeviceResourcesByMinor(n.deviceFree[schedulingv1alpha1.GPU])
+		orderedDeviceResources := sortDeviceResourcesByMinor(freeGPUs)
 		for _, deviceResource := range orderedDeviceResources {
 			if satisfied, _ := quotav1.LessThanOrEqual(podRequestPerCard, deviceResource.resources); satisfied {
 				satisfiedDeviceCount++
@@ -365,7 +416,7 @@ func (n *nodeDevice) tryAllocateGPU(podRequest corev1.ResourceList, allocateResu
 		return fmt.Errorf("node does not have enough GPU")
 	}
 
-	orderedDeviceResources := sortDeviceResourcesByMinor(n.deviceFree[schedulingv1alpha1.GPU])
+	orderedDeviceResources := sortDeviceResourcesByMinor(freeGPUs)
 	for _, deviceResource := range orderedDeviceResources {
 		if satisfied, _ := quotav1.LessThanOrEqual(podRequest, deviceResource.resources); !satisfied {
 			continue

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -26,6 +26,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 const (
@@ -254,4 +255,53 @@ func fillGPUTotalMem(nodeDeviceTotal deviceResources, podRequest corev1.Resource
 		gpuMemRatio := podRequest[apiext.ResourceGPUMemoryRatio]
 		podRequest[apiext.ResourceGPUMemory] = memRatioToBytes(gpuMemRatio, nodeDeviceTotal[activeMinor][apiext.ResourceGPUMemory])
 	}
+}
+
+func subtractAllocated(m, podAllocated map[schedulingv1alpha1.DeviceType]deviceResources, removeZero bool) map[schedulingv1alpha1.DeviceType]deviceResources {
+	for deviceType, podToAddDevices := range podAllocated {
+		ra := m[deviceType]
+		if len(ra) == 0 {
+			continue
+		}
+		for minor, res := range podToAddDevices {
+			raRes, ok := ra[minor]
+			if !ok {
+				continue
+			}
+			resourceNames := quotav1.ResourceNames(raRes)
+			raRes = quotav1.SubtractWithNonNegativeResult(raRes, quotav1.Mask(res, resourceNames))
+			if removeZero && quotav1.IsZero(raRes) {
+				delete(ra, minor)
+			} else {
+				ra[minor] = raRes
+			}
+		}
+		if removeZero && len(ra) == 0 {
+			delete(m, deviceType)
+		}
+	}
+	return m
+}
+
+func appendAllocatedDevices(m, podAllocated map[schedulingv1alpha1.DeviceType]deviceResources) map[schedulingv1alpha1.DeviceType]deviceResources {
+	if m == nil {
+		m = map[schedulingv1alpha1.DeviceType]deviceResources{}
+	}
+	for deviceType, deviceResources := range podAllocated {
+		devices := m[deviceType]
+		if devices == nil {
+			m[deviceType] = deviceResources.DeepCopy()
+		} else {
+			for minor, resources := range deviceResources {
+				device, ok := devices[minor]
+				if !ok {
+					devices[minor] = resources.DeepCopy()
+				} else {
+					util.AddResourceList(device, resources)
+					devices[minor] = device
+				}
+			}
+		}
+	}
+	return m
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Enhanced DeviceShare scheduling plugins
- support preempting Devices

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Create a Pod and apply for all GPUs on a specified node. In the scenario I tested, a node has two GPU instances
```bash
$ cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: test-reserve-gpu
  name: test-gpu-deploy
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: test-reserve-gpu
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: test-reserve-gpu
        koordinator.sh/qosClass: LS
    spec:
      containers:
      - args:
        - "3600"
        command:
        - sleep
        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
        name: test
        resources:
          limits:
            cpu: "1"
            memory: 1Gi
            koordinator.sh/gpu: "200"
      schedulerName: koord-scheduler
EOF
deployment.apps/test-gpu-deploy created
```
2. Check Pod status
```bash
$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE                    NOMINATED NODE   READINESS GATES
test-gpu-deploy-849874876f-cfvrr   1/1     Running   0          10s   10.0.3.7   cn-beijing.10.0.3.245   <none>           <none>
``` 
3. Create a Pod with high priority than pre-created pod
```bash
$ cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: high-test-reserve-gpu
  name: high-test-gpu-deploy
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: high-test-reserve-gpu
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: high-test-reserve-gpu
        koordinator.sh/qosClass: LS
    spec:
      containers:
      - args:
        - "3600"
        command:
        - sleep
        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
        name: test
        resources:
          limits:
            cpu: "1"
            memory: 1Gi
            koordinator.sh/gpu: "100"
      priorityClassName: system-cluster-critical
      schedulerName: koord-scheduler
EOF
deployment.apps/high-test-gpu-deploy created
```
5. Watch the Pod status
```bash
$ kubectl get pod -o wide
NAME                                   READY   STATUS        RESTARTS   AGE   IP         NODE                    NOMINATED NODE          READINESS GATES
high-test-gpu-deploy-dcd465c44-mq9bv   0/1     Pending       0          4s    <none>     <none>                  cn-beijing.10.0.3.245   <none>
test-gpu-deploy-849874876f-8fpsk       0/1     Pending       0          4s    <none>     <none>                  <none>                  <none>
test-gpu-deploy-849874876f-cfvrr       1/1     Terminating   0          21s   10.0.3.4   cn-beijing.10.0.3.245   <none>                  <none>
```
7.  Get events of preempted pod
```bash
$ kubectl get event | grep cfvrr
38s         Normal    Preempted           pod/test-gpu-deploy-849874876f-cfvrr        Preempted by default/high-test-gpu-deploy-dcd465c44-mq9bv on node cn-beijing.10.0.3.245
```
As the result shows, Pod `test-gpu-deploy-849874876f-cfvrr` is preempted by `high-test-gpu-deploy-dcd465c44-mq9bv`.

```bash
$ kubectl get pod 
NAME                                   READY   STATUS    RESTARTS   AGE
high-test-gpu-deploy-dcd465c44-mq9bv   1/1     Running   0          6m39s
test-gpu-deploy-849874876f-8fpsk       0/1     Pending   0          6m38s
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
