### PR TITLE
koord-scheduler: refresh specific NodeInfos on demand instead of all

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -409,7 +409,8 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		}
 	}
 
-	frameworkExtenderFactory.InitScheduler(sched)
+	frameworkExtenderFactory.InterceptSchedulerError(sched)
+	frameworkExtenderFactory.InitScheduler(&frameworkext.SchedulerAdapter{Scheduler: sched})
 	schedAdapter := frameworkExtenderFactory.Scheduler()
 
 	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, frameworkExtenderFactory.KoordinatorSharedInformerFactory())

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -19,6 +19,7 @@ package eventhandlers
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/utils/pointer"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
@@ -251,6 +253,9 @@ func Test_addReservationToCache(t *testing.T) {
 			wantPod := tt.wantPod
 			if tt.wantPodFromObj {
 				wantPod = reservationutil.NewReservePod(tt.obj)
+				if wantPod.Spec.NodeName != "" {
+					wantPod.Spec.Priority = pointer.Int32(math.MaxInt32)
+				}
 			}
 			assert.Equal(t, wantPod, pod)
 		})
@@ -547,6 +552,9 @@ func Test_updateReservationInCache(t *testing.T) {
 			wantPod := tt.wantPod
 			if tt.wantPodFromObj {
 				wantPod = reservationutil.NewReservePod(tt.newObj)
+				if wantPod.Spec.NodeName != "" {
+					wantPod.Spec.Priority = pointer.Int32(math.MaxInt32)
+				}
 			}
 			assert.Equal(t, wantPod, pod)
 		})

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -131,10 +131,11 @@ func (f *FrameworkExtenderFactory) Scheduler() Scheduler {
 	return f.scheduler
 }
 
-func (f *FrameworkExtenderFactory) InitScheduler(sched *scheduler.Scheduler) {
-	f.scheduler = &SchedulerAdapter{
-		Scheduler: sched,
-	}
+func (f *FrameworkExtenderFactory) InitScheduler(sched Scheduler) {
+	f.scheduler = sched
+}
+
+func (f *FrameworkExtenderFactory) InterceptSchedulerError(sched *scheduler.Scheduler) {
 	f.errorHandlerDispatcher.setDefaultHandler(sched.Error)
 	sched.Error = f.errorHandlerDispatcher.Error
 }

--- a/pkg/scheduler/frameworkext/scheduler_adapter.go
+++ b/pkg/scheduler/frameworkext/scheduler_adapter.go
@@ -18,6 +18,8 @@ package frameworkext
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -38,6 +40,7 @@ type SchedulerCache interface {
 	IsAssumedPod(pod *corev1.Pod) (bool, error)
 	GetPod(pod *corev1.Pod) (*corev1.Pod, error)
 	ForgetPod(pod *corev1.Pod) error
+	InvalidNodeInfo(nodeName string) error
 }
 
 type SchedulingQueue interface {
@@ -58,7 +61,7 @@ type SchedulerAdapter struct {
 }
 
 func (s *SchedulerAdapter) GetCache() SchedulerCache {
-	return s.Scheduler.Cache
+	return &cacheAdapter{scheduler: s.Scheduler}
 }
 
 func (s *SchedulerAdapter) GetSchedulingQueue() SchedulingQueue {
@@ -67,6 +70,58 @@ func (s *SchedulerAdapter) GetSchedulingQueue() SchedulingQueue {
 
 func (s *SchedulerAdapter) MoveAllToActiveOrBackoffQueue(event framework.ClusterEvent) {
 	s.Scheduler.SchedulingQueue.MoveAllToActiveOrBackoffQueue(event, nil)
+}
+
+var _ SchedulerCache = &cacheAdapter{}
+
+type cacheAdapter struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (c *cacheAdapter) AddPod(pod *corev1.Pod) error {
+	return c.scheduler.Cache.AddPod(pod)
+}
+
+func (c *cacheAdapter) UpdatePod(oldPod, newPod *corev1.Pod) error {
+	return c.scheduler.Cache.UpdatePod(oldPod, newPod)
+}
+func (c *cacheAdapter) RemovePod(pod *corev1.Pod) error {
+	return c.scheduler.Cache.RemovePod(pod)
+
+}
+func (c *cacheAdapter) AssumePod(pod *corev1.Pod) error {
+	return c.scheduler.Cache.AssumePod(pod)
+}
+
+func (c *cacheAdapter) IsAssumedPod(pod *corev1.Pod) (bool, error) {
+	return c.scheduler.Cache.IsAssumedPod(pod)
+}
+
+func (c *cacheAdapter) GetPod(pod *corev1.Pod) (*corev1.Pod, error) {
+	return c.scheduler.Cache.GetPod(pod)
+}
+
+func (c *cacheAdapter) ForgetPod(pod *corev1.Pod) error {
+	return c.scheduler.Cache.ForgetPod(pod)
+}
+
+func (c *cacheAdapter) InvalidNodeInfo(nodeName string) error {
+	uid := uuid.NewUUID()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      string(uid),
+			Namespace: "default",
+			UID:       uid,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+	err := c.scheduler.Cache.AddPod(pod)
+	if err != nil {
+		return err
+	}
+	return c.scheduler.Cache.RemovePod(pod)
 }
 
 var _ SchedulingQueue = &queueAdapter{}
@@ -184,6 +239,10 @@ func (f *FakeScheduler) GetPod(pod *corev1.Pod) (*corev1.Pod, error) {
 func (f *FakeScheduler) ForgetPod(pod *corev1.Pod) error {
 	key, _ := framework.GetPodKey(pod)
 	delete(f.AssumedPod, key)
+	return nil
+}
+
+func (f *FakeScheduler) InvalidNodeInfo(nodeName string) error {
 	return nil
 }
 

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -111,6 +111,12 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			return
 		}
 
+		if err := extender.Scheduler().GetCache().InvalidNodeInfo(node.Name); err != nil {
+			klog.ErrorS(err, "Failed to InvalidNodeInfo", "node", node.Name)
+			errCh.SendErrorWithCancel(err, cancel)
+			return
+		}
+
 		for _, rInfo := range unmatched {
 			if err = restoreUnmatchedReservations(nodeInfo, rInfo); err != nil {
 				errCh.SendErrorWithCancel(err, cancel)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When there is a Reservation on the node, the NodeInfo in the Snapshot will be modified, which requires that the modified NodeInfo in the snapshot be refreshed from the Cache during the next scheduling. The existing implementation is to take over the generation in the snapshot and force it to be set to 0. Although this solves the problem, it will refresh all node data, which leads to serious performance regression.
Because now we can operate the Scheduler.Cache, we can mark the NodeInfo in the Cache as changing by forging the Pod update and delete actions, thereby triggering the update of the Snapshot. In this way, when there is no Reservation, there will be no impact. When there is a Reservation, only update the corresponding node.

In addition, Reservation.PostFilter will modify the priority of the Reserve Pod in order to prevent the Reservation from being preempted. In theory, NodeInfo also needs to be updated, but in fact, we can optimize this implementation by directly modifying the priority to prohibit preemption before adding it to the Cache.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
