### PR TITLE
koord-scheduler: optimize the Reservation deletion process

### DIFF
--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -58,6 +58,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 		},
 		Status: schedulingv1alpha1.ReservationStatus{
 			NodeName: "test-node-1",
+			Phase:    schedulingv1alpha1.ReservationAvailable,
 			Allocatable: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("4"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -69,7 +70,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 		},
 	}
 	cache.updateReservation(reservation)
-	reservationInfos := cache.listReservationInfosOnNode(reservation.Status.NodeName)
+	reservationInfos := cache.listAvailableReservationInfosOnNode(reservation.Status.NodeName)
 	assert.Len(t, reservationInfos, 1)
 	rInfo := reservationInfos[0]
 	expectReservationInfo := &frameworkext.ReservationInfo{
@@ -92,7 +93,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 	assert.Equal(t, expectReservationInfo, rInfo)
 
 	cache.updateReservation(reservation)
-	reservationInfos = cache.listReservationInfosOnNode(reservation.Status.NodeName)
+	reservationInfos = cache.listAvailableReservationInfosOnNode(reservation.Status.NodeName)
 	assert.Len(t, reservationInfos, 1)
 	rInfo = reservationInfos[0]
 	expectReservationInfo.Allocated = corev1.ResourceList{}
@@ -161,7 +162,7 @@ func TestCacheDeleteReservation(t *testing.T) {
 	})
 	assert.Equal(t, expectReservationInfo, rInfo)
 
-	cache.deleteReservation(reservation)
+	cache.DeleteReservation(reservation)
 	rInfo = cache.getReservationInfoByUID(reservation.UID)
 	assert.Nil(t, rInfo)
 }

--- a/pkg/scheduler/plugins/reservation/eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler_test.go
@@ -170,25 +170,25 @@ func TestEventHandlerUpdate(t *testing.T) {
 			name:            "active to failed",
 			oldReservation:  activeReservation,
 			newReservation:  failedReservation,
-			wantReservation: nil,
+			wantReservation: failedReservation,
 		},
 		{
 			name:            "active to succeeded",
 			oldReservation:  activeReservation,
 			newReservation:  succeededReservation,
-			wantReservation: nil,
+			wantReservation: succeededReservation,
 		},
 		{
 			name:            "pending to failed",
 			oldReservation:  pendingReservation,
 			newReservation:  failedReservation,
-			wantReservation: nil,
+			wantReservation: failedReservation,
 		},
 		{
 			name:            "pending to succeeded",
 			oldReservation:  pendingReservation,
 			newReservation:  succeededReservation,
-			wantReservation: nil,
+			wantReservation: succeededReservation,
 		},
 	}
 	for _, tt := range tests {
@@ -245,5 +245,6 @@ func TestEventHandlerDelete(t *testing.T) {
 	assert.NotNil(t, rInfo)
 	eh.OnDelete(activeReservation)
 	rInfo = cache.getReservationInfoByUID(activeReservation.UID)
-	assert.Nil(t, rInfo)
+	assert.NotNil(t, rInfo)
+	assert.False(t, rInfo.IsAvailable())
 }

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -744,6 +744,7 @@ func TestPostFilter(t *testing.T) {
 		},
 		Status: schedulingv1alpha1.ReservationStatus{
 			NodeName: "node1",
+			Phase:    schedulingv1alpha1.ReservationAvailable,
 		},
 	}
 	tests := []struct {

--- a/pkg/scheduler/plugins/reservation/service.go
+++ b/pkg/scheduler/plugins/reservation/service.go
@@ -52,7 +52,7 @@ type NodeReservations struct {
 func (pl *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 	group.GET("/nodeReservations/:nodeName", func(c *gin.Context) {
 		nodeName := c.Param("nodeName")
-		rInfos := pl.reservationCache.listReservationInfosOnNode(nodeName)
+		rInfos := pl.reservationCache.listAvailableReservationInfosOnNode(nodeName)
 		if len(rInfos) == 0 {
 			c.JSON(http.StatusOK, &NodeReservations{Items: []ReservationItem{}})
 			return

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -81,7 +81,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			return
 		}
 
-		rOnNode := pl.reservationCache.listReservationInfosOnNode(node.Name)
+		rOnNode := pl.reservationCache.listAvailableReservationInfosOnNode(node.Name)
 		if len(rOnNode) == 0 {
 			return
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Part of #1247.

In general scenarios such as reserving CPU/Memory, the existing Reservation allocation information including the concurrent cleaning process of Reserve Pod in NodeInfo is not a problem. However, the port reservation scenario will make this problem more complicated. It is possible that due to concurrency and timing, the port allocated by the Pod may be released incorrectly.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
