### PR TITLE
koord-scheduler: fix pods outside the Reservation preempt pods in the Reservation

### DIFF
--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -1,0 +1,273 @@
+package scheduling
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework/manifest"
+	e2epod "github.com/koordinator-sh/koordinator/test/e2e/framework/pod"
+)
+
+var _ = SIGDescribe("Preemption", func() {
+	f := framework.NewDefaultFramework("preemption")
+
+	ginkgo.BeforeEach(func() {
+		framework.AllNodesReady(f.ClientSet, time.Minute)
+	})
+
+	ginkgo.AfterEach(func() {
+		ls := metav1.SetAsLabelSelector(map[string]string{
+			"e2e-test-reservation": "true",
+		})
+		reservationList, err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(ls),
+		})
+		framework.ExpectNoError(err)
+		for _, v := range reservationList.Items {
+			err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+		}
+	})
+
+	framework.KoordinatorDescribe("Basic Preemption", func() {
+		framework.ConformanceIt("preempt device", func() {
+			nodeName := runPodAndGetNodeName(f, pausePodConfig{
+				Name: "without-label",
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+				},
+				SchedulerName: "koord-scheduler",
+			})
+
+			ginkgo.By("Create low priority Pod requests all GPUs")
+			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err, fmt.Sprintf("unable to get node %v", nodeName))
+
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:      nodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain GPUs")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "high-priority-pod",
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:          nodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, highPriorityPod), "unable preempt lowest priority pod")
+		})
+
+		framework.ConformanceIt("pods outside Reservation cannot preempt pods in Reservation", func() {
+			nodeName := runPodAndGetNodeName(f, pausePodConfig{
+				Name: "without-label",
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+				},
+				SchedulerName: "koord-scheduler",
+			})
+			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err, fmt.Sprintf("unable to get node %v", nodeName))
+
+			ginkgo.By("Create Reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+			reservation.Spec.AllocateOnce = false
+			reservation.Spec.Template.Spec.NodeName = nodeName
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation-preempt": "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+						},
+						Requests: corev1.ResourceList{
+							apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+						},
+					},
+				},
+			}
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+			waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create low priority Pod requests all GPUs")
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:      nodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, lowPriorityPod.Namespace, lowPriorityPod.Name, reservation.Name)
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain GPUs")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "high-priority-pod",
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:          nodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, highPriorityPod.Namespace, highPriorityPod.Name, "wait for pod schedule failed", 60*time.Second, func(pod *corev1.Pod) (bool, error) {
+				_, scheduledCondition := k8spodutil.GetPodCondition(&pod.Status, corev1.PodScheduled)
+				return scheduledCondition != nil && scheduledCondition.Status == corev1.ConditionFalse, nil
+			}))
+
+			pod, err := f.PodClient().Get(context.TODO(), lowPriorityPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(pod.DeletionTimestamp, (*metav1.Time)(nil))
+		})
+
+		framework.ConformanceIt("highest priority pods in Reservation preempt lowest priority pods in Reservation", func() {
+			nodeName := runPodAndGetNodeName(f, pausePodConfig{
+				Name: "without-label",
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: resource.MustParse("100"),
+					},
+				},
+				SchedulerName: "koord-scheduler",
+			})
+			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err, fmt.Sprintf("unable to get node %v", nodeName))
+
+			ginkgo.By("Create Reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+			reservation.Spec.AllocateOnce = false
+			reservation.Spec.Template.Spec.NodeName = nodeName
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation-preempt": "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+						},
+						Requests: corev1.ResourceList{
+							apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+						},
+					},
+				},
+			}
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+			waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create low priority Pod requests all GPUs")
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:      nodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, lowPriorityPod.Namespace, lowPriorityPod.Name, reservation.Name)
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain GPUs")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "high-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+					Requests: corev1.ResourceList{
+						apiext.ResourceGPU: node.Status.Allocatable[apiext.ResourceGPU],
+					},
+				},
+				NodeName:          nodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, highPriorityPod), "unable to preempt")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, highPriorityPod.Namespace, highPriorityPod.Name, reservation.Name)
+		})
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The pods outside the Reservation cannot preempt pods in Reservation.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1187 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
