### PR TITLE
koord-scheduler: only remove unallocated ports if Reservation released

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -326,7 +326,7 @@ func updateReservationInCache(sched frameworkext.Scheduler, oldObj, newObj inter
 	if err := sched.GetCache().UpdatePod(oldReservePod, newReservePod); err != nil {
 		klog.Errorf("scheduler cache UpdatePod failed for reservation, old %s, new %s, err: %v", klog.KObj(oldR), klog.KObj(newR), err)
 	}
-	sched.GetSchedulingQueue().AssignedPodUpdated(newReservePod)
+	sched.GetSchedulingQueue().AssignedPodAdded(newReservePod)
 }
 
 func deleteReservationFromCache(sched frameworkext.Scheduler, obj interface{}) {

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -326,7 +326,7 @@ func updateReservationInCache(sched frameworkext.Scheduler, oldObj, newObj inter
 	if err := sched.GetCache().UpdatePod(oldReservePod, newReservePod); err != nil {
 		klog.Errorf("scheduler cache UpdatePod failed for reservation, old %s, new %s, err: %v", klog.KObj(oldR), klog.KObj(newR), err)
 	}
-	sched.GetSchedulingQueue().AssignedPodAdded(newReservePod)
+	sched.GetSchedulingQueue().AssignedPodUpdated(newReservePod)
 }
 
 func deleteReservationFromCache(sched frameworkext.Scheduler, obj interface{}) {
@@ -356,10 +356,24 @@ func deleteReservationFromCache(sched frameworkext.Scheduler, obj interface{}) {
 	}
 
 	reservePod := reservationutil.NewReservePod(r)
-	if err := sched.GetCache().RemovePod(reservePod); err != nil {
-		klog.Errorf("scheduler cache RemovePod failed for reservation, reservation %s, err: %v", klog.KObj(r), err)
+	if _, err = sched.GetCache().GetPod(reservePod); err == nil {
+		if len(rInfo.AllocatedPorts) > 0 {
+			allocatablePorts := util.RequestedHostPorts(reservePod)
+			util.RemoveHostPorts(allocatablePorts, rInfo.AllocatedPorts)
+			util.ResetHostPorts(reservePod, allocatablePorts)
+
+			// The Pod status in the Cache must be refreshed once to ensure that subsequent deletions are valid.
+			if err := sched.GetCache().UpdatePod(reservePod, reservePod); err != nil {
+				klog.Errorf("scheduler cache UpdatePod failed for reservation in delete stage, obj %s, err: %v", klog.KObj(r), err)
+			}
+		}
+
+		if err := sched.GetCache().RemovePod(reservePod); err != nil {
+			klog.Errorf("scheduler cache RemovePod failed for reservation, reservation %s, err: %v", klog.KObj(r), err)
+		}
+
+		sched.GetSchedulingQueue().MoveAllToActiveOrBackoffQueue(frameworkext.AssignedPodDelete)
 	}
-	sched.GetSchedulingQueue().MoveAllToActiveOrBackoffQueue(frameworkext.AssignedPodDelete)
 }
 
 func addReservationToSchedulingQueue(sched frameworkext.Scheduler, obj interface{}) {

--- a/pkg/scheduler/plugins/reservation/service.go
+++ b/pkg/scheduler/plugins/reservation/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
@@ -36,13 +37,15 @@ type ReservationItem struct {
 	UID       types.UID `json:"uid,omitempty"`
 	Kind      string    `json:"kind,omitempty"`
 
-	Available      bool                                         `json:"available,omitempty"`
-	AllocateOnce   bool                                         `json:"allocateOnce,omitempty"`
-	Allocatable    corev1.ResourceList                          `json:"allocatable,omitempty"`
-	Allocated      corev1.ResourceList                          `json:"allocated,omitempty"`
-	Owners         []schedulingv1alpha1.ReservationOwner        `json:"owners,omitempty"`
-	AllocatePolicy schedulingv1alpha1.ReservationAllocatePolicy `json:"allocatePolicy,omitempty"`
-	AssignedPods   []*frameworkext.PodRequirement               `json:"assignedPods,omitempty"`
+	Available        bool                                         `json:"available,omitempty"`
+	AllocateOnce     bool                                         `json:"allocateOnce,omitempty"`
+	Allocatable      corev1.ResourceList                          `json:"allocatable,omitempty"`
+	Allocated        corev1.ResourceList                          `json:"allocated,omitempty"`
+	AllocatablePorts framework.HostPortInfo                       `json:"allocatablePorts,omitempty"`
+	AllocatedPorts   framework.HostPortInfo                       `json:"allocatedPorts,omitempty"`
+	Owners           []schedulingv1alpha1.ReservationOwner        `json:"owners,omitempty"`
+	AllocatePolicy   schedulingv1alpha1.ReservationAllocatePolicy `json:"allocatePolicy,omitempty"`
+	AssignedPods     []*frameworkext.PodRequirement               `json:"assignedPods,omitempty"`
 }
 
 type NodeReservations struct {
@@ -64,15 +67,17 @@ func (pl *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 
 		for _, r := range rInfos {
 			item := ReservationItem{
-				Name:           r.GetName(),
-				Namespace:      r.GetNamespace(),
-				UID:            r.UID(),
-				AllocateOnce:   r.IsAllocateOnce(),
-				Available:      r.IsAvailable(),
-				Owners:         r.GetPodOwners(),
-				AllocatePolicy: r.GetAllocatePolicy(),
-				Allocatable:    r.Allocatable,
-				Allocated:      r.Allocated,
+				Name:             r.GetName(),
+				Namespace:        r.GetNamespace(),
+				UID:              r.UID(),
+				AllocateOnce:     r.IsAllocateOnce(),
+				Available:        r.IsAvailable(),
+				Owners:           r.GetPodOwners(),
+				AllocatePolicy:   r.GetAllocatePolicy(),
+				Allocatable:      r.Allocatable,
+				Allocated:        r.Allocated,
+				AllocatablePorts: r.AllocatablePorts,
+				AllocatedPorts:   r.AllocatedPorts,
 			}
 			switch r.GetObject().(type) {
 			case *schedulingv1alpha1.Reservation:

--- a/pkg/util/hostport.go
+++ b/pkg/util/hostport.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func RequestedHostPorts(pod *corev1.Pod) framework.HostPortInfo {
+	requestedPorts := framework.HostPortInfo{}
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		for _, podPort := range container.Ports {
+			requestedPorts.Add(podPort.HostIP, string(podPort.Protocol), podPort.HostPort)
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		for _, podPort := range container.Ports {
+			requestedPorts.Add(podPort.HostIP, string(podPort.Protocol), podPort.HostPort)
+		}
+	}
+	if len(requestedPorts) == 0 {
+		return nil
+	}
+	return requestedPorts
+}
+
+func ResetHostPorts(pod *corev1.Pod, ports framework.HostPortInfo) {
+	var targetContainer *corev1.Container
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if len(container.Ports) > 0 {
+			container.Ports = nil
+			targetContainer = container
+		}
+	}
+
+	if len(ports) > 0 && targetContainer != nil {
+		for ip, protocolPortMap := range ports {
+			for ports := range protocolPortMap {
+				targetContainer.Ports = append(targetContainer.Ports, corev1.ContainerPort{
+					HostPort: ports.Port,
+					Protocol: corev1.Protocol(ports.Protocol),
+					HostIP:   ip,
+				})
+			}
+		}
+	}
+}
+
+func CloneHostPorts(ports framework.HostPortInfo) framework.HostPortInfo {
+	if len(ports) == 0 {
+		return nil
+	}
+	r := framework.HostPortInfo{}
+	for ip, protocolPorts := range ports {
+		for v := range protocolPorts {
+			r.Add(ip, v.Protocol, v.Port)
+		}
+	}
+	return r
+}
+
+func AppendHostPorts(ports framework.HostPortInfo, r framework.HostPortInfo) framework.HostPortInfo {
+	if len(r) == 0 {
+		return ports
+	}
+	if ports == nil {
+		ports = framework.HostPortInfo{}
+	}
+	for ip, protocolPorts := range r {
+		for v := range protocolPorts {
+			ports.Add(ip, v.Protocol, v.Port)
+		}
+	}
+	return ports
+}
+
+func RemoveHostPorts(ports framework.HostPortInfo, r framework.HostPortInfo) {
+	if len(r) == 0 || len(ports) == 0 {
+		return
+	}
+	for ip, protocolPorts := range r {
+		for v := range protocolPorts {
+			ports.Remove(ip, v.Protocol, v.Port)
+		}
+	}
+}

--- a/pkg/util/hostport_test.go
+++ b/pkg/util/hostport_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestRequestedHostPorts(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want framework.HostPortInfo
+	}{
+		{
+			name: "no ports",
+			pod:  &corev1.Pod{},
+			want: nil,
+		},
+		{
+			name: "container request ports",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostPort: 8888,
+									Protocol: corev1.ProtocolTCP,
+								},
+								{
+									HostPort: 6666,
+									Protocol: corev1.ProtocolUDP,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+					*framework.NewProtocolPort(string(corev1.ProtocolUDP), 6666): struct{}{},
+				},
+			},
+		},
+		{
+			name: "container and init container request ports",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostPort: 8888,
+									Protocol: corev1.ProtocolTCP,
+								},
+								{
+									HostPort: 6666,
+									Protocol: corev1.ProtocolUDP,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostPort: 7777,
+									Protocol: corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 7777): struct{}{},
+					*framework.NewProtocolPort(string(corev1.ProtocolUDP), 6666): struct{}{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequestedHostPorts(tt.pod)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResetHostPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		ports   framework.HostPortInfo
+		wantPod *corev1.Pod
+	}{
+		{
+			name:    "no ports",
+			pod:     &corev1.Pod{},
+			ports:   nil,
+			wantPod: &corev1.Pod{},
+		},
+		{
+			name: "clean ports",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostPort: 8888,
+									Protocol: corev1.ProtocolTCP,
+								},
+								{
+									HostPort: 6666,
+									Protocol: corev1.ProtocolUDP,
+								},
+							},
+						},
+					},
+				},
+			},
+			ports: nil,
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+		},
+		{
+			name: "reserve some ports",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostPort: 8888,
+									Protocol: corev1.ProtocolTCP,
+								},
+								{
+									HostPort: 6666,
+									Protocol: corev1.ProtocolUDP,
+								},
+							},
+						},
+					},
+				},
+			},
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									HostIP:   framework.DefaultBindAllHostIP,
+									HostPort: 8888,
+									Protocol: corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetHostPorts(tt.pod, tt.ports)
+			assert.Equal(t, tt.wantPod, tt.pod)
+		})
+	}
+}
+
+func TestCloneHostPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports framework.HostPortInfo
+		want  framework.HostPortInfo
+	}{
+		{
+			name:  "no ports",
+			ports: framework.HostPortInfo{},
+			want:  nil,
+		},
+		{
+			name: "clone ports",
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CloneHostPorts(tt.ports)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAppendHostPorts(t *testing.T) {
+	tests := []struct {
+		name   string
+		ports  framework.HostPortInfo
+		nports framework.HostPortInfo
+		want   framework.HostPortInfo
+	}{
+		{
+			name:   "no ports to append",
+			ports:  nil,
+			nports: nil,
+			want:   nil,
+		},
+		{
+			name:  "append ports",
+			ports: nil,
+			nports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+		},
+		{
+			name: "append existing ports",
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			nports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+		},
+		{
+			name: "append non-existing ports",
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 6666): struct{}{},
+				},
+			},
+			nports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 6666): struct{}{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppendHostPorts(tt.ports, tt.nports)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRemoveHostPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		ports   framework.HostPortInfo
+		removed framework.HostPortInfo
+		want    framework.HostPortInfo
+	}{
+		{
+			name: "no ports to removed",
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			removed: nil,
+			want: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+		},
+		{
+			name: "remove ports",
+			ports: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			removed: framework.HostPortInfo{
+				framework.DefaultBindAllHostIP: {
+					*framework.NewProtocolPort(string(corev1.ProtocolTCP), 8888): struct{}{},
+				},
+			},
+			want: framework.HostPortInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveHostPorts(tt.ports, tt.removed)
+			assert.Equal(t, tt.want, tt.ports)
+		})
+	}
+}

--- a/test/e2e/scheduling/hostport.go
+++ b/test/e2e/scheduling/hostport.go
@@ -1,0 +1,388 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/utils/pointer"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework/manifest"
+	e2epod "github.com/koordinator-sh/koordinator/test/e2e/framework/pod"
+)
+
+var _ = SIGDescribe("HostPort", func() {
+	f := framework.NewDefaultFramework("hostport")
+
+	ginkgo.BeforeEach(func() {
+		framework.AllNodesReady(f.ClientSet, time.Minute)
+	})
+
+	ginkgo.AfterEach(func() {
+		ls := metav1.SetAsLabelSelector(map[string]string{
+			"e2e-test-reservation": "true",
+		})
+		reservationList, err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(ls),
+		})
+		framework.ExpectNoError(err)
+		for _, v := range reservationList.Items {
+			err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+		}
+	})
+
+	framework.KoordinatorDescribe("HostPort Reservation", func() {
+		framework.ConformanceIt("Create Reservation disables AllocateOnce, reserve ports only can be allocated once", func() {
+			ginkgo.By("Create reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+
+			targetPodLabel := "test-reserve-ports"
+			reservation.Spec.AllocateOnce = pointer.Bool(false)
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							targetPodLabel: "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "port-54321",
+							ContainerPort: 1111,
+							HostPort:      54321,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+
+			_, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+
+			ginkgo.By("Wait for reservation scheduled")
+			reservation = waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create one pod allocate port 54321")
+			pod := runPausePod(f, pausePodConfig{
+				Name:      "allocate-port-54321",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				NodeName:      reservation.Status.NodeName,
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			ginkgo.By("Create one pod allocate port 54321 and expect failed")
+			failedPod := createPausePod(f, pausePodConfig{
+				Name:      "failed-allocate-port-54321",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				NodeName:      reservation.Status.NodeName,
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, failedPod.Namespace, failedPod.Name, "wait for pod schedule failed", 60*time.Second, func(pod *corev1.Pod) (bool, error) {
+				_, scheduledCondition := k8spodutil.GetPodCondition(&pod.Status, corev1.PodScheduled)
+				return scheduledCondition != nil && scheduledCondition.Status == corev1.ConditionFalse, nil
+			}))
+
+			ginkgo.By("Check pods and reservation status")
+
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), reservation.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			gomega.Expect(reservation.Status.CurrentOwners).Should(gomega.Equal([]corev1.ObjectReference{
+				{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+					UID:       pod.UID,
+				},
+			}), "unexpected reservation owner")
+		})
+
+		framework.ConformanceIt("Create Reservation enable AllocateOnce, reserve ports only can be allocated once", func() {
+			ginkgo.By("Create reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+
+			targetPodLabel := "test-reserve-ports"
+			reservation.Spec.AllocateOnce = pointer.Bool(true)
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							targetPodLabel: "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "port-54321",
+							ContainerPort: 1111,
+							HostPort:      54321,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+
+			_, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+
+			ginkgo.By("Wait for reservation scheduled")
+			reservation = waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create one pod allocate port 54321")
+			pod := runPausePod(f, pausePodConfig{
+				Name:      "allocate-port-54321",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				NodeName:      reservation.Status.NodeName,
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			ginkgo.By("Create one pod allocate port 54321 and expect failed")
+			failedPod := createPausePod(f, pausePodConfig{
+				Name:      "failed-allocate-port-54321",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				NodeName:      reservation.Status.NodeName,
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, failedPod.Namespace, failedPod.Name, "wait for pod schedule failed", 60*time.Second, func(pod *corev1.Pod) (bool, error) {
+				_, scheduledCondition := k8spodutil.GetPodCondition(&pod.Status, corev1.PodScheduled)
+				return scheduledCondition != nil && scheduledCondition.Status == corev1.ConditionFalse, nil
+			}))
+
+			ginkgo.By("Check pods and reservation status")
+
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), reservation.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			gomega.Expect(reservation.Status.CurrentOwners).Should(gomega.Equal([]corev1.ObjectReference{
+				{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+					UID:       pod.UID,
+				},
+			}), "unexpected reservation owner")
+		})
+
+		framework.ConformanceIt("Create Reservation disables AllocateOnce, reserve ports to pod", func() {
+			ginkgo.By("Create reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+
+			targetPodLabel := "test-reserve-ports"
+			reservation.Spec.AllocateOnce = pointer.Bool(false)
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							targetPodLabel: "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "port-54321",
+							ContainerPort: 1111,
+							HostPort:      54321,
+							Protocol:      corev1.ProtocolTCP,
+						},
+						{
+							Name:          "port-54322",
+							ContainerPort: 2222,
+							HostPort:      54322,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+
+			_, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+
+			ginkgo.By("Wait for reservation scheduled")
+			reservation = waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create one pod allocate port 54321")
+			pod := runPausePod(f, pausePodConfig{
+				Name:      "allocate-port-54321",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			ginkgo.By("Create one pod allocate port 54321 and 54322")
+			runPausePod(f, pausePodConfig{
+				Name:      "other-allocate-port-54321-54322",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					targetPodLabel: "true",
+				},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "port-54321",
+						ContainerPort: 1111,
+						HostPort:      54321,
+						Protocol:      corev1.ProtocolTCP,
+					},
+					{
+						Name:          "port-54322",
+						ContainerPort: 2222,
+						HostPort:      54322,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				SchedulerName: reservation.Spec.Template.Spec.SchedulerName,
+			})
+
+			ginkgo.By("Check pods and reservation status")
+
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), reservation.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			gomega.Expect(reservation.Status.CurrentOwners).Should(gomega.Equal([]corev1.ObjectReference{
+				{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+					UID:       pod.UID,
+				},
+			}), "unexpected reservation owner")
+		})
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

fix #1247 : Reservation reserved ports that has been allocated by Pod but incorrectly removed from NdoeInfo if Reservation is deleted.   Now, just remove the unallocated ports in Reservation. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
