### PR TITLE
koordlet: add various configurations to the prediction package

### DIFF
--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -89,7 +89,7 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 		return nil, err
 	}
 	predictServer := prediction.NewPeakPredictServer(config.PredictionConf)
-	predictorFactory := prediction.NewPredictorFactory(predictServer, config.PredictionConf.PredictionColdStartDuration)
+	predictorFactory := prediction.NewPredictorFactory(predictServer, config.PredictionConf.ColdStartDuration, config.PredictionConf.SafetyMarginPercent)
 
 	statesInformer := statesinformerimpl.NewStatesInformer(config.StatesInformerConf, kubeClient, crdClient, topologyClient, metricCache, nodeName, schedulingClient, predictorFactory)
 	collectorService := metricsadvisor.NewMetricAdvisor(config.CollectorConf, statesInformer, metricCache)

--- a/pkg/koordlet/prediction/config.go
+++ b/pkg/koordlet/prediction/config.go
@@ -22,18 +22,39 @@ import (
 )
 
 type Config struct {
-	PredictionCheckpointFilepath string
-	PredictionColdStartDuration  time.Duration
+	CheckpointFilepath           string
+	ColdStartDuration            time.Duration
+	SafetyMarginPercent          int
+	MemoryHistogramDecayHalfLife time.Duration
+	CPUHistogramDecayHalfLife    time.Duration
+	TrainingInterval             time.Duration
+	ModelExpirationDuration      time.Duration
+	ModelCheckpointInterval      time.Duration
+	ModelCheckpointMaxPerStep    int
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		PredictionCheckpointFilepath: "/prediction-checkpoints",
-		PredictionColdStartDuration:  24 * time.Hour,
+		CheckpointFilepath:           "/prediction-checkpoints",
+		ColdStartDuration:            24 * time.Hour,
+		SafetyMarginPercent:          10,
+		MemoryHistogramDecayHalfLife: 24 * time.Hour,
+		CPUHistogramDecayHalfLife:    12 * time.Hour,
+		TrainingInterval:             time.Minute,
+		ModelExpirationDuration:      30 * time.Minute,
+		ModelCheckpointInterval:      10 * time.Minute,
+		ModelCheckpointMaxPerStep:    12,
 	}
 }
 
 func (c *Config) InitFlags(fs *flag.FlagSet) {
-	fs.StringVar(&c.PredictionCheckpointFilepath, "prediction-checkpoint-filepath", c.PredictionCheckpointFilepath, "The filepath is used to store the checkpoints of the prediction system's state.")
-	fs.DurationVar(&c.PredictionColdStartDuration, "prediction-cold-start-duration", c.PredictionColdStartDuration, "Cold start refers to the period of time after a Pod starts and enters into a stable state")
+	fs.StringVar(&c.CheckpointFilepath, "prediction-checkpoint-filepath", c.CheckpointFilepath, "The filepath is used to store the checkpoints of the prediction system's state.")
+	fs.DurationVar(&c.ColdStartDuration, "prediction-cold-start-duration", c.ColdStartDuration, "Cold start refers to the period of time after a Pod starts and enters into a stable state")
+	fs.IntVar(&c.SafetyMarginPercent, "prediction-safety-margin-percent", c.SafetyMarginPercent, "The redundancy preserved above peak prediction")
+	fs.DurationVar(&c.MemoryHistogramDecayHalfLife, "prediction-memory-histogram-decay-halflife", c.MemoryHistogramDecayHalfLife, "Half-life, the older the data, the lower the weight")
+	fs.DurationVar(&c.CPUHistogramDecayHalfLife, "prediction-cpu-histogram-decay-halflife", c.CPUHistogramDecayHalfLife, "Half-life, the older the data, the lower the weight")
+	fs.DurationVar(&c.TrainingInterval, "prediction-training-interval", c.TrainingInterval, "Period of prediction model update")
+	fs.DurationVar(&c.ModelExpirationDuration, "prediction-model-expiration-duration", c.ModelExpirationDuration, "Expiration of prediction model without updated")
+	fs.DurationVar(&c.ModelCheckpointInterval, "prediction-model-checkpoint-interval", c.ModelCheckpointInterval, "Interval of prediction model take checkpoint")
+	fs.IntVar(&c.ModelCheckpointMaxPerStep, "prediction-model-checkpoint-max-per-step", c.ModelCheckpointMaxPerStep, "The maximum number of prediction models saved at a time")
 }

--- a/pkg/koordlet/prediction/config_test.go
+++ b/pkg/koordlet/prediction/config_test.go
@@ -35,15 +35,15 @@ func TestInitFlags(t *testing.T) {
 	// Test case 1: Check if the PredictionCheckpointFilepath flag is set correctly
 	expectedCheckpointFilepath := "/prediction-checkpoints"
 	fs.Set("prediction-checkpoint-filepath", expectedCheckpointFilepath)
-	if config.PredictionCheckpointFilepath != expectedCheckpointFilepath {
-		t.Errorf("Expected PredictionCheckpointFilepath: %s, but got: %s", expectedCheckpointFilepath, config.PredictionCheckpointFilepath)
+	if config.CheckpointFilepath != expectedCheckpointFilepath {
+		t.Errorf("Expected PredictionCheckpointFilepath: %s, but got: %s", expectedCheckpointFilepath, config.CheckpointFilepath)
 	}
 
 	// Test case 2: Check if the PredictionColdStartDuration flag is set correctly
 	expectedColdStartDuration := 24 * time.Hour
 	fs.Set("prediction-cold-start-duration", "24h")
-	if config.PredictionColdStartDuration != expectedColdStartDuration {
-		t.Errorf("Expected PredictionColdStartDuration: %s, but got: %s", expectedColdStartDuration, config.PredictionColdStartDuration)
+	if config.ColdStartDuration != expectedColdStartDuration {
+		t.Errorf("Expected PredictionColdStartDuration: %s, but got: %s", expectedColdStartDuration, config.ColdStartDuration)
 	}
 }
 
@@ -53,13 +53,13 @@ func TestNewDefaultConfig(t *testing.T) {
 
 	// Test if the PredictionCheckpointFilepath is set to the default value
 	expectedCheckpointFilepath := "/prediction-checkpoints"
-	if config.PredictionCheckpointFilepath != expectedCheckpointFilepath {
-		t.Errorf("Expected default PredictionCheckpointFilepath: %s, but got: %s", expectedCheckpointFilepath, config.PredictionCheckpointFilepath)
+	if config.CheckpointFilepath != expectedCheckpointFilepath {
+		t.Errorf("Expected default PredictionCheckpointFilepath: %s, but got: %s", expectedCheckpointFilepath, config.CheckpointFilepath)
 	}
 
 	// Test if the PredictionColdStartDuration is set to the default value
 	expectedColdStartDuration := 24 * time.Hour
-	if config.PredictionColdStartDuration != expectedColdStartDuration {
-		t.Errorf("Expected default PredictionColdStartDuration: %s, but got: %s", expectedColdStartDuration, config.PredictionColdStartDuration)
+	if config.ColdStartDuration != expectedColdStartDuration {
+		t.Errorf("Expected default PredictionColdStartDuration: %s, but got: %s", expectedColdStartDuration, config.ColdStartDuration)
 	}
 }

--- a/pkg/koordlet/prediction/peak_predictor_test.go
+++ b/pkg/koordlet/prediction/peak_predictor_test.go
@@ -61,7 +61,7 @@ func TestProdReclaimablePredictor_AddPod(t *testing.T) {
 	predictServer := &mockPredictServer{}
 	coldStartDuration := time.Hour
 
-	factory := NewPredictorFactory(predictServer, coldStartDuration)
+	factory := NewPredictorFactory(predictServer, coldStartDuration, 10)
 	predictor := factory.New(ProdReclaimablePredictor)
 
 	pod1 := &v1.Pod{

--- a/pkg/koordlet/prediction/prediction.go
+++ b/pkg/koordlet/prediction/prediction.go
@@ -109,19 +109,21 @@ type MetricServer interface {
 	GetNodeMetric(desc MetricDesc, m MetricKey) (float64, error)
 }
 
-func NewMetricServer(metricCache metriccache.MetricCache) MetricServer {
+func NewMetricServer(metricCache metriccache.MetricCache, dataInterval time.Duration) MetricServer {
 	return &metricServer{
-		metricCache: metricCache,
+		dataInterval: dataInterval,
+		metricCache:  metricCache,
 	}
 }
 
 type metricServer struct {
-	metricCache metriccache.MetricCache
+	metricCache  metriccache.MetricCache
+	dataInterval time.Duration
 }
 
 func (ms *metricServer) GetPodMetric(desc MetricDesc, m MetricKey) (float64, error) {
 	now := time.Now()
-	start := now.Add(-DefaultTrainingInterval)
+	start := now.Add(-ms.dataInterval)
 	querier, err := ms.metricCache.Querier(start, now)
 	if err != nil {
 		return 0, err
@@ -152,7 +154,7 @@ func (ms *metricServer) GetPodMetric(desc MetricDesc, m MetricKey) (float64, err
 
 func (ms *metricServer) GetNodeMetric(desc MetricDesc, m MetricKey) (float64, error) {
 	now := time.Now()
-	start := now.Add(-DefaultTrainingInterval)
+	start := now.Add(-ms.dataInterval)
 	querier, err := ms.metricCache.Querier(start, now)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Part of #1361 

Fill in the configurations that were missing before.