### PR TITLE
koord-scheduler: coscheduling supports skipping check schedule cycle

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -194,6 +194,9 @@ type CoschedulingArgs struct {
 	// Workers number of controller
 	// default is 1
 	ControllerWorkers *int64 `json:"controllerWorkers,omitempty"`
+	// Skip check schedule cycle
+	// default is false
+	SkipCheckScheduleCycle bool `json:"SkipCheckScheduleCycle,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -190,6 +190,9 @@ type CoschedulingArgs struct {
 	// Workers number of controller
 	// default is 1
 	ControllerWorkers *int64 `json:"controllerWorkers,omitempty"`
+	// Skip check schedule cycle
+	// default is false
+	SkipCheckScheduleCycle *bool `json:"SkipCheckScheduleCycle,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -127,6 +127,9 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1beta2_CoschedulingArgs_To_config_CoschedulingArgs(in *CoschedulingArgs, out *config.CoschedulingArgs, s conversion.Scope) error {
 	out.DefaultTimeout = (*v1.Duration)(unsafe.Pointer(in.DefaultTimeout))
 	out.ControllerWorkers = (*int64)(unsafe.Pointer(in.ControllerWorkers))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.SkipCheckScheduleCycle, &out.SkipCheckScheduleCycle, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -138,6 +141,9 @@ func Convert_v1beta2_CoschedulingArgs_To_config_CoschedulingArgs(in *Coschedulin
 func autoConvert_config_CoschedulingArgs_To_v1beta2_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	out.DefaultTimeout = (*v1.Duration)(unsafe.Pointer(in.DefaultTimeout))
 	out.ControllerWorkers = (*int64)(unsafe.Pointer(in.ControllerWorkers))
+	if err := v1.Convert_bool_To_Pointer_bool(&in.SkipCheckScheduleCycle, &out.SkipCheckScheduleCycle, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -42,6 +42,11 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.SkipCheckScheduleCycle != nil {
+		in, out := &in.SkipCheckScheduleCycle, &out.SkipCheckScheduleCycle
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The plugin `coscheduling` in koord-scheduler supports skip check schedule cycle to enable more aggressive retry scheduling.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
