### PR TITLE
koord-descheduler: fix externally created MigrationJob not using default mode

### DIFF
--- a/pkg/descheduler/controllers/migration/controller.go
+++ b/pkg/descheduler/controllers/migration/controller.go
@@ -286,7 +286,8 @@ func (r *Reconciler) doMigrate(ctx context.Context, job *sev1alpha1.PodMigration
 		}
 	}
 
-	if job.Spec.Mode == sev1alpha1.PodMigrationJobModeEvictionDirectly {
+	if job.Spec.Mode == sev1alpha1.PodMigrationJobModeEvictionDirectly ||
+		(job.Spec.Mode == "" && r.args.DefaultJobMode == string(sev1alpha1.PodMigrationJobModeEvictionDirectly)) {
 		return r.evictPodDirectly(ctx, job)
 	}
 

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	evictPodAnnotationKey = "descheduler.alpha.kubernetes.io/evict"
+	EvictPodAnnotationKey = "descheduler.alpha.kubernetes.io/evict"
 )
 
 type nodePodEvictedCount map[string]uint
@@ -352,7 +352,7 @@ func (ef *EvictorFilter) Filter(pod *corev1.Pod) bool {
 
 // HaveEvictAnnotation checks if the pod have evict annotation
 func HaveEvictAnnotation(obj metav1.Object) bool {
-	_, found := obj.GetAnnotations()[evictPodAnnotationKey]
+	_, found := obj.GetAnnotations()[EvictPodAnnotationKey]
 	return found
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The migrationController in koord-descheduler does not support external created MigrationJob using default mod if the job does not set the spec.Mode. This PR fixes the issue.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
