### PR TITLE
koordlet: adjust the log output of bvt plugin, call klog.Failf will cause koodlet exit.

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/interceptor.go
@@ -17,7 +17,8 @@ limitations under the License.
 package groupidentity
 
 import (
-	"k8s.io/klog/v2"
+	"fmt"
+
 	"k8s.io/utils/pointer"
 
 	ext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -27,18 +28,15 @@ import (
 
 func (b *bvtPlugin) SetPodBvtValue(p protocol.HooksProtocol) error {
 	if !b.SystemSupported() {
-		klog.V(5).Infof("plugin %s is not supported by system", name)
-		return nil
+		return fmt.Errorf("plugin %s is not supported by system", name)
 	}
 	r := b.getRule()
 	if r == nil {
-		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
-		return nil
+		return fmt.Errorf("hook plugin rule is nil, nothing to do for plugin %v", name)
 	}
 	err := b.initialize()
 	if err != nil {
-		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
-		return nil
+		return fmt.Errorf("failed to initialize plugin %s, err: %s", name, err)
 	}
 
 	podCtx := p.(*protocol.PodContext)
@@ -52,18 +50,15 @@ func (b *bvtPlugin) SetPodBvtValue(p protocol.HooksProtocol) error {
 
 func (b *bvtPlugin) SetKubeQOSBvtValue(p protocol.HooksProtocol) error {
 	if !b.SystemSupported() {
-		klog.V(5).Infof("plugin %s is not supported by system", name)
-		return nil
+		return fmt.Errorf("plugin %s is not supported by system", name)
 	}
 	r := b.getRule()
 	if r == nil {
-		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
-		return nil
+		return fmt.Errorf("hook plugin rule is nil, nothing to do for plugin %v", name)
 	}
 	err := b.initialize()
 	if err != nil {
-		klog.V(4).Infof("failed to initialize plugin %s, err: %s", name, err)
-		return nil
+		return fmt.Errorf("failed to initialize plugin %s, err: %s", name, err)
 	}
 
 	kubeQOSCtx := p.(*protocol.KubeQOSContext)

--- a/pkg/koordlet/runtimehooks/rule/rule.go
+++ b/pkg/koordlet/runtimehooks/rule/rule.go
@@ -46,7 +46,7 @@ var globalRWMutex sync.RWMutex
 func Register(name, description string, injectOpts ...InjectOption) *Rule {
 	r, exist := find(name)
 	if exist {
-		klog.Fatalf("rule %s is conflict since name is already registered")
+		klog.Errorf("rule %s is conflict since name is already registered")
 		return r
 	}
 	r.description = description


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
adjust the log output of bvt plugin, call klog.Failf causes the program to exit.

### Ⅱ. Does this pull request fix one issue?

See: https://github.com/koordinator-sh/koordinator/blob/main/pkg/koordlet/runtimehooks/rule/rule.go#L49

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
