### PR TITLE
koordlet: add a resource usage predictserver to estimate long-term reclaimed resource

### DIFF
--- a/pkg/koordlet/prediction/checkpoint.go
+++ b/pkg/koordlet/prediction/checkpoint.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/histogram"
+)
+
+const (
+	TmpFileSuffix = ".tmp"
+)
+
+// ModelCheckpoint represents a checkpoint for a model.
+type ModelCheckpoint struct {
+	UID         UIDType
+	CPU         *histogram.HistogramCheckpoint
+	Memory      *histogram.HistogramCheckpoint
+	LastUpdated metav1.Time
+
+	Error error `json:"-,omitempty"`
+}
+
+// Checkpointer is an interface for saving and restoring model checkpoints.
+type Checkpointer interface {
+	Save(checkpoint ModelCheckpoint) error
+	Remove(UID UIDType) error
+	Restore() ([]*ModelCheckpoint, error)
+}
+
+// NewFileCheckpointer creates a new file-based checkpointer with the specified directory.
+func NewFileCheckpointer(path string) *fileCheckpointer {
+	return &fileCheckpointer{path: path}
+}
+
+// fileCheckpointer is an implementation of the Checkpointer interface using files.
+type fileCheckpointer struct {
+	path string // The directory path where checkpoints are stored.
+}
+
+// Save saves the given model as a checkpoint with the specified UID.
+func (f *fileCheckpointer) Save(checkpoint ModelCheckpoint) error {
+	filename := filepath.Join(f.path, string(checkpoint.UID))
+	tmpFilename := filename + TmpFileSuffix
+	file, err := os.Create(tmpFilename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	if err := encoder.Encode(checkpoint); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpFilename, filename)
+}
+
+// Remove removes the given model the specified UID.
+func (f *fileCheckpointer) Remove(UID UIDType) error {
+	filename := filepath.Join(f.path, string(UID))
+	return os.Remove(filename)
+}
+
+// Restore returns a slice of ModelCheckpoint instances by scanning and decoding checkpoint files from the specified path.
+func (f *fileCheckpointer) Restore() ([]*ModelCheckpoint, error) {
+	models := make([]*ModelCheckpoint, 0, 32)
+	err := filepath.Walk(f.path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, TmpFileSuffix) {
+			err := os.Remove(path)
+			klog.InfoS("remove tmp file", path, err)
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			klog.InfoS("open file failed, skip it", path)
+			return nil
+		}
+		defer file.Close()
+
+		checkpoint := &ModelCheckpoint{}
+		decoder := json.NewDecoder(file)
+		if err := decoder.Decode(checkpoint); err != nil {
+			checkpoint.Error = err
+		}
+		// reset UID to the file name
+		checkpoint.UID = UIDType(filepath.Base(path))
+		models = append(models, checkpoint)
+		return nil
+	})
+	return models, err
+}

--- a/pkg/koordlet/prediction/checkpoint_test.go
+++ b/pkg/koordlet/prediction/checkpoint_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/histogram"
+)
+
+func TestSaveAndRestore(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("/tmp", "checkpoints")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a fileCheckpointer instance
+	checkpointer := NewFileCheckpointer(tempDir)
+
+	// Create a sample model
+	uid := UIDType("sample_uid")
+	cpuCheckpoint := &histogram.HistogramCheckpoint{
+		TotalWeight: 2,
+	}
+	memoryCheckpoint := &histogram.HistogramCheckpoint{
+		TotalWeight: 3,
+	}
+	lastUpdated := metav1.Now()
+	model := ModelCheckpoint{
+		UID:         uid,
+		CPU:         cpuCheckpoint,
+		Memory:      memoryCheckpoint,
+		LastUpdated: lastUpdated,
+	}
+
+	// Save the model as a checkpoint
+	err = checkpointer.Save(model)
+	if err != nil {
+		t.Fatalf("Failed to save checkpoint: %v", err)
+	}
+
+	// Restore the checkpoints
+	restoredCheckpoints, err := checkpointer.Restore()
+	if err != nil {
+		t.Fatalf("Failed to restore checkpoints: %v", err)
+	}
+
+	// Verify the restored checkpoints
+	if len(restoredCheckpoints) != 1 {
+		t.Fatalf("Expected 1 restored checkpoint, got %d", len(restoredCheckpoints))
+	}
+
+	restoredCheckpoint := restoredCheckpoints[0]
+	if restoredCheckpoint.UID != uid {
+		t.Errorf("Expected UID to be %s, got %s", uid, restoredCheckpoint.UID)
+	}
+	if restoredCheckpoint.CPU.TotalWeight != cpuCheckpoint.TotalWeight {
+		t.Errorf("Expected CPU checkpoint to be equal")
+	}
+	if restoredCheckpoint.Memory.TotalWeight != memoryCheckpoint.TotalWeight {
+		t.Errorf("Expected memory checkpoint to be equal")
+	}
+}
+
+func TestSaveError(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("/tmp", "checkpoints")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a fileCheckpointer instance with invalid directory path
+	checkpointer := &fileCheckpointer{
+		path: "/invalid/directory",
+	}
+
+	// Create a sample model
+	uid := UIDType("sample_uid")
+	cpuCheckpoint := &histogram.HistogramCheckpoint{}
+	memoryCheckpoint := &histogram.HistogramCheckpoint{}
+	lastUpdated := metav1.Now()
+	model := ModelCheckpoint{
+		UID:         uid,
+		CPU:         cpuCheckpoint,
+		Memory:      memoryCheckpoint,
+		LastUpdated: lastUpdated,
+	}
+
+	// Save the model as a checkpoint
+	err = checkpointer.Save(model)
+	if err == nil {
+		t.Error("Expected error when saving checkpoint, got nil")
+	}
+}
+
+func TestRestoreError(t *testing.T) {
+	// Create a fileCheckpointer instance with an invalid directory path
+	checkpointer := &fileCheckpointer{
+		path: "/invalid/directory",
+	}
+
+	// Attempt to restore the checkpoints
+	checkpoints, err := checkpointer.Restore()
+	if err == nil {
+		t.Error("Expected error when restoring checkpoints, got nil")
+	}
+
+	if len(checkpoints) != 0 {
+		t.Errorf("Expected nil checkpoints, got %+v", checkpoints)
+	}
+}

--- a/pkg/koordlet/prediction/predict_server.go
+++ b/pkg/koordlet/prediction/predict_server.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/util/histogram"
+)
+
+var (
+	// MinSampleWeight is the minimal weight of any sample (prior to including decaying factor)
+	MinSampleWeight = 0.1
+	// epsilon is the minimal weight kept in histograms, it should be small enough that old samples
+	// (just inside MemoryAggregationWindowLength) added with MinSampleWeight are still kept
+	epsilon = 0.001 * MinSampleWeight
+	// DefaultHistogramBucketSizeGrowth is the default value for histogramBucketSizeGrowth.
+	DefaultHistogramBucketSizeGrowth = 0.05
+	// DefaultMemoryHistogramDecayHalfLife is the default value for MemoryHistogramDecayHalfLife.
+	DefaultMemoryHistogramDecayHalfLife = time.Hour * 24
+	// DefaultCPUHistogramDecayHalfLife is the default value for CPUHistogramDecayHalfLife.
+	DefaultCPUHistogramDecayHalfLife = time.Hour * 12
+	// DefaultTrainingInterval is the default interval at which the model runs.
+	DefaultTrainingInterval = time.Minute
+	// DefaultModelExpirationTime is the default value for model expiration. Models that
+	// are not updated after this time will be GC.
+	DefaultModelExpirationTime = time.Minute * 30
+	// DefaultModelCheckPointInterval is the default value for model checkpoint.
+	DefaultModelCheckpointInterval   = time.Minute * 10
+	DefaultModelCheckpointMaxPerStep = 12
+)
+
+/*
+PredictServer is responsible for fetching data from MetricCache, training prediction results
+according to predefined models, and providing an interface for obtaining prediction results.
+
+It is important to note that the prediction results made by PredictServer based on the captured
+data are only related to the data it sees. For example, when we need to deal with cold starts,
+this business logic should be processed when using the predicted data instead of being coupled
+to the predictive model.
+
+The predictive model currently provides histogram-based statistics with exponentially decaying
+weights over time periods. PredictServer is responsible for storing the intermediate results of
+the model and recovering when the process restarts.
+*/
+type PredictServer interface {
+	Run(stopCh <-chan struct{}) error
+	HasSynced() bool
+	GetPrediction(MetricDesc) (Result, error)
+}
+
+type PredictModel struct {
+	CPU    histogram.Histogram
+	Memory histogram.Histogram
+
+	LastUpdated      time.Time
+	LastCheckpointed time.Time
+	Lock             sync.Mutex
+}
+
+type peakPredictServer struct {
+	informer     Informer
+	metricServer MetricServer
+
+	uidGenerator UIDGenerator
+	models       map[UIDType]*PredictModel
+	modelsLock   sync.Mutex
+
+	clock        clock.Clock
+	hasSynced    *atomic.Bool
+	checkpointer Checkpointer
+}
+
+func NewPeakPredictServer(statesInformer statesinformer.StatesInformer, metricCache metriccache.MetricCache, options Options) PredictServer {
+	return &peakPredictServer{
+		informer:     NewInformer(statesInformer),
+		metricServer: NewMetricServer(metricCache),
+
+		uidGenerator: &generator{},
+		models:       make(map[UIDType]*PredictModel),
+		clock:        clock.RealClock{},
+		hasSynced:    &atomic.Bool{},
+		checkpointer: NewFileCheckpointer(options.Filepath),
+	}
+}
+
+func (p *peakPredictServer) Run(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, p.informer.HasSynced) {
+		return fmt.Errorf("time out waiting for states informer caches to sync")
+	}
+
+	unknownUIDs := p.restoreModels()
+
+	// remove unknown checkpoints before starting to work
+	for _, uid := range unknownUIDs {
+		err := p.checkpointer.Remove(uid)
+		klog.InfoS("remove unknown checkpoint", "uid", uid)
+		if err != nil {
+			klog.Errorf("remove checkpoint %v failed, err: %v", uid, err)
+		}
+	}
+
+	go wait.Until(p.training, DefaultTrainingInterval, stopCh)
+	go wait.Until(p.gcModels, time.Minute, stopCh)
+	go wait.Until(p.doCheckpoint, time.Minute, stopCh)
+	<-stopCh
+	return nil
+}
+
+func (p *peakPredictServer) HasSynced() bool {
+	return p.hasSynced.Load()
+}
+
+func (p *peakPredictServer) training() {
+	// get pod metrics
+	// 1. list pods, update models
+	pods := p.informer.ListPods()
+	for _, pod := range pods {
+		uid := p.uidGenerator.Pod(pod)
+		lastCPUUsage, err := p.metricServer.GetPodMetric(MetricDesc{UID: uid}, CPUUsage)
+		if err != nil {
+			klog.Warning("failed to query pod cpu metric", err)
+			continue
+		}
+		lastMemoryUsage, err := p.metricServer.GetPodMetric(MetricDesc{UID: uid}, MemoryUsage)
+		if err != nil {
+			klog.Warning("failed to query pod memory metric", err)
+			continue
+		}
+
+		// update the model
+		p.updateMode(uid, lastCPUUsage, lastMemoryUsage)
+	}
+
+	// 2. get node, update models
+	node := p.informer.GetNode()
+	nodeUID := p.uidGenerator.Node(node)
+	lastNodeCPUUsage, errCPU := p.metricServer.GetNodeMetric(MetricDesc{UID: nodeUID}, CPUUsage)
+	lastNodeMemoryUsage, errMem := p.metricServer.GetNodeMetric(MetricDesc{UID: nodeUID}, MemoryUsage)
+	if errCPU != nil || errMem != nil {
+		klog.Warning("failed to query node cpu and memory metric", errCPU, errMem)
+	} else {
+		p.updateMode(nodeUID, lastNodeCPUUsage, lastNodeMemoryUsage)
+	}
+
+	p.hasSynced.Store(true)
+}
+
+// From 0.05 to 1024 cores, maintain the bucket of the CPU histogram at a rate of 5%
+func defaultCPUHistogram() histogram.Histogram {
+	options, err := histogram.NewExponentialHistogramOptions(1024, 0.025, 1.+DefaultHistogramBucketSizeGrowth, epsilon)
+	if err != nil {
+		klog.Fatal("failed to create CPU HistogramOptions")
+	}
+	return histogram.NewDecayingHistogram(options, DefaultCPUHistogramDecayHalfLife)
+}
+
+// From 10M to 2T, maintain the bucket of the Memory histogram at a rate of 5%
+func defaultMemoryHistogram() histogram.Histogram {
+	options, err := histogram.NewExponentialHistogramOptions(1<<31, 5<<20, 1.+DefaultHistogramBucketSizeGrowth, epsilon)
+	if err != nil {
+		klog.Fatal("failed to create Memory HistogramOptions")
+	}
+	return histogram.NewDecayingHistogram(options, DefaultMemoryHistogramDecayHalfLife)
+}
+
+func (p *peakPredictServer) updateMode(uid UIDType, cpu, memory float64) {
+	p.modelsLock.Lock()
+	defer p.modelsLock.Unlock()
+	model, ok := p.models[uid]
+	if !ok {
+		model = &PredictModel{
+			CPU:    defaultCPUHistogram(),
+			Memory: defaultMemoryHistogram(),
+		}
+		p.models[uid] = model
+	}
+	now := p.clock.Now()
+	model.Lock.Lock()
+	defer model.Lock.Unlock()
+	model.LastUpdated = now
+	// TODO Add adjusted weights
+	model.CPU.AddSample(cpu, 1, now)
+	model.Memory.AddSample(memory, 1, now)
+}
+
+func (p *peakPredictServer) GetPrediction(metric MetricDesc) (Result, error) {
+	p.modelsLock.Lock()
+	defer p.modelsLock.Unlock()
+	model, ok := p.models[metric.UID]
+	if !ok {
+		return Result{}, fmt.Errorf("UID %v node found in predict server", metric.UID)
+	}
+	model.Lock.Lock()
+	defer model.Lock.Unlock()
+	//
+	return Result{
+		Data: map[string]v1.ResourceList{
+			"p60": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(int64(model.CPU.Percentile(0.6)*1000.0), resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(int64(model.Memory.Percentile(0.6)), resource.BinarySI),
+			},
+			"p90": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(int64(model.CPU.Percentile(0.9)*1000.0), resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(int64(model.Memory.Percentile(0.9)), resource.BinarySI),
+			},
+			"p95": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(int64(model.CPU.Percentile(0.95)*1000.0), resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(int64(model.Memory.Percentile(0.95)), resource.BinarySI),
+			},
+			"p98": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(int64(model.CPU.Percentile(0.98)*1000.0), resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(int64(model.Memory.Percentile(0.98)), resource.BinarySI),
+			},
+			"max": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(int64(model.CPU.Percentile(1.0)*1000.0), resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(int64(model.Memory.Percentile(1.0)), resource.BinarySI),
+			},
+		},
+	}, nil
+}
+
+func (p *peakPredictServer) gcModels() {
+	if !p.HasSynced() {
+		klog.Infof("wait for the state to be synchronized, skipping the step of model GC")
+		return
+	}
+
+	tobeRemovedModels := make([]UIDType, 0)
+	p.modelsLock.Lock()
+	for uid, model := range p.models {
+		if p.clock.Since(model.LastUpdated) > DefaultModelExpirationTime {
+			delete(p.models, uid)
+			klog.InfoS("gc model", "uid", uid)
+			tobeRemovedModels = append(tobeRemovedModels, uid)
+		}
+	}
+	p.modelsLock.Unlock()
+
+	// do the io operations out of lock
+	for _, uid := range tobeRemovedModels {
+		err := p.checkpointer.Remove(uid)
+		klog.InfoS("remove checkpoint", "uid", uid)
+		if err != nil {
+			klog.Errorf("remove checkpoint %v failed, err: %v", uid, err)
+		}
+	}
+}
+
+func (p *peakPredictServer) doCheckpoint() {
+	if !p.HasSynced() {
+		klog.Infof("wait for the state to be synchronized, skipping the step of model GC")
+		return
+	}
+
+	type pair struct {
+		UID   UIDType
+		Model *PredictModel
+	}
+
+	p.modelsLock.Lock()
+	pairs := make([]pair, 0, len(p.models))
+	for key, model := range p.models {
+		pairs = append(pairs, pair{UID: key, Model: model})
+	}
+	p.modelsLock.Unlock()
+
+	// Sort models and keys by LastCheckpointed time
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Model.LastCheckpointed.Before(pairs[j].Model.LastCheckpointed)
+	})
+
+	checkpointModelsCount := 0
+	for _, pair := range pairs {
+		if checkpointModelsCount >= DefaultModelCheckpointMaxPerStep {
+			break
+		}
+		if p.clock.Since(pair.Model.LastCheckpointed) < DefaultModelCheckpointInterval {
+			break
+		}
+		ckpt := ModelCheckpoint{
+			UID:         pair.UID,
+			LastUpdated: metav1.NewTime(p.clock.Now()),
+		}
+		pair.Model.Lock.Lock()
+		ckpt.CPU, _ = pair.Model.CPU.SaveToCheckpoint()
+		ckpt.Memory, _ = pair.Model.Memory.SaveToCheckpoint()
+		pair.Model.Lock.Unlock()
+
+		err := p.checkpointer.Save(ckpt)
+		if err != nil {
+			klog.Errorf("save checkpoint uid %v failed", pair.UID)
+		} else {
+			klog.InfoS("save checkpoint", "uid", pair.UID)
+		}
+		pair.Model.LastCheckpointed = p.clock.Now()
+		checkpointModelsCount++
+	}
+}
+
+func (p *peakPredictServer) restoreModels() (unknownUIDs []UIDType) {
+	checkpoints, err := p.checkpointer.Restore()
+	if err != nil {
+		klog.Errorf("restore models failed, err %v", err)
+		return
+	}
+
+	knownUIDs := make(map[UIDType]bool)
+	pods := p.informer.ListPods()
+	for _, pod := range pods {
+		knownUIDs[UIDType(pod.UID)] = true
+	}
+	node := p.informer.GetNode()
+	if node != nil {
+		knownUIDs[UIDType(node.UID)] = true
+	}
+
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Error != nil || !knownUIDs[checkpoint.UID] {
+			unknownUIDs = append(unknownUIDs, checkpoint.UID)
+			continue
+		}
+
+		model := &PredictModel{
+			CPU:         defaultCPUHistogram(),
+			Memory:      defaultMemoryHistogram(),
+			LastUpdated: checkpoint.LastUpdated.Time,
+		}
+		if err := model.CPU.LoadFromCheckpoint(checkpoint.CPU); err != nil {
+			klog.Errorf("failed to CPU checkpoint %v, err %v", checkpoint.UID, err)
+		}
+		if err := model.Memory.LoadFromCheckpoint(checkpoint.Memory); err != nil {
+			klog.Errorf("failed to Memory checkpoint %v, err %v", checkpoint.UID, err)
+		}
+		klog.InfoS("restoring checkpoint", "uid", checkpoint.UID, "lastUpdated", checkpoint.LastUpdated)
+		p.modelsLock.Lock()
+		p.models[checkpoint.UID] = model
+		p.modelsLock.Unlock()
+	}
+
+	return unknownUIDs
+}

--- a/pkg/koordlet/prediction/predict_server_test.go
+++ b/pkg/koordlet/prediction/predict_server_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/histogram"
+)
+
+func deltaPer(a, b float64) float64 {
+	return math.Abs(a-b) / b
+}
+
+func TestDefaultHistogram(t *testing.T) {
+	testCases := []struct {
+		hist     histogram.Histogram
+		minValue float64
+		maxValue float64
+	}{
+		{
+			hist:     defaultCPUHistogram(),
+			minValue: 0.05,
+			maxValue: 1024,
+		},
+		{
+			hist:     defaultMemoryHistogram(),
+			minValue: 10 << 20,
+			maxValue: 1 << 31,
+		},
+	}
+
+	now := time.Now()
+	for _, tc := range testCases {
+		tc.hist.AddSample(tc.minValue, 1, now)
+		tc.hist.AddSample(tc.maxValue, 1, now)
+
+		maxValue := tc.hist.Percentile(1.0)
+		if deltaPer(maxValue, tc.maxValue) > DefaultHistogramBucketSizeGrowth {
+			t.Errorf("failed to get max value, expected %v actual %v", tc.maxValue, maxValue)
+		}
+
+		minValue := tc.hist.Percentile(0.0)
+		if deltaPer(minValue, tc.minValue) > DefaultHistogramBucketSizeGrowth {
+			t.Errorf("failed to get min value, expected %v actual %v", tc.minValue, minValue)
+		}
+	}
+}
+
+var _ Informer = &mockInformer{}
+
+type mockInformer struct {
+	Pods []*v1.Pod
+	Node *v1.Node
+}
+
+func (i *mockInformer) HasSynced() bool {
+	return true
+}
+
+func (i *mockInformer) ListPods() []*v1.Pod {
+	return i.Pods
+}
+
+func (i *mockInformer) GetNode() *v1.Node {
+	return i.Node
+}
+
+var _ MetricServer = &mockMetricServer{}
+
+type podUsage struct {
+	PodCPUUsage    float64
+	PodMemoryUsage float64
+}
+
+type mockMetricServer struct {
+	PodUsage        map[UIDType]podUsage
+	NodeCPUUsage    float64
+	NodeMemoryUsage float64
+}
+
+func (ms *mockMetricServer) GetPodMetric(desc MetricDesc, m MetricKey) (float64, error) {
+	usage, ok := ms.PodUsage[desc.UID]
+	if !ok {
+		return 0, fmt.Errorf("pod not found")
+	}
+	switch m {
+	case CPUUsage:
+		return usage.PodCPUUsage, nil
+	case MemoryUsage:
+		return usage.PodMemoryUsage, nil
+	}
+	return 0, fmt.Errorf("unsupported metric: %v", m)
+}
+
+func (ms *mockMetricServer) GetNodeMetric(desc MetricDesc, m MetricKey) (float64, error) {
+	switch m {
+	case CPUUsage:
+		return ms.NodeCPUUsage, nil
+	case MemoryUsage:
+		return ms.NodeMemoryUsage, nil
+	}
+	return 0, fmt.Errorf("unsupported metric: %v", m)
+}
+
+func TestPredictServerMainLoop(t *testing.T) {
+	informer := &mockInformer{}
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			UID:  "node1",
+		},
+		Spec: v1.NodeSpec{},
+	}
+	informer.Node = node
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pod1",
+				UID:       "pod1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pod2",
+				UID:       "pod2",
+			},
+		},
+	}
+	informer.Pods = pods
+
+	metricServer := &mockMetricServer{
+		PodUsage: make(map[UIDType]podUsage),
+	}
+	nodeMemoryUsed := resource.NewQuantity(1024*1024*256, resource.BinarySI)
+	metricServer.NodeMemoryUsage = float64(nodeMemoryUsed.Value())
+	metricServer.PodUsage[UIDType(pods[0].UID)] = podUsage{PodCPUUsage: 1, PodMemoryUsage: 128 * 1024 * 1024}
+	metricServer.PodUsage[UIDType(pods[1].UID)] = podUsage{PodCPUUsage: 3, PodMemoryUsage: 128 * 1024 * 1024}
+
+	peakPrediction := NewPeakPredictServer(nil, nil, Options{})
+	peakPrediction.(*peakPredictServer).informer = informer
+	peakPrediction.(*peakPredictServer).metricServer = metricServer
+
+	stopCh := make(chan struct{})
+	go peakPrediction.Run(stopCh)
+	defer close(stopCh)
+
+	peakPrediction.(*peakPredictServer).training()
+
+	if len(peakPrediction.(*peakPredictServer).models) != 3 {
+		t.Errorf("failed to update models, expected 3, actual %v", len(peakPrediction.(*peakPredictServer).models))
+	}
+
+	gen := &generator{}
+	peak, err := peakPrediction.GetPrediction(MetricDesc{UID: gen.Node(node)})
+	if err != nil {
+		t.Errorf("err %v", err)
+	}
+	p90CPU, ok := peak.Data["p90"][v1.ResourceCPU]
+	if !ok || p90CPU.MilliValue() != 25 {
+		t.Errorf("failed to get node cpu prediction, expected ~25 actual %v", p90CPU.MilliValue())
+	}
+	p90Mem, ok := peak.Data["p90"][v1.ResourceMemory]
+	if !ok || p90Mem.Value() < 10<<20 {
+		t.Errorf("failed to get node memory prediction, expected ~%v actual %v", nodeMemoryUsed.Value(), p90Mem.Value())
+	}
+
+	// add 100 samples
+	for i := 2; i <= 100; i++ {
+		metricServer.PodUsage[UIDType(pods[0].UID)] = podUsage{PodCPUUsage: float64(i), PodMemoryUsage: 128 * 1024 * 1024}
+		peakPrediction.(*peakPredictServer).training()
+	}
+	peak, err = peakPrediction.GetPrediction(MetricDesc{UID: gen.Pod(pods[0])})
+	if err != nil {
+		t.Errorf("err %v", err)
+	}
+	p90CPU, ok = peak.Data["p90"][v1.ResourceCPU]
+	if !ok || p90CPU.MilliValue() < 90 {
+		t.Errorf("failed to get pods cpu prediction, expected ~1000 actual %v", p90CPU.Value())
+	}
+}
+
+func TestPredictServerGCOldModels(t *testing.T) {
+	informer := &mockInformer{}
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			UID:  "node1",
+		},
+		Spec: v1.NodeSpec{},
+	}
+	informer.Node = node
+	informer.Pods = nil
+
+	metricServer := &mockMetricServer{
+		PodUsage: make(map[UIDType]podUsage),
+	}
+	nodeMemoryUsed := resource.NewQuantity(1024*1024*256, resource.BinarySI)
+	metricServer.NodeMemoryUsage = float64(nodeMemoryUsed.Value())
+
+	mockClock := clock.NewFakeClock(time.Now())
+	peakPrediction := NewPeakPredictServer(nil, nil, Options{})
+	peakPrediction.(*peakPredictServer).informer = informer
+	peakPrediction.(*peakPredictServer).metricServer = metricServer
+	peakPrediction.(*peakPredictServer).clock = mockClock
+	peakPrediction.(*peakPredictServer).training()
+
+	modelSize := len(peakPrediction.(*peakPredictServer).models)
+	if modelSize != 1 {
+		t.Errorf("unexpected modelSize, expected 1 actual %v", modelSize)
+	}
+	mockClock.Step(DefaultModelExpirationTime)
+	mockClock.Step(time.Minute)
+	peakPrediction.(*peakPredictServer).gcModels()
+
+	modelSize = len(peakPrediction.(*peakPredictServer).models)
+	if modelSize != 0 {
+		t.Errorf("unexpected modelSize, expected 0 actual %v", modelSize)
+	}
+}
+
+func makeTestHistogram() histogram.Histogram {
+	options, _ := histogram.NewLinearHistogramOptions(100, 1024, 0.001)
+	return histogram.NewHistogram(options)
+}
+
+type mockCheckpointer struct {
+}
+
+func (ckpt *mockCheckpointer) Save(checkpoint ModelCheckpoint) error {
+	return nil
+}
+
+func (ckpt *mockCheckpointer) Remove(UID UIDType) error {
+	return nil
+}
+
+func (ckpt *mockCheckpointer) Restore() ([]*ModelCheckpoint, error) {
+	return nil, nil
+}
+
+func TestDoCheckpoint(t *testing.T) {
+	now := time.Now()
+	predictServer := &peakPredictServer{
+		hasSynced:    &atomic.Bool{},
+		informer:     &mockInformer{},
+		metricServer: &mockMetricServer{},
+		uidGenerator: &generator{},
+		clock:        clock.NewFakeClock(now),
+		models: map[UIDType]*PredictModel{
+			UIDType("model1"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("model2"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+		},
+		checkpointer: &mockCheckpointer{},
+	}
+	predictServer.hasSynced.Store(true)
+	predictServer.doCheckpoint()
+
+	model1 := predictServer.models[UIDType("model1")]
+	assert.Equal(t, now, model1.LastCheckpointed)
+
+	model2 := predictServer.models[UIDType("model2")]
+	assert.Equal(t, now, model2.LastCheckpointed)
+}
+
+func temporarySetInt(v *int, target int) func() {
+	old := *v
+	*v = target
+
+	return func() {
+		*v = old
+	}
+}
+
+func TestDoCheckpoint_MaxPerStep(t *testing.T) {
+	now := time.Now()
+	predictServer := &peakPredictServer{
+		hasSynced:    &atomic.Bool{},
+		informer:     &mockInformer{},
+		metricServer: &mockMetricServer{},
+		uidGenerator: &generator{},
+		clock:        clock.NewFakeClock(now),
+		models: map[UIDType]*PredictModel{
+			UIDType("model1"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("model2"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("model3"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+		},
+		checkpointer: &mockCheckpointer{},
+	}
+	predictServer.hasSynced.Store(true)
+
+	defer temporarySetInt(&DefaultModelCheckpointMaxPerStep, 1)()
+
+	predictServer.doCheckpoint()
+	updatedModelCount := countModelsCheckpointAtTime(predictServer.models, now)
+	assert.Equal(t, 1, updatedModelCount)
+}
+
+func countModelsCheckpointAtTime(models map[UIDType]*PredictModel, t time.Time) int {
+	updatedModelCount := 0
+	for _, model := range models {
+		if model.LastCheckpointed.Equal(t) {
+			updatedModelCount++
+		}
+	}
+	return updatedModelCount
+}
+
+func TestDoCheckpoint_CheckpointInterval(t *testing.T) {
+	now := time.Now()
+	mockClock := clock.NewFakeClock(now)
+	predictServer := &peakPredictServer{
+		hasSynced:    &atomic.Bool{},
+		informer:     &mockInformer{},
+		metricServer: &mockMetricServer{},
+		uidGenerator: &generator{},
+		clock:        mockClock,
+		models: map[UIDType]*PredictModel{
+			UIDType("model1"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("model2"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("model3"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+		},
+		checkpointer: &mockCheckpointer{},
+	}
+	predictServer.hasSynced.Store(true)
+	predictServer.doCheckpoint()
+
+	newTime := now.Add(DefaultModelCheckpointInterval / 2)
+	mockClock.SetTime(newTime)
+	predictServer.doCheckpoint()
+	updatedModelCount := countModelsCheckpointAtTime(predictServer.models, newTime)
+	assert.Equal(t, 0, updatedModelCount)
+
+	newTime = now.Add(DefaultModelCheckpointInterval + time.Minute)
+	mockClock.SetTime(newTime)
+	predictServer.doCheckpoint()
+	updatedModelCount = countModelsCheckpointAtTime(predictServer.models, newTime)
+	assert.Equal(t, 3, updatedModelCount)
+}
+
+func TestDoCheckpoint_RestoreModels(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("/tmp", "checkpoints")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	now := time.Now()
+	mockClock := clock.NewFakeClock(now)
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			UID:  "node1",
+		},
+		Spec: v1.NodeSpec{},
+	}
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pod1",
+				UID:       "pod1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pod2",
+				UID:       "pod2",
+			},
+		},
+	}
+	defer temporarySetInt(&DefaultModelCheckpointMaxPerStep, 5)()
+	predictServer := &peakPredictServer{
+		hasSynced:    &atomic.Bool{},
+		informer:     &mockInformer{Pods: pods, Node: node},
+		metricServer: &mockMetricServer{},
+		uidGenerator: &generator{},
+		clock:        mockClock,
+		models: map[UIDType]*PredictModel{
+			UIDType("node1"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("pod1"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+			UIDType("pod2"): {
+				CPU:    makeTestHistogram(),
+				Memory: makeTestHistogram(),
+			},
+		},
+		checkpointer: NewFileCheckpointer(tempDir),
+	}
+	predictServer.hasSynced.Store(true)
+	predictServer.doCheckpoint()
+
+	// clear the models in memory and restore it
+	predictServer.models = make(map[UIDType]*PredictModel)
+	predictServer.restoreModels()
+	assert.Equal(t, 3, len(predictServer.models), "restore models from checkpoint")
+
+	// mock another model and restore it to unknownUIDs
+	predictServer.models["unknown"] = &PredictModel{
+		CPU:    makeTestHistogram(),
+		Memory: makeTestHistogram(),
+	}
+	predictServer.doCheckpoint()
+	delete(predictServer.models, "unknown")
+
+	unknownUIDs := predictServer.restoreModels()
+	assert.Equal(t, 1, len(unknownUIDs), "unknown uids")
+}

--- a/pkg/koordlet/prediction/prediction.go
+++ b/pkg/koordlet/prediction/prediction.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+type UIDType string
+
+type UIDGenerator interface {
+	Pod(pod *v1.Pod) UIDType
+	Node(node *v1.Node) UIDType
+}
+
+type Options struct {
+	Filepath string
+	// TODO add configs here
+}
+
+// The kubernetes UID is unique within the Pod lifecycle, so use this first. If there
+// are some special scenarios in the future, such as deleting a Pod and creating a Pod
+// with the same name, consider using NamespacedName as the UID.
+type generator struct {
+}
+
+func (gen *generator) Pod(pod *v1.Pod) UIDType {
+	return UIDType(pod.GetUID())
+}
+
+func (gen *generator) Node(node *v1.Node) UIDType {
+	return UIDType(node.GetUID())
+}
+
+type Result struct {
+	// Use different quantile type as key, currently support "p60", "p90", "p95" "p98", "max".
+	Data map[string]v1.ResourceList
+}
+
+// FIXME
+// This is used for the agent's dependence on the basic data structure, and the
+// basic data structure will be reconstructed later to better support testing.
+type Informer interface {
+	HasSynced() bool
+	ListPods() []*v1.Pod
+	GetNode() *v1.Node
+}
+
+func NewInformer(statesInformer statesinformer.StatesInformer) Informer {
+	return &informer{
+		statesInformer: statesInformer,
+	}
+}
+
+type informer struct {
+	statesInformer statesinformer.StatesInformer
+}
+
+func (i *informer) HasSynced() bool {
+	return i.statesInformer.HasSynced()
+}
+
+func (i *informer) ListPods() []*v1.Pod {
+	pods := i.statesInformer.GetAllPods()
+	result := make([]*v1.Pod, len(pods))
+	for i := range pods {
+		result[i] = pods[i].Pod
+	}
+	return result
+}
+
+func (i *informer) GetNode() *v1.Node {
+	return i.statesInformer.GetNode()
+}
+
+type MetricDesc struct {
+	UID UIDType
+}
+
+type MetricKey int
+
+const (
+	CPUUsage MetricKey = iota
+	MemoryUsage
+)
+
+type MetricServer interface {
+	GetPodMetric(desc MetricDesc, m MetricKey) (float64, error)
+	GetNodeMetric(desc MetricDesc, m MetricKey) (float64, error)
+}
+
+func NewMetricServer(metricCache metriccache.MetricCache) MetricServer {
+	return &metricServer{
+		metricCache: metricCache,
+	}
+}
+
+type metricServer struct {
+	metricCache metriccache.MetricCache
+}
+
+func (ms *metricServer) GetPodMetric(desc MetricDesc, m MetricKey) (float64, error) {
+	now := time.Now()
+	start := now.Add(-DefaultTrainingInterval)
+	querier, err := ms.metricCache.Querier(start, now)
+	if err != nil {
+		return 0, err
+	}
+
+	podProperties := metriccache.MetricPropertiesFunc.Pod(string(desc.UID))
+	queryPodMetric := func(m metriccache.MetricResource) (float64, error) {
+		meta, err := m.BuildQueryMeta(podProperties)
+		if err != nil {
+			return 0, err
+		}
+		result := metriccache.DefaultAggregateResultFactory.New(meta)
+		if err = querier.Query(meta, nil, result); err != nil {
+			return 0, err
+		}
+		return result.Value(metriccache.AggregationTypeP90)
+	}
+
+	switch m {
+	case CPUUsage:
+		return queryPodMetric(metriccache.PodCPUUsageMetric)
+	case MemoryUsage:
+		return queryPodMetric(metriccache.PodMemUsageMetric)
+	}
+
+	return 0, fmt.Errorf("unsupported metric: %v", m)
+}
+
+func (ms *metricServer) GetNodeMetric(desc MetricDesc, m MetricKey) (float64, error) {
+	now := time.Now()
+	start := now.Add(-DefaultTrainingInterval)
+	querier, err := ms.metricCache.Querier(start, now)
+	if err != nil {
+		return 0, err
+	}
+
+	queryNodeMetric := func(m metriccache.MetricResource) (float64, error) {
+		meta, err := m.BuildQueryMeta(nil)
+		if err != nil {
+			return 0, err
+		}
+		result := metriccache.DefaultAggregateResultFactory.New(meta)
+		if err = querier.Query(meta, nil, result); err != nil {
+			return 0, err
+		}
+		return result.Value(metriccache.AggregationTypeP90)
+	}
+
+	switch m {
+	case CPUUsage:
+		return queryNodeMetric(metriccache.NodeCPUUsageMetric)
+	case MemoryUsage:
+		return queryNodeMetric(metriccache.NodeMemoryUsageMetric)
+	}
+
+	return 0, fmt.Errorf("unsupported metric: %v", m)
+}

--- a/pkg/koordlet/prediction/prediction_test.go
+++ b/pkg/koordlet/prediction/prediction_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prediction
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	mock_statesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/mockstatesinformer"
+)
+
+func TestInformer(t *testing.T) {
+	pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod1"}}
+	pod2 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod2"}}
+	pod3 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod3"}}
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{UID: "node1"}}
+	podMetaList := []*statesinformer.PodMeta{
+		{
+			Pod: pod1,
+		},
+		{
+			Pod: pod2,
+		},
+		{
+			Pod: pod3,
+		},
+	}
+	ctl := gomock.NewController(t)
+	mockstatesinformer := mock_statesinformer.NewMockStatesInformer(ctl)
+	mockstatesinformer.EXPECT().GetAllPods().Return(podMetaList).AnyTimes()
+	mockstatesinformer.EXPECT().GetNode().Return(node).AnyTimes()
+	mockstatesinformer.EXPECT().HasSynced().Return(true).AnyTimes()
+
+	informer := NewInformer(mockstatesinformer)
+
+	if !informer.HasSynced() {
+		t.Error("Expected HasSynced to return true")
+	}
+
+	pods := informer.ListPods()
+	if len(pods) != 3 {
+		t.Errorf("Expected 3 pods, got %d", len(pods))
+	}
+
+	if informer.GetNode() != node {
+		t.Error("Expected GetNode to return the node")
+	}
+}
+
+func TestUIDGenerator(t *testing.T) {
+	generator := &generator{}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod1"}}
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{UID: "node1"}}
+
+	podUID := generator.Pod(pod)
+	if podUID != "pod1" {
+		t.Errorf("Expected pod UID to be 'pod1', got '%s'", podUID)
+	}
+
+	nodeUID := generator.Node(node)
+	if nodeUID != "node1" {
+		t.Errorf("Expected node UID to be 'node1', got '%s'", nodeUID)
+	}
+}

--- a/pkg/util/histogram/decaying_histogram.go
+++ b/pkg/util/histogram/decaying_histogram.go
@@ -116,8 +116,8 @@ func (h *decayingHistogram) decayFactor(timestamp time.Time) float64 {
 	return math.Exp2(float64(timestamp.Sub(h.referenceTimestamp)) / float64(h.halfLife))
 }
 
-func (h *decayingHistogram) SaveToChekpoint() (*HistogramCheckpoint, error) {
-	checkpoint, err := h.histogram.SaveToChekpoint()
+func (h *decayingHistogram) SaveToCheckpoint() (*HistogramCheckpoint, error) {
+	checkpoint, err := h.histogram.SaveToCheckpoint()
 	if err != nil {
 		return checkpoint, err
 	}

--- a/pkg/util/histogram/decaying_histogram_test.go
+++ b/pkg/util/histogram/decaying_histogram_test.go
@@ -137,7 +137,7 @@ func TestDecayingHistogramSaveToCheckpoint(t *testing.T) {
 	d.AddSample(2, 1, startTime.Add(time.Hour*100))
 	assert.NotEqual(t, d.referenceTimestamp, time.Time{})
 
-	checkpoint, err := d.SaveToChekpoint()
+	checkpoint, err := d.SaveToCheckpoint()
 	assert.NoError(t, err)
 	assert.Equal(t, checkpoint.ReferenceTimestamp, d.referenceTimestamp)
 	// Just check that buckets are not empty, actual testing of bucketing

--- a/pkg/util/histogram/histogram.go
+++ b/pkg/util/histogram/histogram.go
@@ -61,10 +61,10 @@ type Histogram interface {
 	// Returns a human-readable text description of the histogram.
 	String() string
 
-	// SaveToChekpoint returns a representation of the histogram as a
+	// SaveToCheckpoint returns a representation of the histogram as a
 	// HistogramCheckpoint. During conversion buckets with small weights
 	// can be omitted.
-	SaveToChekpoint() (*HistogramCheckpoint, error)
+	SaveToCheckpoint() (*HistogramCheckpoint, error)
 
 	// LoadFromCheckpoint loads data from the checkpoint into the histogram
 	// by appending samples.
@@ -220,7 +220,7 @@ func (h *histogram) updateMinAndMaxBucket() {
 	}
 }
 
-func (h *histogram) SaveToChekpoint() (*HistogramCheckpoint, error) {
+func (h *histogram) SaveToCheckpoint() (*HistogramCheckpoint, error) {
 	result := HistogramCheckpoint{
 		BucketWeights: make(map[int]uint32),
 	}

--- a/pkg/util/histogram/histogram_test.go
+++ b/pkg/util/histogram/histogram_test.go
@@ -135,7 +135,7 @@ func TestHistogramMerge(t *testing.T) {
 
 func TestHistogramSaveToCheckpointEmpty(t *testing.T) {
 	h := NewHistogram(testHistogramOptions)
-	s, err := h.SaveToChekpoint()
+	s, err := h.SaveToCheckpoint()
 	assert.NoError(t, err)
 	assert.Equal(t, 0., s.TotalWeight)
 	assert.Len(t, s.BucketWeights, 0)
@@ -144,7 +144,7 @@ func TestHistogramSaveToCheckpointEmpty(t *testing.T) {
 func TestHistogramSaveToCheckpoint(t *testing.T) {
 	h := NewHistogram(testHistogramOptions)
 	h.AddSample(1, 1, anyTime)
-	s, err := h.SaveToChekpoint()
+	s, err := h.SaveToCheckpoint()
 	assert.NoError(t, err)
 	bucket := testHistogramOptions.FindBucket(1)
 	assert.Equal(t, 1., s.TotalWeight)
@@ -167,7 +167,7 @@ func TestHistogramSaveToCheckpointDropsRelativelySmallValues(t *testing.T) {
 	assert.NotEqualf(t, bucket1, bucket2, "For this test %v and %v have to be stored in different buckets", v1, v2)
 	assert.True(t, w1 < (w2/float64(MaxCheckpointWeight))/2, "w1 to be omitted has to be less than (0.5*w2)/MaxCheckpointWeight")
 
-	s, err := h.SaveToChekpoint()
+	s, err := h.SaveToCheckpoint()
 	assert.NoError(t, err)
 
 	assert.Equal(t, 100001. /*w1+w2*/, s.TotalWeight)
@@ -194,7 +194,7 @@ func TestHistogramSaveToCheckpointForMultipleValues(t *testing.T) {
 
 	assert.Truef(t, areUnique(bucket1, bucket2, bucket3), "For this test values %v have to be stored in different buckets", []float64{v1, v2, v3})
 
-	s, err := h.SaveToChekpoint()
+	s, err := h.SaveToCheckpoint()
 	assert.NoError(t, err)
 	assert.Equal(t, 10051. /*w1 + w2 + w3*/, s.TotalWeight)
 	assert.Len(t, s.BucketWeights, 3)


### PR DESCRIPTION
Ref #1361

This PR contains:
- [x]  collecte metrics and store in the histogram
- [x]  checkpoint histogram and restore

Capture Pod/Node utilization data and update it into the model, and provide the ability to query results.
