### PR TITLE
koord-descheduler: the reservation created during migration skips the original node

### DIFF
--- a/pkg/descheduler/controllers/migration/reservation/util_test.go
+++ b/pkg/descheduler/controllers/migration/reservation/util_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestCreateOrUpdateReservationOptions(t *testing.T) {
+	ownerReferences := []metav1.OwnerReference{
+		{
+			Controller: pointer.Bool(true),
+			Name:       "test",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		wantOptions *sev1alpha1.PodMigrateReservationOptions
+	}{
+		{
+			name: "skip current node",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: ownerReferences,
+					Namespace:       "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+			},
+			wantOptions: &sev1alpha1.PodMigrateReservationOptions{
+				Template: &sev1alpha1.ReservationTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelCreatedBy: "koord-descheduler",
+						},
+					},
+					Spec: sev1alpha1.ReservationSpec{
+						AllocateOnce: true,
+						Owners: []sev1alpha1.ReservationOwner{
+							{
+								Controller: &sev1alpha1.ReservationControllerReference{
+									OwnerReference: ownerReferences[0],
+									Namespace:      "default",
+								},
+							},
+						},
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       "default",
+								OwnerReferences: ownerReferences,
+							},
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{
+									NodeAffinity: &corev1.NodeAffinity{
+										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+											NodeSelectorTerms: []corev1.NodeSelectorTerm{
+												{
+													MatchFields: []corev1.NodeSelectorRequirement{
+														{
+															Key:      "metadata.name",
+															Operator: corev1.NodeSelectorOpNotIn,
+															Values:   []string{"test-node"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "skip current node with existing node affinity",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: ownerReferences,
+					Namespace:       "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "test",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"xxxx"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantOptions: &sev1alpha1.PodMigrateReservationOptions{
+				Template: &sev1alpha1.ReservationTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelCreatedBy: "koord-descheduler",
+						},
+					},
+					Spec: sev1alpha1.ReservationSpec{
+						AllocateOnce: true,
+						Owners: []sev1alpha1.ReservationOwner{
+							{
+								Controller: &sev1alpha1.ReservationControllerReference{
+									OwnerReference: ownerReferences[0],
+									Namespace:      "default",
+								},
+							},
+						},
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       "default",
+								OwnerReferences: ownerReferences,
+							},
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{
+									NodeAffinity: &corev1.NodeAffinity{
+										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+											NodeSelectorTerms: []corev1.NodeSelectorTerm{
+												{
+													MatchExpressions: []corev1.NodeSelectorRequirement{
+														{
+															Key:      "test",
+															Operator: corev1.NodeSelectorOpIn,
+															Values:   []string{"xxxx"},
+														},
+													},
+													MatchFields: []corev1.NodeSelectorRequirement{
+														{
+															Key:      "metadata.name",
+															Operator: corev1.NodeSelectorOpNotIn,
+															Values:   []string{"test-node"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &sev1alpha1.PodMigrationJob{}
+			got := CreateOrUpdateReservationOptions(job, tt.pod)
+			assert.True(t, got.Template.Labels[apiext.LabelReservationOrder] != "")
+			delete(got.Template.Labels, apiext.LabelReservationOrder)
+			assert.Equal(t, tt.wantOptions, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The Reservation created by the migrationController of koord-descheduler may be scheduled to the node where the migrated Pod is located. Although this is the most suitable node from the perspective of the scheduler, it is not suitable from the perspective of descheduling. Therefore, when migrating The created Reservation should skip the original node.

When creating a Reservation, skipped terms will be added to each required term in the original Pod.Spec.Affinity.NodeAffinity to ensure that any condition will not be dispatched to the original node.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1114 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
