### PR TITLE
koord-scheduler: clean up the adaptation code in NodeNUMAResource

### DIFF
--- a/apis/extension/priority.go
+++ b/apis/extension/priority.go
@@ -33,6 +33,10 @@ const (
 	PriorityNone  PriorityClass = ""
 )
 
+var (
+	DefaultPriorityClass = PriorityNone
+)
+
 // Define Koordinator priority as a variable value to support customizing different priority ranges
 var (
 	PriorityProdValueMax int32 = 9999
@@ -71,7 +75,7 @@ func getPriorityClassByPriority(priority *int32) PriorityClass {
 		return PriorityFree
 	}
 
-	return PriorityNone
+	return DefaultPriorityClass
 }
 
 // GetPodSubPriority get pod's sub-priority in Koordinator from label

--- a/apis/extension/resource.go
+++ b/apis/extension/resource.go
@@ -149,6 +149,20 @@ func GetResourceSpec(annotations map[string]string) (*ResourceSpec, error) {
 	return resourceSpec, nil
 }
 
+func SetResourceSpec(obj metav1.Object, spec *ResourceSpec) error {
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[AnnotationResourceSpec] = string(data)
+	obj.SetAnnotations(annotations)
+	return nil
+}
+
 // GetResourceStatus parses ResourceStatus from annotations
 func GetResourceStatus(annotations map[string]string) (*ResourceStatus, error) {
 	resourceStatus := &ResourceStatus{}

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -108,17 +108,17 @@ type NodeNUMAResourceArgs struct {
 }
 
 // CPUBindPolicy defines the CPU binding policy
-type CPUBindPolicy = extension.CPUBindPolicy
+type CPUBindPolicy = string
 
 const (
 	// CPUBindPolicyDefault performs the default bind policy that specified in koord-scheduler configuration
-	CPUBindPolicyDefault CPUBindPolicy = extension.CPUBindPolicyDefault
+	CPUBindPolicyDefault = CPUBindPolicy(extension.CPUBindPolicyDefault)
 	// CPUBindPolicyFullPCPUs favor cpuset allocation that pack in few physical cores
-	CPUBindPolicyFullPCPUs CPUBindPolicy = extension.CPUBindPolicyFullPCPUs
+	CPUBindPolicyFullPCPUs = CPUBindPolicy(extension.CPUBindPolicyFullPCPUs)
 	// CPUBindPolicySpreadByPCPUs favor cpuset allocation that evenly allocate logical cpus across physical cores
-	CPUBindPolicySpreadByPCPUs CPUBindPolicy = extension.CPUBindPolicySpreadByPCPUs
+	CPUBindPolicySpreadByPCPUs = CPUBindPolicy(extension.CPUBindPolicySpreadByPCPUs)
 	// CPUBindPolicyConstrainedBurst constrains the CPU Shared Pool range of the Burstable Pod
-	CPUBindPolicyConstrainedBurst CPUBindPolicy = extension.CPUBindPolicyConstrainedBurst
+	CPUBindPolicyConstrainedBurst = CPUBindPolicy(extension.CPUBindPolicyConstrainedBurst)
 )
 
 type CPUExclusivePolicy = extension.CPUExclusivePolicy

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -106,8 +106,8 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 
 // SetDefaults_NodeNUMAResourceArgs sets the default parameters for NodeNUMANodeResource plugin.
 func SetDefaults_NodeNUMAResourceArgs(obj *NodeNUMAResourceArgs) {
-	if obj.DefaultCPUBindPolicy == "" {
-		obj.DefaultCPUBindPolicy = defaultPreferredCPUBindPolicy
+	if obj.DefaultCPUBindPolicy == nil {
+		obj.DefaultCPUBindPolicy = &defaultPreferredCPUBindPolicy
 	}
 	if obj.ScoringStrategy == nil {
 		obj.ScoringStrategy = defaultNodeNUMAResourceScoringStrategy

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -99,22 +99,22 @@ type ScoringStrategy struct {
 type NodeNUMAResourceArgs struct {
 	metav1.TypeMeta
 
-	DefaultCPUBindPolicy CPUBindPolicy    `json:"defaultCPUBindPolicy,omitempty"`
+	DefaultCPUBindPolicy *CPUBindPolicy   `json:"defaultCPUBindPolicy,omitempty"`
 	ScoringStrategy      *ScoringStrategy `json:"scoringStrategy,omitempty"`
 }
 
 // CPUBindPolicy defines the CPU binding policy
-type CPUBindPolicy = extension.CPUBindPolicy
+type CPUBindPolicy = string
 
 const (
 	// CPUBindPolicyDefault performs the default bind policy that specified in koord-scheduler configuration
-	CPUBindPolicyDefault CPUBindPolicy = extension.CPUBindPolicyDefault
+	CPUBindPolicyDefault = CPUBindPolicy(extension.CPUBindPolicyDefault)
 	// CPUBindPolicyFullPCPUs favor cpuset allocation that pack in few physical cores
-	CPUBindPolicyFullPCPUs CPUBindPolicy = extension.CPUBindPolicyFullPCPUs
+	CPUBindPolicyFullPCPUs = CPUBindPolicy(extension.CPUBindPolicyFullPCPUs)
 	// CPUBindPolicySpreadByPCPUs favor cpuset allocation that evenly allocate logical cpus across physical cores
-	CPUBindPolicySpreadByPCPUs CPUBindPolicy = extension.CPUBindPolicySpreadByPCPUs
+	CPUBindPolicySpreadByPCPUs = CPUBindPolicy(extension.CPUBindPolicySpreadByPCPUs)
 	// CPUBindPolicyConstrainedBurst constrains the CPU Shared Pool range of the Burstable Pod
-	CPUBindPolicyConstrainedBurst CPUBindPolicy = extension.CPUBindPolicyConstrainedBurst
+	CPUBindPolicyConstrainedBurst = CPUBindPolicy(extension.CPUBindPolicyConstrainedBurst)
 )
 
 type CPUExclusivePolicy = extension.CPUExclusivePolicy

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta2
 import (
 	unsafe "unsafe"
 
-	extension "github.com/koordinator-sh/koordinator/apis/extension"
 	v1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	config "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	corev1 "k8s.io/api/core/v1"
@@ -297,7 +296,9 @@ func Convert_config_LoadAwareSchedulingArgs_To_v1beta2_LoadAwareSchedulingArgs(i
 }
 
 func autoConvert_v1beta2_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in *NodeNUMAResourceArgs, out *config.NodeNUMAResourceArgs, s conversion.Scope) error {
-	out.DefaultCPUBindPolicy = extension.CPUBindPolicy(in.DefaultCPUBindPolicy)
+	if err := v1.Convert_Pointer_string_To_string(&in.DefaultCPUBindPolicy, &out.DefaultCPUBindPolicy, s); err != nil {
+		return err
+	}
 	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	return nil
 }
@@ -308,7 +309,9 @@ func Convert_v1beta2_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in *Nod
 }
 
 func autoConvert_config_NodeNUMAResourceArgs_To_v1beta2_NodeNUMAResourceArgs(in *config.NodeNUMAResourceArgs, out *NodeNUMAResourceArgs, s conversion.Scope) error {
-	out.DefaultCPUBindPolicy = extension.CPUBindPolicy(in.DefaultCPUBindPolicy)
+	if err := v1.Convert_string_To_Pointer_string(&in.DefaultCPUBindPolicy, &out.DefaultCPUBindPolicy, s); err != nil {
+		return err
+	}
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	return nil
 }

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -262,6 +262,11 @@ func (in *LoadAwareSchedulingArgs) DeepCopyObject() runtime.Object {
 func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DefaultCPUBindPolicy != nil {
+		in, out := &in.DefaultCPUBindPolicy, &out.DefaultCPUBindPolicy
+		*out = new(string)
+		**out = **in
+	}
 	if in.ScoringStrategy != nil {
 		in, out := &in.ScoringStrategy, &out.ScoringStrategy
 		*out = new(ScoringStrategy)

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -57,22 +57,6 @@ const (
 )
 
 var (
-	GetResourceSpec   = extension.GetResourceSpec
-	GetResourceStatus = extension.GetResourceStatus
-	SetResourceStatus = extension.SetResourceStatus
-	GetPodQoSClass    = extension.GetPodQoSClass
-	GetPriorityClass  = extension.GetPriorityClass
-	AllowUseCPUSet    = func(pod *corev1.Pod) bool {
-		if pod == nil {
-			return false
-		}
-		qosClass := GetPodQoSClass(pod)
-		priorityClass := GetPriorityClass(pod)
-		return (qosClass == extension.QoSLSE || qosClass == extension.QoSLSR) && priorityClass == extension.PriorityProd
-	}
-)
-
-var (
 	_ framework.EnqueueExtensions = &Plugin{}
 
 	_ framework.PreFilterPlugin = &Plugin{}
@@ -95,20 +79,13 @@ type Plugin struct {
 type Option func(*pluginOptions)
 
 type pluginOptions struct {
-	topologyManager    CPUTopologyManager
-	customSyncTopology bool
-	cpuManager         CPUManager
+	topologyManager CPUTopologyManager
+	cpuManager      CPUManager
 }
 
 func WithCPUTopologyManager(topologyManager CPUTopologyManager) Option {
 	return func(opts *pluginOptions) {
 		opts.topologyManager = topologyManager
-	}
-}
-
-func WithCustomSyncTopology(customSyncTopology bool) Option {
-	return func(options *pluginOptions) {
-		options.customSyncTopology = customSyncTopology
 	}
 }
 
@@ -138,10 +115,8 @@ func NewWithOptions(args runtime.Object, handle framework.Handle, opts ...Option
 		options.cpuManager = NewCPUManager(handle, defaultNUMAAllocateStrategy, options.topologyManager)
 	}
 
-	if !options.customSyncTopology {
-		if err := registerNodeResourceTopologyEventHandler(handle, options.topologyManager); err != nil {
-			return nil, err
-		}
+	if err := registerNodeResourceTopologyEventHandler(handle, options.topologyManager); err != nil {
+		return nil, err
 	}
 	registerPodEventHandler(handle, options.cpuManager)
 
@@ -215,7 +190,7 @@ func (p *Plugin) EventsToRegister() []framework.ClusterEvent {
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) (*framework.PreFilterResult, *framework.Status) {
-	resourceSpec, err := GetResourceSpec(pod.Annotations)
+	resourceSpec, err := extension.GetResourceSpec(pod.Annotations)
 	if err != nil {
 		return nil, framework.NewStatus(framework.Error, err.Error())
 	}
@@ -224,7 +199,7 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 		skip: true,
 	}
 	if AllowUseCPUSet(pod) {
-		preferredCPUBindPolicy := resourceSpec.PreferredCPUBindPolicy
+		preferredCPUBindPolicy := schedulingconfig.CPUBindPolicy(resourceSpec.PreferredCPUBindPolicy)
 		if preferredCPUBindPolicy == "" || preferredCPUBindPolicy == schedulingconfig.CPUBindPolicyDefault {
 			preferredCPUBindPolicy = p.pluginArgs.DefaultCPUBindPolicy
 		}
@@ -248,6 +223,15 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 
 	cycleState.Write(stateKey, state)
 	return nil, nil
+}
+
+func AllowUseCPUSet(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	qosClass := extension.GetPodQoSClass(pod)
+	priorityClass := extension.GetPriorityClass(pod)
+	return (qosClass == extension.QoSLSE || qosClass == extension.QoSLSR) && priorityClass == extension.PriorityProd
 }
 
 func (p *Plugin) PreFilterExtensions() framework.PreFilterExtensions {
@@ -432,11 +416,12 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState *framework.CycleS
 
 	annotations := object.GetAnnotations()
 	// Write back ResourceSpec annotation if LSR Pod hasn't specified CPUBindPolicy
-	if state.resourceSpec.PreferredCPUBindPolicy == "" ||
-		state.resourceSpec.PreferredCPUBindPolicy == schedulingconfig.CPUBindPolicyDefault ||
-		state.resourceSpec.PreferredCPUBindPolicy != state.preferredCPUBindPolicy {
+	preferredCPUBindPolicy := schedulingconfig.CPUBindPolicy(state.resourceSpec.PreferredCPUBindPolicy)
+	if preferredCPUBindPolicy == "" ||
+		preferredCPUBindPolicy == schedulingconfig.CPUBindPolicyDefault ||
+		preferredCPUBindPolicy != state.preferredCPUBindPolicy {
 		resourceSpec := &extension.ResourceSpec{
-			PreferredCPUBindPolicy: state.preferredCPUBindPolicy,
+			PreferredCPUBindPolicy: extension.CPUBindPolicy(state.preferredCPUBindPolicy),
 		}
 		resourceSpecData, err := json.Marshal(resourceSpec)
 		if err != nil {
@@ -450,7 +435,7 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState *framework.CycleS
 	}
 
 	resourceStatus := &extension.ResourceStatus{CPUSet: state.allocatedCPUs.String()}
-	if err := SetResourceStatus(object, resourceStatus); err != nil {
+	if err := extension.SetResourceStatus(object, resourceStatus); err != nil {
 		return framework.AsStatus(err)
 	}
 	return nil

--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/util"
@@ -99,7 +100,7 @@ func (c *podEventHandler) updatePod(oldPod, pod *corev1.Pod) {
 		return
 	}
 
-	resourceStatus, err := GetResourceStatus(pod.Annotations)
+	resourceStatus, err := extension.GetResourceStatus(pod.Annotations)
 	if err != nil {
 		return
 	}
@@ -108,7 +109,7 @@ func (c *podEventHandler) updatePod(oldPod, pod *corev1.Pod) {
 		return
 	}
 
-	resourceSpec, err := GetResourceSpec(pod.Annotations)
+	resourceSpec, err := extension.GetResourceSpec(pod.Annotations)
 	if err != nil {
 		return
 	}
@@ -121,7 +122,7 @@ func (c *podEventHandler) deletePod(pod *corev1.Pod) {
 		return
 	}
 
-	resourceStatus, err := GetResourceStatus(pod.Annotations)
+	resourceStatus, err := extension.GetResourceStatus(pod.Annotations)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Now because there is a better compatibility mechanism compatible with internal already existing Pods, the adaptation code implemented by the NodeNUMAResource plugin can be removed.

And in order to support internal compatible implementations, it is allowed to disable `NodeNUMAResourceArgs.DefaultCPUBindPolicy`.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
