### PR TITLE
koord-scheduler: skip daemonset usageThreshold check

### DIFF
--- a/pkg/scheduler/plugins/loadaware/helper.go
+++ b/pkg/scheduler/plugins/loadaware/helper.go
@@ -184,3 +184,13 @@ func sumPodUsages(podMetrics map[string]corev1.ResourceList, estimatedPods sets.
 	}
 	return podUsages, estimatedPodsUsages
 }
+
+// isDaemonSetPod returns true if the pod is a IsDaemonSetPod.
+func isDaemonSetPod(ownerRefList []metav1.OwnerReference) bool {
+	for _, ownerRef := range ownerRefList {
+		if ownerRef.Kind == "DaemonSet" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -114,6 +114,10 @@ func (p *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *c
 		return framework.NewStatus(framework.Error, "node not found")
 	}
 
+	if isDaemonSetPod(pod.OwnerReferences) {
+		return nil
+	}
+
 	nodeMetric, err := p.nodeMetricLister.Get(node.Name)
 	if err != nil {
 		// For nodes that lack load information, fall back to the situation where there is no load-aware scheduling.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

DaemonSet Pod should be scheduled even if the node's usage exceeds the thresholds
### Ⅱ. Does this pull request fix one issue?

fixes #1229 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
