### PR TITLE
koord-scheduler: fix leaky operating pod in reservation

### DIFF
--- a/pkg/scheduler/plugins/reservation/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler.go
@@ -115,10 +115,9 @@ func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 
 func (h *podEventHandler) deletePod(pod *corev1.Pod) {
 	reservationAllocated, err := apiext.GetReservationAllocated(pod)
-	if err != nil || reservationAllocated == nil || reservationAllocated.UID == "" {
-		return
+	if err == nil && reservationAllocated != nil && reservationAllocated.UID != "" {
+		h.cache.deletePod(reservationAllocated.UID, pod)
 	}
-	h.cache.deletePod(reservationAllocated.UID, pod)
 
 	if apiext.IsReservationOperatingMode(pod) {
 		h.cache.deleteReservationOperatingPod(pod)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The operating pod does not have reservation allocated information, which will lead to failure to release ReservationInfo correctly.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
