### PR TITLE
koord-scheduler: fix duplicate allocate GPU after leader selection changed

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/pod_handler_test.go
+++ b/pkg/scheduler/plugins/deviceshare/pod_handler_test.go
@@ -361,9 +361,14 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 }
 
 func Test_nodeDeviceCache_onPodUpdate(t *testing.T) {
+	podNamespacedName := types.NamespacedName{
+		Namespace: "default",
+		Name:      "test",
+	}
 	tests := []struct {
 		name        string
-		pod         interface{}
+		oldPod      *corev1.Pod
+		pod         *corev1.Pod
 		deviceCache *nodeDeviceCache
 		wantCache   map[string]*nodeDevice
 	}{
@@ -372,11 +377,116 @@ func Test_nodeDeviceCache_onPodUpdate(t *testing.T) {
 			pod:       &corev1.Pod{},
 			wantCache: map[string]*nodeDevice{},
 		},
+		{
+			name:   "correct device allocation annotation",
+			oldPod: &corev1.Pod{},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "123456789",
+					Namespace: "default",
+					Name:      "test",
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			deviceCache: &nodeDeviceCache{
+				nodeDeviceInfos: map[string]*nodeDevice{
+					"test-node": {
+						deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+									apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+								},
+							},
+						},
+						deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
+							schedulingv1alpha1.GPU: {},
+						},
+						allocateSet: make(map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]deviceResources),
+					},
+				},
+			},
+			wantCache: map[string]*nodeDevice{
+				"test-node": {
+					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        *resource.NewQuantity(40, resource.DecimalSI),
+								apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+							},
+						},
+					},
+					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("100"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+							},
+						},
+					},
+					deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{
+								apiext.ResourceGPUCore:        resource.MustParse("60"),
+								apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+								apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+							},
+						},
+					},
+					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]deviceResources{
+						schedulingv1alpha1.GPU: {
+							podNamespacedName: {
+								1: corev1.ResourceList{
+									apiext.ResourceGPUCore:        resource.MustParse("60"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deviceCache := newNodeDeviceCache()
-			deviceCache.onPodUpdate(nil, tt.pod)
+			deviceCache := tt.deviceCache
+			if deviceCache == nil {
+				deviceCache = newNodeDeviceCache()
+			}
+			deviceCache.onPodUpdate(tt.oldPod, tt.pod)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The master and slave instances of koord-scheduler  both sync pods from api-server via informer and both build nodeDeviceCache with add events. But the slave instance ignore the update event that missed the bound pod by master instance that leaky the pod's deviceAllocations. So if the leader election changed, the slave instance will serve with old states that allocates GPUs that already be allocated for the new Pod. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
