### PR TITLE
koord-scheduler: implement EnqueueExtensions

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -52,6 +52,8 @@ const (
 )
 
 var (
+	_ framework.EnqueueExtensions = &Plugin{}
+
 	_ framework.PreFilterPlugin = &Plugin{}
 	_ framework.FilterPlugin    = &Plugin{}
 	_ framework.ReservePlugin   = &Plugin{}
@@ -123,6 +125,15 @@ func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, *fram
 	}
 	state := value.(*preFilterState)
 	return state, nil
+}
+
+func (p *Plugin) EventsToRegister() []framework.ClusterEvent {
+	// To register a custom event, follow the naming convention at:
+	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
+	gvk := fmt.Sprintf("devices.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
+	return []framework.ClusterEvent{
+		{Resource: framework.GVK(gvk), ActionType: framework.Add | framework.Update | framework.Delete},
+	}
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -56,6 +56,8 @@ const (
 )
 
 var (
+	_ framework.EnqueueExtensions = &Plugin{}
+
 	_ framework.FilterPlugin  = &Plugin{}
 	_ framework.ScorePlugin   = &Plugin{}
 	_ framework.ReservePlugin = &Plugin{}
@@ -107,6 +109,15 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 }
 
 func (p *Plugin) Name() string { return Name }
+
+func (p *Plugin) EventsToRegister() []framework.ClusterEvent {
+	// To register a custom event, follow the naming convention at:
+	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
+	gvk := fmt.Sprintf("nodemetrics.%v.%v", slov1alpha1.GroupVersion.Version, slov1alpha1.GroupVersion.Group)
+	return []framework.ClusterEvent{
+		{Resource: framework.GVK(gvk), ActionType: framework.Add | framework.Update | framework.Delete},
+	}
+}
 
 func (p *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
 	node := nodeInfo.Node()

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -58,6 +58,8 @@ const (
 )
 
 var (
+	_ framework.EnqueueExtensions = &Plugin{}
+
 	_ framework.PreFilterPlugin  = &Plugin{}
 	_ framework.FilterPlugin     = &Plugin{}
 	_ framework.PostFilterPlugin = &Plugin{}
@@ -118,6 +120,15 @@ func (pl *Plugin) NewControllers() ([]frameworkext.Controller, error) {
 		pl.handle.KoordinatorClientSet(),
 		1)
 	return []frameworkext.Controller{reservationController}, nil
+}
+
+func (pl *Plugin) EventsToRegister() []framework.ClusterEvent {
+	// To register a custom event, follow the naming convention at:
+	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
+	gvk := fmt.Sprintf("reservations.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
+	return []framework.ClusterEvent{
+		{Resource: framework.GVK(gvk), ActionType: framework.Add | framework.Update | framework.Delete},
+	}
 }
 
 var _ framework.StateData = &stateData{}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Implement EnqueueExtensions to efficiently move unschedulable Pods in internal scheduling queues.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
