### PR TITLE
koord-manager: use GenerationChangedPredicate to prevent unnessary repeated reconcile calls

### DIFF
--- a/pkg/slo-controller/nodemetric/nodemetric_controller.go
+++ b/pkg/slo-controller/nodemetric/nodemetric_controller.go
@@ -27,8 +27,10 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
@@ -179,7 +181,7 @@ func (r *NodeMetricReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	handler := config.NewColocationHandlerForConfigMapEvent(r.Client, *sloconfig.NewDefaultColocationCfg(), r.Recorder)
 	r.cfgCache = handler
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&slov1alpha1.NodeMetric{}).
+		For(&slov1alpha1.NodeMetric{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Node{}}, &EnqueueRequestForNode{}).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler).
 		Named(Name).

--- a/pkg/slo-controller/nodeslo/nodeslo_controller.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_controller.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -203,7 +205,7 @@ func (r *NodeSLOReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	configMapCacheHandler := NewSLOCfgHandlerForConfigMapEvent(r.Client, DefaultSLOCfg(), r.Recorder)
 	r.sloCfgCache = configMapCacheHandler
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&slov1alpha1.NodeSLO{}).
+		For(&slov1alpha1.NodeSLO{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Node{}}, &nodemetric.EnqueueRequestForNode{
 			Client: r.Client,
 		}).


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This predicate will skip update events that have no change in the object's metadata.generation field. The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object. This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
