### PR TITLE
koordlet: refactor statesinformer to solve the circular dependency problem

### DIFF
--- a/pkg/koordlet/config/config.go
+++ b/pkg/koordlet/config/config.go
@@ -38,7 +38,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resmanager"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks"
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	statesinformerimpl "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/impl"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
@@ -53,7 +53,7 @@ type Configuration struct {
 	ConfigMapName      string
 	ConfigMapNamesapce string
 	KubeRestConf       *rest.Config
-	StatesInformerConf *statesinformer.Config
+	StatesInformerConf *statesinformerimpl.Config
 	CollectorConf      *maframework.Config
 	MetricCacheConf    *metriccache.Config
 	ResManagerConf     *resmanager.Config
@@ -67,7 +67,7 @@ func NewConfiguration() *Configuration {
 	return &Configuration{
 		ConfigMapName:      DefaultKoordletConfigMapName,
 		ConfigMapNamesapce: DefaultKoordletConfigMapNamespace,
-		StatesInformerConf: statesinformer.NewDefaultConfig(),
+		StatesInformerConf: statesinformerimpl.NewDefaultConfig(),
 		CollectorConf:      maframework.NewDefaultConfig(),
 		MetricCacheConf:    metriccache.NewDefaultConfig(),
 		ResManagerConf:     resmanager.NewDefaultConfig(),

--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -42,6 +42,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resmanager"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	statesinformerimpl "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/impl"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
@@ -89,7 +90,7 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 		return nil, err
 	}
 
-	statesInformer := statesinformer.NewStatesInformer(config.StatesInformerConf, kubeClient, crdClient, topologyClient, metricCache, nodeName, schedulingClient)
+	statesInformer := statesinformerimpl.NewStatesInformer(config.StatesInformerConf, kubeClient, crdClient, topologyClient, metricCache, nodeName, schedulingClient)
 
 	// setup cgroup path formatter from cgroup driver type
 	var detectCgroupDriver system.CgroupDriverType

--- a/pkg/koordlet/prediction/predict_server_test.go
+++ b/pkg/koordlet/prediction/predict_server_test.go
@@ -288,6 +288,7 @@ func TestDoCheckpoint(t *testing.T) {
 		checkpointer: &mockCheckpointer{},
 	}
 	predictServer.hasSynced.Store(true)
+
 	predictServer.doCheckpoint()
 
 	model1 := predictServer.models[UIDType("model1")]
@@ -375,6 +376,7 @@ func TestDoCheckpoint_CheckpointInterval(t *testing.T) {
 		checkpointer: &mockCheckpointer{},
 	}
 	predictServer.hasSynced.Store(true)
+
 	predictServer.doCheckpoint()
 
 	newTime := now.Add(DefaultModelCheckpointInterval / 2)
@@ -447,6 +449,7 @@ func TestDoCheckpoint_RestoreModels(t *testing.T) {
 		checkpointer: NewFileCheckpointer(tempDir),
 	}
 	predictServer.hasSynced.Store(true)
+
 	predictServer.doCheckpoint()
 
 	// clear the models in memory and restore it

--- a/pkg/koordlet/prediction/predict_server_test.go
+++ b/pkg/koordlet/prediction/predict_server_test.go
@@ -288,7 +288,6 @@ func TestDoCheckpoint(t *testing.T) {
 		checkpointer: &mockCheckpointer{},
 	}
 	predictServer.hasSynced.Store(true)
-
 	predictServer.doCheckpoint()
 
 	model1 := predictServer.models[UIDType("model1")]
@@ -376,7 +375,6 @@ func TestDoCheckpoint_CheckpointInterval(t *testing.T) {
 		checkpointer: &mockCheckpointer{},
 	}
 	predictServer.hasSynced.Store(true)
-
 	predictServer.doCheckpoint()
 
 	newTime := now.Add(DefaultModelCheckpointInterval / 2)
@@ -449,7 +447,6 @@ func TestDoCheckpoint_RestoreModels(t *testing.T) {
 		checkpointer: NewFileCheckpointer(tempDir),
 	}
 	predictServer.hasSynced.Store(true)
-
 	predictServer.doCheckpoint()
 
 	// clear the models in memory and restore it

--- a/pkg/koordlet/statesinformer/impl/callback_runner_test.go
+++ b/pkg/koordlet/statesinformer/impl/callback_runner_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"testing"
@@ -24,11 +24,12 @@ import (
 	"k8s.io/utils/pointer"
 
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 )
 
 func TestRegisterCallbacksAndRun(t *testing.T) {
 	type args struct {
-		objType     RegisterType
+		objType     statesinformer.RegisterType
 		name        string
 		description string
 	}
@@ -39,7 +40,7 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 		{
 			name: "register RegisterTypeNodeSLOSpec and run",
 			args: args{
-				objType:     RegisterTypeNodeSLOSpec,
+				objType:     statesinformer.RegisterTypeNodeSLOSpec,
 				name:        "set-bool-var",
 				description: "set test bool var as true",
 			},
@@ -47,7 +48,7 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 		{
 			name: "register RegisterTypeAllPods and run",
 			args: args{
-				objType:     RegisterTypeAllPods,
+				objType:     statesinformer.RegisterTypeAllPods,
 				name:        "set-bool-var",
 				description: "set test bool var as true",
 			},
@@ -55,7 +56,7 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 		{
 			name: "register RegisterTypeNodeSLOSpec and run",
 			args: args{
-				objType:     RegisterTypeNodeSLOSpec,
+				objType:     statesinformer.RegisterTypeNodeSLOSpec,
 				name:        "set-bool-var",
 				description: "set test bool var as true",
 			},
@@ -64,14 +65,14 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testVar := pointer.Bool(false)
-			callbackFn := func(t RegisterType, obj interface{}, pods []*PodMeta) {
+			callbackFn := func(t statesinformer.RegisterType, obj interface{}, pods []*statesinformer.PodMeta) {
 				*testVar = true
 			}
 			si := &callbackRunner{
-				stateUpdateCallbacks: map[RegisterType][]updateCallback{
-					RegisterTypeNodeSLOSpec:  {},
-					RegisterTypeAllPods:      {},
-					RegisterTypeNodeTopology: {},
+				stateUpdateCallbacks: map[statesinformer.RegisterType][]updateCallback{
+					statesinformer.RegisterTypeNodeSLOSpec:  {},
+					statesinformer.RegisterTypeAllPods:      {},
+					statesinformer.RegisterTypeNodeTopology: {},
 				},
 				statesInformer: &statesInformer{
 					states: &PluginState{
@@ -80,7 +81,7 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 								nodeSLO: &slov1alpha1.NodeSLO{},
 							},
 							podsInformerName: &podsInformer{
-								podMap: map[string]*PodMeta{},
+								podMap: map[string]*statesinformer.PodMeta{},
 							},
 						},
 					},
@@ -105,11 +106,11 @@ func Test_statesInformer_startCallbackRunners(t *testing.T) {
 	}
 	stopCh := make(chan struct{}, 1)
 	type args struct {
-		objType     RegisterType
+		objType     statesinformer.RegisterType
 		nodeSLO     *slov1alpha1.NodeSLO
 		name        string
 		description string
-		fn          UpdateCbFn
+		fn          statesinformer.UpdateCbFn
 	}
 	tests := []struct {
 		name       string
@@ -119,11 +120,11 @@ func Test_statesInformer_startCallbackRunners(t *testing.T) {
 		{
 			name: "callback get nodeslo label",
 			args: args{
-				objType:     RegisterTypeNodeSLOSpec,
+				objType:     statesinformer.RegisterTypeNodeSLOSpec,
 				nodeSLO:     nodeSLO,
 				name:        "get value from node slo label",
 				description: "get value from node slo label",
-				fn: func(t RegisterType, obj interface{}, pods []*PodMeta) {
+				fn: func(t statesinformer.RegisterType, obj interface{}, pods []*statesinformer.PodMeta) {
 					output <- nodeSLO.Labels["test-label-key"]
 					stopCh <- struct{}{}
 				},
@@ -134,10 +135,10 @@ func Test_statesInformer_startCallbackRunners(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cr := &callbackRunner{
-				callbackChans: map[RegisterType]chan UpdateCbCtx{
+				callbackChans: map[statesinformer.RegisterType]chan UpdateCbCtx{
 					tt.args.objType: make(chan UpdateCbCtx, 1),
 				},
-				stateUpdateCallbacks: map[RegisterType][]updateCallback{
+				stateUpdateCallbacks: map[statesinformer.RegisterType][]updateCallback{
 					tt.args.objType: {},
 				},
 			}
@@ -149,7 +150,7 @@ func Test_statesInformer_startCallbackRunners(t *testing.T) {
 							nodeSLO: tt.args.nodeSLO,
 						},
 						podsInformerName: &podsInformer{
-							podMap: map[string]*PodMeta{},
+							podMap: map[string]*statesinformer.PodMeta{},
 						},
 					},
 				},

--- a/pkg/koordlet/statesinformer/impl/config.go
+++ b/pkg/koordlet/statesinformer/impl/config.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"flag"

--- a/pkg/koordlet/statesinformer/impl/config_test.go
+++ b/pkg/koordlet/statesinformer/impl/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"flag"

--- a/pkg/koordlet/statesinformer/impl/extension_utils.go
+++ b/pkg/koordlet/statesinformer/impl/extension_utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/koordlet/statesinformer/impl/kubelet_stub.go
+++ b/pkg/koordlet/statesinformer/impl/kubelet_stub.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"encoding/json"

--- a/pkg/koordlet/statesinformer/impl/kubelet_stub_test.go
+++ b/pkg/koordlet/statesinformer/impl/kubelet_stub_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"encoding/json"

--- a/pkg/koordlet/statesinformer/impl/registry.go
+++ b/pkg/koordlet/statesinformer/impl/registry.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 // NOTE: variables in this file can be overwritten for extension
 

--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"

--- a/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"

--- a/pkg/koordlet/statesinformer/impl/states_device_unsupported.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_unsupported.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 func (s *statesInformer) reportDevice() {
 	return

--- a/pkg/koordlet/statesinformer/impl/states_informer.go
+++ b/pkg/koordlet/statesinformer/impl/states_informer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"fmt"
@@ -36,6 +36,7 @@ import (
 	schedv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 )
 
 const (
@@ -50,13 +51,13 @@ type StatesInformer interface {
 	GetNode() *corev1.Node
 	GetNodeSLO() *slov1alpha1.NodeSLO
 
-	GetAllPods() []*PodMeta
+	GetAllPods() []*statesinformer.PodMeta
 
 	GetNodeTopo() *topov1alpha1.NodeResourceTopology
 
 	GetVolumeName(pvcNamespace, pvcName string) string
 
-	RegisterCallbacks(objType RegisterType, name, description string, callbackFn UpdateCbFn)
+	RegisterCallbacks(objType statesinformer.RegisterType, name, description string, callbackFn statesinformer.UpdateCbFn)
 }
 
 type PluginName string
@@ -226,7 +227,7 @@ func (s *statesInformer) GetNodeTopo() *topov1alpha1.NodeResourceTopology {
 	return nodeTopoInformer.GetNodeTopo()
 }
 
-func (s *statesInformer) GetAllPods() []*PodMeta {
+func (s *statesInformer) GetAllPods() []*statesinformer.PodMeta {
 	podsInformerIf := s.states.informerPlugins[podsInformerName]
 	podsInformer, ok := podsInformerIf.(*podsInformer)
 	if !ok {
@@ -245,6 +246,6 @@ func (s *statesInformer) GetVolumeName(pvcNamespace, pvcName string) string {
 	return pvcInformer.GetVolumeName(pvcNamespace, pvcName)
 }
 
-func (s *statesInformer) RegisterCallbacks(rType RegisterType, name, description string, callbackFn UpdateCbFn) {
+func (s *statesInformer) RegisterCallbacks(rType statesinformer.RegisterType, name, description string, callbackFn statesinformer.UpdateCbFn) {
 	s.states.callbackRunner.RegisterCallbacks(rType, name, description, callbackFn)
 }

--- a/pkg/koordlet/statesinformer/impl/states_informer_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_informer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -34,6 +34,7 @@ import (
 	fakekoordclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
 	fakeschedv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/scheduling/v1alpha1/fake"
 	mock_metriccache "github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache/mockmetriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 )
 
 func Test_statesInformer_GetNode(t *testing.T) {
@@ -176,17 +177,17 @@ func Test_statesInformer_GetNodeTopo(t *testing.T) {
 
 func Test_statesInformer_GetAllPods(t *testing.T) {
 	type fields struct {
-		podMap map[string]*PodMeta
+		podMap map[string]*statesinformer.PodMeta
 	}
 	tests := []struct {
 		name   string
 		fields fields
-		want   []*PodMeta
+		want   []*statesinformer.PodMeta
 	}{
 		{
 			name: "get all pods",
 			fields: fields{
-				podMap: map[string]*PodMeta{
+				podMap: map[string]*statesinformer.PodMeta{
 					"test-pod": {
 						Pod: &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -198,7 +199,7 @@ func Test_statesInformer_GetAllPods(t *testing.T) {
 					},
 				},
 			},
-			want: []*PodMeta{
+			want: []*statesinformer.PodMeta{
 				{
 					Pod: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/koordlet/statesinformer/impl/states_node.go
+++ b/pkg/koordlet/statesinformer/impl/states_node.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"

--- a/pkg/koordlet/statesinformer/impl/states_node_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_node_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"testing"

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -46,6 +46,7 @@ import (
 	clientsetv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/slo/v1alpha1"
 	listerv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
@@ -505,7 +506,7 @@ func (r *nodeMetricInformer) collectNodeAggregateMetric(endTime time.Time, aggre
 	return aggregateUsages
 }
 
-func (r *nodeMetricInformer) collectPodMetric(podMeta *PodMeta, queryParam metriccache.QueryParam) (*slov1alpha1.PodMetricInfo, error) {
+func (r *nodeMetricInformer) collectPodMetric(podMeta *statesinformer.PodMeta, queryParam metriccache.QueryParam) (*slov1alpha1.PodMetricInfo, error) {
 	if podMeta == nil || podMeta.Pod == nil {
 		return nil, fmt.Errorf("invalid pod meta %v", podMeta)
 	}

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -44,6 +44,7 @@ import (
 	listerv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
 	mockmetriccache "github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache/mockmetriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 )
 
@@ -284,7 +285,7 @@ func Test_reporter_sync_with_single_node_metric(t *testing.T) {
 					return mockMetricCache
 				},
 				podsInformer: &podsInformer{
-					podMap: map[string]*PodMeta{
+					podMap: map[string]*statesinformer.PodMeta{
 						"default/test-pod": {
 							Pod: &v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -47,6 +47,7 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/kubelet"
 	"github.com/koordinator-sh/koordinator/pkg/util"
@@ -382,7 +383,7 @@ func (s *nodeTopoInformer) calGuaranteedCpu(usedCPUs map[int32]*extension.CPUInf
 		return nil, err
 	}
 
-	pods := make(map[types.UID]*PodMeta)
+	pods := make(map[types.UID]*statesinformer.PodMeta)
 	managedPods := make(map[types.UID]struct{})
 	for _, podMeta := range s.podsInformer.GetAllPods() {
 		pods[podMeta.Pod.UID] = podMeta
@@ -637,7 +638,7 @@ func (s *nodeTopoInformer) calCPUTopology() (*metriccache.NodeCPUInfo, *extensio
 func (s *nodeTopoInformer) updateNodeTopo(newTopo *v1alpha1.NodeResourceTopology) {
 	s.setNodeTopo(newTopo)
 	klog.V(5).Infof("local node topology info updated %v", newTopo)
-	s.callbackRunner.SendCallback(RegisterTypeNodeTopology)
+	s.callbackRunner.SendCallback(statesinformer.RegisterTypeNodeTopology)
 }
 
 func (s *nodeTopoInformer) setNodeTopo(newTopo *v1alpha1.NodeResourceTopology) {

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -44,6 +44,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
 	mock_metriccache "github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache/mockmetriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
@@ -135,7 +136,7 @@ func Test_nodeResourceTopology_NewAndSetup(t *testing.T) {
 func Test_calGuaranteedCpu(t *testing.T) {
 	testCases := []struct {
 		name              string
-		podMap            map[string]*PodMeta
+		podMap            map[string]*statesinformer.PodMeta
 		checkpointContent string
 		expectedError     bool
 		expectedPodAllocs []extension.PodCPUAlloc
@@ -211,7 +212,7 @@ func Test_calGuaranteedCpu(t *testing.T) {
 				    },
 				    "checksum": 962272150
 				}`,
-			podMap: map[string]*PodMeta{
+			podMap: map[string]*statesinformer.PodMeta{
 				"pod": {
 					Pod: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -331,7 +332,7 @@ func Test_reportNodeTopology(t *testing.T) {
 		},
 	}
 
-	mockPodMeta := map[string]*PodMeta{
+	mockPodMeta := map[string]*statesinformer.PodMeta{
 		"pod1": {
 			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"
@@ -31,6 +31,7 @@ import (
 
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	koordclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	"github.com/koordinator-sh/koordinator/pkg/util/sloconfig"
 )
@@ -104,7 +105,7 @@ func (s *nodeSLOInformer) HasSynced() bool {
 
 func (s *nodeSLOInformer) updateNodeSLOSpec(nodeSLO *slov1alpha1.NodeSLO) {
 	s.setNodeSLOSpec(nodeSLO)
-	s.callbackRunner.SendCallback(RegisterTypeNodeSLOSpec)
+	s.callbackRunner.SendCallback(statesinformer.RegisterTypeNodeSLOSpec)
 }
 
 func (s *nodeSLOInformer) setNodeSLOSpec(nodeSLO *slov1alpha1.NodeSLO) {

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"testing"

--- a/pkg/koordlet/statesinformer/impl/states_pods_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_pods_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"errors"
@@ -36,6 +36,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
@@ -416,7 +417,7 @@ func Test_recordPodResourceMetrics(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		arg  *PodMeta
+		arg  *statesinformer.PodMeta
 	}{
 		{
 			name: "pod meta is invalid",
@@ -424,17 +425,17 @@ func Test_recordPodResourceMetrics(t *testing.T) {
 		},
 		{
 			name: "pod meta is invalid 1",
-			arg:  &PodMeta{},
+			arg:  &statesinformer.PodMeta{},
 		},
 		{
 			name: "record a normally pod",
-			arg: &PodMeta{
+			arg: &statesinformer.PodMeta{
 				Pod: testingPod,
 			},
 		},
 		{
 			name: "record a batch pod",
-			arg: &PodMeta{
+			arg: &statesinformer.PodMeta{
 				Pod: testingBatchPod,
 			},
 		},

--- a/pkg/koordlet/statesinformer/impl/states_pvc.go
+++ b/pkg/koordlet/statesinformer/impl/states_pvc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statesinformer
+package impl
 
 import (
 	"context"

--- a/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
+++ b/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
@@ -28,6 +28,7 @@ import (
 	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	v1alpha10 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	statesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	statesinformerimpl "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/impl"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -202,7 +203,7 @@ func (mr *MockinformerPluginMockRecorder) HasSynced() *gomock.Call {
 }
 
 // Setup mocks base method.
-func (m *MockinformerPlugin) Setup(ctx *statesinformer.PluginOption, state *statesinformer.PluginState) {
+func (m *MockinformerPlugin) Setup(ctx *statesinformerimpl.PluginOption, state *statesinformerimpl.PluginState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Setup", ctx, state)
 }


### PR DESCRIPTION
Part of #1361 

Separate the interface and implementation of stateinformer to solve the problem of circular dependency. The current abstraction of stateinformer still has some problems, which will not be resolved for the time being.