### PR TITLE
koord-scheduler: load-aware supports estimate node allocatable

### DIFF
--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -53,7 +53,7 @@ func (e *DefaultEstimator) Name() string {
 	return defaultEstimatorName
 }
 
-func (e *DefaultEstimator) Estimate(pod *corev1.Pod) (map[corev1.ResourceName]int64, error) {
+func (e *DefaultEstimator) EstimatePod(pod *corev1.Pod) (map[corev1.ResourceName]int64, error) {
 	return estimatedPodUsed(pod, e.resourceWeights, e.scalingFactors), nil
 }
 
@@ -104,4 +104,8 @@ func estimatedUsedByResource(requests, limits corev1.ResourceList, resourceName 
 		}
 	}
 	return estimatedUsed
+}
+
+func (e *DefaultEstimator) EstimateNode(node *corev1.Node) (corev1.ResourceList, error) {
+	return node.Status.Allocatable, nil
 }

--- a/pkg/scheduler/plugins/loadaware/estimator/types.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/types.go
@@ -31,7 +31,8 @@ var Estimators = map[string]FactoryFn{
 
 type Estimator interface {
 	Name() string
-	Estimate(pod *corev1.Pod) (map[corev1.ResourceName]int64, error)
+	EstimatePod(pod *corev1.Pod) (map[corev1.ResourceName]int64, error)
+	EstimateNode(node *corev1.Node) (corev1.ResourceList, error)
 }
 
 func NewEstimator(args *config.LoadAwareSchedulingArgs, handle framework.Handle) (Estimator, error) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Some special oversold mechanisms will adjust Node.Status.Allocatable, and zoom in or out according to the actual situation. The enlarged situation will be special and needs to be evaluated according to the actual total amount of physical resources.
So extend the Estimator in the LoadAware plugin to support custom node.status.allocatable. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
