### PR TITLE
koordlet: fix koordlet batchresource when batch resource limit is not set

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
@@ -172,7 +172,8 @@ func (p *plugin) SetPodCFSQuota(proto protocol.HooksProtocol) error {
 	// TODO: count init container and pod overhead
 	for _, c := range extendedResourceSpec.Containers {
 		if c.Limits == nil {
-			continue
+			milliCPULimit = -1
+			break
 		}
 		containerLimit := util.GetBatchMilliCPUFromResourceList(c.Limits)
 		if containerLimit <= 0 { // pod unlimited once a container is unlimited
@@ -185,8 +186,7 @@ func (p *plugin) SetPodCFSQuota(proto protocol.HooksProtocol) error {
 	cfsQuota := milliCPULimit * sysutil.CFSBasePeriodValue / 1000 // TBD: assert base cfs period not changed
 	if cfsQuota <= 0 {                                            // pod unlimited
 		cfsQuota = -1
-	}
-	if cfsQuota < sysutil.CFSQuotaMinValue { // cfs_quota_us should be no less than 1000
+	} else if cfsQuota < sysutil.CFSQuotaMinValue { // cfs_quota_us should be no less than 1000
 		cfsQuota = sysutil.CFSQuotaMinValue
 	}
 
@@ -214,7 +214,8 @@ func (p *plugin) SetPodMemoryLimit(proto protocol.HooksProtocol) error {
 	// TODO: count init container and pod overhead
 	for _, c := range extendedResourceSpec.Containers {
 		if c.Limits == nil {
-			continue
+			memoryLimit = -1
+			break
 		}
 		containerLimit := util.GetBatchMemoryFromResourceList(c.Limits)
 		if containerLimit <= 0 { // pod unlimited once a container is unlimited

--- a/test/e2e/slocontroller/batchresource.go
+++ b/test/e2e/slocontroller/batchresource.go
@@ -169,7 +169,7 @@ var _ = SIGDescribe("BatchResource", func() {
 				totalCount, allocatableCount = len(nodeList.Items), 0
 
 				return false
-			}, 60*time.Second, 5*time.Second).Should(gomega.Equal(true))
+			}, 180*time.Second, 5*time.Second).Should(gomega.Equal(true))
 
 			framework.Logf("check node batch resources finished, total[%v], allocatable[%v]", totalCount, allocatableCount)
 		})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. Fix the koordlet's BatchResource runtime hook which sets the pod-level cfs quota and memory limit as the minimal instead of the unlimited value (i.e. `-1`, `max`) when the batch pod does not set the limits of batch resources.
2. Increase the timeout of the BatchResource e2e test.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1218.

### Ⅲ. Describe how to verify it

1. Create a batch pod that does not set the limits of the batch-cpu and batch-memory.
2. Check the pod-level cgroups of the batch pod.
3. Verify if the cpu limit (`cpu.cfs_quota_us` for cgroup v1, while `cpu.max` for cgroup v2) and memory limit (`memory.limit_in_bytes` for v1, while `memory.max` for v2) are set as unlimited values.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
