### PR TITLE
koord-descheduler: allow annotated pod only pass non-retriable filter

### DIFF
--- a/pkg/descheduler/controllers/migration/controller.go
+++ b/pkg/descheduler/controllers/migration/controller.go
@@ -414,18 +414,17 @@ func (r *Reconciler) preparePendingJob(ctx context.Context, job *sev1alpha1.PodM
 			return reconcile.Result{}, err
 		}
 	}
-
+	markPodPrepareMigrating(pod)
 	if !evictionsutil.HaveEvictAnnotation(job) {
-		markPodPrepareMigrating(pod)
 		if aborted, err := r.abortJobIfNonRetryablePodFilterFailed(ctx, pod, job); aborted || err != nil {
 			if err == nil {
 				err = fmt.Errorf("abort job since failed to non-retryable Pod filter")
 			}
 			return reconcile.Result{}, err
 		}
-		if requeue, err := r.requeueJobIfRetryablePodFilterFailed(ctx, pod, job); requeue || err != nil {
-			return reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
-		}
+	}
+	if requeue, err := r.requeueJobIfRetryablePodFilterFailed(ctx, pod, job); requeue || err != nil {
+		return reconcile.Result{RequeueAfter: defaultRequeueAfter}, err
 	}
 
 	job.Status.Phase = sev1alpha1.PodMigrationJobRunning

--- a/pkg/descheduler/controllers/migration/controller_test.go
+++ b/pkg/descheduler/controllers/migration/controller_test.go
@@ -2537,14 +2537,15 @@ func TestFilterObjectLimiter(t *testing.T) {
 
 func TestAllowAnnotatedPodMigrationJobPassFilter(t *testing.T) {
 	reconciler := newTestReconciler()
-	enter := false
+	enterNonRetryable := false
+	enterRetryable := false
 	reconciler.nonRetryablePodFilter = func(pod *corev1.Pod) bool {
-		enter = true
+		enterNonRetryable = true
 		return false
 	}
 	reconciler.retryablePodFilter = func(pod *corev1.Pod) bool {
-		enter = true
-		return false
+		enterRetryable = true
+		return true
 	}
 
 	job := &sev1alpha1.PodMigrationJob{
@@ -2582,7 +2583,8 @@ func TestAllowAnnotatedPodMigrationJobPassFilter(t *testing.T) {
 	assert.Nil(t, reconciler.Client.Create(context.TODO(), pod))
 
 	result, err := reconciler.preparePendingJob(context.TODO(), job)
-	assert.False(t, enter)
+	assert.True(t, enterRetryable)
+	assert.False(t, enterNonRetryable)
 	assert.Nil(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The user of podMigrationJob may know the risk of migrationPod. So we allow annotated job to pass filter. Then user can use annotation to indicate he/she knows the risk. 
However, user just want the annotated job to pass non-retryable filter and the retryable-filter(flow-control ability) should remain unchanged.

### Ⅱ. Does this pull request fix one issue?

None

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
