### PR TITLE
koord-scheduler: fix pod outside reservation unexpected preemption

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -372,7 +372,8 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity)
 		}
 
-		if preemptible := state.preemptible[node.Name]; len(preemptible) > 0 {
+		if len(state.preemptible[node.Name]) > 0 || len(state.preemptibleInRRs[node.Name]) > 0 {
+			preemptible := state.preemptible[node.Name]
 			preemptibleResource := framework.NewResource(preemptible)
 			nodeFits := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, nil, preemptibleResource)
 			if !nodeFits {

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -716,6 +716,47 @@ func Test_filterWithReservations(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
+			name: "filter non-reservations with preemption but no preemptible resources",
+			stateData: &stateData{
+				podRequestsResources: &framework.Resource{
+					MilliCPU: 4 * 1000,
+				},
+				preemptible: map[string]corev1.ResourceList{},
+				nodeReservationStates: map[string]nodeReservationState{
+					node.Name: {
+						podRequested: &framework.Resource{
+							MilliCPU: 32 * 1000,
+						},
+					},
+				},
+			},
+			wantStatus: nil,
+		},
+		{
+			name: "filter non-reservations with preemption but no preemptible resources and have preemptibleInRR",
+			stateData: &stateData{
+				podRequestsResources: &framework.Resource{
+					MilliCPU: 4 * 1000,
+				},
+				preemptible: map[string]corev1.ResourceList{},
+				preemptibleInRRs: map[string]map[types.UID]corev1.ResourceList{
+					node.Name: {
+						"123456": {
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+				nodeReservationStates: map[string]nodeReservationState{
+					node.Name: {
+						podRequested: &framework.Resource{
+							MilliCPU: 32 * 1000,
+						},
+					},
+				},
+			},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPreemptionFailed),
+		},
+		{
 			name: "filter non-reservations with preemption",
 			stateData: &stateData{
 				podRequestsResources: &framework.Resource{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fix a missing test case: If there are only Pods using Reservation on a node as preemption candidate instances, `state.preemptible` will be nil at this time, resulting in a false positive that can be preempted.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1405

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
