### PR TITLE
chore: move koord-manager scheme under options, add host run mount

### DIFF
--- a/cmd/koord-manager/main.go
+++ b/cmd/koord-manager/main.go
@@ -25,20 +25,13 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 
-	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
-	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
-	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/cmd/koord-manager/extensions"
 	"github.com/koordinator-sh/koordinator/cmd/koord-manager/options"
 	extclient "github.com/koordinator-sh/koordinator/pkg/client"
@@ -53,27 +46,11 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 
 	restConfigQPS   = flag.Int("rest-config-qps", 30, "QPS of rest config.")
 	restConfigBurst = flag.Int("rest-config-burst", 50, "Burst of rest config.")
 )
-
-func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = configv1alpha1.AddToScheme(clientgoscheme.Scheme)
-	_ = slov1alpha1.AddToScheme(clientgoscheme.Scheme)
-	_ = schedulingv1alpha1.AddToScheme(clientgoscheme.Scheme)
-
-	_ = configv1alpha1.AddToScheme(scheme)
-	_ = slov1alpha1.AddToScheme(scheme)
-	_ = schedulingv1alpha1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
-
-	scheme.AddUnversionedTypes(metav1.SchemeGroupVersion, &metav1.UpdateOptions{}, &metav1.DeleteOptions{}, &metav1.CreateOptions{})
-	// +kubebuilder:scaffold:scheme
-}
 
 func main() {
 	var metricsAddr, pprofAddr string
@@ -132,7 +109,7 @@ func main() {
 		}
 	}
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                     scheme,
+		Scheme:                     options.Scheme,
 		MetricsBindAddress:         metricsAddr,
 		HealthProbeBindAddress:     healthProbeAddr,
 		LeaderElection:             enableLeaderElection,

--- a/cmd/koord-manager/options/scheme.go
+++ b/cmd/koord-manager/options/scheme.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+
+	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+)
+
+var Scheme = runtime.NewScheme()
+
+func init() {
+	_ = clientgoscheme.AddToScheme(Scheme)
+	_ = configv1alpha1.AddToScheme(clientgoscheme.Scheme)
+	_ = slov1alpha1.AddToScheme(clientgoscheme.Scheme)
+	_ = schedulingv1alpha1.AddToScheme(clientgoscheme.Scheme)
+
+	_ = configv1alpha1.AddToScheme(Scheme)
+	_ = slov1alpha1.AddToScheme(Scheme)
+	_ = schedulingv1alpha1.AddToScheme(Scheme)
+	_ = v1alpha1.AddToScheme(Scheme)
+
+	Scheme.AddUnversionedTypes(metav1.SchemeGroupVersion, &metav1.UpdateOptions{}, &metav1.DeleteOptions{}, &metav1.CreateOptions{})
+	// +kubebuilder:scaffold:scheme
+}

--- a/config/manager/koordlet.yaml
+++ b/config/manager/koordlet.yaml
@@ -65,6 +65,9 @@ spec:
             - mountPath: /host-var-run/
               name: host-var-run
               readOnly: true
+            - mountPath: /host-run/
+              name: host-run
+              readOnly: true
             - mountPath: /host-var-run-koordlet/
               mountPropagation: Bidirectional
               name: host-var-run-koordlet
@@ -108,6 +111,10 @@ spec:
             path: /var/run/
             type: ""
           name: host-var-run
+        - hostPath:
+            path: /run/
+            type: ""
+          name: host-run
         - hostPath:
             path: /var/run/koordlet/
             type: DirectoryOrCreate

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	SysFSRootDir          string
 	ProcRootDir           string
 	VarRunRootDir         string
+	RunRootDir            string
 	RuntimeHooksConfigDir string
 
 	ContainerdEndPoint string
@@ -66,6 +67,7 @@ func NewHostModeConfig() *Config {
 		SysRootDir:            "/sys/",
 		SysFSRootDir:          "/sys/fs/",
 		VarRunRootDir:         "/var/run/",
+		RunRootDir:            "/run/",
 		RuntimeHooksConfigDir: "/etc/runtime/hookserver.d",
 	}
 }
@@ -79,6 +81,7 @@ func NewDsModeConfig() *Config {
 		SysRootDir:            "/host-sys/",
 		SysFSRootDir:          "/host-sys-fs/",
 		VarRunRootDir:         "/host-var-run/",
+		RunRootDir:            "/host-run/",
 		RuntimeHooksConfigDir: "/host-etc-hookserver/",
 	}
 }
@@ -93,6 +96,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.SysFSRootDir, "sys-fs-root-dir", c.SysFSRootDir, "host /sys/fs dir in container, used by resctrl fs")
 	fs.StringVar(&c.ProcRootDir, "proc-root-dir", c.ProcRootDir, "host /proc dir in container")
 	fs.StringVar(&c.VarRunRootDir, "var-run-root-dir", c.VarRunRootDir, "host /var/run dir in container")
+	fs.StringVar(&c.RunRootDir, "run-root-dir", c.RunRootDir, "host /run dir in container")
 
 	fs.StringVar(&c.CgroupKubePath, "cgroup-kube-dir", c.CgroupKubePath, "Cgroup kube dir")
 	fs.StringVar(&c.ContainerdEndPoint, "containerd-endpoint", c.ContainerdEndPoint, "containerd endPoint")

--- a/pkg/koordlet/util/system/config_test.go
+++ b/pkg/koordlet/util/system/config_test.go
@@ -30,6 +30,7 @@ func Test_NewDsModeConfig(t *testing.T) {
 		SysRootDir:            "/host-sys/",
 		SysFSRootDir:          "/host-sys-fs/",
 		VarRunRootDir:         "/host-var-run/",
+		RunRootDir:            "/host-run/",
 		RuntimeHooksConfigDir: "/host-etc-hookserver/",
 	}
 	defaultConfig := NewDsModeConfig()
@@ -44,6 +45,7 @@ func Test_NewHostModeConfig(t *testing.T) {
 		SysRootDir:            "/sys/",
 		SysFSRootDir:          "/sys/fs/",
 		VarRunRootDir:         "/var/run/",
+		RunRootDir:            "/run/",
 		RuntimeHooksConfigDir: "/etc/runtime/hookserver.d",
 	}
 	defaultConfig := NewHostModeConfig()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Move the scheme of the koord-manager into options.
Add a host path mount of /run.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
