### PR TITLE
koordlet: fix custom runtime endpoint path

### DIFF
--- a/pkg/koordlet/util/runtime/handler/containerd_runtime.go
+++ b/pkg/koordlet/util/runtime/handler/containerd_runtime.go
@@ -33,11 +33,16 @@ import (
 )
 
 var (
-	ContainerdEndpoint1 = filepath.Join(system.Conf.VarRunRootDir, "containerd.sock")
-	ContainerdEndpoint2 = filepath.Join(system.Conf.VarRunRootDir, "containerd/containerd.sock")
-
 	GrpcDial = grpc.DialContext // for test
 )
+
+func GetContainerdEndpoint() string {
+	return filepath.Join(system.Conf.VarRunRootDir, "containerd/containerd.sock")
+}
+
+func GetContainerdEndpoint2() string {
+	return filepath.Join(system.Conf.VarRunRootDir, "containerd.sock")
+}
 
 type ContainerdRuntimeHandler struct {
 	runtimeServiceClient runtimeapi.RuntimeServiceClient

--- a/pkg/koordlet/util/runtime/handler/docker_runtime.go
+++ b/pkg/koordlet/util/runtime/handler/docker_runtime.go
@@ -31,11 +31,11 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
-var (
-	DockerEndpoint = filepath.Join(system.Conf.VarRunRootDir, "docker.sock")
-)
-
 var GetDockerClient = createDockerClient // for test
+
+func GetDockerEndpoint() string {
+	return filepath.Join(system.Conf.VarRunRootDir, "docker.sock")
+}
 
 type DockerRuntimeHandler struct {
 	dockerClient *dclient.Client

--- a/pkg/koordlet/util/runtime/runtime.go
+++ b/pkg/koordlet/util/runtime/runtime.go
@@ -69,8 +69,8 @@ func getDockerHandler() (handler.ContainerRuntimeHandler, error) {
 }
 
 func getDockerEndpoint() (string, error) {
-	if isFile(handler.DockerEndpoint) {
-		return fmt.Sprintf("unix://%s", handler.DockerEndpoint), nil
+	if dockerEndpoint := handler.GetDockerEndpoint(); isFile(dockerEndpoint) {
+		return fmt.Sprintf("unix://%s", dockerEndpoint), nil
 	}
 	if len(system.Conf.DockerEndPoint) > 0 && isFile(system.Conf.DockerEndPoint) {
 		klog.Infof("find docker Endpoint : %v", system.Conf.DockerEndPoint)
@@ -100,12 +100,12 @@ func getContainerdHandler() (handler.ContainerRuntimeHandler, error) {
 }
 
 func getContainerdEndpoint() (string, error) {
-	if isFile(handler.ContainerdEndpoint1) {
-		return fmt.Sprintf("unix://%s", handler.ContainerdEndpoint1), nil
+	if containerdEndpoint := handler.GetContainerdEndpoint(); isFile(containerdEndpoint) {
+		return fmt.Sprintf("unix://%s", containerdEndpoint), nil
 	}
 
-	if isFile(handler.ContainerdEndpoint2) {
-		return fmt.Sprintf("unix://%s", handler.ContainerdEndpoint2), nil
+	if containerdEndpoint2 := handler.GetContainerdEndpoint2(); isFile(containerdEndpoint2) {
+		return fmt.Sprintf("unix://%s", containerdEndpoint2), nil
 	}
 
 	if len(system.Conf.ContainerdEndPoint) > 0 && isFile(system.Conf.ContainerdEndPoint) {

--- a/pkg/koordlet/util/runtime/runtime_test.go
+++ b/pkg/koordlet/util/runtime/runtime_test.go
@@ -156,7 +156,7 @@ func dockerStub() *gostub.Stubs {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}
-		endpoint := fmt.Sprintf("unix://%s", handler.DockerEndpoint)
+		endpoint := fmt.Sprintf("unix://%s", handler.GetDockerEndpoint())
 		client := &http.Client{
 			Transport: transportFunc(info),
 		}
@@ -166,9 +166,6 @@ func dockerStub() *gostub.Stubs {
 }
 
 func resetEndpoint() {
-	handler.DockerEndpoint = filepath.Join(system.Conf.VarRunRootDir, "docker.sock")
-	handler.ContainerdEndpoint1 = filepath.Join(system.Conf.VarRunRootDir, "containerd.sock")
-	handler.ContainerdEndpoint2 = filepath.Join(system.Conf.VarRunRootDir, "containerd/containerd.sock")
 	DockerHandler = nil
 	ContainerdHandler = nil
 }

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -38,7 +38,6 @@ type Config struct {
 	SysFSRootDir          string
 	ProcRootDir           string
 	VarRunRootDir         string
-	NodeNameOverride      string
 	RuntimeHooksConfigDir string
 
 	ContainerdEndPoint string
@@ -96,7 +95,6 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.VarRunRootDir, "var-run-root-dir", c.VarRunRootDir, "host /var/run dir in container")
 
 	fs.StringVar(&c.CgroupKubePath, "cgroup-kube-dir", c.CgroupKubePath, "Cgroup kube dir")
-	fs.StringVar(&c.NodeNameOverride, "node-name-override", c.NodeNameOverride, "If non-empty, will use this string as identification instead of the actual machine name. ")
 	fs.StringVar(&c.ContainerdEndPoint, "containerd-endpoint", c.ContainerdEndPoint, "containerd endPoint")
 	fs.StringVar(&c.DockerEndPoint, "docker-endpoint", c.DockerEndPoint, "docker endPoint")
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the fixed runtime endpoint path which can be incorrect when the host VarRunRoot dir changes.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
