### PR TITLE
koordlet: revise cgroup update err when unsupported or path not exist

### DIFF
--- a/pkg/koordlet/resourceexecutor/cgroup.go
+++ b/pkg/koordlet/resourceexecutor/cgroup.go
@@ -56,6 +56,8 @@ func cgroupFileWriteIfDifferent(cgroupTaskDir string, r sysutil.Resource, value 
 	if currentErr != nil {
 		return false, currentErr
 	}
+	// FIXME(saintube): Instead of handling cpuset resource in writing function, we should use a updater and do
+	//  MergeUpdate in resourceexecutor's LeveledUpdateBatch.
 	if r.ResourceType() == sysutil.CPUSetCPUSName && cpuset.IsEqualStrCpus(currentValue, value) {
 		return false, nil
 	}

--- a/pkg/koordlet/resourceexecutor/config_test.go
+++ b/pkg/koordlet/resourceexecutor/config_test.go
@@ -32,17 +32,12 @@ func Test_NewDefaultConfig(t *testing.T) {
 }
 
 func Test_InitFlags(t *testing.T) {
-	cmdArgs := []string{
-		"",
-		"--resource-force-update-seconds=120",
-	}
-	fs := flag.NewFlagSet(cmdArgs[0], flag.ExitOnError)
-
 	type fields struct {
 		ResourceForceUpdateSeconds int
 	}
 	type args struct {
-		fs *flag.FlagSet
+		fs      *flag.FlagSet
+		cmdArgs []string
 	}
 	tests := []struct {
 		name   string
@@ -54,18 +49,38 @@ func Test_InitFlags(t *testing.T) {
 			fields: fields{
 				ResourceForceUpdateSeconds: 120,
 			},
-			args: args{fs: fs},
+			args: args{
+				fs: flag.NewFlagSet("", flag.ExitOnError),
+				cmdArgs: []string{
+					"",
+					"--resource-force-update-seconds=120",
+				},
+			},
+		},
+		{
+			name: "not default 1",
+			fields: fields{
+				ResourceForceUpdateSeconds: 90,
+			},
+			args: args{
+				fs: flag.NewFlagSet("", flag.ExitOnError),
+				cmdArgs: []string{
+					"",
+					"--resource-force-update-seconds=90",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			raw := &Config{
+			want := &Config{
 				ResourceForceUpdateSeconds: tt.fields.ResourceForceUpdateSeconds,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)
-			tt.args.fs.Parse(cmdArgs[1:])
-			assert.Equal(t, raw, c)
+			err := tt.args.fs.Parse(tt.args.cmdArgs[1:])
+			assert.NoError(t, err, err)
+			assert.Equal(t, want, c)
 		})
 	}
 }

--- a/pkg/koordlet/resourceexecutor/updater.go
+++ b/pkg/koordlet/resourceexecutor/updater.go
@@ -302,7 +302,7 @@ func NewMergeableCgroupUpdaterIfCPUSetLooser(resourceType sysutil.ResourceType, 
 }
 
 // NewDetailCgroupUpdater returns a new *CgroupResourceUpdater according to the given Resource, which is generally used
-// for backwards compatibility. It it not guaranteed for updating successfully since it does not retrieve from the
+// for backwards compatibility. It is not guaranteed for updating successfully since it does not retrieve from the
 // known cgroup resources.
 func NewDetailCgroupUpdater(resource sysutil.Resource, parentDir string, value string, updateFunc UpdateFunc, e *audit.EventHelper) (ResourceUpdater, error) {
 	return &CgroupResourceUpdater{
@@ -458,6 +458,10 @@ func MergeConditionIfCPUSetIsLooser(oldValue, newValue string) (string, bool, er
 		return newValue, false, fmt.Errorf("old value is not valid cpuset, err: %v", err)
 	}
 
+	// no need to merge if new cpuset is equal to old
+	if v.Equals(old) {
+		return newValue, false, nil
+	}
 	// no need to merge if new cpuset is a subset of the old
 	if v.IsSubsetOf(old) {
 		return newValue, false, nil
@@ -499,10 +503,10 @@ func BlkIOUpdateFunc(resource ResourceUpdater) error {
 	return cgroupBlkIOFileWriteIfDifferent(info.parentDir, info.file, info.Value())
 }
 
-// resourceType sysutil.ResourceType, parentDir string, value string, updateFunc UpdateFunc
 func NewBlkIOResourceUpdater(resourceType sysutil.ResourceType, parentDir string, value string, e *audit.EventHelper) (ResourceUpdater, error) {
 	return NewCgroupUpdater(resourceType, parentDir, value, BlkIOUpdateFunc, e)
 }
+
 func cgroupBlkIOFileWriteIfDifferent(cgroupTaskDir string, file sysutil.Resource, value string) error {
 	var needUpdate bool
 	currentValue, currentErr := cgroupFileRead(cgroupTaskDir, file)

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt_test.go
@@ -95,6 +95,7 @@ func Test_bvtPlugin_systemSupported(t *testing.T) {
 			testHelper := system.NewFileTestUtil(t)
 			defer testHelper.Cleanup()
 			testHelper.SetCgroupsV2(tt.fields.UseCgroupsV2)
+			testHelper.SetValidateResource(false)
 			if tt.fields.initPath != nil {
 				initCPUBvt(*tt.fields.initPath, 0, testHelper)
 			}

--- a/pkg/koordlet/util/system/system_resource.go
+++ b/pkg/koordlet/util/system/system_resource.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package system
 
 import (

--- a/pkg/koordlet/util/system/system_resource_test.go
+++ b/pkg/koordlet/util/system/system_resource_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package system
 
 import (

--- a/pkg/koordlet/util/system/util_test_tool.go
+++ b/pkg/koordlet/util/system/util_test_tool.go
@@ -58,6 +58,8 @@ var (
 type FileTestUtil struct {
 	// Temporary directory to store mock cgroup filesystem.
 	TempDir string
+	// whether to validate when writing cgroups resources
+	ValidateResource bool
 
 	t *testing.T
 }
@@ -79,7 +81,11 @@ func NewFileTestUtil(t *testing.T) *FileTestUtil {
 
 	initSupportConfigs()
 
-	return &FileTestUtil{TempDir: tempDir, t: t}
+	return &FileTestUtil{
+		TempDir:          tempDir,
+		ValidateResource: true,
+		t:                t,
+	}
 }
 
 func (c *FileTestUtil) Cleanup() {
@@ -102,6 +108,10 @@ func (c *FileTestUtil) SetAnolisOSResourcesSupported(supported bool) {
 
 func (c *FileTestUtil) SetCgroupsV2(useCgroupsV2 bool) {
 	UseCgroupsV2 = useCgroupsV2
+}
+
+func (c *FileTestUtil) SetValidateResource(enabled bool) {
+	c.ValidateResource = enabled
 }
 
 // if dir contain TempDir, mkdir direct, else join with TempDir and mkdir
@@ -213,13 +223,15 @@ func (c *FileTestUtil) WriteCgroupFileContents(taskDir string, r Resource, conte
 		c.CreateCgroupFile(taskDir, r)
 	}
 
-	if supported, msg := r.IsSupported(taskDir); !supported {
-		err := ResourceUnsupportedErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
-		c.t.Fatal(err)
-	}
-	if valid, msg := r.IsValid(contents); !valid {
-		err := fmt.Errorf("write cgroup %s failed, value[%v] not valid, msg: %s", r.ResourceType(), contents, msg)
-		c.t.Fatal(err)
+	if c.ValidateResource {
+		if supported, msg := r.IsSupported(taskDir); !supported {
+			err := ResourceUnsupportedErr(fmt.Sprintf("write cgroup %s failed, msg: %s", r.ResourceType(), msg))
+			c.t.Fatal(err)
+		}
+		if valid, msg := r.IsValid(contents); !valid {
+			err := fmt.Errorf("write cgroup %s failed, value[%v] not valid, msg: %s", r.ResourceType(), contents, msg)
+			c.t.Fatal(err)
+		}
 	}
 	filePath = r.Path(taskDir)
 	klog.V(5).Infof("write %s [%s]", filePath, contents)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Revise the error handling when the cgroup resource update fails because the cgroup is unsupported or the file does not exist.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
