### PR TITLE
koordlet: fix cgroup driver detection on cgroups-v2, revise UTs

### DIFF
--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -73,11 +73,11 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 	if len(nodeName) == 0 {
 		return nil, fmt.Errorf("failed to new daemon: NODE_NAME env is empty")
 	}
-	klog.Infof("NODE_NAME is %v,start time %v", nodeName, float64(time.Now().Unix()))
+	klog.Infof("NODE_NAME is %v, start time %v", nodeName, float64(time.Now().Unix()))
 	metrics.RecordKoordletStartTime(nodeName, float64(time.Now().Unix()))
 
-	klog.Infof("sysconf: %+v,agentMode:%v", system.Conf, system.AgentMode)
-	klog.Infof("kernel version INFO : %+v", system.HostSystemInfo)
+	klog.Infof("sysconf: %+v, agentMode: %v", system.Conf, system.AgentMode)
+	klog.Infof("kernel version INFO: %+v", system.HostSystemInfo)
 
 	kubeClient := clientset.NewForConfigOrDie(config.KubeRestConf)
 	crdClient := clientsetbeta1.NewForConfigOrDie(config.KubeRestConf)
@@ -103,7 +103,7 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 
 		node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, v1.GetOptions{})
 		if err != nil || node == nil {
-			klog.Error("Can't get node")
+			klog.Errorf("Can't get node, err: %v", err)
 			return false, nil
 		}
 

--- a/pkg/koordlet/metricsadvisor/collectors/podthrottled/pod_throttled_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podthrottled/pod_throttled_collector_test.go
@@ -166,7 +166,7 @@ func Test_podThrottledCollector_collectPodThrottledInfo(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			metricCache, err := metriccache.NewMetricCache(&metriccache.Config{
-				TSDBPath:              t.TempDir(),
+				TSDBPath:              helper.TempDir,
 				TSDBEnablePromMetrics: false,
 			})
 			assert.NoError(t, err)

--- a/pkg/koordlet/util/node.go
+++ b/pkg/koordlet/util/node.go
@@ -34,13 +34,6 @@ const (
 	ContainerCgroupPathRelativeDepth = 2
 )
 
-func GetRootCgroupSubfsDir(subfs string) string {
-	if system.GetCurrentCgroupVersion() == system.CgroupVersionV2 {
-		return filepath.Join(system.Conf.CgroupRootDir)
-	}
-	return filepath.Join(system.Conf.CgroupRootDir, subfs)
-}
-
 // GetRootCgroupCPUSetDir gets the cpuset parent directory of the specified podQos' root cgroup
 // @output /sys/fs/cgroup/cpuset/kubepods.slice/kubepods-besteffort.slice
 func GetRootCgroupCPUSetDir(qosClass corev1.PodQOSClass) string {
@@ -71,7 +64,7 @@ func GetBECgroupCurCPUSet() ([]int32, error) {
 func GetBECPUSetPathsByMaxDepth(relativeDepth int) ([]string, error) {
 	// walk from root path to lower nodes
 	rootCgroupPath := GetRootCgroupCPUSetDir(corev1.PodQOSBestEffort)
-	rootCPUSetSubfsPath := GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
+	rootCPUSetSubfsPath := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	_, err := os.Stat(rootCgroupPath)
 	if err != nil {
 		// make sure the rootCgroupPath is available
@@ -101,7 +94,7 @@ func GetBECPUSetPathsByMaxDepth(relativeDepth int) ([]string, error) {
 // GetBECPUSetPathsByTargetDepth only gets the be containers' cpuset groups' paths
 func GetBECPUSetPathsByTargetDepth(relativeDepth int) ([]string, error) {
 	rootCgroupPath := GetRootCgroupCPUSetDir(corev1.PodQOSBestEffort)
-	rootCPUSetSubfsPath := GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
+	rootCPUSetSubfsPath := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	_, err := os.Stat(rootCgroupPath)
 	if err != nil {
 		// make sure the rootCgroupPath is available

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -44,10 +44,11 @@ func GetPIDsInPod(podParentDir string, cs []corev1.ContainerStatus) ([]uint32, e
 	return pids, nil
 }
 
-// list all dirs of pod cgroup(cpuset), exclude containers' dir, get sandbox hash id from the remaining dir
+// GetPodSandboxContainerID lists all dirs of pod cgroup(cpuset), exclude containers' dir, get sandbox hash id from the
+// remaining dir.
 // e.g. return "containerd://91cf0413ee0e6745335e9043b261a829ce07d28a5a66b5ec39b06811ef75a1ff"
 func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
-	cpuSetCgroupRootDir := GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
+	cpuSetCgroupRootDir := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	podCgroupDir := GetPodCgroupParentDir(pod)
 	podCPUSetCgroupRootDir := filepath.Join(cpuSetCgroupRootDir, podCgroupDir)
 

--- a/pkg/koordlet/util/system/cgroup.go
+++ b/pkg/koordlet/util/system/cgroup.go
@@ -19,6 +19,7 @@ package system
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -201,4 +202,11 @@ func CalcCPUThrottledRatio(curPoint, prePoint *CPUStatRaw) float64 {
 		throttledRatio = float64(deltaThrottled) / float64(deltaPeriod)
 	}
 	return throttledRatio
+}
+
+func GetRootCgroupSubfsDir(subfs string) string {
+	if GetCurrentCgroupVersion() == CgroupVersionV2 {
+		return filepath.Join(Conf.CgroupRootDir)
+	}
+	return filepath.Join(Conf.CgroupRootDir, subfs)
 }

--- a/pkg/koordlet/util/system/cgroup_driver.go
+++ b/pkg/koordlet/util/system/cgroup_driver.go
@@ -192,7 +192,7 @@ var cgroupPathFormatterInCgroupfs = formatter{
 	},
 }
 
-// default use Systemd cgroup path format
+// CgroupPathFormatter uses the Systemd cgroup driver by default.
 var CgroupPathFormatter = cgroupPathFormatterInSystemd
 
 func SetupCgroupPathFormatter(driver CgroupDriverType) {

--- a/pkg/koordlet/util/system/cgroup_driver_linux.go
+++ b/pkg/koordlet/util/system/cgroup_driver_linux.go
@@ -47,8 +47,8 @@ var (
 )
 
 func GuessCgroupDriverFromCgroupName() CgroupDriverType {
-	systemdKubepodDirExists := FileExists(filepath.Join(Conf.CgroupRootDir, "cpu", KubeRootNameSystemd))
-	cgroupfsKubepodDirExists := FileExists(filepath.Join(Conf.CgroupRootDir, "cpu", KubeRootNameCgroupfs))
+	systemdKubepodDirExists := FileExists(filepath.Join(GetRootCgroupSubfsDir(CgroupCPUDir), KubeRootNameSystemd))
+	cgroupfsKubepodDirExists := FileExists(filepath.Join(GetRootCgroupSubfsDir(CgroupCPUDir), KubeRootNameCgroupfs))
 	if systemdKubepodDirExists != cgroupfsKubepodDirExists {
 		if systemdKubepodDirExists {
 			return Systemd
@@ -59,7 +59,7 @@ func GuessCgroupDriverFromCgroupName() CgroupDriverType {
 	return ""
 }
 
-// Guess Kubelet's cgroup driver from kubelet port.
+// GuessCgroupDriverFromKubeletPort guesses Kubelet's cgroup driver from kubelet port.
 // 1. use KubeletPortToPid to get kubelet pid.
 // 2. If '--cgroup-driver' in args, that's it.
 //    else if '--config' not in args, is default driver('cgroupfs').
@@ -133,6 +133,7 @@ func GuessCgroupDriverFromKubeletPort(port int) (CgroupDriverType, error) {
 	return kubeletDefaultCgroupDriver, nil
 }
 
+// IsUsingCgroupsV2 checks once if the CGroup V2 is in use.
 // modify base: github.com/opencontainers/runc/libcontainer/cgroups/utils.go IsCgroup2UnifiedMode
 func IsUsingCgroupsV2() bool {
 	unifiedMountpoint := strings.TrimSuffix(Conf.CgroupRootDir, "/")

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -54,8 +54,8 @@ func init() {
 }
 
 func initSupportConfigs() {
-	HostSystemInfo = collectVersionInfo()
 	initCgroupsVersion()
+	HostSystemInfo = collectVersionInfo()
 	_, _ = IsSupportResctrl()
 }
 

--- a/pkg/koordlet/util/system/version.go
+++ b/pkg/koordlet/util/system/version.go
@@ -40,14 +40,14 @@ func isAnolisOS() bool {
 }
 
 func isSupportBvtOrWmarRatio() bool {
-	bvtFilePath := filepath.Join(Conf.CgroupRootDir, CgroupCPUDir, CPUBVTWarpNsName)
+	bvtFilePath := filepath.Join(GetRootCgroupSubfsDir(CgroupCPUDir), CPUBVTWarpNsName)
 	exists, err := PathExists(bvtFilePath)
 	klog.V(2).Infof("[%v] PathExists exists %v, err: %v", bvtFilePath, exists, err)
 	if err == nil && exists {
 		return true
 	}
 
-	wmarkRatioPath := filepath.Join(Conf.CgroupRootDir, CgroupMemDir, "*", MemoryWmarkRatioName)
+	wmarkRatioPath := filepath.Join(GetRootCgroupSubfsDir(CgroupMemDir), "*", MemoryWmarkRatioName)
 	matches, err := filepath.Glob(wmarkRatioPath)
 	klog.V(2).Infof("[%v] PathExists wmark_ratio exists %v, err: %v", wmarkRatioPath, matches, err)
 	if err == nil && len(matches) > 0 {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. Fix the cgroup driver detection when the koordlet pod runs on cgroups-v2.
2. Revise UTs of the metrics advisor where the TSDB might be failed to create because of the local path.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1346.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
