### PR TITLE
koordlet: compare the nodeMetric generation to improve the nodemetric informer updateFunc performance

### DIFF
--- a/pkg/koordlet/statesinformer/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/states_nodemetric.go
@@ -149,11 +149,12 @@ func (r *nodeMetricInformer) Setup(ctx *pluginOption, state *pluginState) {
 				klog.Errorf("unable to convert object to *slov1alpha1.NodeMetric, old %T, new %T", oldObj, newObj)
 				return
 			}
-			if reflect.DeepEqual(oldNodeMetric.Spec, newNodeMetric.Spec) {
+
+			if newNodeMetric.Generation == oldNodeMetric.Generation || reflect.DeepEqual(oldNodeMetric.Spec, newNodeMetric.Spec) {
 				klog.V(5).Infof("find nodeMetric spec %s has not changed.", newNodeMetric.Name)
 				return
 			}
-			klog.Infof("update node metric spec %v", newNodeMetric.Spec)
+			klog.V(2).Infof("update node metric spec %v", newNodeMetric.Spec)
 			r.updateMetricSpec(newNodeMetric)
 		},
 	})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Compare the `nodeMetric` `metadata.Generation` to improve the nodemetric informer `updateFunc` performance.

### Ⅱ. Does this pull request fix one issue?

```
NONE
```

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
