### PR TITLE
koord-scheduler: strictly check whether ReservationInfo is available or terminating

### DIFF
--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -23,6 +23,7 @@ import (
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
+	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -168,10 +169,14 @@ func (ri *ReservationInfo) IsAvailable() bool {
 	if ri.Reservation != nil {
 		return reservationutil.IsReservationAvailable(ri.Reservation)
 	}
-	if ri.Pod != nil {
+	if ri.Pod != nil && ri.Pod.Status.Phase == corev1.PodRunning && k8spodutil.IsPodReady(ri.Pod) {
 		return true
 	}
 	return false
+}
+
+func (ri *ReservationInfo) IsTerminating() bool {
+	return !ri.GetObject().GetDeletionTimestamp().IsZero()
 }
 
 func (ri *ReservationInfo) Clone() *ReservationInfo {

--- a/pkg/scheduler/frameworkext/reservation_info_test.go
+++ b/pkg/scheduler/frameworkext/reservation_info_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestIsAvailable(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  metav1.Object
+		want bool
+	}{
+		{
+			name: "normal reservation",
+			obj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-r",
+					UID:  "123456",
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{},
+				},
+				Status: schedulingv1alpha1.ReservationStatus{
+					Phase:    schedulingv1alpha1.ReservationAvailable,
+					NodeName: "test-node",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "failed reservation",
+			obj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-r",
+					UID:  "123456",
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{},
+				},
+				Status: schedulingv1alpha1.ReservationStatus{
+					Phase:    schedulingv1alpha1.ReservationFailed,
+					NodeName: "test-node",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ready and running pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-p",
+					Namespace: "default",
+					UID:       "123456",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not ready and running pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-p",
+					Namespace: "default",
+					UID:       "123456",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not ready and not running pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-p",
+					Namespace: "default",
+					UID:       "123456",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rInfo *ReservationInfo
+			switch obj := tt.obj.(type) {
+			case *schedulingv1alpha1.Reservation:
+				rInfo = NewReservationInfo(obj)
+			case *corev1.Pod:
+				rInfo = NewReservationInfoFromPod(obj)
+			}
+			assert.NotNil(t, rInfo)
+			assert.Equal(t, tt.want, rInfo.IsAvailable())
+		})
+	}
+}
+
+func TestIsTerminating(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  metav1.Object
+		want bool
+	}{
+		{
+			name: "normal reservation",
+			obj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-r",
+					UID:  "123456",
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{},
+				},
+				Status: schedulingv1alpha1.ReservationStatus{
+					Phase:    schedulingv1alpha1.ReservationAvailable,
+					NodeName: "test-node",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "deleting reservation",
+			obj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-r",
+					UID:               "123456",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{},
+				},
+				Status: schedulingv1alpha1.ReservationStatus{
+					Phase:    schedulingv1alpha1.ReservationAvailable,
+					NodeName: "test-node",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ready and running pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-p",
+					Namespace: "default",
+					UID:       "123456",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ready, running and deleting pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-p",
+					Namespace:         "default",
+					UID:               "123456",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rInfo *ReservationInfo
+			switch obj := tt.obj.(type) {
+			case *schedulingv1alpha1.Reservation:
+				rInfo = NewReservationInfo(obj)
+			case *corev1.Pod:
+				rInfo = NewReservationInfoFromPod(obj)
+			}
+			assert.NotNil(t, rInfo)
+			assert.Equal(t, tt.want, rInfo.IsTerminating())
+		})
+	}
+}

--- a/pkg/scheduler/plugins/reservation/service_test.go
+++ b/pkg/scheduler/plugins/reservation/service_test.go
@@ -139,6 +139,15 @@ func TestQueryNodeReservations(t *testing.T) {
 				},
 			},
 		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
 	}
 
 	pl.reservationCache.updateReservationOperatingPod(operatingPod, &corev1.ObjectReference{

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -98,7 +98,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 				continue
 			}
 
-			if !isReservedPod && matchReservation(pod, node, rInfo, reservationAffinity) {
+			if !isReservedPod && !rInfo.IsTerminating() && matchReservation(pod, node, rInfo, reservationAffinity) {
 				matched = append(matched, rInfo)
 
 			} else if len(rInfo.AssignedPods) > 0 {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Users create reused Reservation with finalizer, when need to delete Reservation, users first mark Reservation deleting, and clean other resources, then finally remove the finalizer to release Reservation. 

- If the ReservationInfo (both Reservation CRD object and operating Pod)  is terminating, the ReservationInfo cannot be used.
- In assume stage, if the ReservationInfo in cache is terminating, the assume operation will be rejected.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
