### PR TITLE
koord-scheduler: load-aware estimates pod that only has requests

### DIFF
--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -94,13 +94,13 @@ func estimatedUsedByResource(requests, limits corev1.ResourceList, resourceName 
 	switch resourceName {
 	case corev1.ResourceCPU:
 		estimatedUsed = int64(math.Round(float64(quantity.MilliValue()) * float64(scalingFactor) / 100))
-		if estimatedUsed > limitQuantity.MilliValue() {
-			estimatedUsed = limitQuantity.MilliValue()
+		if limit := limitQuantity.MilliValue(); limit > 0 && estimatedUsed > limit {
+			estimatedUsed = limit
 		}
 	default:
 		estimatedUsed = int64(math.Round(float64(quantity.Value()) * float64(scalingFactor) / 100))
-		if estimatedUsed > limitQuantity.Value() {
-			estimatedUsed = limitQuantity.Value()
+		if limit := limitQuantity.Value(); limit > 0 && estimatedUsed > limit {
+			estimatedUsed = limit
 		}
 	}
 	return estimatedUsed

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
@@ -196,6 +196,38 @@ func TestDefaultEstimatorEstimatePod(t *testing.T) {
 				corev1.ResourceMemory: 6012954214, // 5.6Gi
 			},
 		},
+		{
+			name: "estimate pod only has request",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: pointer.Int32(extension.PriorityProdValueMax),
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			scalarFactors: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    80,
+				corev1.ResourceMemory: 80,
+			},
+			want: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    3200,
+				corev1.ResourceMemory: 6871947674,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Pod can only set the requests that caused estimator of load-aware plugin got error results.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1310 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
