### PR TITLE
koord-scheduler: enhance the preemption when common resources are reserved

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -57,6 +58,8 @@ const (
 	ErrReasonReservationInactive = "reservation is not active"
 	// ErrReasonReservationInsufficientResources is the reason for the reservation's resources are insufficient.
 	ErrReasonReservationInsufficientResources = "node(s) reservations insufficient resources"
+	// ErrReasonPreemptionFailed is the reason for preemption failed
+	ErrReasonPreemptionFailed = "node(s) preemption failed due to insufficient resources"
 )
 
 var (
@@ -144,6 +147,8 @@ type stateData struct {
 	hasAffinity          bool
 	podRequests          corev1.ResourceList
 	podRequestsResources *framework.Resource
+	preemptible          map[string]corev1.ResourceList
+	preemptibleInRRs     map[string]map[types.UID]corev1.ResourceList
 
 	nodeReservationStates map[string]nodeReservationState
 	preferredNode         string
@@ -165,7 +170,34 @@ type nodeReservationState struct {
 }
 
 func (s *stateData) Clone() framework.StateData {
-	return s
+	ns := &stateData{
+		hasAffinity:           s.hasAffinity,
+		podRequests:           s.podRequests,
+		podRequestsResources:  s.podRequestsResources,
+		nodeReservationStates: s.nodeReservationStates,
+		preferredNode:         s.preferredNode,
+		assumed:               s.assumed,
+	}
+	preemptible := map[string]corev1.ResourceList{}
+	for nodeName, returned := range s.preemptible {
+		preemptible[nodeName] = returned.DeepCopy()
+	}
+	ns.preemptible = preemptible
+
+	preemptibleInRRs := map[string]map[types.UID]corev1.ResourceList{}
+	for nodeName, rrs := range s.preemptibleInRRs {
+		rrInNode := preemptibleInRRs[nodeName]
+		if rrInNode == nil {
+			rrInNode = map[types.UID]corev1.ResourceList{}
+			preemptibleInRRs[nodeName] = rrInNode
+		}
+		for reservationUID, returned := range rrs {
+			rrInNode[reservationUID] = returned.DeepCopy()
+		}
+	}
+	ns.preemptibleInRRs = preemptibleInRRs
+
+	return ns
 }
 
 func getStateData(cycleState *framework.CycleState) *stateData {
@@ -211,6 +243,77 @@ func (pl *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleStat
 }
 
 func (pl *Plugin) PreFilterExtensions() framework.PreFilterExtensions {
+	return pl
+}
+
+func (pl *Plugin) AddPod(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	if reservationutil.IsReservePod(podInfoToAdd.Pod) || nodeInfo.Node() == nil {
+		return nil
+	}
+	podRequests, _ := resourceapi.PodRequestsAndLimits(podInfoToAdd.Pod)
+	if quotav1.IsZero(podRequests) {
+		return nil
+	}
+
+	boundReservation, err := apiext.GetReservationAllocated(podInfoToAdd.Pod)
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+
+	node := nodeInfo.Node()
+	state := getStateData(cycleState)
+	if boundReservation == nil || boundReservation.UID == "" {
+		preemptible := quotav1.SubtractWithNonNegativeResult(state.preemptible[node.Name], podRequests)
+		if quotav1.IsZero(preemptible) {
+			delete(state.preemptible, node.Name)
+		} else {
+			state.preemptible[node.Name] = preemptible
+		}
+	} else {
+		preemptibleInRRs := state.preemptibleInRRs[node.Name]
+		preemptible := preemptibleInRRs[boundReservation.UID]
+		preemptible = quotav1.SubtractWithNonNegativeResult(preemptible, podRequests)
+		if quotav1.IsZero(preemptible) {
+			delete(preemptibleInRRs, boundReservation.UID)
+		}
+		if len(preemptibleInRRs) == 0 {
+			delete(state.preemptibleInRRs, node.Name)
+		}
+	}
+
+	return nil
+}
+
+func (pl *Plugin) RemovePod(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	if reservationutil.IsReservePod(podInfoToRemove.Pod) || nodeInfo.Node() == nil {
+		return nil
+	}
+
+	podRequests, _ := resourceapi.PodRequestsAndLimits(podInfoToRemove.Pod)
+	if quotav1.IsZero(podRequests) {
+		return nil
+	}
+
+	boundReservation, err := apiext.GetReservationAllocated(podInfoToRemove.Pod)
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+
+	node := nodeInfo.Node()
+	state := getStateData(cycleState)
+	if boundReservation == nil || boundReservation.UID == "" {
+		preemptible := state.preemptible[node.Name]
+		state.preemptible[node.Name] = quotav1.Add(preemptible, podRequests)
+	} else {
+		preemptibleInRRs := state.preemptibleInRRs[node.Name]
+		if preemptibleInRRs == nil {
+			preemptibleInRRs = map[types.UID]corev1.ResourceList{}
+			state.preemptibleInRRs[node.Name] = preemptibleInRRs
+		}
+		preemptible := preemptibleInRRs[boundReservation.UID]
+		preemptibleInRRs[boundReservation.UID] = quotav1.Add(preemptible, podRequests)
+	}
+
 	return nil
 }
 
@@ -266,25 +369,52 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 	matchedReservations := nodeRState.matched
 	if len(matchedReservations) == 0 {
 		if state.hasAffinity {
-			return framework.NewStatus(framework.Unschedulable, ErrReasonReservationAffinity)
+			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity)
+		}
+
+		if preemptible := state.preemptible[node.Name]; len(preemptible) > 0 {
+			preemptibleResource := framework.NewResource(preemptible)
+			nodeFits := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, nil, preemptibleResource)
+			if !nodeFits {
+				return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPreemptionFailed)
+			}
 		}
 		return nil
 	}
 
-	var insufficientAligned, insufficientRestricted int
+	var (
+		totalDefault           int
+		insufficientDefault    int
+		insufficientAligned    int
+		insufficientRestricted int
+	)
 	for _, rInfo := range matchedReservations {
+		preemptibleInRR := state.preemptibleInRRs[node.Name][rInfo.UID()]
+		preemptible := framework.NewResource(preemptibleInRR)
+		preemptible.Add(state.preemptible[node.Name])
 		allocatePolicy := rInfo.GetAllocatePolicy()
 		if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyDefault {
+			totalDefault++
+			if len(preemptibleInRR) > 0 || len(state.preemptible[node.Name]) > 0 {
+				if !fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo, preemptible) {
+					insufficientDefault++
+				}
+			}
 			continue
 		}
-		nodeFits := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo)
+		nodeFits := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo, preemptible)
 		if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyAligned {
 			if nodeFits {
 				return nil
 			}
 			insufficientAligned++
 		} else if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyRestricted {
-			rRemained := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, rInfo.Allocated)
+			allocated := rInfo.Allocated
+			if len(preemptibleInRR) > 0 {
+				allocated = quotav1.SubtractWithNonNegativeResult(allocated, preemptibleInRR)
+				allocated = quotav1.Mask(allocated, rInfo.ResourceNames)
+			}
+			rRemained := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, allocated)
 			fits, _ := quotav1.LessThanOrEqual(state.podRequests, rRemained)
 			if fits && nodeFits {
 				return nil
@@ -292,15 +422,18 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 			insufficientRestricted++
 		}
 	}
-	if (nodeRState.totalAligned > 0 && nodeRState.totalAligned == insufficientAligned) ||
+	if (totalDefault > 0 && totalDefault == insufficientDefault) ||
+		(nodeRState.totalAligned > 0 && nodeRState.totalAligned == insufficientAligned) ||
 		(nodeRState.totalRestricted > 0 && nodeRState.totalRestricted == insufficientRestricted) {
 		return framework.NewStatus(framework.Unschedulable, ErrReasonReservationInsufficientResources)
 	}
 	return nil
 }
 
+var dummyResource = framework.NewResource(nil)
+
 // fitsNode checks if node have enough resources to host the pod.
-func fitsNode(podRequest *framework.Resource, nodeInfo *framework.NodeInfo, nodeRState *nodeReservationState, rInfo *frameworkext.ReservationInfo) bool {
+func fitsNode(podRequest *framework.Resource, nodeInfo *framework.NodeInfo, nodeRState *nodeReservationState, rInfo *frameworkext.ReservationInfo, preemptible *framework.Resource) bool {
 	allowedPodNumber := nodeInfo.Allocatable.AllowedPodNumber
 	if len(nodeInfo.Pods)-len(nodeRState.matched)+1 > allowedPodNumber {
 		return false
@@ -310,25 +443,40 @@ func fitsNode(podRequest *framework.Resource, nodeInfo *framework.NodeInfo, node
 		podRequest.Memory == 0 &&
 		podRequest.EphemeralStorage == 0 &&
 		len(podRequest.ScalarResources) == 0 {
-		return false
+		return true
 	}
 
-	rRemained := framework.NewResource(quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, rInfo.Allocated))
+	var rRemained *framework.Resource
+	if rInfo != nil {
+		resources := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, rInfo.Allocated)
+		rRemained = framework.NewResource(resources)
+	} else {
+		rRemained = dummyResource
+	}
 	allRAllocated := nodeRState.rAllocated
+	if allRAllocated == nil {
+		allRAllocated = dummyResource
+	}
 	podRequested := nodeRState.podRequested
+	if podRequested == nil {
+		podRequested = dummyResource
+	}
+	if preemptible == nil {
+		preemptible = dummyResource
+	}
 
-	if podRequest.MilliCPU > (nodeInfo.Allocatable.MilliCPU - (podRequested.MilliCPU - rRemained.MilliCPU - allRAllocated.MilliCPU)) {
+	if podRequest.MilliCPU > (nodeInfo.Allocatable.MilliCPU - (podRequested.MilliCPU - rRemained.MilliCPU - allRAllocated.MilliCPU - preemptible.MilliCPU)) {
 		return false
 	}
-	if podRequest.Memory > (nodeInfo.Allocatable.Memory - (podRequested.Memory - rRemained.Memory - allRAllocated.Memory)) {
+	if podRequest.Memory > (nodeInfo.Allocatable.Memory - (podRequested.Memory - rRemained.Memory - allRAllocated.Memory - preemptible.Memory)) {
 		return false
 	}
-	if podRequest.EphemeralStorage > (nodeInfo.Allocatable.EphemeralStorage - (podRequested.EphemeralStorage - rRemained.EphemeralStorage - allRAllocated.EphemeralStorage)) {
+	if podRequest.EphemeralStorage > (nodeInfo.Allocatable.EphemeralStorage - (podRequested.EphemeralStorage - rRemained.EphemeralStorage - allRAllocated.EphemeralStorage - preemptible.EphemeralStorage)) {
 		return false
 	}
 
 	for rName, rQuant := range podRequest.ScalarResources {
-		if rQuant > (nodeInfo.Allocatable.ScalarResources[rName] - (podRequested.ScalarResources[rName] - rRemained.ScalarResources[rName] - allRAllocated.ScalarResources[rName])) {
+		if rQuant > (nodeInfo.Allocatable.ScalarResources[rName] - (podRequested.ScalarResources[rName] - rRemained.ScalarResources[rName] - allRAllocated.ScalarResources[rName] - preemptible.ScalarResources[rName])) {
 			return false
 		}
 	}

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -184,6 +184,8 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 		hasAffinity:           reservationAffinity != nil,
 		podRequests:           podRequests,
 		podRequestsResources:  podRequestResources,
+		preemptible:           map[string]corev1.ResourceList{},
+		preemptibleInRRs:      map[string]map[types.UID]corev1.ResourceList{},
 		nodeReservationStates: map[string]nodeReservationState{},
 	}
 	pluginToNodeReservationRestoreState := frameworkext.PluginToNodeReservationRestoreStates{}

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/utils/pointer"
@@ -295,6 +296,8 @@ func TestRestoreReservation(t *testing.T) {
 	expectedStat := &stateData{
 		podRequests:          corev1.ResourceList{},
 		podRequestsResources: framework.NewResource(nil),
+		preemptible:          map[string]corev1.ResourceList{},
+		preemptibleInRRs:     map[string]map[types.UID]corev1.ResourceList{},
 		nodeReservationStates: map[string]nodeReservationState{
 			node.Name: {
 				nodeName: node.Name,

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -56,8 +56,8 @@ var _ = SIGDescribe("Preemption", func() {
 		}
 	})
 
-	framework.KoordinatorDescribe("Basic Preemption", func() {
-		framework.ConformanceIt("preempt device", func() {
+	framework.KoordinatorDescribe("Preemption with device", func() {
+		framework.ConformanceIt("basic preempt device", func() {
 			nodeName := runPodAndGetNodeName(f, pausePodConfig{
 				Name: "without-label",
 				Resources: &corev1.ResourceRequirements{
@@ -280,6 +280,299 @@ var _ = SIGDescribe("Preemption", func() {
 					},
 				},
 				NodeName:          nodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, highPriorityPod), "unable to preempt")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, highPriorityPod.Namespace, highPriorityPod.Name, reservation.Name)
+		})
+	})
+
+	ginkgo.Context("Preempt basic resources", func() {
+		var testNodeName string
+		var fakeResourceName corev1.ResourceName = "koordinator.sh/fake-resource"
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Add fake resource")
+			// find a node which can run a pod:
+			testNodeName = GetNodeThatCanRunPod(f)
+
+			// Get node object:
+			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "unable to get node object for node %v", testNodeName)
+
+			// update Node API object with a fake resource
+			nodeCopy := node.DeepCopy()
+			nodeCopy.ResourceVersion = "0"
+
+			nodeCopy.Status.Capacity[fakeResourceName] = resource.MustParse("1000")
+			nodeCopy.Status.Allocatable[fakeResourceName] = resource.MustParse("1000")
+			_, err = f.ClientSet.CoreV1().Nodes().UpdateStatus(context.TODO(), nodeCopy, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "unable to apply fake resource to %v", testNodeName)
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By("Remove fake resource")
+			// remove fake resource:
+			if testNodeName != "" {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+				framework.ExpectNoError(err, "unable to get node object for node %v", testNodeName)
+
+				nodeCopy := node.DeepCopy()
+				// force it to update
+				nodeCopy.ResourceVersion = "0"
+				delete(nodeCopy.Status.Capacity, fakeResourceName)
+				delete(nodeCopy.Status.Allocatable, fakeResourceName)
+				_, err = f.ClientSet.CoreV1().Nodes().UpdateStatus(context.TODO(), nodeCopy, metav1.UpdateOptions{})
+				framework.ExpectNoError(err, "unable to update node %v", testNodeName)
+			}
+		})
+
+		framework.ConformanceIt("basic preempt", func() {
+			resourceRequirements := &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Limits: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			}
+			nodeName := runPodAndGetNodeName(f, pausePodConfig{
+				Name:          "without-label",
+				Resources:     resourceRequirements,
+				SchedulerName: "koord-scheduler",
+			})
+
+			ginkgo.By("Create low priority Pod requests all fakeResource")
+
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name:          "low-priority-pod",
+				Resources:     resourceRequirements,
+				NodeName:      nodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain fakeResource")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name:              "high-priority-pod",
+				Resources:         resourceRequirements,
+				NodeName:          nodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, highPriorityPod), "unable preempt lowest priority pod")
+		})
+
+		framework.ConformanceIt("pods outside Reservation cannot preempt pods in Reservation", func() {
+			resourceRequirements := &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Limits: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			}
+
+			ginkgo.By("Create Reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+			reservation.Spec.AllocateOnce = pointer.Bool(false)
+			reservation.Spec.Template.Spec.NodeName = testNodeName
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation-preempt": "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+						Limits: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+					},
+				},
+			}
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+			waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create low priority Pod requests all fakeResource")
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources:     resourceRequirements,
+				NodeName:      testNodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, lowPriorityPod.Namespace, lowPriorityPod.Name, reservation.Name)
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain fakeResource")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name:              "high-priority-pod",
+				Resources:         resourceRequirements,
+				NodeName:          testNodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, highPriorityPod.Namespace, highPriorityPod.Name, "wait for pod schedule failed", 60*time.Second, func(pod *corev1.Pod) (bool, error) {
+				_, scheduledCondition := k8spodutil.GetPodCondition(&pod.Status, corev1.PodScheduled)
+				return scheduledCondition != nil && scheduledCondition.Status == corev1.ConditionFalse, nil
+			}))
+
+			pod, err := f.PodClient().Get(context.TODO(), lowPriorityPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(pod.DeletionTimestamp, (*metav1.Time)(nil))
+		})
+
+		framework.ConformanceIt("highest priority pods in Reservation preempt lowest priority pods in Reservation", func() {
+			resourceRequirements := &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Limits: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			}
+
+			ginkgo.By("Create Reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+			reservation.Spec.AllocateOnce = pointer.Bool(false)
+			reservation.Spec.Template.Spec.NodeName = testNodeName
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation-preempt": "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+						Limits: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+					},
+				},
+			}
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+			waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create low priority Pod requests all fakeResource")
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources:     resourceRequirements,
+				NodeName:      testNodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, lowPriorityPod.Namespace, lowPriorityPod.Name, reservation.Name)
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain fakeResource")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "high-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources:         resourceRequirements,
+				NodeName:          testNodeName,
+				SchedulerName:     "koord-scheduler",
+				PriorityClassName: "system-cluster-critical",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, highPriorityPod), "unable to preempt")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, highPriorityPod.Namespace, highPriorityPod.Name, reservation.Name)
+		})
+
+		framework.ConformanceIt("highest priority pods in Restricted Reservation preempt lowest priority pods in Restricted Reservation", func() {
+			resourceRequirements := &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Limits: corev1.ResourceList{
+					fakeResourceName:   resource.MustParse("1000"),
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			}
+
+			ginkgo.By("Create Reservation")
+			reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+			framework.ExpectNoError(err, "unable to load reservation")
+			reservation.Spec.AllocateOnce = pointer.Bool(false)
+			reservation.Spec.Template.Spec.NodeName = testNodeName
+			reservation.Spec.AllocatePolicy = schedulingv1alpha1.ReservationAllocatePolicyRestricted
+			reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test-reservation-preempt": "true",
+						},
+					},
+				},
+			}
+			reservation.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+						Limits: corev1.ResourceList{
+							fakeResourceName: resource.MustParse("1000"),
+						},
+					},
+				},
+			}
+			reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "unable to create reservation")
+			waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+
+			ginkgo.By("Create low priority Pod requests all fakeResource")
+			lowPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "low-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources:     resourceRequirements,
+				NodeName:      testNodeName,
+				SchedulerName: "koord-scheduler",
+			})
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(f.ClientSet, lowPriorityPod), "unable schedule the lowest priority pod")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, lowPriorityPod.Namespace, lowPriorityPod.Name, reservation.Name)
+
+			ginkgo.By("Create highest priority Pod preempt lowest priority pod to obtain fakeResource")
+			highPriorityPod := createPausePod(f, pausePodConfig{
+				Name: "high-priority-pod",
+				Labels: map[string]string{
+					"test-reservation-preempt": "true",
+				},
+				Resources:         resourceRequirements,
+				NodeName:          testNodeName,
 				SchedulerName:     "koord-scheduler",
 				PriorityClassName: "system-cluster-critical",
 			})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

After the introduction of Reservation, Pods outside the Reservation cannot preempt Pods in the Reservation. In the previous PR, this problem was solved for the Device Share scenario, but for common resources, such as CPU/Memory, this PR can be used to solve it.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1187

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Create a Reservation reserving all remained CPUs of one Node . 
2. Create a Pod using the Reservation to allocate 4000m CPU.
3. Create a high-priority Pod but does not use the Reservation and try to allocate the node that Reservation reserved.
4. If not using the PR, the high-priority Pod will preempt the Pod that using Reservation, but both of the Pods cannot be scheduled.
5. If using the PR, the high-priority Pod will not preempt the Pod that using Reservation.

More cases see the E2E tests.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
