### PR TITLE
koordlet: fix host cgroup check failed when the config is not the default

### DIFF
--- a/pkg/koordlet/util/system/cgroup_driver_linux.go
+++ b/pkg/koordlet/util/system/cgroup_driver_linux.go
@@ -135,7 +135,6 @@ func GuessCgroupDriverFromKubeletPort(port int) (CgroupDriverType, error) {
 
 // modify base: github.com/opencontainers/runc/libcontainer/cgroups/utils.go IsCgroup2UnifiedMode
 func IsUsingCgroupsV2() bool {
-
 	unifiedMountpoint := strings.TrimSuffix(Conf.CgroupRootDir, "/")
 
 	isUnifiedOnce.Do(func() {

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -51,8 +51,6 @@ func init() {
 		Conf = NewHostModeConfig()
 		AgentMode = agentMode
 	}
-
-	initSupportConfigs()
 }
 
 func initSupportConfigs() {

--- a/pkg/koordlet/util/system/util_test_tool.go
+++ b/pkg/koordlet/util/system/util_test_tool.go
@@ -77,6 +77,8 @@ func NewFileTestUtil(t *testing.T) *FileTestUtil {
 	Conf.CgroupRootDir = tempDir
 	Conf.SysRootDir = tempDir
 
+	initSupportConfigs()
+
 	return &FileTestUtil{TempDir: tempDir, t: t}
 }
 


### PR DESCRIPTION
…ault

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the koordlet panic when the host path configs are changed.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

After #1021, the koordlet panics when the host cgroup path is not correctly configured. However, the check is invoked in `init()` in which the value of the `CgroupRoot` has not been parsed from the command line arguments. So the koordlet always panics when the host cgroup is not mounted at the default path `/host-cgroup`. 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
