### PR TITLE
Fix: Add mutex lock to resolve concurrent lru cache access is not safe

### DIFF
--- a/pkg/runtimeproxy/client/hookclient.go
+++ b/pkg/runtimeproxy/client/hookclient.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/golang/groupcache/lru"
 	"google.golang.org/grpc"
@@ -32,6 +33,7 @@ type HookServerClientManagerInterface interface {
 }
 
 type HookServerClientManager struct {
+	sync.RWMutex
 	cache *lru.Cache
 }
 
@@ -72,6 +74,9 @@ func newRuntimeHookClient(sockPath string) (*RuntimeHookClient, error) {
 }
 
 func (cm *HookServerClientManager) RuntimeHookServerClient(serverPath HookServerPath) (*RuntimeHookClient, error) {
+	cm.Lock()
+	defer cm.Unlock()
+
 	if client, ok := cm.cache.Get(serverPath); ok {
 		return client.(*RuntimeHookClient), nil
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Add mutex lock to resolve concurrent `lru cache` access is not safe.

### Ⅱ. Does this pull request fix one issue?
```
NONE
```
### Ⅲ. Describe how to verify it
https://github.com/golang/groupcache/blob/master/lru/lru.go#L23

### Ⅳ. Special notes for reviews
/cc @eahydra @jasonliu747 

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
