### PR TITLE
koord-scheduler: support reserve by pod

### DIFF
--- a/apis/extension/operating_pod.go
+++ b/apis/extension/operating_pod.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+const (
+	// LabelPodOperatingMode describes the mode of operation for Pod.
+	LabelPodOperatingMode = SchedulingDomainPrefix + "/operating-mode"
+
+	// AnnotationReservationOwners indicates the owner specification which can allocate reserved resources
+	AnnotationReservationOwners = SchedulingDomainPrefix + "/reservation-owners"
+
+	// AnnotationReservationCurrentOwner indicates current resource owners which allocated the reservation resources.
+	AnnotationReservationCurrentOwner = SchedulingDomainPrefix + "/reservation-current-owner"
+)
+
+// The concept of PodOperatingMode refers to the design document https://docs.google.com/document/d/1sbFUA_9qWtorJkcukNULr12FKX6lMvISiINxAURHNFo/edit#heading=h.xgjl2srtytjt
+
+type PodOperatingMode string
+
+const (
+	// RunnablePodOperatingMode represents the original pod behavior, it is the default mode where the
+	// pod’s containers are executed by Kubelet when the pod is assigned a node.
+	RunnablePodOperatingMode PodOperatingMode = "Runnable"
+
+	// ReservationPodOperatingMode means the pod represents a scheduling and resource reservation unit
+	ReservationPodOperatingMode PodOperatingMode = "Reservation"
+)
+
+func IsReservationOperatingMode(pod *corev1.Pod) bool {
+	return pod.Labels[LabelPodOperatingMode] == string(ReservationPodOperatingMode)
+}
+
+func GetReservationOwners(annotations map[string]string) ([]schedulingv1alpha1.ReservationOwner, error) {
+	var owners []schedulingv1alpha1.ReservationOwner
+	if s := annotations[AnnotationReservationOwners]; s != "" {
+		err := json.Unmarshal([]byte(s), &owners)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return owners, nil
+}
+
+func GetReservationCurrentOwner(annotations map[string]string) (*corev1.ObjectReference, error) {
+	var owner corev1.ObjectReference
+	s := annotations[AnnotationReservationCurrentOwner]
+	if s == "" {
+		return nil, nil
+	}
+	err := json.Unmarshal([]byte(s), &owner)
+	if err != nil {
+		return nil, err
+	}
+	return &owner, nil
+}
+
+func SetReservationCurrentOwner(annotations map[string]string, owner *corev1.ObjectReference) error {
+	if owner == nil {
+		return nil
+	}
+	data, err := json.Marshal(owner)
+	if err != nil {
+		return err
+	}
+	annotations[AnnotationReservationCurrentOwner] = string(data)
+	return nil
+}
+
+func RemoveReservationCurrentOwner(annotations map[string]string) {
+	delete(annotations, AnnotationReservationCurrentOwner)
+}

--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
@@ -82,13 +83,13 @@ func GetReservationAllocated(pod *corev1.Pod) (*ReservationAllocated, error) {
 	return reservationAllocated, nil
 }
 
-func SetReservationAllocated(pod *corev1.Pod, r *schedulingv1alpha1.Reservation) {
+func SetReservationAllocated(pod *corev1.Pod, r metav1.Object) {
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}
 	reservationAllocated := &ReservationAllocated{
-		Name: r.Name,
-		UID:  r.UID,
+		Name: r.GetName(),
+		UID:  r.GetUID(),
 	}
 	data, _ := json.Marshal(reservationAllocated) // assert no error
 	pod.Annotations[AnnotationReservationAllocated] = string(data)

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
-	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/sharedlisterext"
@@ -359,11 +358,11 @@ func (ext *frameworkExtenderImpl) RunReservationExtensionFinalRestoreReservation
 }
 
 // RunReservationFilterPlugins determines whether the Reservation can participate in the Reserve
-func (ext *frameworkExtenderImpl) RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservation *schedulingv1alpha1.Reservation, nodeName string) *framework.Status {
+func (ext *frameworkExtenderImpl) RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status {
 	for _, pl := range ext.reservationFilterPlugins {
-		status := pl.FilterReservation(ctx, cycleState, pod, reservation, nodeName)
+		status := pl.FilterReservation(ctx, cycleState, pod, reservationInfo, nodeName)
 		if !status.IsSuccess() {
-			klog.Infof("Failed to FilterReservation for Pod %q with Reservation %q on Node %q, failedPlugin: %s, reason: %s", klog.KObj(pod), klog.KObj(reservation), nodeName, pl.Name(), status.Message())
+			klog.Infof("Failed to FilterReservation for Pod %q with Reservation %q on Node %q, failedPlugin: %s, reason: %s", klog.KObj(pod), klog.KObj(reservationInfo), nodeName, pl.Name(), status.Message())
 			return status
 		}
 	}
@@ -371,25 +370,27 @@ func (ext *frameworkExtenderImpl) RunReservationFilterPlugins(ctx context.Contex
 }
 
 // RunReservationScorePlugins ranks the Reservations
-func (ext *frameworkExtenderImpl) RunReservationScorePlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservations []*schedulingv1alpha1.Reservation, nodeName string) (ps PluginToReservationScores, status *framework.Status) {
-	if len(reservations) == 0 {
+func (ext *frameworkExtenderImpl) RunReservationScorePlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfos []*ReservationInfo, nodeName string) (ps PluginToReservationScores, status *framework.Status) {
+	if len(reservationInfos) == 0 {
 		return
 	}
 	pluginToReservationScores := make(PluginToReservationScores, len(ext.reservationScorePlugins))
 	for _, pl := range ext.reservationScorePlugins {
-		pluginToReservationScores[pl.Name()] = make(ReservationScoreList, len(reservations))
+		pluginToReservationScores[pl.Name()] = make(ReservationScoreList, len(reservationInfos))
 	}
 
 	for _, pl := range ext.reservationScorePlugins {
-		for index, reservation := range reservations {
-			s, status := pl.ScoreReservation(ctx, cycleState, pod, reservation, nodeName)
+		for index, rInfo := range reservationInfos {
+			s, status := pl.ScoreReservation(ctx, cycleState, pod, rInfo, nodeName)
 			if !status.IsSuccess() {
 				err := fmt.Errorf("plugin %q failed with: %w", pl.Name(), status.AsError())
 				return nil, framework.AsStatus(err)
 			}
 			pluginToReservationScores[pl.Name()][index] = ReservationScore{
-				Name:  reservation.Name,
-				Score: s,
+				Name:      rInfo.GetName(),
+				Namespace: rInfo.GetNamespace(),
+				UID:       rInfo.UID(),
+				Score:     s,
 			}
 		}
 	}

--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -18,20 +18,25 @@ package frameworkext
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 type ReservationInfo struct {
 	Reservation   *schedulingv1alpha1.Reservation
+	Pod           *corev1.Pod
 	ResourceNames []corev1.ResourceName
 	Allocatable   corev1.ResourceList
 	Allocated     corev1.ResourceList
-	Pods          map[types.UID]*PodRequirement
+	AssignedPods  map[types.UID]*PodRequirement
 }
 
 type PodRequirement struct {
@@ -47,10 +52,126 @@ func NewReservationInfo(r *schedulingv1alpha1.Reservation) *ReservationInfo {
 
 	return &ReservationInfo{
 		Reservation:   r.DeepCopy(),
+		Pod:           reservationutil.NewReservePod(r),
 		ResourceNames: resourceNames,
 		Allocatable:   allocatable,
-		Pods:          map[types.UID]*PodRequirement{},
+		AssignedPods:  map[types.UID]*PodRequirement{},
 	}
+}
+
+func NewReservationInfoFromPod(pod *corev1.Pod) *ReservationInfo {
+	allocatable, _ := resource.PodRequestsAndLimits(pod)
+	resourceNames := quotav1.ResourceNames(allocatable)
+
+	return &ReservationInfo{
+		Pod:           pod,
+		ResourceNames: resourceNames,
+		Allocatable:   allocatable,
+		AssignedPods:  map[types.UID]*PodRequirement{},
+	}
+}
+
+func (ri *ReservationInfo) GetName() string {
+	if ri.Reservation != nil {
+		return ri.Reservation.Name
+	}
+	if ri.Pod != nil {
+		return ri.Pod.Name
+	}
+	return ""
+}
+
+func (ri *ReservationInfo) GetNamespace() string {
+	if ri.Reservation != nil {
+		return ri.Reservation.Namespace
+	}
+	if ri.Pod != nil {
+		return ri.Pod.Namespace
+	}
+	return ""
+}
+
+func (ri *ReservationInfo) UID() types.UID {
+	if ri.Reservation != nil {
+		return ri.Reservation.UID
+	}
+	if ri.Pod != nil {
+		return ri.Pod.UID
+	}
+	return ""
+}
+
+func (ri *ReservationInfo) GetObject() metav1.Object {
+	if ri.Reservation != nil {
+		return ri.Reservation
+	}
+	if ri.Pod != nil {
+		return ri.Pod
+	}
+	return nil
+}
+
+func (ri *ReservationInfo) GetReservePod() *corev1.Pod {
+	if ri.Pod != nil {
+		return ri.Pod
+	}
+	return nil
+}
+
+func (ri *ReservationInfo) IsAllocateOnce() bool {
+	if ri.Reservation != nil {
+		return apiext.IsReservationAllocateOnce(ri.Reservation)
+	}
+	if ri.Pod != nil {
+		// Reservation Operating Mode Pod MUST BE AllocateOnce
+		return true
+	}
+	return true
+}
+
+func (ri *ReservationInfo) GetAllocatePolicy() schedulingv1alpha1.ReservationAllocatePolicy {
+	if ri.Reservation != nil {
+		return ri.Reservation.Spec.AllocatePolicy
+	}
+	if ri.Pod != nil && apiext.IsReservationOperatingMode(ri.Pod) {
+		return schedulingv1alpha1.ReservationAllocatePolicyAligned
+	}
+	return schedulingv1alpha1.ReservationAllocatePolicyDefault
+}
+
+func (ri *ReservationInfo) GetPriority() int32 {
+	if ri.Reservation != nil {
+		return reservationutil.PodPriority(ri.Reservation)
+	}
+	if ri.Pod != nil {
+		return corev1helpers.PodPriority(ri.Pod)
+	}
+	return 0
+}
+
+func (ri *ReservationInfo) GetPodOwners() []schedulingv1alpha1.ReservationOwner {
+	if ri.Reservation != nil {
+		return ri.Reservation.Spec.Owners
+	}
+	if ri.Pod != nil {
+		owners, err := apiext.GetReservationOwners(ri.Pod.Annotations)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get ReservationOwners from Pod", "pod", klog.KObj(ri.Pod))
+			return nil
+		}
+		return owners
+	}
+	return nil
+}
+
+func (ri *ReservationInfo) IsAvailable() bool {
+	if ri.Reservation != nil {
+		return reservationutil.IsReservationAvailable(ri.Reservation)
+	}
+	if ri.Pod != nil {
+		return true
+	}
+	return false
 }
 
 func (ri *ReservationInfo) Clone() *ReservationInfo {
@@ -60,7 +181,7 @@ func (ri *ReservationInfo) Clone() *ReservationInfo {
 	}
 
 	pods := map[types.UID]*PodRequirement{}
-	for k, v := range ri.Pods {
+	for k, v := range ri.AssignedPods {
 		pods[k] = &PodRequirement{
 			Namespace: v.Namespace,
 			Name:      v.Name,
@@ -69,26 +190,40 @@ func (ri *ReservationInfo) Clone() *ReservationInfo {
 		}
 	}
 
+	var reservation *schedulingv1alpha1.Reservation
+	if ri.Reservation != nil {
+		reservation = ri.Reservation.DeepCopy()
+	}
+
 	return &ReservationInfo{
-		Reservation:   ri.Reservation.DeepCopy(),
+		Reservation:   reservation,
+		Pod:           ri.Pod.DeepCopy(),
 		ResourceNames: resourceNames,
 		Allocatable:   ri.Allocatable.DeepCopy(),
 		Allocated:     ri.Allocated.DeepCopy(),
-		Pods:          pods,
+		AssignedPods:  pods,
 	}
 }
 
 func (ri *ReservationInfo) UpdateReservation(r *schedulingv1alpha1.Reservation) {
 	ri.Reservation = r.DeepCopy()
+	ri.Pod = reservationutil.NewReservePod(r)
 	ri.Allocatable = reservationutil.ReservationRequests(r)
 	ri.ResourceNames = quotav1.ResourceNames(ri.Allocatable)
 	ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
 }
 
-func (ri *ReservationInfo) AddPod(pod *corev1.Pod) {
+func (ri *ReservationInfo) UpdatePod(pod *corev1.Pod) {
+	ri.Pod = pod.DeepCopy()
+	ri.Allocatable, _ = resource.PodRequestsAndLimits(pod)
+	ri.ResourceNames = quotav1.ResourceNames(ri.Allocatable)
+	ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
+}
+
+func (ri *ReservationInfo) AddAssignedPod(pod *corev1.Pod) {
 	requests, _ := resource.PodRequestsAndLimits(pod)
 	ri.Allocated = quotav1.Add(ri.Allocated, quotav1.Mask(requests, ri.ResourceNames))
-	ri.Pods[pod.UID] = &PodRequirement{
+	ri.AssignedPods[pod.UID] = &PodRequirement{
 		Namespace: pod.Namespace,
 		Name:      pod.Name,
 		UID:       pod.UID,
@@ -96,11 +231,11 @@ func (ri *ReservationInfo) AddPod(pod *corev1.Pod) {
 	}
 }
 
-func (ri *ReservationInfo) RemovePod(pod *corev1.Pod) {
-	if requirement, ok := ri.Pods[pod.UID]; ok {
+func (ri *ReservationInfo) RemoveAssignedPod(pod *corev1.Pod) {
+	if requirement, ok := ri.AssignedPods[pod.UID]; ok {
 		if len(requirement.Requests) > 0 {
 			ri.Allocated = quotav1.SubtractWithNonNegativeResult(ri.Allocated, quotav1.Mask(requirement.Requests, ri.ResourceNames))
 		}
-		delete(ri.Pods, pod.UID)
+		delete(ri.AssignedPods, pod.UID)
 	}
 }

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -328,7 +328,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 	return framework.NewStatus(framework.Unschedulable, ErrInsufficientDevices)
 }
 
-func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservation *schedulingv1alpha1.Reservation, nodeName string) *framework.Status {
+func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
 	state, status := getPreFilterState(cycleState)
 	if !status.IsSuccess() {
 		return status
@@ -342,7 +342,7 @@ func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.Cy
 
 	allocIndex := -1
 	for i, v := range restoreState.matched {
-		if v.rInfo.Reservation.UID == reservation.UID {
+		if v.rInfo.UID() == reservationInfo.UID() {
 			allocIndex = i
 			break
 		}

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -1243,7 +1243,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 	})
 	assert.True(t, status.IsSuccess())
 
-	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservation, "test-node-1")
+	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
 	assert.True(t, status.IsSuccess())
 
 	allocatedPod := &corev1.Pod{
@@ -1256,7 +1256,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 		},
 	}
 	nd.updateCacheUsed(allocations, allocatedPod, true)
-	reservationInfo.AddPod(allocatedPod)
+	reservationInfo.AddAssignedPod(allocatedPod)
 	nodeToState, status = pl.RestoreReservation(context.TODO(), cycleState, pod, []*frameworkext.ReservationInfo{reservationInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
 	status = pl.FinalRestoreReservation(context.TODO(), cycleState, pod, frameworkext.NodeReservationRestoreStates{
@@ -1264,7 +1264,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 	})
 	assert.True(t, status.IsSuccess())
 
-	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservation, "test-node-1")
+	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
 	assert.Equal(t, framework.NewStatus(framework.Unschedulable, ErrInsufficientDevices), status)
 }
 
@@ -2123,7 +2123,8 @@ func Test_Plugin_Reserve(t *testing.T) {
 					},
 				}
 				cycleState.Write(reservationRestoreStateKey, restoreState)
-				frameworkext.SetNominatedReservation(cycleState, reservation)
+				rInfo := frameworkext.NewReservationInfo(reservation)
+				frameworkext.SetNominatedReservation(cycleState, rInfo)
 			}
 
 			status := p.Reserve(context.TODO(), cycleState, tt.args.pod, tt.args.nodeName)

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -152,7 +152,7 @@ func Test_Plugin_ReservationRestore(t *testing.T) {
 	assert.True(t, status.IsSuccess())
 
 	reservationInfo := frameworkext.NewReservationInfo(reservation)
-	reservationInfo.AddPod(allocatedPod)
+	reservationInfo.AddAssignedPod(allocatedPod)
 	nodeRestoreState, status := pl.RestoreReservation(context.TODO(), cycleState, pod, []*frameworkext.ReservationInfo{reservationInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
 	assert.NotNil(t, nodeRestoreState)

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -385,13 +385,13 @@ func (p *Plugin) getReservationReservedCPUs(cycleState *framework.CycleState, po
 		return result, nil
 	}
 
-	allocatedCPUs, _ := p.cpuManager.GetAllocatedCPUSet(node.Name, nominatedReservation.UID)
+	allocatedCPUs, _ := p.cpuManager.GetAllocatedCPUSet(node.Name, nominatedReservation.UID())
 	if allocatedCPUs.IsEmpty() {
 		return result, nil
 	}
 	reservationRestoreState := getReservationRestoreState(cycleState)
 	nodeReservationRestoreState := reservationRestoreState.getNodeState(node.Name)
-	reservedCPUs := nodeReservationRestoreState.reservedCPUs[nominatedReservation.UID]
+	reservedCPUs := nodeReservationRestoreState.reservedCPUs[nominatedReservation.UID()]
 	if !reservedCPUs.IsEmpty() && !reservedCPUs.IsSubsetOf(allocatedCPUs) {
 		return result, fmt.Errorf("reservation reserved CPUs are invalid")
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -1028,12 +1028,14 @@ func TestPlugin_Reserve(t *testing.T) {
 				cycleState.Write(stateKey, tt.state)
 				if len(tt.reservedCPUs) > 0 {
 					for reservationUID := range tt.reservedCPUs {
-						frameworkext.SetNominatedReservation(cycleState, &schedulingv1alpha1.Reservation{
+						reservation := &schedulingv1alpha1.Reservation{
 							ObjectMeta: metav1.ObjectMeta{
 								UID:  reservationUID,
 								Name: "test-reservation",
 							},
-						})
+						}
+						rInfo := frameworkext.NewReservationInfo(reservation)
+						frameworkext.SetNominatedReservation(cycleState, rInfo)
 					}
 					cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
 						skip: false,
@@ -1299,7 +1301,7 @@ func TestRestoreReservation(t *testing.T) {
 	nodeInfo.SetNode(node)
 
 	rInfo := frameworkext.NewReservationInfo(reservation)
-	rInfo.AddPod(podA)
+	rInfo.AddAssignedPod(podA)
 
 	testPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1327,7 +1329,7 @@ func TestRestoreReservation(t *testing.T) {
 	assert.True(t, status.IsSuccess())
 	assert.Equal(t, cpuset.NewCPUSet(8, 9), nodeReservationState.(*nodeReservationRestoreStateData).reservedCPUs[reservation.UID])
 
-	rInfo.AddPod(podB)
+	rInfo.AddAssignedPod(podB)
 	nodeReservationState, status = pl.RestoreReservation(context.TODO(), cycleState, testPod, []*frameworkext.ReservationInfo{rInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
 	assert.Nil(t, nodeReservationState)

--- a/pkg/scheduler/plugins/nodenumaresource/reservation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation.go
@@ -82,12 +82,12 @@ func (p *Plugin) RestoreReservation(ctx context.Context, cycleState *framework.C
 	nodeName := nodeInfo.Node().Name
 	reservedCPUs := map[types.UID]cpuset.CPUSet{}
 	for _, rInfo := range matched {
-		allocatedCPUs, ok := p.cpuManager.GetAllocatedCPUSet(nodeName, rInfo.Reservation.UID)
+		allocatedCPUs, ok := p.cpuManager.GetAllocatedCPUSet(nodeName, rInfo.UID())
 		if !ok || allocatedCPUs.IsEmpty() {
 			continue
 		}
 
-		for _, pod := range rInfo.Pods {
+		for _, pod := range rInfo.AssignedPods {
 			podCPUs, ok := p.cpuManager.GetAllocatedCPUSet(nodeName, pod.UID)
 			if !ok || podCPUs.IsEmpty() {
 				continue
@@ -97,9 +97,9 @@ func (p *Plugin) RestoreReservation(ctx context.Context, cycleState *framework.C
 		}
 
 		if !allocatedCPUs.IsEmpty() {
-			reservedCPUs[rInfo.Reservation.UID] = allocatedCPUs
+			reservedCPUs[rInfo.UID()] = allocatedCPUs
 		} else {
-			delete(reservedCPUs, rInfo.Reservation.UID)
+			delete(reservedCPUs, rInfo.UID())
 		}
 	}
 

--- a/pkg/scheduler/plugins/reservation/cache.go
+++ b/pkg/scheduler/plugins/reservation/cache.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -31,37 +32,37 @@ type reservationCache struct {
 	reservationLister  schedulinglister.ReservationLister
 	lock               sync.Mutex
 	reservationInfos   map[types.UID]*frameworkext.ReservationInfo
-	reservationsOnNode map[string]map[types.UID]*schedulingv1alpha1.Reservation
+	reservationsOnNode map[string]map[types.UID]struct{}
 }
 
 func newReservationCache(reservationLister schedulinglister.ReservationLister) *reservationCache {
 	cache := &reservationCache{
 		reservationLister:  reservationLister,
 		reservationInfos:   map[types.UID]*frameworkext.ReservationInfo{},
-		reservationsOnNode: map[string]map[types.UID]*schedulingv1alpha1.Reservation{},
+		reservationsOnNode: map[string]map[types.UID]struct{}{},
 	}
 	return cache
 }
 
-func (cache *reservationCache) updateReservationsOnNode(nodeName string, r *schedulingv1alpha1.Reservation) {
+func (cache *reservationCache) updateReservationsOnNode(nodeName string, uid types.UID) {
 	if nodeName == "" {
 		return
 	}
 
-	reservations := cache.reservationsOnNode[r.Status.NodeName]
+	reservations := cache.reservationsOnNode[nodeName]
 	if reservations == nil {
-		reservations = map[types.UID]*schedulingv1alpha1.Reservation{}
-		cache.reservationsOnNode[r.Status.NodeName] = reservations
+		reservations = map[types.UID]struct{}{}
+		cache.reservationsOnNode[nodeName] = reservations
 	}
-	reservations[r.UID] = r
+	reservations[uid] = struct{}{}
 }
 
-func (cache *reservationCache) deleteReservationOnNode(nodeName string, r *schedulingv1alpha1.Reservation) {
+func (cache *reservationCache) deleteReservationOnNode(nodeName string, uid types.UID) {
 	if nodeName == "" {
 		return
 	}
 	reservations := cache.reservationsOnNode[nodeName]
-	delete(reservations, r.UID)
+	delete(reservations, uid)
 	if len(reservations) == 0 {
 		delete(cache.reservationsOnNode, nodeName)
 	}
@@ -86,7 +87,7 @@ func (cache *reservationCache) updateReservation(newR *schedulingv1alpha1.Reserv
 		rInfo.UpdateReservation(newR)
 	}
 	if newR.Status.NodeName != "" {
-		cache.updateReservationsOnNode(newR.Status.NodeName, newR)
+		cache.updateReservationsOnNode(newR.Status.NodeName, newR.UID)
 	}
 }
 
@@ -94,7 +95,38 @@ func (cache *reservationCache) deleteReservation(r *schedulingv1alpha1.Reservati
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	delete(cache.reservationInfos, r.UID)
-	cache.deleteReservationOnNode(r.Status.NodeName, r)
+	cache.deleteReservationOnNode(r.Status.NodeName, r.UID)
+}
+
+func (cache *reservationCache) updateReservationOperatingPod(newPod *corev1.Pod, currentOwner *corev1.ObjectReference) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	rInfo := cache.reservationInfos[newPod.UID]
+	if rInfo == nil {
+		rInfo = frameworkext.NewReservationInfoFromPod(newPod)
+		cache.reservationInfos[newPod.UID] = rInfo
+	} else {
+		rInfo.UpdatePod(newPod)
+	}
+	if newPod.Spec.NodeName != "" {
+		cache.updateReservationsOnNode(newPod.Spec.NodeName, newPod.UID)
+	}
+	if currentOwner != nil {
+		rInfo.AddAssignedPod(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      currentOwner.Name,
+				Namespace: currentOwner.Namespace,
+				UID:       currentOwner.UID,
+			},
+		})
+	}
+}
+
+func (cache *reservationCache) deleteReservationOperatingPod(pod *corev1.Pod) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	delete(cache.reservationInfos, pod.UID)
+	cache.deleteReservationOnNode(pod.Spec.NodeName, pod.UID)
 }
 
 func (cache *reservationCache) assumePod(reservationUID types.UID, pod *corev1.Pod) {
@@ -111,7 +143,7 @@ func (cache *reservationCache) addPod(reservationUID types.UID, pod *corev1.Pod)
 
 	rInfo := cache.reservationInfos[reservationUID]
 	if rInfo != nil {
-		rInfo.AddPod(pod)
+		rInfo.AddAssignedPod(pod)
 	}
 }
 
@@ -122,10 +154,10 @@ func (cache *reservationCache) updatePod(reservationUID types.UID, oldPod, newPo
 	rInfo := cache.reservationInfos[reservationUID]
 	if rInfo != nil {
 		if oldPod != nil {
-			rInfo.RemovePod(oldPod)
+			rInfo.RemoveAssignedPod(oldPod)
 		}
 		if newPod != nil {
-			rInfo.AddPod(newPod)
+			rInfo.AddAssignedPod(newPod)
 		}
 	}
 }
@@ -136,7 +168,7 @@ func (cache *reservationCache) deletePod(reservationUID types.UID, pod *corev1.P
 
 	rInfo := cache.reservationInfos[reservationUID]
 	if rInfo != nil {
-		rInfo.RemovePod(pod)
+		rInfo.RemoveAssignedPod(pod)
 	}
 }
 
@@ -166,8 +198,8 @@ func (cache *reservationCache) listReservationInfosOnNode(nodeName string) []*fr
 		return nil
 	}
 	result := make([]*frameworkext.ReservationInfo, 0, len(rOnNode))
-	for _, v := range rOnNode {
-		rInfo := cache.reservationInfos[v.UID]
+	for uid := range rOnNode {
+		rInfo := cache.reservationInfos[uid]
 		if rInfo != nil {
 			result = append(result, rInfo.Clone())
 		}

--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -30,6 +30,7 @@ import (
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 func TestCacheUpdateReservation(t *testing.T) {
@@ -73,6 +74,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 	rInfo := reservationInfos[0]
 	expectReservationInfo := &frameworkext.ReservationInfo{
 		Reservation: reservation,
+		Pod:         reservationutil.NewReservePod(reservation),
 		ResourceNames: []corev1.ResourceName{
 			corev1.ResourceCPU,
 			corev1.ResourceMemory,
@@ -81,8 +83,8 @@ func TestCacheUpdateReservation(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("4Gi"),
 		},
-		Allocated: nil,
-		Pods:      map[types.UID]*frameworkext.PodRequirement{},
+		Allocated:    nil,
+		AssignedPods: map[types.UID]*frameworkext.PodRequirement{},
 	}
 	sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 		return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
@@ -142,6 +144,7 @@ func TestCacheDeleteReservation(t *testing.T) {
 
 	expectReservationInfo := &frameworkext.ReservationInfo{
 		Reservation: reservation,
+		Pod:         reservationutil.NewReservePod(reservation),
 		ResourceNames: []corev1.ResourceName{
 			corev1.ResourceCPU,
 			corev1.ResourceMemory,
@@ -150,8 +153,8 @@ func TestCacheDeleteReservation(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("4"),
 			corev1.ResourceMemory: resource.MustParse("4Gi"),
 		},
-		Allocated: nil,
-		Pods:      map[types.UID]*frameworkext.PodRequirement{},
+		Allocated:    nil,
+		AssignedPods: map[types.UID]*frameworkext.PodRequirement{},
 	}
 	sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 		return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
@@ -231,6 +234,7 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 	})
 	expectReservationInfo := &frameworkext.ReservationInfo{
 		Reservation: reservation,
+		Pod:         reservationutil.NewReservePod(reservation),
 		ResourceNames: []corev1.ResourceName{
 			corev1.ResourceCPU,
 			corev1.ResourceMemory,
@@ -243,7 +247,7 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("2000m"),
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		},
-		Pods: map[types.UID]*frameworkext.PodRequirement{
+		AssignedPods: map[types.UID]*frameworkext.PodRequirement{
 			pod.UID: {
 				Namespace: pod.Namespace,
 				Name:      pod.Name,
@@ -277,6 +281,6 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 		corev1.ResourceCPU:    resource.MustParse("0"),
 		corev1.ResourceMemory: resource.MustParse("0"),
 	}
-	expectReservationInfo.Pods = map[types.UID]*frameworkext.PodRequirement{}
+	expectReservationInfo.AssignedPods = map[types.UID]*frameworkext.PodRequirement{}
 	assert.Equal(t, expectReservationInfo, rInfo)
 }

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -232,8 +232,12 @@ func TestNominateReservation(t *testing.T) {
 				pl.reservationCache.updateReservation(reservation)
 			}
 			cycleState.Write(stateKey, state)
-			reservation, status := pl.NominateReservation(context.TODO(), cycleState, tt.pod, "test-node")
-			assert.Equal(t, tt.wantReservation, reservation)
+			nominateRInfo, status := pl.NominateReservation(context.TODO(), cycleState, tt.pod, "test-node")
+			if tt.wantReservation == nil {
+				assert.Nil(t, nominateRInfo)
+			} else {
+				assert.Equal(t, tt.wantReservation, nominateRInfo.Reservation)
+			}
 			assert.Equal(t, tt.wantStatus, status.IsSuccess())
 		})
 	}

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -76,13 +76,13 @@ func TestPodEventHandler(t *testing.T) {
 
 	handler.OnAdd(pod)
 	rInfo := handler.cache.getReservationInfoByUID(reservationUID)
-	assert.Empty(t, rInfo.Pods)
+	assert.Empty(t, rInfo.AssignedPods)
 
 	newPod := pod.DeepCopy()
 	apiext.SetReservationAllocated(newPod, reservation)
 	handler.OnUpdate(pod, newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
-	assert.Len(t, rInfo.Pods, 1)
+	assert.Len(t, rInfo.AssignedPods, 1)
 	expectPodRequirement := &frameworkext.PodRequirement{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,
@@ -91,9 +91,9 @@ func TestPodEventHandler(t *testing.T) {
 			corev1.ResourceCPU: resource.MustParse("4"),
 		},
 	}
-	assert.Equal(t, expectPodRequirement, rInfo.Pods[pod.UID])
+	assert.Equal(t, expectPodRequirement, rInfo.AssignedPods[pod.UID])
 
 	handler.OnDelete(newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
-	assert.Empty(t, rInfo.Pods)
+	assert.Empty(t, rInfo.AssignedPods)
 }

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -29,7 +29,6 @@ import (
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
-	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/util"
@@ -89,23 +88,23 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 
 		var unmatched, matched []*frameworkext.ReservationInfo
 		for _, rInfo := range rOnNode {
-			if !reservationutil.IsReservationAvailable(rInfo.Reservation) {
+			if !rInfo.IsAvailable() {
 				continue
 			}
 
 			// In this case, the Controller has not yet updated the status of the Reservation to Succeeded,
 			// but in fact it can no longer be used for allocation. So it's better to skip first.
-			if extension.IsReservationAllocateOnce(rInfo.Reservation) && len(rInfo.Pods) > 0 {
+			if rInfo.IsAllocateOnce() && len(rInfo.AssignedPods) > 0 {
 				continue
 			}
 
-			if !isReservedPod && matchReservation(pod, node, rInfo.Reservation, reservationAffinity) {
+			if !isReservedPod && matchReservation(pod, node, rInfo, reservationAffinity) {
 				matched = append(matched, rInfo)
 
-			} else if len(rInfo.Pods) > 0 {
+			} else if len(rInfo.AssignedPods) > 0 {
 				unmatched = append(unmatched, rInfo)
 				if !isReservedPod {
-					klog.V(6).InfoS("got reservation on node does not match the pod", "reservation", klog.KObj(rInfo.Reservation), "pod", klog.KObj(pod))
+					klog.V(6).InfoS("got reservation on node does not match the pod", "reservation", klog.KObj(rInfo), "pod", klog.KObj(pod))
 				}
 			}
 		}
@@ -138,7 +137,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			}
 
 			util.AddResourceList(rAllocated, rInfo.Allocated)
-			switch rInfo.Reservation.Spec.AllocatePolicy {
+			switch rInfo.GetAllocatePolicy() {
 			case schedulingv1alpha1.ReservationAllocatePolicyAligned:
 				totalAligned++
 			case schedulingv1alpha1.ReservationAllocatePolicyRestricted:
@@ -216,11 +215,11 @@ func (pl *Plugin) AfterPreFilter(ctx context.Context, cycleState *framework.Cycl
 }
 
 func restoreMatchedReservation(nodeInfo *framework.NodeInfo, rInfo *frameworkext.ReservationInfo, podInfoMap map[types.UID]*framework.PodInfo) error {
-	reservePod := reservationutil.NewReservePod(rInfo.Reservation)
+	reservePod := rInfo.GetReservePod()
 
 	// Retain ports that are not used by other Pods. These ports need to be erased from NodeInfo.UsedPorts,
 	// otherwise it may cause Pod port conflicts
-	retainReservePodUnusedPorts(reservePod, rInfo.Reservation, podInfoMap)
+	reservePod = retainReservePodUnusedPorts(reservePod, podInfoMap)
 
 	// When AllocateOnce is disabled, some resources may have been allocated,
 	// and an additional resource record will be accumulated at this time.
@@ -240,9 +239,9 @@ func restoreUnmatchedReservations(nodeInfo *framework.NodeInfo, rInfo *framework
 	// For example, on a 32C machine, ReservationA reserves 8C, and then PodA uses ReservationA to allocate 4C,
 	// then the record on NodeInfo is that 12C is allocated. But in fact it should be calculated according to 8C,
 	// so we need to return some resources.
-	reservePod := reservationutil.NewReservePod(rInfo.Reservation)
+	reservePod := rInfo.GetReservePod().DeepCopy()
 	if err := nodeInfo.RemovePod(reservePod); err != nil {
-		klog.Errorf("Failed to remove reserve pod %v from node %v, err: %v", klog.KObj(rInfo.Reservation), nodeInfo.Node().Name, err)
+		klog.Errorf("Failed to remove reserve pod %v from node %v, err: %v", klog.KObj(rInfo), nodeInfo.Node().Name, err)
 		return err
 	}
 	occupyUnallocatedResources(rInfo, reservePod, nodeInfo)
@@ -250,7 +249,7 @@ func restoreUnmatchedReservations(nodeInfo *framework.NodeInfo, rInfo *framework
 }
 
 func occupyUnallocatedResources(rInfo *frameworkext.ReservationInfo, reservePod *corev1.Pod, nodeInfo *framework.NodeInfo) {
-	if len(rInfo.Pods) == 0 {
+	if len(rInfo.AssignedPods) == 0 {
 		nodeInfo.AddPod(reservePod)
 	} else {
 		for i := range reservePod.Spec.Containers {
@@ -266,18 +265,16 @@ func occupyUnallocatedResources(rInfo *frameworkext.ReservationInfo, reservePod 
 	}
 }
 
-func retainReservePodUnusedPorts(reservePod *corev1.Pod, reservation *schedulingv1alpha1.Reservation, podInfoMap map[types.UID]*framework.PodInfo) {
-	port := reservationutil.ReservePorts(reservation)
-	if len(port) == 0 {
-		return
-	}
-
+func retainReservePodUnusedPorts(reservePod *corev1.Pod, podInfoMap map[types.UID]*framework.PodInfo) *corev1.Pod {
 	// TODO(joseph): maybe we can record allocated Ports by Pods in Reservation.Status
 	portReserved := framework.HostPortInfo{}
-	for ip, protocolPortMap := range port {
-		for protocolPort := range protocolPortMap {
-			portReserved.Add(ip, protocolPort.Protocol, protocolPort.Port)
+	for _, container := range reservePod.Spec.Containers {
+		for _, podPort := range container.Ports {
+			portReserved.Add(podPort.HostIP, string(podPort.Protocol), podPort.HostPort)
 		}
+	}
+	if len(portReserved) == 0 {
+		return reservePod
 	}
 
 	removed := false
@@ -292,9 +289,10 @@ func retainReservePodUnusedPorts(reservePod *corev1.Pod, reservation *scheduling
 		}
 	}
 	if !removed {
-		return
+		return reservePod
 	}
 
+	reservePod = reservePod.DeepCopy()
 	for i := range reservePod.Spec.Containers {
 		container := &reservePod.Spec.Containers[i]
 		if len(container.Ports) > 0 {
@@ -312,10 +310,11 @@ func retainReservePodUnusedPorts(reservePod *corev1.Pod, reservation *scheduling
 			})
 		}
 	}
+	return reservePod
 }
 
-func matchReservation(pod *corev1.Pod, node *corev1.Node, reservation *schedulingv1alpha1.Reservation, reservationAffinity *reservationutil.RequiredReservationAffinity) bool {
-	if !reservationutil.MatchReservationOwners(pod, reservation) {
+func matchReservation(pod *corev1.Pod, node *corev1.Node, reservation *frameworkext.ReservationInfo, reservationAffinity *reservationutil.RequiredReservationAffinity) bool {
+	if !reservationutil.MatchReservationOwners(pod, reservation.GetPodOwners()) {
 		return false
 	}
 
@@ -325,14 +324,14 @@ func matchReservation(pod *corev1.Pod, node *corev1.Node, reservation *schedulin
 		// does not have this information, so it needs to perceive the label of the Node when Matching Affinity.
 		fakeNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   reservation.Name,
+				Name:   reservation.GetName(),
 				Labels: map[string]string{},
 			},
 		}
 		for k, v := range node.Labels {
 			fakeNode.Labels[k] = v
 		}
-		for k, v := range reservation.Labels {
+		for k, v := range reservation.GetObject().GetLabels() {
 			fakeNode.Labels[k] = v
 		}
 		return reservationAffinity.Match(fakeNode)

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -420,7 +420,8 @@ func Test_matchReservation(t *testing.T) {
 			}
 			reservationAffinity, err := reservationutil.GetRequiredReservationAffinity(tt.pod)
 			assert.NoError(t, err)
-			got := matchReservation(tt.pod, &corev1.Node{}, tt.reservation, reservationAffinity)
+			rInfo := frameworkext.NewReservationInfo(tt.reservation)
+			got := matchReservation(tt.pod, &corev1.Node{}, rInfo, reservationAffinity)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -463,7 +463,7 @@ func Test_matchReservationOwners(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MatchReservationOwners(tt.args.pod, tt.args.r)
+			got := MatchReservationOwners(tt.args.pod, tt.args.r.Spec.Owners)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Supports using real Pods to reserve resources.
- If the Pod has the special label `scheduling.koordinator.sh/operating-mode` and the value is `Reservation`, it means that the purpose of the Pod is to reserve resources.
- Such Pods are collectively called Operating Pods. It can also be allocated from a Reservation CRD, or it can be preempted like a normal Pod.
- Pod whose Operating Mode is `Reservation`, its Reservation allocation policy defaults to `Aligned`, and it is assigned only once.
- Users can set annotation `scheduling.koordinator.sh/reservation-owners` such as `Reservation.Spec.Owners` to indicate which Pods can use resources reserved by real Pods.
- Once the Operating Pod is bound by other Pods, the Operating Pod will be annotated with `scheduling.koordinator.sh/reservat-current-owner` to indicate who uses the Pod.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
