### PR TITLE
koord-scheduler: optimize the flow of restore Reservation

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -4,6 +4,7 @@ pkg/descheduler/controllers/migration/controllerfinder
 pkg/scheduler/frameworkext/temporary_snapshot.go
 pkg/scheduler/frameworkext/temporary_snapshot_test.go
 pkg/scheduler/plugins/coscheduling
+pkg/scheduler/plugins/reservation/error_channel.go
 pkg/koordlet/util/kubelet
 pkg/util/cpuset/cpuset.go
 pkg/util/cpuset/cpuset_test.go

--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+const reservationRestoreStateKey = Name + "/reservationRestoreState"
+
+type reservationRestoreStateData struct {
+	skip        bool
+	nodeToState frameworkext.NodeReservationRestoreStates
+}
+
+type nodeReservationRestoreStateData struct {
+	reservedDevices map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources
+}
+
+func getReservationRestoreState(cycleState *framework.CycleState) *reservationRestoreStateData {
+	var state *reservationRestoreStateData
+	value, err := cycleState.Read(reservationRestoreStateKey)
+	if err == nil {
+		state, _ = value.(*reservationRestoreStateData)
+	}
+	if state == nil {
+		state = &reservationRestoreStateData{
+			skip: true,
+		}
+	}
+	return state
+}
+
+func (s *reservationRestoreStateData) Clone() framework.StateData {
+	return s
+}
+
+func (s *reservationRestoreStateData) getNodeState(nodeName string) *nodeReservationRestoreStateData {
+	val := s.nodeToState[nodeName]
+	ns, ok := val.(*nodeReservationRestoreStateData)
+	if !ok {
+		ns = &nodeReservationRestoreStateData{}
+	}
+	return ns
+}
+
+func (p *Plugin) PreRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {
+	skip, _, status := preparePod(pod)
+	if !status.IsSuccess() {
+		return status
+	}
+	cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{skip: skip})
+	return nil
+}
+
+func (p *Plugin) RestoreReservation(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, matched []*frameworkext.ReservationInfo, unmatched []*frameworkext.ReservationInfo, nodeInfo *framework.NodeInfo) (interface{}, *framework.Status) {
+	state := getReservationRestoreState(cycleState)
+	if state.skip {
+		return nil, nil
+	}
+
+	nodeName := nodeInfo.Node().Name
+	nd := p.nodeDeviceCache.getNodeDevice(nodeName, false)
+	if nd == nil {
+		return nil, nil
+	}
+
+	nd.lock.RLock()
+	defer nd.lock.RUnlock()
+
+	reservedDevices := map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources{}
+	for _, rInfo := range matched {
+		namespacedName := reservationutil.GetReservationNamespacedName(rInfo.Reservation)
+		reserved := nd.getUsed(namespacedName.Namespace, namespacedName.Name)
+		if len(reserved) == 0 {
+			continue
+		}
+		for _, pod := range rInfo.Pods {
+			podAllocated := nd.getUsed(pod.Namespace, pod.Name)
+			if len(podAllocated) == 0 {
+				continue
+			}
+			subtractAllocated(reserved, podAllocated, false)
+		}
+		reservedDevices[rInfo.Reservation.UID] = reserved
+	}
+	return &nodeReservationRestoreStateData{
+		reservedDevices: reservedDevices,
+	}, nil
+}
+
+func (p *Plugin) FinalRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeToStates frameworkext.NodeReservationRestoreStates) *framework.Status {
+	state := getReservationRestoreState(cycleState)
+	if state.skip {
+		return nil
+	}
+	state.nodeToState = nodeToStates
+	return nil
+}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -225,7 +225,6 @@ func TestPlugin_PreFilter(t *testing.T) {
 				resourceSpec:           &extension.ResourceSpec{PreferredCPUBindPolicy: extension.CPUBindPolicyFullPCPUs},
 				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
 				numCPUsNeeded:          4,
-				reservedCPUs:           map[string]map[types.UID]cpuset.CPUSet{},
 			},
 		},
 		{
@@ -258,7 +257,6 @@ func TestPlugin_PreFilter(t *testing.T) {
 				resourceSpec:           &extension.ResourceSpec{PreferredCPUBindPolicy: extension.CPUBindPolicyFullPCPUs},
 				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
 				numCPUsNeeded:          4,
-				reservedCPUs:           map[string]map[types.UID]cpuset.CPUSet{},
 			},
 		},
 		{
@@ -288,15 +286,13 @@ func TestPlugin_PreFilter(t *testing.T) {
 				resourceSpec:           &extension.ResourceSpec{PreferredCPUBindPolicy: extension.CPUBindPolicyDefault},
 				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
 				numCPUsNeeded:          4,
-				reservedCPUs:           map[string]map[types.UID]cpuset.CPUSet{},
 			},
 		},
 		{
 			name: "skip cpu share pod",
 			pod:  &corev1.Pod{},
 			wantState: &preFilterState{
-				skip:         true,
-				reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{},
+				skip: true,
 			},
 		},
 		{
@@ -325,8 +321,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 				},
 			},
 			wantState: &preFilterState{
-				skip:         true,
-				reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{},
+				skip: true,
 			},
 		},
 		{
@@ -345,8 +340,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 				},
 			},
 			wantState: &preFilterState{
-				skip:         true,
-				reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{},
+				skip: true,
 			},
 		},
 		{
@@ -392,8 +386,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 				},
 			},
 			wantState: &preFilterState{
-				skip:         true,
-				reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{},
+				skip: true,
 			},
 		},
 	}
@@ -835,6 +828,7 @@ func TestPlugin_Reserve(t *testing.T) {
 		name          string
 		nodeLabels    map[string]string
 		state         *preFilterState
+		reservedCPUs  map[types.UID]cpuset.CPUSet
 		pod           *corev1.Pod
 		cpuTopology   *CPUTopology
 		allocatedCPUs []int
@@ -973,11 +967,9 @@ func TestPlugin_Reserve(t *testing.T) {
 					PreferredCPUBindPolicy: extension.CPUBindPolicyFullPCPUs,
 				},
 				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
-				reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{
-					"test-node-1": {
-						uuid.NewUUID(): cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
-					},
-				},
+			},
+			reservedCPUs: map[types.UID]cpuset.CPUSet{
+				uuid.NewUUID(): cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
 			},
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
@@ -1019,8 +1011,8 @@ func TestPlugin_Reserve(t *testing.T) {
 				if len(tt.allocatedCPUs) > 0 {
 					allocationState.addCPUs(tt.cpuTopology, uuid.NewUUID(), cpuset.NewCPUSet(tt.allocatedCPUs...), schedulingconfig.CPUExclusivePolicyNone)
 				}
-				if len(tt.state.reservedCPUs) > 0 {
-					for reservationUID, cpus := range tt.state.reservedCPUs["test-node-1"] {
+				if len(tt.reservedCPUs) > 0 {
+					for reservationUID, cpus := range tt.reservedCPUs {
 						allocationState.addCPUs(tt.cpuTopology, reservationUID, cpus, schedulingconfig.CPUExclusivePolicyNone)
 					}
 				}
@@ -1034,8 +1026,8 @@ func TestPlugin_Reserve(t *testing.T) {
 			cycleState := framework.NewCycleState()
 			if tt.state != nil {
 				cycleState.Write(stateKey, tt.state)
-				if len(tt.state.reservedCPUs) > 0 {
-					for reservationUID := range tt.state.reservedCPUs["test-node-1"] {
+				if len(tt.reservedCPUs) > 0 {
+					for reservationUID := range tt.reservedCPUs {
 						frameworkext.SetNominatedReservation(cycleState, &schedulingv1alpha1.Reservation{
 							ObjectMeta: metav1.ObjectMeta{
 								UID:  reservationUID,
@@ -1043,6 +1035,12 @@ func TestPlugin_Reserve(t *testing.T) {
 							},
 						})
 					}
+					cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+						skip: false,
+						nodeToState: frameworkext.NodeReservationRestoreStates{
+							"test-node-1": &nodeReservationRestoreStateData{reservedCPUs: tt.reservedCPUs},
+						},
+					})
 				}
 			}
 
@@ -1245,7 +1243,7 @@ func TestPlugin_PreBindReservation(t *testing.T) {
 	assert.Equal(t, expectResourceStatus, resourceStatus)
 }
 
-func TestReservationPreFilterExtension(t *testing.T) {
+func TestRestoreReservation(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
 	p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
 	assert.NoError(t, err)
@@ -1257,7 +1255,6 @@ func TestReservationPreFilterExtension(t *testing.T) {
 		resourceSpec: &extension.ResourceSpec{
 			PreferredCPUBindPolicy: extension.CPUBindPolicyFullPCPUs,
 		},
-		reservedCPUs: map[string]map[types.UID]cpuset.CPUSet{},
 	}
 	cycleState.Write(stateKey, state)
 
@@ -1265,6 +1262,9 @@ func TestReservationPreFilterExtension(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-reservation",
 			UID:  uuid.NewUUID(),
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{},
 		},
 		Status: schedulingv1alpha1.ReservationStatus{
 			NodeName: "test-node",
@@ -1307,16 +1307,37 @@ func TestReservationPreFilterExtension(t *testing.T) {
 	nodeInfo := framework.NewNodeInfo()
 	nodeInfo.SetNode(node)
 
-	status := pl.RemoveReservation(context.TODO(), cycleState, &corev1.Pod{}, reservation, nodeInfo)
-	assert.True(t, status.IsSuccess())
-	assert.Equal(t, cpuset.NewCPUSet(6, 7, 8, 9), state.reservedCPUs["test-node"][reservation.UID])
+	rInfo := frameworkext.NewReservationInfo(reservation)
+	rInfo.AddPod(podA)
 
-	status = pl.AddPodInReservation(context.TODO(), cycleState, &corev1.Pod{}, framework.NewPodInfo(podA), reservation, nodeInfo)
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				extension.LabelPodQoS: string(extension.QoSLSR),
+			},
+		},
+		Spec: corev1.PodSpec{
+			Priority: pointer.Int32(extension.PriorityProdValueMax),
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+		},
+	}
+	status := pl.PreRestoreReservation(context.TODO(), cycleState, testPod)
 	assert.True(t, status.IsSuccess())
-	assert.Equal(t, cpuset.NewCPUSet(8, 9), state.reservedCPUs["test-node"][reservation.UID])
 
-	status = pl.AddPodInReservation(context.TODO(), cycleState, &corev1.Pod{}, framework.NewPodInfo(podB), reservation, nodeInfo)
+	nodeReservationState, status := pl.RestoreReservation(context.TODO(), cycleState, testPod, []*frameworkext.ReservationInfo{rInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
-	assert.True(t, state.reservedCPUs["test-node"][reservation.UID].IsEmpty())
-	assert.Empty(t, state.reservedCPUs)
+	assert.Equal(t, cpuset.NewCPUSet(8, 9), nodeReservationState.(*nodeReservationRestoreStateData).reservedCPUs[reservation.UID])
+
+	rInfo.AddPod(podB)
+	nodeReservationState, status = pl.RestoreReservation(context.TODO(), cycleState, testPod, []*frameworkext.ReservationInfo{rInfo}, nil, nodeInfo)
+	assert.True(t, status.IsSuccess())
+	assert.Nil(t, nodeReservationState)
 }

--- a/pkg/scheduler/plugins/nodenumaresource/reservation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+)
+
+const reservationRestoreStateKey = Name + "/reservationRestoreState"
+
+type reservationRestoreStateData struct {
+	skip        bool
+	nodeToState frameworkext.NodeReservationRestoreStates
+}
+
+type nodeReservationRestoreStateData struct {
+	reservedCPUs map[types.UID]cpuset.CPUSet
+}
+
+func getReservationRestoreState(cycleState *framework.CycleState) *reservationRestoreStateData {
+	var state *reservationRestoreStateData
+	value, err := cycleState.Read(reservationRestoreStateKey)
+	if err == nil {
+		state, _ = value.(*reservationRestoreStateData)
+	}
+	if state == nil {
+		state = &reservationRestoreStateData{
+			skip: true,
+		}
+	}
+	return state
+}
+
+func (s *reservationRestoreStateData) Clone() framework.StateData {
+	return s
+}
+
+func (s *reservationRestoreStateData) getNodeState(nodeName string) *nodeReservationRestoreStateData {
+	val := s.nodeToState[nodeName]
+	ns, ok := val.(*nodeReservationRestoreStateData)
+	if !ok {
+		ns = &nodeReservationRestoreStateData{}
+	}
+	return ns
+}
+
+func (p *Plugin) PreRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {
+	state := &reservationRestoreStateData{
+		skip: !AllowUseCPUSet(pod),
+	}
+	cycleState.Write(reservationRestoreStateKey, state)
+	return nil
+}
+
+func (p *Plugin) RestoreReservation(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, matched []*frameworkext.ReservationInfo, unmatched []*frameworkext.ReservationInfo, nodeInfo *framework.NodeInfo) (interface{}, *framework.Status) {
+	state := getReservationRestoreState(cycleState)
+	if state.skip {
+		return nil, nil
+	}
+
+	nodeName := nodeInfo.Node().Name
+	reservedCPUs := map[types.UID]cpuset.CPUSet{}
+	for _, rInfo := range matched {
+		allocatedCPUs, ok := p.cpuManager.GetAllocatedCPUSet(nodeName, rInfo.Reservation.UID)
+		if !ok || allocatedCPUs.IsEmpty() {
+			continue
+		}
+
+		for _, pod := range rInfo.Pods {
+			podCPUs, ok := p.cpuManager.GetAllocatedCPUSet(nodeName, pod.UID)
+			if !ok || podCPUs.IsEmpty() {
+				continue
+			}
+
+			allocatedCPUs = allocatedCPUs.Difference(podCPUs)
+		}
+
+		if !allocatedCPUs.IsEmpty() {
+			reservedCPUs[rInfo.Reservation.UID] = allocatedCPUs
+		} else {
+			delete(reservedCPUs, rInfo.Reservation.UID)
+		}
+	}
+
+	if len(reservedCPUs) == 0 {
+		return nil, nil
+	}
+
+	return &nodeReservationRestoreStateData{
+		reservedCPUs: reservedCPUs,
+	}, nil
+}
+
+func (p *Plugin) FinalRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeToStates frameworkext.NodeReservationRestoreStates) *framework.Status {
+	state := getReservationRestoreState(cycleState)
+	if state.skip {
+		return nil
+	}
+	state.nodeToState = nodeToStates
+	return nil
+}

--- a/pkg/scheduler/plugins/reservation/error_channel.go
+++ b/pkg/scheduler/plugins/reservation/error_channel.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import "context"
+
+// ErrorChannel supports non-blocking send and receive operation to capture error.
+// A maximum of one error is kept in the channel and the rest of the errors sent
+// are ignored, unless the existing error is received and the channel becomes empty
+// again.
+type ErrorChannel struct {
+	errCh chan error
+}
+
+// SendError sends an error without blocking the sender.
+func (e *ErrorChannel) SendError(err error) {
+	select {
+	case e.errCh <- err:
+	default:
+	}
+}
+
+// SendErrorWithCancel sends an error without blocking the sender and calls
+// cancel function.
+func (e *ErrorChannel) SendErrorWithCancel(err error, cancel context.CancelFunc) {
+	e.SendError(err)
+	cancel()
+}
+
+// ReceiveError receives an error from channel without blocking on the receiver.
+func (e *ErrorChannel) ReceiveError() error {
+	select {
+	case err := <-e.errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+// NewErrorChannel returns a new ErrorChannel.
+func NewErrorChannel() *ErrorChannel {
+	return &ErrorChannel{
+		errCh: make(chan error, 1),
+	}
+}

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -36,12 +36,12 @@ func (pl *Plugin) NominateReservation(ctx context.Context, cycleState *framework
 	}
 
 	state := getStateData(cycleState)
-	rOnNode := state.matched[nodeName]
-	if len(rOnNode) == 0 {
+	reservationInfos := state.nodeReservationStates[nodeName].matched
+	if len(reservationInfos) == 0 {
 		return nil, nil
 	}
 
-	highestScorer, _ := findMostPreferredReservationByOrder(rOnNode)
+	highestScorer, _ := findMostPreferredReservationByOrder(reservationInfos)
 	if highestScorer != nil {
 		return highestScorer, nil
 	}
@@ -51,8 +51,8 @@ func (pl *Plugin) NominateReservation(ctx context.Context, cycleState *framework
 		return nil, framework.AsStatus(fmt.Errorf("not implemented frameworkext.FrameworkExtender"))
 	}
 
-	reservations := make([]*schedulingv1alpha1.Reservation, 0, len(rOnNode))
-	for _, rInfo := range rOnNode {
+	reservations := make([]*schedulingv1alpha1.Reservation, 0, len(reservationInfos))
+	for _, rInfo := range reservationInfos {
 		status := extender.RunReservationFilterPlugins(ctx, cycleState, pod, rInfo.Reservation, nodeName)
 		if !status.IsSuccess() {
 			continue

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -218,14 +218,17 @@ func TestNominateReservation(t *testing.T) {
 			pl := plugin.(*Plugin)
 			cycleState := framework.NewCycleState()
 			state := &stateData{
-				matched: map[string][]*frameworkext.ReservationInfo{},
+				nodeReservationStates: map[string]nodeReservationState{},
 			}
 			for _, reservation := range tt.reservations {
 				rInfo := frameworkext.NewReservationInfo(reservation)
 				if allocated := tt.allocated[reservation.UID]; len(allocated) > 0 {
 					rInfo.Allocated = allocated
 				}
-				state.matched[reservation.Status.NodeName] = append(state.matched[reservation.Status.NodeName], rInfo)
+				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
+				nodeRState.nodeName = reservation.Status.NodeName
+				nodeRState.matched = append(nodeRState.matched, rInfo)
+				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
 				pl.reservationCache.updateReservation(reservation)
 			}
 			cycleState.Write(stateKey, state)

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -725,7 +725,7 @@ func TestFilterReservation(t *testing.T) {
 			}
 
 			state := &stateData{
-				matched: map[string][]*frameworkext.ReservationInfo{},
+				nodeReservationStates: map[string]nodeReservationState{},
 			}
 			for _, v := range tt.reservations {
 				pl.reservationCache.updateReservation(v)
@@ -733,7 +733,10 @@ func TestFilterReservation(t *testing.T) {
 					pl.reservationCache.addPod(v.UID, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "allocated-pod", UID: uuid.NewUUID()}})
 				}
 				rInfo := pl.reservationCache.getReservationInfoByUID(v.UID)
-				state.matched[v.Status.NodeName] = append(state.matched[v.Status.NodeName], rInfo)
+				nodeRState := state.nodeReservationStates[v.Status.NodeName]
+				nodeRState.nodeName = v.Status.NodeName
+				nodeRState.matched = append(nodeRState.matched, rInfo)
+				state.nodeReservationStates[v.Status.NodeName] = nodeRState
 			}
 			cycleState.Write(stateKey, state)
 

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -19,15 +19,13 @@ package reservation
 import (
 	"context"
 	"fmt"
-	"sync"
+	"sync/atomic"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
-	"k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
@@ -37,70 +35,194 @@ import (
 )
 
 func (pl *Plugin) BeforePreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool, *framework.Status) {
-	state, err := pl.prepareMatchReservationState(ctx, pod)
+	state, restored, err := pl.prepareMatchReservationState(ctx, cycleState, pod)
 	if err != nil {
 		return nil, false, framework.AsStatus(err)
 	}
 	cycleState.Write(stateKey, state)
-
-	klog.V(4).Infof("Pod %v has %d matched reservations and %d unmatched reservations before PreFilter", klog.KObj(pod), len(state.matched), len(state.unmatched))
-	return pod, len(state.matched) > 0 || len(state.unmatched) > 0, nil
+	return pod, restored, nil
 }
 
-func (pl *Plugin) AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {
-	state := getStateData(cycleState)
-	for nodeName, reservationInfos := range state.unmatched {
-		nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
-		if err != nil {
-			continue
-		}
-		if nodeInfo.Node() == nil {
-			continue
-		}
+func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) (*stateData, bool, error) {
+	allNodes, err := pl.handle.SnapshotSharedLister().NodeInfos().List()
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot list NodeInfo, err: %v", err)
+	}
 
-		if err := pl.restoreUnmatchedReservations(cycleState, pod, nodeInfo, reservationInfos, true); err != nil {
-			return framework.AsStatus(err)
+	reservationAffinity, err := reservationutil.GetRequiredReservationAffinity(pod)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse reservation affinity", "pod", klog.KObj(pod))
+		return nil, false, err
+	}
+
+	var stateIndex int32
+	allNodeReservationStates := make([]*nodeReservationState, len(allNodes))
+	allPluginToRestoreState := make([]frameworkext.PluginToReservationRestoreStates, len(allNodes))
+
+	isReservedPod := reservationutil.IsReservePod(pod)
+	parallelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := NewErrorChannel()
+
+	extender, _ := pl.handle.(frameworkext.FrameworkExtender)
+	if extender != nil {
+		status := extender.RunReservationExtensionPreRestoreReservation(ctx, cycleState, pod)
+		if !status.IsSuccess() {
+			return nil, false, status.AsError()
 		}
 	}
 
-	if !reservationutil.IsReservePod(pod) {
-		for nodeName, reservationInfos := range state.matched {
-			nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
-			if err != nil {
-				continue
+	processNode := func(i int) {
+		nodeInfo := allNodes[i]
+		node := nodeInfo.Node()
+		if node == nil {
+			klog.V(4).InfoS("BeforePreFilter failed to get node", "pod", klog.KObj(pod), "nodeInfo", nodeInfo)
+			return
+		}
+
+		rOnNode := pl.reservationCache.listReservationInfosOnNode(node.Name)
+		if len(rOnNode) == 0 {
+			return
+		}
+
+		podInfoMap := make(map[types.UID]*framework.PodInfo)
+		for _, podInfo := range nodeInfo.Pods {
+			if !reservationutil.IsReservePod(podInfo.Pod) {
+				podInfoMap[podInfo.Pod.UID] = podInfo
 			}
-			if nodeInfo.Node() == nil {
+		}
+
+		var unmatched, matched []*frameworkext.ReservationInfo
+		for _, rInfo := range rOnNode {
+			if !reservationutil.IsReservationAvailable(rInfo.Reservation) {
 				continue
 			}
 
-			// NOTE: After PreFilter, all reserved resources need to be returned to the corresponding NodeInfo,
-			// and each plugin is triggered to adjust its own StateData through RemovePod, RemoveReservation and AddPodInReservation,
-			// and adjust the state data related to Reservation and Pod
-			if err := pl.restoreMatchedReservations(cycleState, pod, nodeInfo, reservationInfos, true); err != nil {
-				return framework.AsStatus(err)
+			// In this case, the Controller has not yet updated the status of the Reservation to Succeeded,
+			// but in fact it can no longer be used for allocation. So it's better to skip first.
+			if extension.IsReservationAllocateOnce(rInfo.Reservation) && len(rInfo.Pods) > 0 {
+				continue
+			}
+
+			if !isReservedPod && matchReservation(pod, node, rInfo.Reservation, reservationAffinity) {
+				if err = restoreMatchedReservation(nodeInfo, rInfo, podInfoMap); err != nil {
+					errCh.SendErrorWithCancel(err, cancel)
+					return
+				}
+
+				matched = append(matched, rInfo)
+
+			} else if len(rInfo.Pods) > 0 {
+				if err = restoreUnmatchedReservations(nodeInfo, rInfo); err != nil {
+					errCh.SendErrorWithCancel(err, cancel)
+					return
+				}
+
+				unmatched = append(unmatched, rInfo)
+				if !isReservedPod {
+					klog.V(6).InfoS("got reservation on node does not match the pod", "reservation", klog.KObj(rInfo.Reservation), "pod", klog.KObj(pod))
+				}
 			}
 		}
+
+		var pluginToRestoreState frameworkext.PluginToReservationRestoreStates
+		if extender != nil {
+			var status *framework.Status
+			pluginToRestoreState, status = extender.RunReservationExtensionRestoreReservation(ctx, cycleState, pod, matched, unmatched, nodeInfo)
+			if !status.IsSuccess() {
+				errCh.SendErrorWithCancel(err, cancel)
+				return
+			}
+		}
+
+		if len(matched) > 0 || len(unmatched) > 0 {
+			index := atomic.AddInt32(&stateIndex, 1)
+			allNodeReservationStates[index-1] = &nodeReservationState{
+				nodeName: node.Name,
+				matched:  matched,
+			}
+			allPluginToRestoreState[index-1] = pluginToRestoreState
+		}
+		klog.V(4).Infof("Pod %v has reservations on node %v, %d matched, %d unmatched", klog.KObj(pod), node.Name, len(matched), len(unmatched))
+	}
+	pl.handle.Parallelizer().Until(parallelCtx, len(allNodes), processNode)
+	err = errCh.ReceiveError()
+	if err != nil {
+		return nil, false, err
+	}
+
+	allNodeReservationStates = allNodeReservationStates[:stateIndex]
+	allPluginToRestoreState = allPluginToRestoreState[:stateIndex]
+	pluginToNodeReservationRestoreState := frameworkext.PluginToNodeReservationRestoreStates{}
+	state := &stateData{
+		nodeReservationStates: map[string]nodeReservationState{},
+	}
+	for index, v := range allNodeReservationStates {
+		state.nodeReservationStates[v.nodeName] = *v
+		for pluginName, pluginState := range allPluginToRestoreState[index] {
+			if pluginState == nil {
+				continue
+			}
+			nodeRestoreStates := pluginToNodeReservationRestoreState[pluginName]
+			if nodeRestoreStates == nil {
+				nodeRestoreStates = frameworkext.NodeReservationRestoreStates{}
+				pluginToNodeReservationRestoreState[pluginName] = nodeRestoreStates
+			}
+			nodeRestoreStates[v.nodeName] = pluginState
+		}
+	}
+	if extender != nil {
+		status := extender.RunReservationExtensionFinalRestoreReservation(ctx, cycleState, pod, pluginToNodeReservationRestoreState)
+		if !status.IsSuccess() {
+			return nil, false, status.AsError()
+		}
+	}
+
+	return state, len(allNodeReservationStates) > 0, nil
+}
+
+func (pl *Plugin) AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {
+	return nil
+}
+
+func restoreMatchedReservation(nodeInfo *framework.NodeInfo, rInfo *frameworkext.ReservationInfo, podInfoMap map[types.UID]*framework.PodInfo) error {
+	reservePod := reservationutil.NewReservePod(rInfo.Reservation)
+
+	// Retain ports that are not used by other Pods. These ports need to be erased from NodeInfo.UsedPorts,
+	// otherwise it may cause Pod port conflicts
+	retainReservePodUnusedPorts(reservePod, rInfo.Reservation, podInfoMap)
+
+	// When AllocateOnce is disabled, some resources may have been allocated,
+	// and an additional resource record will be accumulated at this time.
+	// Even if the Reservation is not bound by the Pod (e.g. Reservation is enabled with AllocateOnce),
+	// these resources held by the Reservation need to be returned, to ensure that
+	// the Pod can pass through each filter plugin during scheduling.
+	// The returned resources include scalar resources such as CPU/Memory, ports etc..
+	if err := nodeInfo.RemovePod(reservePod); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func (pl *Plugin) restoreUnmatchedReservations(cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo, reservationInfos []*frameworkext.ReservationInfo, shouldRestoreStates bool) error {
-	for _, rInfo := range reservationInfos {
-		if len(rInfo.Pods) == 0 {
-			continue
-		}
+func restoreUnmatchedReservations(nodeInfo *framework.NodeInfo, rInfo *frameworkext.ReservationInfo) error {
+	// Reservations and Pods that consume the Reservations are cumulative in resource accounting.
+	// For example, on a 32C machine, ReservationA reserves 8C, and then PodA uses ReservationA to allocate 4C,
+	// then the record on NodeInfo is that 12C is allocated. But in fact it should be calculated according to 8C,
+	// so we need to return some resources.
+	reservePod := reservationutil.NewReservePod(rInfo.Reservation)
+	if err := nodeInfo.RemovePod(reservePod); err != nil {
+		klog.Errorf("Failed to remove reserve pod %v from node %v, err: %v", klog.KObj(rInfo.Reservation), nodeInfo.Node().Name, err)
+		return err
+	}
+	occupyUnallocatedResources(rInfo, reservePod, nodeInfo)
+	return nil
+}
 
-		// Reservations and Pods that consume the Reservations are cumulative in resource accounting.
-		// For example, on a 32C machine, ReservationA reserves 8C, and then PodA uses ReservationA to allocate 4C,
-		// then the record on NodeInfo is that 12C is allocated. But in fact it should be calculated according to 8C,
-		// so we need to return some resources.
-		reservePod := reservationutil.NewReservePod(rInfo.Reservation)
-		if err := nodeInfo.RemovePod(reservePod); err != nil {
-			klog.Errorf("Failed to remove reserve pod %v from node %v, err: %v", klog.KObj(rInfo.Reservation), nodeInfo.Node().Name, err)
-			return err
-		}
-
+func occupyUnallocatedResources(rInfo *frameworkext.ReservationInfo, reservePod *corev1.Pod, nodeInfo *framework.NodeInfo) {
+	if len(rInfo.Pods) == 0 {
+		nodeInfo.AddPod(reservePod)
+	} else {
 		for i := range reservePod.Spec.Containers {
 			reservePod.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
 		}
@@ -111,104 +233,7 @@ func (pl *Plugin) restoreUnmatchedReservations(cycleState *framework.CycleState,
 			})
 		}
 		nodeInfo.AddPod(reservePod)
-
-		if shouldRestoreStates {
-			reservePodInfo := framework.NewPodInfo(reservePod)
-			status := pl.handle.RunPreFilterExtensionRemovePod(context.Background(), cycleState, pod, reservePodInfo, nodeInfo)
-			if !status.IsSuccess() {
-				return status.AsError()
-			}
-		}
 	}
-	return nil
-}
-
-func (pl *Plugin) restoreMatchedReservations(cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo, reservationInfos []*frameworkext.ReservationInfo, shouldRestoreStates bool) error {
-	podInfoMap := make(map[types.UID]*framework.PodInfo)
-	for _, podInfo := range nodeInfo.Pods {
-		if !reservationutil.IsReservePod(podInfo.Pod) {
-			podInfoMap[podInfo.Pod.UID] = podInfo
-		}
-	}
-
-	// Currently, only one reusable Reservation matching the Pod is supported on a same node.
-	// Although there is a Filter that can intercept Reservations of the same Owner, if the user creates
-	// multiple reusable Reservations that can be used by different Owners for the Pod and bypasses the Filter,
-	// we choose the instance with the earliest creation time.
-	var earliestReusableRInfo *frameworkext.ReservationInfo
-	for _, v := range reservationInfos {
-		if !extension.IsReservationAllocateOnce(v.Reservation) {
-			if earliestReusableRInfo == nil ||
-				v.Reservation.CreationTimestamp.Before(&earliestReusableRInfo.Reservation.CreationTimestamp) {
-				earliestReusableRInfo = v
-				break
-			}
-		}
-	}
-
-	for _, rInfo := range reservationInfos {
-		if !extension.IsReservationAllocateOnce(rInfo.Reservation) && earliestReusableRInfo != nil && rInfo != earliestReusableRInfo {
-			continue
-		}
-		if err := restoreReservedResources(pl.handle, cycleState, pod, rInfo, nodeInfo, podInfoMap, shouldRestoreStates); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func restoreReservedResources(handle frameworkext.ExtendedHandle, cycleState *framework.CycleState, pod *corev1.Pod, rInfo *frameworkext.ReservationInfo, nodeInfo *framework.NodeInfo, podInfoMap map[types.UID]*framework.PodInfo, shouldRestoreStates bool) error {
-	reservePod := reservationutil.NewReservePod(rInfo.Reservation)
-	reservePodInfo := framework.NewPodInfo(reservePod)
-
-	// Retain ports that are not used by other Pods. These ports need to be erased from NodeInfo.UsedPorts,
-	// otherwise it may cause Pod port conflicts
-	retainReservePodUnusedPorts(reservePod, rInfo.Reservation, podInfoMap)
-
-	// When AllocateOnce is disabled, some resources may have been allocated,
-	// and an additional resource record will be accumulated at this time.
-	// Even if the Reservation is not bound by the Pod (e.g. Reservation is enabled with AllocateOnce),
-	// these resources held by the Reservation need to be returned, so as to ensure that
-	// the Pod can pass through each filter plugin during scheduling.
-	// The returned resources include scalar resources such as CPU/Memory, ports etc..
-	if err := nodeInfo.RemovePod(reservePod); err != nil {
-		return err
-	}
-
-	if !shouldRestoreStates {
-		return nil
-	}
-
-	// Regardless of whether the Reservation enables AllocateOnce
-	// and whether the Reservation uses high-availability constraints such as InterPodAffinity/PodTopologySpread,
-	// we should trigger the plugins to update the state and erase the Reservation-related state in this round
-	// of scheduling to ensure that the Pod can pass these filters.
-	// Although Reservation may reserve a large number of resources for a batch of Pods to use,
-	// and it is possible to use these high-availability constraints to cause resources to be unallocated and wasteful,
-	// users need to bear this waste.
-	status := handle.RunPreFilterExtensionRemovePod(context.Background(), cycleState, pod, reservePodInfo, nodeInfo)
-	if !status.IsSuccess() {
-		return status.AsError()
-	}
-
-	// We should find an appropriate time to return resources allocated by custom plugins held by Reservation,
-	// such as fine-grained CPUs(CPU Cores), Devices(e.g. GPU/RDMA/FPGA etc.).
-	if extender, ok := handle.(frameworkext.FrameworkExtender); ok {
-		status := extender.RunReservationPreFilterExtensionRemoveReservation(context.Background(), cycleState, pod, rInfo.Reservation, nodeInfo)
-		if !status.IsSuccess() {
-			return status.AsError()
-		}
-
-		for _, assignedPod := range rInfo.Pods {
-			if assignedPodInfo, ok := podInfoMap[assignedPod.UID]; ok {
-				status := extender.RunReservationPreFilterExtensionAddPodInReservation(context.Background(), cycleState, pod, assignedPodInfo, rInfo.Reservation, nodeInfo)
-				if !status.IsSuccess() {
-					return status.AsError()
-				}
-			}
-		}
-	}
-	return nil
 }
 
 func retainReservePodUnusedPorts(reservePod *corev1.Pod, reservation *schedulingv1alpha1.Reservation, podInfoMap map[types.UID]*framework.PodInfo) {
@@ -259,82 +284,6 @@ func retainReservePodUnusedPorts(reservePod *corev1.Pod, reservation *scheduling
 	}
 }
 
-func (pl *Plugin) prepareMatchReservationState(ctx context.Context, pod *corev1.Pod) (*stateData, error) {
-	allNodes, err := pl.handle.SnapshotSharedLister().NodeInfos().List()
-	if err != nil {
-		return nil, fmt.Errorf("cannot list NodeInfo, err: %v", err)
-	}
-
-	reservationAffinity, err := reservationutil.GetRequiredReservationAffinity(pod)
-	if err != nil {
-		klog.ErrorS(err, "Failed to parse reservation affinity", "pod", klog.KObj(pod))
-		return nil, err
-	}
-
-	var lock sync.Mutex
-	state := &stateData{
-		matched:   map[string][]*frameworkext.ReservationInfo{},
-		unmatched: map[string][]*frameworkext.ReservationInfo{},
-	}
-
-	isReservedPod := reservationutil.IsReservePod(pod)
-	processNode := func(i int) {
-		var matched, unmatched []*frameworkext.ReservationInfo
-		nodeInfo := allNodes[i]
-		node := nodeInfo.Node()
-		if node == nil {
-			klog.V(4).InfoS("BeforePreFilter failed to get node", "pod", klog.KObj(pod), "nodeInfo", nodeInfo)
-			return
-		}
-
-		rOnNode := pl.reservationCache.listReservationInfosOnNode(node.Name)
-		for _, rInfo := range rOnNode {
-			if !reservationutil.IsReservationAvailable(rInfo.Reservation) {
-				continue
-			}
-
-			// In this case, the Controller has not yet updated the status of the Reservation to Succeeded,
-			// but in fact it can no longer be used for allocation. So it's better to skip first.
-			if extension.IsReservationAllocateOnce(rInfo.Reservation) && len(rInfo.Pods) > 0 {
-				continue
-			}
-
-			if !isReservedPod && matchReservation(pod, node, rInfo.Reservation, reservationAffinity) {
-				matched = append(matched, rInfo)
-			} else {
-				if len(rInfo.Allocated) > 0 {
-					unmatched = append(unmatched, rInfo)
-				}
-				if !isReservedPod {
-					klog.V(6).InfoS("got reservation on node does not match the pod", "reservation", klog.KObj(rInfo.Reservation), "pod", klog.KObj(pod))
-				}
-			}
-		}
-
-		// Most scenarios do not have reservations. It is better to check if there is a reservation
-		// before deciding whether to add a lock update, which can reduce race conditions.
-		if len(matched) > 0 || len(unmatched) > 0 {
-			lock.Lock()
-			if len(matched) > 0 {
-				state.matched[node.Name] = matched
-			}
-			if len(unmatched) > 0 {
-				state.unmatched[node.Name] = unmatched
-			}
-			lock.Unlock()
-		}
-
-		if len(matched) == 0 {
-			return
-		}
-
-		restorePVCRefCounts(pl.handle.SharedInformerFactory(), nodeInfo, pod, matched)
-		klog.V(4).Infof("Pod %v has %d matched reservations before PreFilter, %d unmatched reservations on node %v", klog.KObj(pod), len(matched), len(unmatched), node.Name)
-	}
-	pl.handle.Parallelizer().Until(ctx, len(allNodes), processNode)
-	return state, nil
-}
-
 func matchReservation(pod *corev1.Pod, node *corev1.Node, reservation *schedulingv1alpha1.Reservation, reservationAffinity *reservationutil.RequiredReservationAffinity) bool {
 	if !reservationutil.MatchReservationOwners(pod, reservation) {
 		return false
@@ -359,36 +308,4 @@ func matchReservation(pod *corev1.Pod, node *corev1.Node, reservation *schedulin
 		return reservationAffinity.Match(fakeNode)
 	}
 	return true
-}
-
-func genPVCRefKey(pvc *corev1.PersistentVolumeClaim) string {
-	return pvc.Namespace + "/" + pvc.Name
-}
-
-func restorePVCRefCounts(informerFactory informers.SharedInformerFactory, nodeInfo *framework.NodeInfo, pod *corev1.Pod, reservationInfos []*frameworkext.ReservationInfo) {
-	// VolumeRestrictions plugin will check PVCRefCounts in NodeInfo in BeforePreFilter phase.
-	// If the scheduling pod declare a PVC with ReadWriteOncePod access mode and the
-	// PVC has been used by other scheduled pod, the scheduling pod will be marked
-	// as UnschedulableAndUnresolvable.
-	// So we need to modify PVCRefCounts that are added by matched reservePod in nodeInfo
-	// to schedule the real pod.
-	pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
-	for _, rInfo := range reservationInfos {
-		podSpecTemplate := rInfo.Reservation.Spec.Template
-		for _, volume := range podSpecTemplate.Spec.Volumes {
-			if volume.PersistentVolumeClaim == nil {
-				continue
-			}
-			pvc, err := pvcLister.PersistentVolumeClaims(pod.Namespace).Get(volume.PersistentVolumeClaim.ClaimName)
-			if err != nil {
-				continue
-			}
-
-			if !v1helper.ContainsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteOncePod) {
-				continue
-			}
-
-			nodeInfo.PVCRefCounts[genPVCRefKey(pvc)] -= 1
-		}
-	}
 }

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -28,8 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/informers"
-	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/utils/pointer"
 
@@ -39,121 +36,7 @@ import (
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
-func TestBeforePreFilter(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-node",
-		},
-	}
-	suit := newPluginTestSuitWith(t, nil, []*corev1.Node{node})
-	p, err := suit.pluginFactory()
-	assert.NoError(t, err)
-	pl := p.(*Plugin)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       uuid.NewUUID(),
-			Namespace: "default",
-			Name:      "test-pod",
-		},
-	}
-
-	matchedReservation := &schedulingv1alpha1.Reservation{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:  uuid.NewUUID(),
-			Name: "matchedReservation",
-		},
-		Spec: schedulingv1alpha1.ReservationSpec{
-			Owners: []schedulingv1alpha1.ReservationOwner{
-				{
-					Object: &corev1.ObjectReference{
-						UID:       pod.UID,
-						Namespace: pod.Namespace,
-						Name:      pod.Name,
-					},
-				},
-			},
-			Template: &corev1.PodTemplateSpec{},
-		},
-		Status: schedulingv1alpha1.ReservationStatus{
-			Phase:    schedulingv1alpha1.ReservationAvailable,
-			NodeName: "test-node",
-		},
-	}
-	pl.reservationCache.updateReservation(matchedReservation)
-
-	unmatchedReservation := &schedulingv1alpha1.Reservation{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:  uuid.NewUUID(),
-			Name: "unmatchedReservation",
-		},
-		Spec: schedulingv1alpha1.ReservationSpec{
-			AllocateOnce: pointer.Bool(false),
-			Owners: []schedulingv1alpha1.ReservationOwner{
-				{
-					Object: &corev1.ObjectReference{
-						UID: uuid.NewUUID(),
-					},
-				},
-			},
-			Template: &corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("4Gi"),
-								},
-							},
-						},
-					},
-				},
-			}},
-		Status: schedulingv1alpha1.ReservationStatus{
-			Phase:    schedulingv1alpha1.ReservationAvailable,
-			NodeName: "test-node",
-		},
-	}
-	pl.reservationCache.updateReservation(unmatchedReservation)
-	pl.reservationCache.assumePod(unmatchedReservation.UID, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       uuid.NewUUID(),
-			Namespace: "default",
-			Name:      "pod-1",
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("2"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-					},
-				},
-			},
-		},
-	})
-
-	cycleState := framework.NewCycleState()
-	pl.BeforePreFilter(context.TODO(), cycleState, pod)
-	expectState := &stateData{
-		matched: map[string][]*frameworkext.ReservationInfo{
-			"test-node": {
-				pl.reservationCache.getReservationInfoByUID(matchedReservation.UID),
-			},
-		},
-		unmatched: map[string][]*frameworkext.ReservationInfo{
-			"test-node": {
-				pl.reservationCache.getReservationInfoByUID(unmatchedReservation.UID),
-			},
-		},
-	}
-	assert.Equal(t, expectState, getStateData(cycleState))
-}
-
-func TestAfterPreFilter(t *testing.T) {
+func TestRestoreReservation(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
@@ -258,6 +141,7 @@ func TestAfterPreFilter(t *testing.T) {
 			Name: "reservation4C8G",
 		},
 		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: pointer.Bool(false),
 			Template: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
@@ -308,6 +192,15 @@ func TestAfterPreFilter(t *testing.T) {
 			Name: "reservation2C4G",
 		},
 		Spec: schedulingv1alpha1.ReservationSpec{
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation": "true",
+						},
+					},
+				},
+			},
 			Template: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
@@ -367,32 +260,44 @@ func TestAfterPreFilter(t *testing.T) {
 	pl.reservationCache.updateReservation(unmatchedReservation)
 	pl.reservationCache.updateReservation(matchedReservation)
 
-	unmatchedRInfo := pl.reservationCache.getReservationInfoByUID(unmatchedReservation.UID)
-	unmatchedRInfo.Allocated = corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse("4"),
-		corev1.ResourceMemory: resource.MustParse("8Gi"),
-	}
-	unmatchedRInfo.Pods[uuid.NewUUID()] = &frameworkext.PodRequirement{}
-
-	matchRInfo := pl.reservationCache.getReservationInfoByUID(matchedReservation.UID)
-
-	cycleState := framework.NewCycleState()
-	cycleState.Write(stateKey, &stateData{
-		matched: map[string][]*frameworkext.ReservationInfo{
-			node.Name: {matchRInfo},
+	pl.reservationCache.addPod(unmatchedReservation.UID, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
+			Name:      "unmatched-allocated-pod-1",
+			Namespace: "default",
 		},
-		unmatched: map[string][]*frameworkext.ReservationInfo{
-			node.Name: {unmatchedRInfo},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
 		},
 	})
 
-	status := pl.AfterPreFilter(context.TODO(), cycleState, &corev1.Pod{})
+	cycleState := framework.NewCycleState()
+	_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test-reservation": "true",
+			},
+		},
+	})
+	assert.True(t, restored)
 	assert.True(t, status.IsSuccess())
 
-	nodeInfo, err = suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
-	assert.NoError(t, err)
-	assert.NotNil(t, nodeInfo)
-	nodeInfo.Generation = 0
+	matchRInfo := pl.reservationCache.getReservationInfoByUID(matchedReservation.UID)
+	expectedStat := &stateData{
+		nodeReservationStates: map[string]nodeReservationState{
+			node.Name: {nodeName: node.Name, matched: []*frameworkext.ReservationInfo{matchRInfo}},
+		},
+	}
+	assert.Equal(t, expectedStat, getStateData(cycleState))
 
 	unmatchedReservePod := pods[2].DeepCopy()
 	unmatchedReservePod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{}
@@ -406,104 +311,14 @@ func TestAfterPreFilter(t *testing.T) {
 	})
 	expectNodeInfo := framework.NewNodeInfo(pods[0], pods[1], unmatchedReservePod)
 	expectNodeInfo.SetNode(node)
-	expectNodeInfo.Generation = 0
 	assert.Equal(t, expectNodeInfo.Requested, nodeInfo.Requested)
 	assert.Equal(t, expectNodeInfo.UsedPorts, nodeInfo.UsedPorts)
+	nodeInfo.Generation = 0
+	expectNodeInfo.Generation = 0
 	assert.True(t, equality.Semantic.DeepEqual(expectNodeInfo, nodeInfo))
-}
 
-func Test_restorePVCRefCounts(t *testing.T) {
-	normalPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "test-pod-1",
-		},
-		Spec: corev1.PodSpec{
-			Volumes: []corev1.Volume{
-				{
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "claim-with-rwop",
-						},
-					},
-				},
-			},
-		},
-	}
-	readWriteOncePodPVC := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "claim-with-rwop",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
-		},
-	}
-
-	testNodeName := "test-node-0"
-	testNode := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testNodeName,
-		},
-	}
-	testNodeInfo := framework.NewNodeInfo()
-	testNodeInfo.SetNode(testNode)
-	testNodeInfo.AddPod(normalPod)
-	testNodeInfo.PodsWithRequiredAntiAffinity = []*framework.PodInfo{
-		framework.NewPodInfo(normalPod),
-	}
-	assert.Equal(t, 1, testNodeInfo.PVCRefCounts["default/claim-with-rwop"])
-
-	reservation := &schedulingv1alpha1.Reservation{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:  uuid.NewUUID(),
-			Name: "reserve-pod-1",
-		},
-		Spec: schedulingv1alpha1.ReservationSpec{
-			Template: &corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "reserve-pod-1",
-				},
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "claim-with-rwop",
-								},
-							},
-						},
-					},
-				},
-			},
-			Owners: []schedulingv1alpha1.ReservationOwner{
-				{
-					Object: &corev1.ObjectReference{
-						Name: "test-pod-1",
-					},
-				},
-			},
-			TTL: &metav1.Duration{Duration: 30 * time.Minute},
-		},
-		Status: schedulingv1alpha1.ReservationStatus{
-			Phase:    schedulingv1alpha1.ReservationAvailable,
-			NodeName: testNodeName,
-		},
-	}
-
-	cs := kubefake.NewSimpleClientset(readWriteOncePodPVC)
-	informerFactory := informers.NewSharedInformerFactory(cs, 0)
-	_ = informerFactory.Core().V1().PersistentVolumeClaims().Lister()
-
-	informerFactory.Start(nil)
-	informerFactory.WaitForCacheSync(nil)
-
-	cache := newReservationCache(nil)
-	cache.updateReservation(reservation)
-	rInfo := cache.getReservationInfoByUID(reservation.UID)
-
-	restorePVCRefCounts(informerFactory, testNodeInfo, normalPod, []*frameworkext.ReservationInfo{rInfo})
-	assert.Zero(t, testNodeInfo.PVCRefCounts["default/claim-with-rwop"])
+	status = pl.AfterPreFilter(context.TODO(), cycleState, &corev1.Pod{})
+	assert.True(t, status.IsSuccess())
 }
 
 func Test_matchReservation(t *testing.T) {

--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
@@ -112,8 +113,26 @@ func ValidateReservation(r *schedulingv1alpha1.Reservation) error {
 	return nil
 }
 
+func PodPriority(r *schedulingv1alpha1.Reservation) int32 {
+	if r.Spec.Template != nil && r.Spec.Template.Spec.Priority != nil {
+		return *r.Spec.Template.Spec.Priority
+	}
+	return 0
+}
+
 func IsReservePod(pod *corev1.Pod) bool {
 	return pod != nil && pod.Annotations != nil && pod.Annotations[AnnotationReservePod] == "true"
+}
+
+func GetReservationNamespacedName(r *schedulingv1alpha1.Reservation) types.NamespacedName {
+	namespacedName := types.NamespacedName{
+		Name:      GetReservationKey(r),
+		Namespace: corev1.NamespaceDefault,
+	}
+	if r.Spec.Template != nil && r.Spec.Template.ObjectMeta.Namespace != "" {
+		namespacedName.Namespace = r.Spec.Template.ObjectMeta.Namespace
+	}
+	return namespacedName
 }
 
 func GetReservationKey(r *schedulingv1alpha1.Reservation) string {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Optimize the flow of restore Reservation from NodeInfo in BeforePreFilter instead of AfterPreFilter.

In the previous implementation, it was necessary to cooperate to modify the scheduling state before and after the PreFilter to ensure the consistency of the data view. The overall performance is relatively poor, and some of the original interfaces cannot help to process data correctly. For example, unmatched reservations are not passed to each plugin, resulting in some data not being corrected, resulting in scheduling results in some scenarios that do not meet expectations.

Now it is optimized to process data concurrently in BeforePreFilter, and removes a lock, which improves the overall performance, and can better coordinate each plugin to process their own internal state.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
