### PR TITLE
koord-scheduler: coscheduling support multiple gang match policy

### DIFF
--- a/apis/extension/scheduling.go
+++ b/apis/extension/scheduling.go
@@ -65,6 +65,13 @@ const (
 
 	GangModeStrict    = "Strict"
 	GangModeNonStrict = "NonStrict"
+
+	// AnnotationGangMatchPolicy defines the Gang Scheduling operation of taking which status pod into account
+	// Support GangMatchPolicyOnlyWaiting, GangMatchPolicyWaitingAndRunning, GangMatchPolicyOnceSatisfied, default is GangMatchPolicyOnceSatisfied
+	AnnotationGangMatchPolicy        = AnnotationGangPrefix + "/match-policy"
+	GangMatchPolicyOnlyWaiting       = "only-waiting"
+	GangMatchPolicyWaitingAndRunning = "waiting-and-running"
+	GangMatchPolicyOnceSatisfied     = "once-satisfied"
 )
 
 const (
@@ -176,4 +183,8 @@ var GetMinNum = func(pod *corev1.Pod) (int, error) {
 
 var GetGangName = func(pod *corev1.Pod) string {
 	return pod.Annotations[AnnotationGangName]
+}
+
+var GetGangMatchPolicy = func(pod *corev1.Pod) string {
+	return pod.Annotations[AnnotationGangMatchPolicy]
 }

--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
@@ -98,6 +98,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					ScheduleCycleValid: true,
 					ScheduleCycle:      1,
 					GangFrom:           GangFromPodAnnotation,
+					GangMatchPolicy:    extension.GangMatchPolicyOnceSatisfied,
 					HasGangInit:        false,
 					Children: map[string]*corev1.Pod{
 						"default/crdPod": {
@@ -160,6 +161,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					GangGroup:         []string{"default/ganga", "default/gangb"},
 					HasGangInit:       true,
 					GangFrom:          GangFromPodAnnotation,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					Children: map[string]*corev1.Pod{
 						"default/pod1": {
 							ObjectMeta: metav1.ObjectMeta{
@@ -261,6 +263,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					GangGroup:         []string{"default/ganga"},
 					HasGangInit:       true,
 					GangFrom:          GangFromPodAnnotation,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					Children: map[string]*corev1.Pod{
 						"default/pod1": {
 							ObjectMeta: metav1.ObjectMeta{
@@ -359,6 +362,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					GangGroupId:       "default/gangb",
 					HasGangInit:       true,
 					GangFrom:          GangFromPodAnnotation,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					Children: map[string]*corev1.Pod{
 						"default/pod3": {
 							ObjectMeta: metav1.ObjectMeta{
@@ -435,6 +439,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					GangGroup:         []string{"default/gangc"},
 					HasGangInit:       true,
 					GangFrom:          GangFromPodAnnotation,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					Children: map[string]*corev1.Pod{
 						"default/pod5": {
 							ObjectMeta: metav1.ObjectMeta{
@@ -466,6 +471,7 @@ func TestGangCache_OnPodAdd(t *testing.T) {
 					GangGroup:         []string{"default/gangd"},
 					HasGangInit:       true,
 					GangFrom:          GangFromPodAnnotation,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					Children: map[string]*corev1.Pod{
 						"default/pod6": {
 							ObjectMeta: metav1.ObjectMeta{
@@ -570,6 +576,7 @@ func TestGangCache_OnPodUpdate(t *testing.T) {
 					WaitTime:          30 * time.Second,
 					CreateTime:        fakeTimeNowFn(),
 					Mode:              extension.GangModeNonStrict,
+					GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 					MinRequiredNumber: 2,
 					TotalChildrenNum:  2,
 					GangGroup:         []string{"default/ganga", "default/gangb"},
@@ -767,6 +774,7 @@ func TestGangCache_OnPodDelete(t *testing.T) {
 					GangGroupId:              "default/gangB",
 					HasGangInit:              true,
 					GangFrom:                 GangFromPodGroupCrd,
+					GangMatchPolicy:          extension.GangMatchPolicyOnceSatisfied,
 					Children:                 map[string]*corev1.Pod{},
 					WaitingForBindChildren:   map[string]*corev1.Pod{},
 					BoundChildren:            map[string]*corev1.Pod{},
@@ -894,6 +902,7 @@ func TestGangCache_OnPodGroupAdd(t *testing.T) {
 					GangGroup:                []string{"default/gangA", "default/gangB"},
 					HasGangInit:              true,
 					GangFrom:                 GangFromPodGroupCrd,
+					GangMatchPolicy:          extension.GangMatchPolicyOnceSatisfied,
 					Children:                 map[string]*corev1.Pod{},
 					WaitingForBindChildren:   map[string]*corev1.Pod{},
 					BoundChildren:            map[string]*corev1.Pod{},
@@ -934,6 +943,7 @@ func TestGangCache_OnPodGroupAdd(t *testing.T) {
 					GangGroupId:              "default/gangA",
 					HasGangInit:              true,
 					GangFrom:                 GangFromPodGroupCrd,
+					GangMatchPolicy:          extension.GangMatchPolicyOnceSatisfied,
 					Children:                 map[string]*corev1.Pod{},
 					WaitingForBindChildren:   map[string]*corev1.Pod{},
 					BoundChildren:            map[string]*corev1.Pod{},
@@ -1024,6 +1034,7 @@ func TestGangCache_OnGangDelete(t *testing.T) {
 		GangGroup:         []string{"default/gangA", "default/gangB"},
 		HasGangInit:       true,
 		GangFrom:          GangFromPodAnnotation,
+		GangMatchPolicy:   extension.GangMatchPolicyOnceSatisfied,
 		Children: map[string]*corev1.Pod{
 			"default/pod1": {
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/plugins/coscheduling/core/gang_summary.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_summary.go
@@ -11,6 +11,7 @@ type GangSummary struct {
 	WaitTime                 time.Duration  `json:"waitTime"`
 	CreateTime               time.Time      `json:"createTime"`
 	Mode                     string         `json:"mode"`
+	GangMatchPolicy          string         `json:"gangMatchPolicy"`
 	MinRequiredNumber        int            `json:"minRequiredNumber"`
 	TotalChildrenNum         int            `json:"totalChildrenNum"`
 	GangGroup                []string       `json:"gangGroup"`
@@ -44,6 +45,7 @@ func (gang *Gang) GetGangSummary() *GangSummary {
 	gangSummary.WaitTime = gang.WaitTime
 	gangSummary.CreateTime = gang.CreateTime
 	gangSummary.Mode = gang.Mode
+	gangSummary.GangMatchPolicy = gang.GangMatchPolicy
 	gangSummary.MinRequiredNumber = gang.MinRequiredNumber
 	gangSummary.TotalChildrenNum = gang.TotalChildrenNum
 	gangSummary.OnceResourceSatisfied = gang.OnceResourceSatisfied

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -512,6 +512,14 @@ func TestPostFilter(t *testing.T) {
 			resourceSatisfied: true,
 		},
 		{
+			name:              "gangA is resourceSatisfied but matchPolicy is only-waiting, reject the gang",
+			pod:               st.MakePod().Name("pod1").Namespace("gangC_ns").UID("pod1").Label(v1alpha1.PodGroupLabel, "gangC").Obj(),
+			pg:                makePg("gangC", "gangC_ns", 1, &gangCreatedTime, nil),
+			expectedEmptyMsg:  false,
+			resourceSatisfied: true,
+			annotations:       map[string]string{extension.AnnotationGangMatchPolicy: extension.GangMatchPolicyOnlyWaiting},
+		},
+		{
 			name:             "resource not Satisfied,but gangB is NonStrictMode,do not reject the gang",
 			pod:              st.MakePod().Name("pod2").Namespace("gangB_ns").UID("pod2").Label(v1alpha1.PodGroupLabel, "gangB").Obj(),
 			pg:               makePg("gangB", "gangB_ns", 4, &gangCreatedTime, nil),
@@ -649,6 +657,19 @@ func TestPermit(t *testing.T) {
 		},
 		{
 			name: "pod4 belongs to gangA that gangA has resourceSatisfied",
+			pod:  st.MakePod().Name("pod4").UID("pod4").Namespace("gangA_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
+			pods: []*corev1.Pod{
+				st.MakePod().Name("pod4-1").UID("pod4-1").Namespace("gangA_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
+				st.MakePod().Name("pod4-2").UID("pod4-2").Namespace("gangA_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
+			},
+			needInWaitingPods: true,
+			waitingGangMap: map[string]bool{
+				"gangA_ns/ganga": true,
+			},
+			want: framework.Success,
+		},
+		{
+			name: "pod4 belongs to gangA that gangA has resourceSatisfied, but gangA matchPolicy is not once-satisfied",
 			pod:  st.MakePod().Name("pod4").UID("pod4").Namespace("gangA_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
 			pods: []*corev1.Pod{
 				st.MakePod().Name("pod4-1").UID("pod4-1").Namespace("gangA_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),

--- a/pkg/scheduler/plugins/coscheduling/plugin_service_test.go
+++ b/pkg/scheduler/plugins/coscheduling/plugin_service_test.go
@@ -97,6 +97,7 @@ func TestEndpointsQueryGangInfo(t *testing.T) {
 		ScheduleCycle:            1,
 		ChildrenScheduleRoundMap: map[string]int{},
 		GangFrom:                 core.GangFromPodAnnotation,
+		GangMatchPolicy:          extension.GangMatchPolicyOnceSatisfied,
 		HasGangInit:              true,
 	}
 	{

--- a/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
+++ b/pkg/scheduler/plugins/coscheduling/util/gang_helper.go
@@ -67,6 +67,14 @@ func GetGangMinNumFromPod(pod *v1.Pod) (minNum int, err error) {
 	return 0, errors.New("missing min available")
 }
 
+func GetGangMatchPolicyByPod(pod *v1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+
+	return extension.GetGangMatchPolicy(pod)
+}
+
 func IsPodNeedGang(pod *v1.Pod) bool {
 	return GetGangNameByPod(pod) != ""
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Expand the logic of determining whether gang is satisfied by "match-policy".

In some specific scenarios, the completed task Pod may not exist. At this time, it is impossible to count the number of completed tasks. In this case, once Gang has been satisfied, all subsequent resource allocations are no longer constrained by Gang rules, which is called once-satisfied, the default gang 'match-policy'.

For GPU topology, all the tasks need to be scheduled at the same time to ensure the best performance, so the gang only consider the number of pods waiting on permit is larger than the min-available, which is called only-waiting. What's more, if the workload support failover, but workload controller can't persist the new gangName or support reconstruct all pods at one-time, only-waiting can help.

For tasks of elastic training, the new workers' arrival is random, so the gang only consider the sum of running pods and waiting pods is larger than the min-available, which is called waiting-and-running. For example, if the gang's total number is 5, min available is 3 and there are 3 pods running at first. After two of the three pods completed,  the fourth pod comes, if the match-policy is once-satisfied, the fourth pod will be scheduled and bound. If the match-policy is waiting-and-running, the fourth pod will keep pending, since there are only 2 pods' status is waiting-and-running which is smaller than min-available.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/koordinator-sh/koordinator/issues/940 Matching Policy part.
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
