### PR TITLE
koord-scheduler: optimize the criteria for whether the Reservation is allocated

### DIFF
--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -117,7 +117,7 @@ func (pl *Plugin) BeforeFilter(handle frameworkext.ExtendedHandle, cycleState *f
 
 func (pl *Plugin) restoreUnmatchedReservations(cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo, reservationInfos []*reservationInfo, shouldRestoreStates bool) error {
 	for _, rInfo := range reservationInfos {
-		if len(rInfo.allocated) == 0 {
+		if len(rInfo.pods) == 0 {
 			continue
 		}
 

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -366,6 +366,7 @@ func TestAfterPreFilter(t *testing.T) {
 		corev1.ResourceCPU:    resource.MustParse("4"),
 		corev1.ResourceMemory: resource.MustParse("8Gi"),
 	}
+	unmatchedRInfo.pods[uuid.NewUUID()] = &podRequirement{}
 
 	matchRInfo := pl.reservationCache.getReservationInfoByUID(matchedReservation.UID)
 
@@ -624,6 +625,7 @@ func TestBeforeFilter(t *testing.T) {
 		corev1.ResourceCPU:    resource.MustParse("4"),
 		corev1.ResourceMemory: resource.MustParse("8Gi"),
 	}
+	unmatchedRInfo.pods[uuid.NewUUID()] = &podRequirement{}
 
 	matchRInfo := pl.reservationCache.getReservationInfoByUID(matchedReservation.UID)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

We restore unmatched reusable reservation when allocated > 0 before. In podTopologySpread/interpodaffinity scenario, pod may be allocated zero resource, but it position on node should be honored. We restore unmatched reusable reservation when pods > 0. 

### Ⅱ. Does this pull request fix one issue?

fix #1238

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
