### PR TITLE
runtime-proxy: extract annotations from labels for docker

### DIFF
--- a/pkg/runtimeproxy/server/docker/server.go
+++ b/pkg/runtimeproxy/server/docker/server.go
@@ -125,10 +125,11 @@ func (d *RuntimeManagerDockerServer) failOver(dockerClient proxyDockerClient) er
 
 	// need to backup pod meta first
 	for _, s := range sandboxes {
+		labels, annos := splitLabelsAndAnnotations(s.Labels)
 		store.WritePodSandboxInfo(s.ID, &store.PodSandboxInfo{
 			PodSandboxHookRequest: &v1alpha1.PodSandboxHookRequest{
-				Labels:       s.Labels,
-				Annotations:  s.Labels,
+				Labels:       labels,
+				Annotations:  annos,
 				CgroupParent: s.ContainerJSON.HostConfig.CgroupParent,
 				PodMeta: &v1alpha1.PodSandboxMetadata{
 					Name: s.Name,
@@ -141,10 +142,11 @@ func (d *RuntimeManagerDockerServer) failOver(dockerClient proxyDockerClient) er
 	}
 
 	for _, c := range containers {
+		_, annos := splitLabelsAndAnnotations(c.Labels)
 		cInfo := &store.ContainerInfo{
 			ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
 				ContainerResources:   HostConfigToResource(c.ContainerJSON.HostConfig),
-				ContainerAnnotations: c.Labels,
+				ContainerAnnotations: annos,
 				ContainerMeta: &v1alpha1.ContainerMetadata{
 					Name: c.Name,
 					Id:   c.ID,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

runtime-proxy: extract annotations from labels for docker

In dockershim，annotations and labels are merged because docker supports only labels.
We should extract annotations from labels for docker in failOver as we do in HandleCreateContainer of RuntimeManagerDockerServer.

### Ⅱ. Does this pull request fix one issue?

None

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
