### PR TITLE
koordlet: revise sysctl initialization of the group identity

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
@@ -35,16 +35,12 @@ func (b *bvtPlugin) SetPodBvtValue(p protocol.HooksProtocol) error {
 		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
 		return nil
 	}
-	enable, err := b.initialize()
+	err := b.initialize()
 	if err != nil {
 		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
 		return nil
 	}
-	// skip if the feature is disabled by the kernel config
-	if !enable && b.hasKernelEnable() {
-		klog.V(5).Infof("skip for pod since hook plugin %s has been disabled by kernel config", name)
-		return nil
-	}
+
 	podCtx := p.(*protocol.PodContext)
 	req := podCtx.Request
 	podQOS := ext.GetQoSClassByAttrs(req.Labels, req.Annotations)
@@ -64,16 +60,12 @@ func (b *bvtPlugin) SetKubeQOSBvtValue(p protocol.HooksProtocol) error {
 		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
 		return nil
 	}
-	enable, err := b.initialize()
+	err := b.initialize()
 	if err != nil {
 		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
 		return nil
 	}
-	// skip if the feature is disabled by the kernel config
-	if !enable && b.hasKernelEnable() {
-		klog.V(5).Infof("skip for qos since hook plugin %s has been disabled by kernel config", name)
-		return nil
-	}
+
 	kubeQOSCtx := p.(*protocol.KubeQOSContext)
 	req := kubeQOSCtx.Request
 	bvtValue := r.getKubeQOSDirBvtValue(req.KubeQOSClass)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the sysctl initialization of the cgroup identity since the `/proc/sys/kernel/sched_group_identity_enabled` may be not allowed to reset in some versions of the Anolis os.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
