### PR TITLE
koord-scheduler: podgroup support minMember = 0

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
@@ -241,7 +241,7 @@ func (ctrl *PodGroupController) syncHandler(key string) error {
 	case "":
 		pgCopy.Status.Phase = schedv1alpha1.PodGroupPending
 	case schedv1alpha1.PodGroupPending:
-		if len(pods) >= int(pg.Spec.MinMember) {
+		if len(pods) >= int(pg.Spec.MinMember) && pg.Spec.MinMember > 0 {
 			pgCopy.Status.Phase = schedv1alpha1.PodGroupPreScheduling
 			fillOccupiedObj(pgCopy, pods[0])
 		}

--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
@@ -230,6 +230,13 @@ func TestFillGroupStatusOccupied(t *testing.T) {
 			groupPhase:           v1alpha1.PodGroupPending,
 			desiredGroupOccupied: []string{"default/new-occupied-1", "default/new-occupied-2"},
 		},
+		{
+			name:                 "minMember == 0",
+			pgName:               "pg",
+			minMember:            0,
+			groupPhase:           v1alpha1.PodGroupPending,
+			desiredGroupOccupied: []string{"test"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

If PodGroup MinMember ==0, scheduler will panic. We fix this bug as a supplement to #1299 

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
