### PR TITLE
koordlet: support resctrl on AMD

### DIFF
--- a/pkg/koordlet/resmanager/resctrl_reconcile_test.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -510,8 +511,8 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -531,8 +532,8 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -551,8 +552,8 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -571,8 +572,8 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -591,16 +592,16 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(10),
-								CATRangeEndPercent:   pointer.Int64Ptr(50),
+								CATRangeStartPercent: pointer.Int64(10),
+								CATRangeEndPercent:   pointer.Int64(50),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -619,16 +620,16 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSRClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(50),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(50),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
@@ -647,16 +648,16 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(10),
-								CATRangeEndPercent:   pointer.Int64Ptr(50),
+								CATRangeStartPercent: pointer.Int64(10),
+								CATRangeEndPercent:   pointer.Int64(50),
 							},
 						},
 					},
@@ -713,9 +714,10 @@ func TestResctrlReconcile_calculateAndApplyCatL3PolicyForGroup(t *testing.T) {
 
 func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 	type args struct {
-		group       string
-		l3Num       int
-		qosStrategy *slov1alpha1.ResourceQOSStrategy
+		group        string
+		l3Num        int
+		basicCPUInfo koordletutil.CPUBasicInfo
+		qosStrategy  *slov1alpha1.ResourceQOSStrategy
 	}
 	type field struct {
 		invalidPath   bool
@@ -738,13 +740,14 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 		{
 			name: "throw an error for write on invalid path",
 			args: args{
-				group: LSResctrlGroup,
-				l3Num: 2,
+				group:        LSResctrlGroup,
+				l3Num:        2,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(90),
+								MBAPercent: pointer.Int64(90),
 							},
 						},
 					},
@@ -757,13 +760,14 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 		{
 			name: "warning to empty policy",
 			args: args{
-				group: LSResctrlGroup,
-				l3Num: 2,
+				group:        LSResctrlGroup,
+				l3Num:        2,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(90),
+								MBAPercent: pointer.Int64(90),
 							},
 						},
 					},
@@ -773,15 +777,16 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "apply policy correctly",
+			name: "apply policy correctly on intel",
 			args: args{
-				group: LSResctrlGroup,
-				l3Num: 2,
+				group:        LSResctrlGroup,
+				l3Num:        2,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(90),
+								MBAPercent: pointer.Int64(90),
 							},
 						},
 					},
@@ -791,22 +796,68 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "apply policy correctly on amd",
+			field: field{
+				schemataData: []string{"    L3:0=f;1=f;2=f;3=f\n    MB:0=2048;1=2048;2=2048;3=2048"},
+			},
+			args: args{
+				group:        BEResctrlGroup,
+				l3Num:        4,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
+				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
+					BEClass: &slov1alpha1.ResourceQOS{
+						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
+							ResctrlQOS: slov1alpha1.ResctrlQOS{
+								MBAPercent: pointer.Int64(30),
+							},
+						},
+					},
+				},
+			},
+			// AMDCCDMaxMBGbps*0.3=25*0.8*8*0.3
+			want:    "MB:0=48;1=48;2=48;3=48;\n",
+			wantErr: false,
+		},
+		{
+			name: "apply unlimited policy correctly on amd",
+			field: field{
+				schemataData: []string{"    L3:0=f;1=f;2=f;3=f\n    MB:0=100;1=100;2=100;3=100"},
+			},
+			args: args{
+				group:        BEResctrlGroup,
+				l3Num:        4,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
+				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
+					BEClass: &slov1alpha1.ResourceQOS{
+						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
+							ResctrlQOS: slov1alpha1.ResctrlQOS{
+								MBAPercent: pointer.Int64(100),
+							},
+						},
+					},
+				},
+			},
+			want:    "MB:0=2048;1=2048;2=2048;3=2048;\n",
+			wantErr: false,
+		},
+		{
 			name: "calculate the policy but no need to update",
 			args: args{
-				group: BEResctrlGroup,
-				l3Num: 2,
+				group:        BEResctrlGroup,
+				l3Num:        2,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(100),
+								MBAPercent: pointer.Int64(100),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(90),
+								MBAPercent: pointer.Int64(90),
 							},
 						},
 					},
@@ -822,20 +873,21 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 		{
 			name: "calculate the policy but no need to update 1",
 			args: args{
-				group: BEResctrlGroup,
-				l3Num: 1,
+				group:        BEResctrlGroup,
+				l3Num:        1,
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(90),
+								MBAPercent: pointer.Int64(90),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								MBAPercent: pointer.Int64Ptr(80),
+								MBAPercent: pointer.Int64(80),
 							},
 						},
 					},
@@ -871,7 +923,7 @@ func TestResctrlReconcile_calculateAndApplyCatMbPolicyForGroup(t *testing.T) {
 			}
 
 			// execute function
-			err = r.calculateAndApplyCatMbPolicyForGroup(tt.args.group, tt.args.l3Num,
+			err = r.calculateAndApplyCatMbPolicyForGroup(tt.args.group, tt.args.l3Num, tt.args.basicCPUInfo,
 				getResourceQOSForResctrlGroup(tt.args.qosStrategy, tt.args.group))
 			assert.Equal(t, tt.wantErr, err != nil)
 
@@ -996,25 +1048,25 @@ func TestResctrlReconcile_reconcileCatResctrlPolicy(t *testing.T) {
 					LSRClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
 							},
 						},
 					},
 					LSClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(100),
-								MBAPercent:           pointer.Int64Ptr(90),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(100),
+								MBAPercent:           pointer.Int64(90),
 							},
 						},
 					},
 					BEClass: &slov1alpha1.ResourceQOS{
 						ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 							ResctrlQOS: slov1alpha1.ResctrlQOS{
-								CATRangeStartPercent: pointer.Int64Ptr(0),
-								CATRangeEndPercent:   pointer.Int64Ptr(50),
+								CATRangeStartPercent: pointer.Int64(0),
+								CATRangeEndPercent:   pointer.Int64(50),
 							},
 						},
 					},
@@ -1188,24 +1240,24 @@ func TestResctrlReconcile_reconcile(t *testing.T) {
 				LSRClass: &slov1alpha1.ResourceQOS{
 					ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 						ResctrlQOS: slov1alpha1.ResctrlQOS{
-							CATRangeStartPercent: pointer.Int64Ptr(0),
-							CATRangeEndPercent:   pointer.Int64Ptr(100),
+							CATRangeStartPercent: pointer.Int64(0),
+							CATRangeEndPercent:   pointer.Int64(100),
 						},
 					},
 				},
 				LSClass: &slov1alpha1.ResourceQOS{
 					ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 						ResctrlQOS: slov1alpha1.ResctrlQOS{
-							CATRangeStartPercent: pointer.Int64Ptr(0),
-							CATRangeEndPercent:   pointer.Int64Ptr(100),
+							CATRangeStartPercent: pointer.Int64(0),
+							CATRangeEndPercent:   pointer.Int64(100),
 						},
 					},
 				},
 				BEClass: &slov1alpha1.ResourceQOS{
 					ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
 						ResctrlQOS: slov1alpha1.ResctrlQOS{
-							CATRangeStartPercent: pointer.Int64Ptr(0),
-							CATRangeEndPercent:   pointer.Int64Ptr(30),
+							CATRangeStartPercent: pointer.Int64(0),
+							CATRangeEndPercent:   pointer.Int64(30),
 						},
 					},
 				},
@@ -1304,8 +1356,9 @@ func TestResctrlReconcile_reconcile(t *testing.T) {
 
 func Test_calculateMbaPercentForGroup(t *testing.T) {
 	type args struct {
-		group     string
-		mbPercent *int64
+		group        string
+		basicCPUInfo koordletutil.CPUBasicInfo
+		mbPercent    *int64
 	}
 	tests := []struct {
 		name string
@@ -1315,46 +1368,69 @@ func Test_calculateMbaPercentForGroup(t *testing.T) {
 		{
 			name: "mbPercent not config",
 			args: args{
-				group: "BE",
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
 			},
 			want: "",
 		},
 		{
 			name: "mbPercent value is invalid,not between (0,100]",
 			args: args{
-				group:     "BE",
-				mbPercent: pointer.Int64Ptr(0),
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
+				mbPercent:    pointer.Int64(0),
 			},
 			want: "",
 		},
 		{
 			name: "mbPercent value is invalid,not between (0,100]",
 			args: args{
-				group:     "BE",
-				mbPercent: pointer.Int64Ptr(101),
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
+				mbPercent:    pointer.Int64(101),
 			},
 			want: "",
 		},
 		{
 			name: "mbPercent value is invalid, not multiple of 10",
 			args: args{
-				group:     "BE",
-				mbPercent: pointer.Int64Ptr(85),
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
+				mbPercent:    pointer.Int64(85),
 			},
 			want: "90",
 		},
 		{
-			name: "mbPercent value is valid",
+			name: "mbPercent value is valid on intel",
 			args: args{
-				group:     "BE",
-				mbPercent: pointer.Int64Ptr(80),
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: "GenuineIntel"},
+				mbPercent:    pointer.Int64(80),
 			},
 			want: "80",
+		},
+		{
+			name: "mbPercent value is valid on amd",
+			args: args{
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
+				mbPercent:    pointer.Int64(80),
+			},
+			want: strconv.FormatInt(int64(0.8*AMDCCDMaxMBGbps), 10),
+		},
+		{
+			name: "mbPercent value is unlimited on amd",
+			args: args{
+				group:        "BE",
+				basicCPUInfo: koordletutil.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
+				mbPercent:    pointer.Int64(100),
+			},
+			want: AMDCCDUnlimitedMB,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calculateMbaPercentForGroup(tt.args.group, tt.args.mbPercent)
+			got := calculateMbaPercentForGroup(tt.args.group, tt.args.mbPercent, tt.args.basicCPUInfo)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/koordlet/resourceexecutor/resctrl_updater.go
+++ b/pkg/koordlet/resourceexecutor/resctrl_updater.go
@@ -72,7 +72,7 @@ func NewResctrlL3SchemataResource(group, schemataDelta string, l3Num int) Resour
 func NewResctrlMbSchemataResource(group, schemataDelta string, l3Num int) ResourceUpdater {
 	schemataFile := sysutil.ResctrlSchemata.Path(group)
 	mbSchemataKey := sysutil.MbSchemataPrefix + ":" + schemataFile
-	schemata := sysutil.NewResctrlSchemataRaw().WithL3Num(l3Num).WithMBPercent(schemataDelta)
+	schemata := sysutil.NewResctrlSchemataRaw().WithL3Num(l3Num).WithMB(schemataDelta)
 	klog.V(6).Infof("generate new resctrl mba schemata resource, file %s, key %s, value %s",
 		schemataFile, mbSchemataKey, schemata.MBString())
 

--- a/pkg/koordlet/util/cpuinfo.go
+++ b/pkg/koordlet/util/cpuinfo.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,7 @@ const cpuCmdTimeout = 3 * time.Second
 type CPUBasicInfo struct {
 	HyperThreadEnabled bool   `json:"hyperThreadEnabled,omitempty"`
 	CatL3CbmMask       string `json:"catL3CbmMask,omitempty"`
+	VendorID           string `json:"vendorID,omitempty"`
 }
 
 // ProcessorInfo describes the processor topology information of a single logic cpu, including the core, socket and numa
@@ -114,6 +116,9 @@ func getCPUBasicInfo() (*CPUBasicInfo, error) {
 	}
 	if cpuBasicInfo.CatL3CbmMask, err = system.ReadCatL3CbmString(); err != nil {
 		klog.V(5).Infof("get l3 cache bit mask error: %v", err)
+	}
+	if cpuBasicInfo.VendorID, err = system.GetVendorIDByCPUInfo(filepath.Join(system.Conf.ProcRootDir, system.CPUInfoFileName)); err != nil {
+		klog.V(5).Infof("get cpu vendor error: %v", err)
 	}
 	return cpuBasicInfo, nil
 }

--- a/pkg/koordlet/util/system/resctrl_linux.go
+++ b/pkg/koordlet/util/system/resctrl_linux.go
@@ -88,6 +88,37 @@ func isResctrlAvailableByCpuInfo(path string) (bool, bool, error) {
 	return isCatFlagSet, isMbaFlagSet, nil
 }
 
+// return vendor_id like AuthenticAMD from cpu info, e.g.
+// vendor_id       : AuthenticAMD
+// vendor_id       : GenuineIntel
+func GetVendorIDByCPUInfo(path string) (string, error) {
+	vendorID := "unknown"
+	f, err := os.Open(path)
+	if err != nil {
+		return vendorID, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return vendorID, err
+		}
+
+		line := s.Text()
+
+		// get "vendor_id" from first line
+		if strings.Contains(line, "vendor_id") {
+			attrs := strings.Split(line, ":")
+			if len(attrs) >= 2 {
+				vendorID = strings.TrimSpace(attrs[1])
+				break
+			}
+		}
+	}
+	return vendorID, nil
+}
+
 // file content example:
 // BOOT_IMAGE=/boot/vmlinuz-4.19.91-24.1.al7.x86_64 root=UUID=231efa3b-302b-4e82-9445-0f7d5d353dda \
 // crashkernel=0M-2G:0M,2G-8G:192M,8G-:256M cryptomgr.notests cgroup.memory=nokmem rcupdate.rcu_cpu_stall_timeout=300 \

--- a/pkg/koordlet/util/system/resctrl_linux_test.go
+++ b/pkg/koordlet/util/system/resctrl_linux_test.go
@@ -125,3 +125,54 @@ func Test_isResctrlAvailableByKernelCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVendorIDByCPUInfo(t *testing.T) {
+	type args struct {
+		content string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test amd",
+			args: args{
+				content: "vendor_id       : AuthenticAMD\n",
+			},
+			want:    AMD_VENDOR_ID,
+			wantErr: false,
+		},
+		{
+			name: "test amd on one line",
+			args: args{
+				content: "vendor_id       : AuthenticAMD",
+			},
+			want:    AMD_VENDOR_ID,
+			wantErr: false,
+		},
+		{
+			name: "test intel",
+			args: args{
+				content: "vendor_id       : GenuineIntel",
+			},
+			want:    "GenuineIntel",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := NewFileTestUtil(t)
+			helper.WriteProcSubFileContents("cpuinfo", tt.args.content)
+			got, err := GetVendorIDByCPUInfo(filepath.Join(Conf.ProcRootDir, "cpuinfo"))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetVendorIDByCPUInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetVendorIDByCPUInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/util/system/resctrl_test.go
+++ b/pkg/koordlet/util/system/resctrl_test.go
@@ -138,7 +138,7 @@ func TestResctrlSchemataRaw(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewResctrlSchemataRaw()
-			r.WithL3Num(tt.fields.l3Num).WithL3Mask(tt.fields.l3Mask).WithMBPercent(tt.fields.mbPercent)
+			r.WithL3Num(tt.fields.l3Num).WithL3Mask(tt.fields.l3Mask).WithMB(tt.fields.mbPercent)
 			if len(tt.fields.l3Mask) > 0 {
 				got := r.L3String()
 				assert.Equal(t, tt.wantL3String, got)

--- a/pkg/koordlet/util/system/resctrl_unsupported.go
+++ b/pkg/koordlet/util/system/resctrl_unsupported.go
@@ -30,6 +30,10 @@ func isResctrlAvailableByCpuInfo(path string) (bool, bool, error) {
 	return false, false, nil
 }
 
+func GetVendorIDByCPUInfo(path string) (string, error) {
+	return "unknown", nil
+}
+
 func isResctrlAvailableByKernelCmd(path string) (bool, bool, error) {
 	return false, false, nil
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The memory bandwidth schema format of resctrl on AMD is different with Intel.
L3 isolation formats are same.
Intel use percentage for MB configuration, however AMD use absolutely value for MB configuration.
We measure the MB extreme limit offline, and convert to absolute value for AMD.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fix #216
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
