### PR TITLE
koordlet: refactor cgroup driver setup and delay resource check

### DIFF
--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -92,6 +92,10 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 	predictorFactory := prediction.NewPredictorFactory(predictServer, config.PredictionConf.ColdStartDuration, config.PredictionConf.SafetyMarginPercent)
 
 	statesInformer := statesinformerimpl.NewStatesInformer(config.StatesInformerConf, kubeClient, crdClient, topologyClient, metricCache, nodeName, schedulingClient, predictorFactory)
+
+	detectCgroupDriver := system.DetectCgroupDriver()
+	system.SetupCgroupPathFormatter(detectCgroupDriver)
+
 	collectorService := metricsadvisor.NewMetricAdvisor(config.CollectorConf, statesInformer, metricCache)
 
 	evictVersion, err := util.FindSupportedEvictVersion(kubeClient)

--- a/pkg/koordlet/koordlet_test.go
+++ b/pkg/koordlet/koordlet_test.go
@@ -1,6 +1,3 @@
-//go:build !linux
-// +build !linux
-
 /*
 Copyright 2022 The Koordinator Authors.
 
@@ -17,16 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package system
+package agent
 
-func GuessCgroupDriverFromCgroupName() CgroupDriverType {
-	return ""
-}
+import (
+	"testing"
 
-func GuessCgroupDriverFromKubeletPort(int) (CgroupDriverType, error) {
-	return kubeletDefaultCgroupDriver, nil
-}
+	"github.com/stretchr/testify/assert"
 
-func IsUsingCgroupsV2() bool {
-	return false
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/config"
+)
+
+func TestNewDaemon(t *testing.T) {
+	cfg := config.NewConfiguration()
+	assert.NotPanics(t, func() {
+		d, err := NewDaemon(cfg)
+		assert.Nil(t, d)
+		assert.Error(t, err)
+	})
 }

--- a/pkg/koordlet/util/system/cgroup_driver.go
+++ b/pkg/koordlet/util/system/cgroup_driver.go
@@ -17,11 +17,18 @@ limitations under the License.
 package system
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type CgroupDriverType string
@@ -50,7 +57,7 @@ func (c CgroupDriverType) Validate() bool {
 	return s == string(Cgroupfs) || s == string(Systemd)
 }
 
-type formatter struct {
+type Formatter struct {
 	ParentDir string
 	QOSDirFn  func(qos corev1.PodQOSClass) string
 	PodDirFn  func(qos corev1.PodQOSClass, podUID string) string
@@ -61,7 +68,7 @@ type formatter struct {
 	ContainerIDParser func(basename string) (string, error)
 }
 
-var cgroupPathFormatterInSystemd = formatter{
+var cgroupPathFormatterInSystemd = Formatter{
 	ParentDir: KubeRootNameSystemd,
 	QOSDirFn: func(qos corev1.PodQOSClass) string {
 		switch qos {
@@ -152,7 +159,7 @@ var cgroupPathFormatterInSystemd = formatter{
 	},
 }
 
-var cgroupPathFormatterInCgroupfs = formatter{
+var cgroupPathFormatterInCgroupfs = Formatter{
 	ParentDir: KubeRootNameCgroupfs,
 	QOSDirFn: func(qos corev1.PodQOSClass) string {
 		switch qos {
@@ -192,10 +199,77 @@ var cgroupPathFormatterInCgroupfs = formatter{
 	},
 }
 
-// CgroupPathFormatter uses the Systemd cgroup driver by default.
+// CgroupPathFormatter is the cgroup driver formatter.
+// It is initialized with a fastly looked-up type and will be slowly detected with the kubelet when the daemon starts.
 var CgroupPathFormatter = GetCgroupFormatter()
 
-func GetCgroupPathFormatter(driver CgroupDriverType) formatter {
+// GetCgroupFormatter gets the cgroup formatter simply looking up the cgroup directory names.
+func GetCgroupFormatter() Formatter {
+	nodeName := os.Getenv("NODE_NAME")
+	// setup cgroup path formatter from cgroup driver type
+	driver := GuessCgroupDriverFromCgroupName()
+	if driver.Validate() {
+		klog.Infof("Node %s use '%s' as cgroup driver guessed with the cgroup name", nodeName, string(driver))
+		return GetCgroupPathFormatter(driver)
+	}
+	klog.V(4).Infof("can not guess cgroup driver from 'kubepods' cgroup name")
+	return cgroupPathFormatterInSystemd
+}
+
+// DetectCgroupDriver gets the cgroup driver both from the cgroup directory names and kubelet configs. Check kubelet
+// config can be slow, so it should be called infrequently.
+func DetectCgroupDriver() CgroupDriverType {
+	klog.Infoln("start to get cgroup driver formatter...")
+	nodeName := os.Getenv("NODE_NAME")
+	// guess cgroup driver from cgroup directory names
+	driver := GuessCgroupDriverFromCgroupName()
+	if driver.Validate() {
+		klog.Infof("Node %s use '%s' as cgroup driver according to the cgroup name", nodeName, string(driver))
+		return driver
+	}
+	klog.Infof("can not detect cgroup driver from 'kubepods' cgroup name")
+
+	// guess cgroup driver from the kubelet; it may take at most 60s
+	driver, err := DetectCgroupDriverFromKubelet(nodeName)
+	if err == nil {
+		klog.Infof("Node %s use '%s' as cgroup driver according to the kubelet config", nodeName, string(driver))
+		return driver
+	}
+	klog.Errorf("can not detect cgroup driver from kubelet, use the default, err: %v", err)
+	return Systemd
+}
+
+func DetectCgroupDriverFromKubelet(nodeName string) (CgroupDriverType, error) {
+	var detectCgroupDriver CgroupDriverType
+	if pollErr := wait.PollImmediate(time.Second*10, time.Minute, func() (bool, error) {
+		cfg, err := config.GetConfig()
+		if err != nil {
+			klog.Errorf("failed to get rest config.err=%v", err)
+			return false, nil
+		}
+		kubeClient := clientset.NewForConfigOrDie(cfg)
+		node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil || node == nil {
+			klog.Errorf("Can't get node, err: %v", err)
+			return false, nil
+		}
+
+		port := int(node.Status.DaemonEndpoints.KubeletEndpoint.Port)
+		if driver, err := GuessCgroupDriverFromKubeletPort(port); err == nil && driver.Validate() {
+			detectCgroupDriver = driver
+			return true, nil
+		} else {
+			klog.Errorf("guess kubelet cgroup driver failed, retry...: %v", err)
+			return false, nil
+		}
+	}); pollErr != nil {
+		return "", pollErr
+	}
+
+	return detectCgroupDriver, nil
+}
+
+func GetCgroupPathFormatter(driver CgroupDriverType) Formatter {
 	switch driver {
 	case Systemd:
 		return cgroupPathFormatterInSystemd

--- a/pkg/koordlet/util/system/cgroup_driver_linux_test.go
+++ b/pkg/koordlet/util/system/cgroup_driver_linux_test.go
@@ -94,7 +94,7 @@ func Test_GuessCgroupDriverFromCgroupName(t *testing.T) {
 func TestGetCgroupFormatter(t *testing.T) {
 	tests := []struct {
 		name       string
-		want       formatter
+		want       Formatter
 		preHandle  func(cgroupRootDir string)
 		isCgroupV2 bool
 	}{

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -207,29 +207,29 @@ var (
 
 	CPUAcctStat           = DefaultFactory.New(CPUAcctStatName, CgroupCPUAcctDir)
 	CPUAcctUsage          = DefaultFactory.New(CPUAcctUsageName, CgroupCPUAcctDir)
-	CPUAcctCPUPressure    = DefaultFactory.New(CPUAcctCPUPressureName, CgroupCPUAcctDir).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctCPUPressureName, CgroupCPUAcctDir))
-	CPUAcctMemoryPressure = DefaultFactory.New(CPUAcctMemoryPressureName, CgroupCPUAcctDir).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctMemoryPressureName, CgroupCPUAcctDir))
-	CPUAcctIOPressure     = DefaultFactory.New(CPUAcctIOPressureName, CgroupCPUAcctDir).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctIOPressureName, CgroupCPUAcctDir))
+	CPUAcctCPUPressure    = DefaultFactory.New(CPUAcctCPUPressureName, CgroupCPUAcctDir).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	CPUAcctMemoryPressure = DefaultFactory.New(CPUAcctMemoryPressureName, CgroupCPUAcctDir).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	CPUAcctIOPressure     = DefaultFactory.New(CPUAcctIOPressureName, CgroupCPUAcctDir).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 
 	MemoryLimit            = DefaultFactory.New(MemoryLimitName, CgroupMemDir)
 	MemoryUsage            = DefaultFactory.New(MemoryUsageName, CgroupMemDir)
 	MemoryStat             = DefaultFactory.New(MemoryStatName, CgroupMemDir)
 	MemoryNumaStat         = DefaultFactory.New(MemoryNumaStatName, CgroupMemDir)
-	MemoryWmarkRatio       = DefaultFactory.New(MemoryWmarkRatioName, CgroupMemDir).WithValidator(MemoryWmarkRatioValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkRatioName, CgroupMemDir))
-	MemoryWmarkScaleFactor = DefaultFactory.New(MemoryWmarkScaleFactorName, CgroupMemDir).WithValidator(MemoryWmarkScaleFactorFileNameValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkScaleFactorName, CgroupMemDir))
-	MemoryWmarkMinAdj      = DefaultFactory.New(MemoryWmarkMinAdjName, CgroupMemDir).WithValidator(MemoryWmarkMinAdjValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryWmarkMinAdjName, CgroupMemDir))
-	MemoryMin              = DefaultFactory.New(MemoryMinName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithSupported(SupportedIfFileExistsInKubepods(MemoryMinName, CgroupMemDir))
-	MemoryLow              = DefaultFactory.New(MemoryLowName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithSupported(SupportedIfFileExistsInKubepods(MemoryLowName, CgroupMemDir))
-	MemoryHigh             = DefaultFactory.New(MemoryHighName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithSupported(SupportedIfFileExistsInKubepods(MemoryHighName, CgroupMemDir))
-	MemoryPriority         = DefaultFactory.New(MemoryPriorityName, CgroupMemDir).WithValidator(MemoryPriorityValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryPriorityName, CgroupMemDir))
-	MemoryUsePriorityOom   = DefaultFactory.New(MemoryUsePriorityOomName, CgroupMemDir).WithValidator(MemoryUsePriorityOomValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryUsePriorityOomName, CgroupMemDir))
-	MemoryOomGroup         = DefaultFactory.New(MemoryOomGroupName, CgroupMemDir).WithValidator(MemoryOomGroupValidator).WithSupported(SupportedIfFileExistsInKubepods(MemoryOomGroupName, CgroupMemDir))
+	MemoryWmarkRatio       = DefaultFactory.New(MemoryWmarkRatioName, CgroupMemDir).WithValidator(MemoryWmarkRatioValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryWmarkScaleFactor = DefaultFactory.New(MemoryWmarkScaleFactorName, CgroupMemDir).WithValidator(MemoryWmarkScaleFactorFileNameValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryWmarkMinAdj      = DefaultFactory.New(MemoryWmarkMinAdjName, CgroupMemDir).WithValidator(MemoryWmarkMinAdjValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryMin              = DefaultFactory.New(MemoryMinName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryLow              = DefaultFactory.New(MemoryLowName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryHigh             = DefaultFactory.New(MemoryHighName, CgroupMemDir).WithValidator(NaturalInt64Validator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryPriority         = DefaultFactory.New(MemoryPriorityName, CgroupMemDir).WithValidator(MemoryPriorityValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryUsePriorityOom   = DefaultFactory.New(MemoryUsePriorityOomName, CgroupMemDir).WithValidator(MemoryUsePriorityOomValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryOomGroup         = DefaultFactory.New(MemoryOomGroupName, CgroupMemDir).WithValidator(MemoryOomGroupValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 
-	BlkioReadIops  = DefaultFactory.New(BlkioTRIopsName, CgroupBlkioDir).WithValidator(BlkioTRIopsValidator).WithSupported(SupportedIfFileExistsInKubepods(BlkioTRIopsName, CgroupBlkioDir))
-	BlkioReadBps   = DefaultFactory.New(BlkioTRBpsName, CgroupBlkioDir).WithValidator(BlkioTRBpsValidator).WithSupported(SupportedIfFileExistsInKubepods(BlkioTRBpsName, CgroupBlkioDir))
-	BlkioWriteIops = DefaultFactory.New(BlkioTWIopsName, CgroupBlkioDir).WithValidator(BlkioTWIopsValidator).WithSupported(SupportedIfFileExistsInKubepods(BlkioTWIopsName, CgroupBlkioDir))
-	BlkioWriteBps  = DefaultFactory.New(BlkioTWBpsName, CgroupBlkioDir).WithValidator(BlkioTWBpsValidator).WithSupported(SupportedIfFileExistsInKubepods(BlkioTWBpsName, CgroupBlkioDir))
-	BlkioIOWeight  = DefaultFactory.New(BlkioIOWeightName, CgroupBlkioDir).WithValidator(BlkioIOWeightValidator).WithSupported(SupportedIfFileExistsInKubepods(BlkioIOWeightName, CgroupBlkioDir))
+	BlkioReadIops  = DefaultFactory.New(BlkioTRIopsName, CgroupBlkioDir).WithValidator(BlkioTRIopsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	BlkioReadBps   = DefaultFactory.New(BlkioTRBpsName, CgroupBlkioDir).WithValidator(BlkioTRBpsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	BlkioWriteIops = DefaultFactory.New(BlkioTWIopsName, CgroupBlkioDir).WithValidator(BlkioTWIopsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	BlkioWriteBps  = DefaultFactory.New(BlkioTWBpsName, CgroupBlkioDir).WithValidator(BlkioTWBpsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	BlkioIOWeight  = DefaultFactory.New(BlkioIOWeightName, CgroupBlkioDir).WithValidator(BlkioIOWeightValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 	BlkioIOQoS     = DefaultFactory.New(BlkioIOQoSName, CgroupBlkioDir).WithValidator(BlkioIOQoSValidator).WithSupported(SupportedIfFileExistsInRootCgroup(BlkioIOQoSName, CgroupBlkioDir))
 
 	knownCgroupResources = []Resource{
@@ -275,9 +275,9 @@ var (
 	CPUAcctStatV2  = DefaultFactory.NewV2(CPUAcctStatName, CPUStatName)
 	CPUAcctUsageV2 = DefaultFactory.NewV2(CPUAcctUsageName, CPUStatName)
 
-	CPUAcctCPUPressureV2    = DefaultFactory.NewV2(CPUAcctCPUPressureName, CPUAcctCPUPressureName).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctCPUPressureName, ""))
-	CPUAcctMemoryPressureV2 = DefaultFactory.NewV2(CPUAcctMemoryPressureName, CPUAcctMemoryPressureName).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctMemoryPressureName, ""))
-	CPUAcctIOPressureV2     = DefaultFactory.NewV2(CPUAcctIOPressureName, CPUAcctIOPressureName).WithSupported(SupportedIfFileExistsInKubepods(CPUAcctIOPressureName, ""))
+	CPUAcctCPUPressureV2    = DefaultFactory.NewV2(CPUAcctCPUPressureName, CPUAcctCPUPressureName).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	CPUAcctMemoryPressureV2 = DefaultFactory.NewV2(CPUAcctMemoryPressureName, CPUAcctMemoryPressureName).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	CPUAcctIOPressureV2     = DefaultFactory.NewV2(CPUAcctIOPressureName, CPUAcctIOPressureName).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 
 	CPUSetV2                 = DefaultFactory.NewV2(CPUSetCPUSName, CPUSetCPUSName).WithValidator(CPUSetCPUSValidator)
 	CPUSetEffectiveV2        = DefaultFactory.NewV2(CPUSetCPUSEffectiveName, CPUSetCPUSEffectiveName) // TODO: unify the R/W
@@ -338,6 +338,7 @@ type CgroupResource struct {
 	Supported      *bool
 	SupportMsg     string
 	CheckSupported func(r Resource, parentDir string) (isSupported bool, msg string)
+	CheckOnce      bool
 	Validator      ResourceValidator
 	CgroupVersion  CgroupVersion
 }
@@ -359,7 +360,12 @@ func (c *CgroupResource) IsSupported(parentDir string) (bool, string) {
 		if c.CheckSupported == nil {
 			return false, "unknown support status"
 		}
-		return c.CheckSupported(c, parentDir)
+		isSupported, msg := c.CheckSupported(c, parentDir)
+		if c.CheckOnce {
+			c.Supported = &isSupported
+			c.SupportMsg = msg
+		}
+		return isSupported, msg
 	}
 	return *c.Supported, c.SupportMsg
 }
@@ -379,6 +385,11 @@ func (c *CgroupResource) WithValidator(validator ResourceValidator) Resource {
 func (c *CgroupResource) WithSupported(isSupported bool, msg string) Resource {
 	c.Supported = pointer.Bool(isSupported)
 	c.SupportMsg = msg
+	return c
+}
+
+func (c *CgroupResource) WithCheckOnce(isCheckOnce bool) Resource {
+	c.CheckOnce = isCheckOnce
 	return c
 }
 

--- a/pkg/koordlet/util/system/resctrl.go
+++ b/pkg/koordlet/util/system/resctrl.go
@@ -159,6 +159,10 @@ func (r *ResctrlResource) WithCheckSupported(checkSupportedFn func(r Resource, p
 	return r
 }
 
+func (r *ResctrlResource) WithCheckOnce(isCheckOnce bool) Resource {
+	return r
+}
+
 func NewCommonResctrlResource(filename string, subdir string) Resource {
 	return &ResctrlResource{
 		Type:           ResourceType(filename),

--- a/pkg/koordlet/util/system/system_resource.go
+++ b/pkg/koordlet/util/system/system_resource.go
@@ -55,6 +55,7 @@ type SystemResource struct {
 	Supported      *bool
 	SupportMsg     string
 	CheckSupported func(r Resource, dynamicPath string) (isSupported bool, msg string)
+	CheckOnce      bool
 }
 
 func (c *SystemResource) ResourceType() ResourceType {
@@ -73,7 +74,12 @@ func (c *SystemResource) IsSupported(dynamicPath string) (bool, string) {
 		if c.CheckSupported == nil {
 			return false, "unknown support status"
 		}
-		return c.CheckSupported(c, dynamicPath)
+		isSupported, msg := c.CheckSupported(c, dynamicPath)
+		if c.CheckOnce {
+			c.Supported = &isSupported
+			c.SupportMsg = msg
+		}
+		return isSupported, msg
 	}
 	return *c.Supported, c.SupportMsg
 }
@@ -99,6 +105,11 @@ func (c *SystemResource) WithSupported(isSupported bool, msg string) Resource {
 func (c *SystemResource) WithCheckSupported(checkSupportedFn func(r Resource, parentDir string) (isSupported bool, msg string)) Resource {
 	c.Supported = nil
 	c.CheckSupported = checkSupportedFn
+	return c
+}
+
+func (c *SystemResource) WithCheckOnce(isCheckOnce bool) Resource {
+	c.CheckOnce = isCheckOnce
 	return c
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Refactor the cgroup driver setup:
    a. Initialize the cgroup driver with the kubepods cgroup names, which is invoked in many pkgs' UTs and takes less than 1s.
    b. Move back the cgroup driver detection on kubelet at the daemon's starting, which runs once and can cost at most 60s.
- Delay the check of cgroup support status. Do the check when the method `IsSupported()` is called at the first time.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixes the issue in which UTs of each koordlet pkg run for more than 60 seconds.

linked: #1402.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
