### PR TITLE
koordlet: fix can not collect psi metrics

### DIFF
--- a/pkg/koordlet/util/system/cgroup_driver.go
+++ b/pkg/koordlet/util/system/cgroup_driver.go
@@ -193,7 +193,19 @@ var cgroupPathFormatterInCgroupfs = formatter{
 }
 
 // CgroupPathFormatter uses the Systemd cgroup driver by default.
-var CgroupPathFormatter = cgroupPathFormatterInSystemd
+var CgroupPathFormatter = GetCgroupFormatter()
+
+func GetCgroupPathFormatter(driver CgroupDriverType) formatter {
+	switch driver {
+	case Systemd:
+		return cgroupPathFormatterInSystemd
+	case Cgroupfs:
+		return cgroupPathFormatterInCgroupfs
+	default:
+		klog.Warningf("cgroup driver formatter not supported: '%s'", string(driver))
+		return cgroupPathFormatterInSystemd
+	}
+}
 
 func SetupCgroupPathFormatter(driver CgroupDriverType) {
 	switch driver {

--- a/pkg/koordlet/util/system/cgroup_driver_linux.go
+++ b/pkg/koordlet/util/system/cgroup_driver_linux.go
@@ -22,19 +22,24 @@ package system
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/userns"
-
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -45,6 +50,49 @@ var (
 	isUnifiedOnce sync.Once
 	isUnified     bool
 )
+
+func GetCgroupFormatter() formatter {
+	klog.Infoln("start to get cgroup driver formatter...")
+	// setup cgroup path formatter from cgroup driver type
+	var detectCgroupDriver CgroupDriverType
+	nodeName := os.Getenv("NODE_NAME")
+	if pollErr := wait.PollImmediate(time.Second*10, time.Minute, func() (bool, error) {
+		driver := GuessCgroupDriverFromCgroupName()
+		if driver.Validate() {
+			detectCgroupDriver = driver
+			return true, nil
+		}
+		klog.Infof("can not detect cgroup driver from 'kubepods' cgroup name")
+
+		cfg, err := config.GetConfig()
+		if err != nil {
+			klog.Errorf("failed to get rest config.err=%v", err)
+			return false, nil
+		}
+		kubeClient := clientset.NewForConfigOrDie(cfg)
+		node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil || node == nil {
+			klog.Errorf("Can't get node, err: %v", err)
+			return false, nil
+		}
+
+		port := int(node.Status.DaemonEndpoints.KubeletEndpoint.Port)
+		if driver, err := GuessCgroupDriverFromKubeletPort(port); err == nil && driver.Validate() {
+			detectCgroupDriver = driver
+			return true, nil
+		} else {
+			klog.Errorf("guess kubelet cgroup driver failed, retry...: %v", err)
+			return false, nil
+		}
+	}); pollErr != nil {
+		klog.Errorf("can not detect kubelet cgroup driver: %v", pollErr)
+		return cgroupPathFormatterInSystemd
+	}
+
+	klog.Infof("Node %s use '%s' as cgroup driver", nodeName, string(detectCgroupDriver))
+
+	return GetCgroupPathFormatter(detectCgroupDriver)
+}
 
 func GuessCgroupDriverFromCgroupName() CgroupDriverType {
 	systemdKubepodDirExists := FileExists(filepath.Join(GetRootCgroupSubfsDir(CgroupCPUDir), KubeRootNameSystemd))

--- a/pkg/koordlet/util/system/cgroup_driver_linux_test.go
+++ b/pkg/koordlet/util/system/cgroup_driver_linux_test.go
@@ -90,3 +90,68 @@ func Test_GuessCgroupDriverFromCgroupName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCgroupFormatter(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       formatter
+		preHandle  func(cgroupRootDir string)
+		isCgroupV2 bool
+	}{
+		{
+			name:      "neither kubepods nor kubepods.slice exists",
+			want:      cgroupPathFormatterInSystemd,
+			preHandle: func(cgroupRootDir string) {},
+		},
+		{
+			name: "only have kubepods dir",
+			want: cgroupPathFormatterInCgroupfs,
+			preHandle: func(cgroupRootDir string) {
+				os.MkdirAll(filepath.Join(cgroupRootDir, "cpu", "kubepods"), 0755)
+			},
+		},
+		{
+			name: "only have kubepods.slice dir",
+			want: cgroupPathFormatterInSystemd,
+			preHandle: func(cgroupRootDir string) {
+				os.MkdirAll(filepath.Join(cgroupRootDir, "cpu", "kubepods.slice"), 0755)
+			},
+		},
+		{
+			name: "both kubepods and kubepods.slice exists",
+			want: cgroupPathFormatterInSystemd,
+			preHandle: func(cgroupRootDir string) {
+				os.MkdirAll(filepath.Join(cgroupRootDir, "cpu", "kubepods"), 0755)
+				os.MkdirAll(filepath.Join(cgroupRootDir, "cpu", "kubepods.slice"), 0755)
+			},
+		},
+		{
+			name: "only have kubepods dir in cgroupv2",
+			want: cgroupPathFormatterInCgroupfs,
+			preHandle: func(cgroupRootDir string) {
+				os.MkdirAll(filepath.Join(cgroupRootDir, "kubepods"), 0755)
+			},
+			isCgroupV2: true,
+		},
+		{
+			name: "only have kubepods.slice dir in cgroupv2",
+			want: cgroupPathFormatterInSystemd,
+			preHandle: func(cgroupRootDir string) {
+				os.MkdirAll(filepath.Join(cgroupRootDir, "kubepods.slice"), 0755)
+			},
+			isCgroupV2: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := NewFileTestUtil(t)
+			defer helper.Cleanup()
+			helper.SetCgroupsV2(tt.isCgroupV2)
+			tmpCgroupRoot := helper.TempDir
+			tt.preHandle(tmpCgroupRoot)
+
+			got := GetCgroupFormatter()
+			assert.Equal(t, tt.want.ParentDir, got.ParentDir)
+		})
+	}
+}

--- a/pkg/koordlet/util/system/cgroup_driver_unsupported.go
+++ b/pkg/koordlet/util/system/cgroup_driver_unsupported.go
@@ -30,3 +30,7 @@ func GuessCgroupDriverFromKubeletPort(int) (CgroupDriverType, error) {
 func IsUsingCgroupsV2() bool {
 	return false
 }
+
+func GetCgroupFormatter() formatter {
+	return cgroupPathFormatterInSystemd
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
koordlet can not collect psi metrics.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
1. kernel with psi feature on
```bash
sudo grubby --update-kernel="/boot/vmlinuz-4.19.91-24.8.an8.x86_64" --args="psi=1 psi_v1=1"
```
`update-kernel` need to be replaced with the actual kernel version
![截屏2023-06-21 10 31 51](https://github.com/koordinator-sh/koordinator/assets/32814765/885a882a-915e-4c6b-8a49-83a3f7ff5dc1)

2. open koordlet's feature for collecting psi metrics.
```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: koordlet
spec:
  template:
    spec:
      containers:
        - name: koordlet
          image: registry.cn-beijing.aliyuncs.com/koordinator-sh/koordlet:v1.2.0
          command:
            - /koordlet
          args:
            - '-cgroup-root-dir=/host-cgroup/'
            - >-
              -feature-gates=BECPUEvict=true,BEMemoryEvict=true,CgroupReconcile=true,Accelerators=true,CPICollector=true,PSICollector=true
            - '-runtime-hooks-host-endpoint=/var/run/koordlet/koordlet.sock'
            - '--logtostderr=true'
            - '--v=4'
```
3. then we can see
  3.1. Access to koordlet's metrics api, but didn't get any info about psi
  3.2. check koordlet's log:
![截屏2023-06-20 17 04 19](https://github.com/koordinator-sh/koordinator/assets/32814765/ea6cd768-eee6-474d-9988-5cc79de83851)
It seems to be saying that there are no pressure related files under cpuacct cgroup
  3.3. looking at the cgroup, we can see that psi-related files exist
![截屏2023-06-21 10 35 30](https://github.com/koordinator-sh/koordinator/assets/32814765/a7254308-5280-4d6b-9b7f-9220a3879cf5)

then there may be a problem with koordlet handling

The essential cause of the problem： 
In golang, global variables are initialized before normal functions, so even though there is logic in the koordlet that modifies `CgroupPathFormatter`, the initialization of global variables only happens once and before the modification, so the logic in `SupportedIfFileExistsInKubepods` will use `cgroupPathFormatterInSystemd`, then the file related to psi can not be find, then making koordlet decide not support psi.
 
![截屏2023-06-21 11 07 10](https://github.com/koordinator-sh/koordinator/assets/32814765/fc5d6691-effc-4f0e-b2ce-cbf70a034c9c)

![截屏2023-06-21 11 14 00](https://github.com/koordinator-sh/koordinator/assets/32814765/1d861426-314f-4726-b71c-5ab0bf3681bb)


### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
