### PR TITLE
koordlet: fix cpu evict api

### DIFF
--- a/pkg/util/pod_evict.go
+++ b/pkg/util/pod_evict.go
@@ -92,10 +92,12 @@ func FindSupportedEvictVersion(client kubernetes.Interface) (groupVersion string
 	}
 	for _, resource := range resourceList.APIResources {
 		if resource.Name == EvictionSubResourceName && resource.Kind == EvictionKind {
-			groupVersion = preferredVersion
+			// compatible with k8s v1.21.x no policy/v1/eviction
+			groupVersion = resource.Version
 			return
 		}
 	}
 
+	groupVersion = preferredVersion
 	return
 }


### PR DESCRIPTION
check group version and use it other than use pod eviction refer: https://github.com/kubernetes/kubernetes/blob/18d05b646d09b2971dc5400bc288062b0414e8cf/staging/src/k8s.io/kubectl/pkg/drain/drain.go#L141

may fix #1373 
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
