### PR TITLE
koord-manager: allow skip update resource 

### DIFF
--- a/apis/extension/cluster_colocation_profile.go
+++ b/apis/extension/cluster_colocation_profile.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
+)
+
+const (
+	AnnotationSkipUpdateResource = "config.koordinator.sh/skip-update-resources"
+)
+
+func ShouldSkipUpdateResource(profile *configv1alpha1.ClusterColocationProfile) bool {
+	if profile == nil || profile.Annotations == nil {
+		return false
+	}
+	_, ok := profile.Annotations[AnnotationSkipUpdateResource]
+	return ok
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -42,18 +42,22 @@ const (
 	// ConfigMapValidatingWebhook enables validating webhook for configmap Creation or updates
 	ConfigMapValidatingWebhook featuregate.Feature = "ConfigMapValidatingWebhook"
 
+	// ColocationProfileSkipMutatingResources config whether to update resourceName according to priority by default
+	ColocationProfileSkipMutatingResources featuregate.Feature = "ColocationProfileSkipMutatingResources"
+
 	// WebhookFramework enables webhook framework
 	WebhookFramework featuregate.Feature = "WebhookFramework"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PodMutatingWebhook:            {Default: true, PreRelease: featuregate.Beta},
-	PodValidatingWebhook:          {Default: true, PreRelease: featuregate.Beta},
-	ElasticQuotaMutatingWebhook:   {Default: true, PreRelease: featuregate.Beta},
-	ElasticQuotaValidatingWebhook: {Default: true, PreRelease: featuregate.Beta},
-	NodeValidatingWebhook:         {Default: false, PreRelease: featuregate.Alpha},
-	ConfigMapValidatingWebhook:    {Default: false, PreRelease: featuregate.Alpha},
-	WebhookFramework:              {Default: true, PreRelease: featuregate.Beta},
+	PodMutatingWebhook:                     {Default: true, PreRelease: featuregate.Beta},
+	PodValidatingWebhook:                   {Default: true, PreRelease: featuregate.Beta},
+	ElasticQuotaMutatingWebhook:            {Default: true, PreRelease: featuregate.Beta},
+	ElasticQuotaValidatingWebhook:          {Default: true, PreRelease: featuregate.Beta},
+	NodeValidatingWebhook:                  {Default: false, PreRelease: featuregate.Alpha},
+	ConfigMapValidatingWebhook:             {Default: false, PreRelease: featuregate.Alpha},
+	WebhookFramework:                       {Default: true, PreRelease: featuregate.Beta},
+	ColocationProfileSkipMutatingResources: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
@@ -35,6 +35,8 @@ import (
 
 	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
+	"github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
 func SetRandIntnFnWhenTest(updatedRandIntnFn func(int) int) func() {
@@ -67,11 +69,13 @@ func newAdmissionRequest(op admissionv1.Operation, object, oldObject runtime.Raw
 
 func TestClusterColocationProfileMutatingPod(t *testing.T) {
 	testCases := []struct {
-		name       string
-		pod        *corev1.Pod
-		expected   *corev1.Pod
-		percent    *int
-		randIntnFn func(int) int
+		name                      string
+		pod                       *corev1.Pod
+		profile                   *configv1alpha1.ClusterColocationProfile
+		percent                   *int
+		randIntnFn                func(int) int
+		defaultSkipUpdateResource bool
+		expected                  *corev1.Pod
 	}{
 		{
 			name: "mutating pod",
@@ -120,6 +124,36 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					},
 					SchedulerName: "nonExistSchedulerName",
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
+				},
+			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
 				},
 			},
 			expected: &corev1.Pod{
@@ -205,6 +239,36 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -267,6 +331,36 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					},
 					SchedulerName: "nonExistSchedulerName",
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
+				},
+			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
 				},
 			},
 			expected: &corev1.Pod{
@@ -352,6 +446,37 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			percent: pointer.Int(100),
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -408,7 +533,6 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					PriorityClassName: "koordinator-batch",
 				},
 			},
-			percent: pointer.Int(100),
 		},
 		{
 			name: "mutating pod, percent 0",
@@ -459,6 +583,37 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			percent: pointer.Int(0),
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -506,7 +661,6 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
-			percent: pointer.Int(0),
 		},
 		{
 			name: "mutating pod, percent 50, rand=70",
@@ -557,6 +711,40 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			percent: pointer.Int(50),
+			randIntnFn: func(i int) int {
+				return 70
+			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -603,10 +791,6 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName: "nonExistSchedulerName",
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
-			},
-			percent: pointer.Int(50),
-			randIntnFn: func(i int) int {
-				return 70
 			},
 		},
 		{
@@ -658,6 +842,40 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
 				},
 			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			percent: pointer.Int(50),
+			randIntnFn: func(i int) int {
+				return 30
+			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -714,15 +932,290 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					PriorityClassName: "koordinator-batch",
 				},
 			},
-			percent: pointer.Int(50),
-			randIntnFn: func(i int) int {
-				return 30
+		},
+		{
+			name: "mutating pod, skip update resource by profile annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName: "nonExistSchedulerName",
+					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
+				},
+			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+					Annotations: map[string]string{
+						extension.AnnotationSkipUpdateResource: "true",
+					},
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod": "true",
+						"testLabelA":                 "valueA",
+						"test-patch-label":           "patch-a",
+						extension.LabelPodQoS:        string(extension.QoSBE),
+						extension.LabelPodPriority:   "1111",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA":       "valueA",
+						"test-patch-annotation": "patch-b",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName:     "koordinator-scheduler",
+					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
+					PriorityClassName: "koordinator-batch",
+				},
+			},
+		},
+		{
+			name: "mutating pod, skip update resource by leveraging profile",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName: "nonExistSchedulerName",
+					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
+				},
+			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA": "valueA",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA":                      "valueA",
+						extension.AnnotationSkipUpdateResource: "true",
+					},
+					SchedulerName:       "koordinator-scheduler",
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			defaultSkipUpdateResource: true,
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod": "true",
+						"testLabelA":                 "valueA",
+						"test-patch-label":           "patch-a",
+						extension.LabelPodQoS:        string(extension.QoSBE),
+						extension.LabelPodPriority:   "1111",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA":                      "valueA",
+						"test-patch-annotation":                "patch-b",
+						extension.AnnotationSkipUpdateResource: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName:     "koordinator-scheduler",
+					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
+					PriorityClassName: "koordinator-batch",
+				},
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			defer feature.SetFeatureGateDuringTest(t, feature.DefaultMutableFeatureGate, features.ColocationProfileSkipMutatingResources, tc.defaultSkipUpdateResource)()
 			assert := assert.New(t)
 
 			client := fake.NewClientBuilder().Build()
@@ -752,44 +1245,14 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 			err = client.Create(context.TODO(), batchPriorityClass)
 			assert.NoError(err)
 
-			profile := &configv1alpha1.ClusterColocationProfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-profile",
-				},
-				Spec: configv1alpha1.ClusterColocationProfileSpec{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"enable-koordinator-colocation": "true",
-						},
-					},
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"koordinator-colocation-pod": "true",
-						},
-					},
-					Labels: map[string]string{
-						"testLabelA": "valueA",
-					},
-					Annotations: map[string]string{
-						"testAnnotationA": "valueA",
-					},
-					SchedulerName:       "koordinator-scheduler",
-					QoSClass:            string(extension.QoSBE),
-					PriorityClassName:   "koordinator-batch",
-					KoordinatorPriority: pointer.Int32(1111),
-					Patch: runtime.RawExtension{
-						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
-					},
-				},
-			}
 			if tc.percent != nil {
 				s := intstr.FromInt(*tc.percent)
-				profile.Spec.Probability = &s
+				tc.profile.Spec.Probability = &s
 			}
 			if tc.randIntnFn != nil {
 				defer SetRandIntnFnWhenTest(tc.randIntnFn)()
 			}
-			err = client.Create(context.TODO(), profile)
+			err = client.Create(context.TODO(), tc.profile)
 			assert.NoError(err)
 
 			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

ClusterColocationProfile always modify the resources's request and limits if the Pod matched and is BE QoSClass, but should support skipping modify resources.

### Ⅱ. Does this pull request fix one issue?

fixes #1308

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
