### PR TITLE
koord-scheduler: support select reservation via reservation affinity

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -34,11 +34,36 @@ const (
 
 	// AnnotationReservationAllocated represents the reservation allocated by the pod.
 	AnnotationReservationAllocated = SchedulingDomainPrefix + "/reservation-allocated"
+
+	// AnnotationReservationAffinity represents the constraints of Pod selection Reservation
+	AnnotationReservationAffinity = SchedulingDomainPrefix + "/reservation-affinity"
 )
 
 type ReservationAllocated struct {
 	Name string    `json:"name,omitempty"`
 	UID  types.UID `json:"uid,omitempty"`
+}
+
+// ReservationAffinity represents the constraints of Pod selection Reservation
+type ReservationAffinity struct {
+	// If the affinity requirements specified by this field are not met at
+	// scheduling time, the pod will not be scheduled onto the node.
+	// If the affinity requirements specified by this field cease to be met
+	// at some point during pod execution (e.g. due to an update), the system
+	// may or may not try to eventually evict the pod from its node.
+	RequiredDuringSchedulingIgnoredDuringExecution *ReservationAffinitySelector `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	// ReservationSelector is a selector which must be true for the pod to fit on a reservation.
+	// Selector which must match a reservation's labels for the pod to be scheduled on that node.
+	ReservationSelector map[string]string `json:"reservationSelector,omitempty"`
+}
+
+// ReservationAffinitySelector represents the union of the results of one or more label queries
+// over a set of reservations; that is, it represents the OR of the selectors represented
+// by the reservation selector terms.
+type ReservationAffinitySelector struct {
+	// Required. A list of reservation selector terms. The terms are ORed.
+	// Reuse corev1.NodeSelectorTerm to avoid defining too many repeated definitions.
+	ReservationSelectorTerms []corev1.NodeSelectorTerm `json:"reservationSelectorTerms,omitempty"`
 }
 
 func GetReservationAllocated(pod *corev1.Pod) (*ReservationAllocated, error) {
@@ -71,4 +96,14 @@ func SetReservationAllocated(pod *corev1.Pod, r *schedulingv1alpha1.Reservation)
 
 func IsReservationAllocateOnce(r *schedulingv1alpha1.Reservation) bool {
 	return pointer.BoolDeref(r.Spec.AllocateOnce, true)
+}
+
+func GetReservationAffinity(annotations map[string]string) (*ReservationAffinity, error) {
+	var affinity ReservationAffinity
+	if s := annotations[AnnotationReservationAffinity]; s != "" {
+		if err := json.Unmarshal([]byte(s), &affinity); err != nil {
+			return nil, err
+		}
+	}
+	return &affinity, nil
 }

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -151,7 +151,11 @@ func (ext *frameworkExtenderImpl) RunPreFilterPlugins(ctx context.Context, cycle
 	}
 
 	for _, transformer := range ext.preFilterTransformers {
-		newPod, transformed := transformer.BeforePreFilter(ext, cycleState, pod)
+		newPod, transformed, err := transformer.BeforePreFilter(ext, cycleState, pod)
+		if err != nil {
+			klog.ErrorS(err, "Failed to BeforePreFilter", "pod", klog.KObj(pod), "plugin", transformer.Name())
+			return framework.AsStatus(err)
+		}
 		if transformed {
 			klog.V(5).InfoS("RunPreFilterPlugins transformed", "transformer", transformer.Name(), "pod", klog.KObj(pod))
 			pod = newPod

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -51,12 +51,12 @@ type TestTransformer struct {
 
 func (h *TestTransformer) Name() string { return "TestTransformer" }
 
-func (h *TestTransformer) BeforePreFilter(handle ExtendedHandle, state *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool) {
+func (h *TestTransformer) BeforePreFilter(handle ExtendedHandle, state *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool, error) {
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}
 	pod.Annotations[fmt.Sprintf("BeforePreFilter-%d", h.index)] = fmt.Sprintf("%d", h.index)
-	return pod, true
+	return pod, true, nil
 }
 
 func (h *TestTransformer) AfterPreFilter(handle ExtendedHandle, cycleState *framework.CycleState, pod *corev1.Pod) error {

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -56,7 +56,7 @@ type SchedulingTransformer interface {
 type PreFilterTransformer interface {
 	SchedulingTransformer
 	// BeforePreFilter If there is a change to the incoming Pod, it needs to be modified after DeepCopy and returned.
-	BeforePreFilter(handle ExtendedHandle, state *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool)
+	BeforePreFilter(handle ExtendedHandle, state *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool, error)
 	// AfterPreFilter is executed after PreFilter.
 	// There is a chance to trigger the correction of the State data of each plugin after the PreFilter.
 	AfterPreFilter(handle ExtendedHandle, cycleState *framework.CycleState, pod *corev1.Pod) error

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -249,6 +249,17 @@ func TestPreFilter(t *testing.T) {
 			reservation: r,
 			want:        nil,
 		},
+		{
+			name: "failed to reservation affinity",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						apiext.AnnotationReservationAffinity: `{"reservationSelector": {"reservation-type": "test"}}`,
+					},
+				},
+			},
+			want: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

If a pod has an affinity annotation, the pod must be allocated from the reservation, otherwise it stops scheduling.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1256 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
