### PR TITLE
koordlet: exclude LSE from share cpu pool

### DIFF
--- a/pkg/koordlet/resmanager/cpu_burst.go
+++ b/pkg/koordlet/resmanager/cpu_burst.go
@@ -274,18 +274,18 @@ func (b *CPUBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 	sharePoolCPUCoresUsage := nodeCPUCoresUsage
 	for _, podMeta := range podsMeta {
 		podQOS := apiext.GetPodQoSClass(podMeta.Pod)
-		// exclude LSR pod cpu from cpu share pool
-		if podQOS == apiext.QoSLSR {
+		// exclude LSE/LSR pod cpu from cpu share pool
+		if podQOS == apiext.QoSLSE || podQOS == apiext.QoSLSR {
 			podRequest := util.GetPodRequest(podMeta.Pod)
 			sharePoolCPUCoresTotal -= float64(podRequest.Cpu().MilliValue()) / 1000
 		}
 
-		// exclude LSR and BE pod cpu usage from cpu share pool
+		// exclude LSE/LSR/BE pod cpu usage from cpu share pool
 		podMetric, exist := podMetricMap[string(podMeta.Pod.UID)]
 		if !exist {
 			continue
 		}
-		if podQOS == apiext.QoSLSR || podQOS == apiext.QoSBE {
+		if podQOS == apiext.QoSLSE || podQOS == apiext.QoSLSR || podQOS == apiext.QoSBE {
 			sharePoolCPUCoresUsage -= podMetric
 		}
 	} // end for podsMeta


### PR DESCRIPTION
we have definition of share cpu pool which should exclude LSE; while calculate share pool cpu usage, we should exclude LSR. see https://koordinator.sh/zh-Hans/docs/architecture/qos

### Ⅰ. Describe what this PR does

#1403 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
