### PR TITLE
koord-descheduler: fix GetMaxUnavailable not properly handling percentage type param

### DIFF
--- a/pkg/descheduler/controllers/migration/util/util.go
+++ b/pkg/descheduler/controllers/migration/util/util.go
@@ -78,7 +78,11 @@ func IsMigratePendingPod(reservationObj reservation.Object) bool {
 }
 
 func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, error) {
-	if intOrPercent == nil || intOrPercent.IntValue() == 0 {
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
+	if err != nil {
+		return 0, err
+	}
+	if maxUnavailable == 0 {
 		if replicas > 10 {
 			s := intstr.FromString("10%")
 			intOrPercent = &s
@@ -89,10 +93,11 @@ func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, err
 			s := intstr.FromInt(1)
 			intOrPercent = &s
 		}
-	}
-	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
-	if err != nil {
-		return 0, err
+	} else {
+		maxUnavailable, err = intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
+		if err != nil {
+			return 0, err
+		}
 	}
 	if maxUnavailable > replicas {
 		maxUnavailable = replicas

--- a/pkg/descheduler/controllers/migration/util/util.go
+++ b/pkg/descheduler/controllers/migration/util/util.go
@@ -78,9 +78,13 @@ func IsMigratePendingPod(reservationObj reservation.Object) bool {
 }
 
 func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, error) {
-	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
-	if err != nil {
-		return 0, err
+	var maxUnavailable int
+	var err error
+	if intOrPercent != nil {
+		maxUnavailable, err = intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
+		if err != nil {
+			return 0, err
+		}
 	}
 	if maxUnavailable == 0 {
 		if replicas > 10 {
@@ -93,7 +97,6 @@ func GetMaxUnavailable(replicas int, intOrPercent *intstr.IntOrString) (int, err
 			s := intstr.FromInt(1)
 			intOrPercent = &s
 		}
-	} else {
 		maxUnavailable, err = intstr.GetScaledValueFromIntOrPercent(intOrPercent, replicas, false)
 		if err != nil {
 			return 0, err

--- a/pkg/descheduler/controllers/migration/util/util_test.go
+++ b/pkg/descheduler/controllers/migration/util/util_test.go
@@ -284,6 +284,27 @@ func TestGetMaxUnavailable(t *testing.T) {
 			},
 			want: 6,
 		},
+		{
+			name:         "case5",
+			replicas:     6,
+			intOrPercent: nil,
+			want:         2,
+		},
+		{
+			name:     "case6",
+			replicas: 50,
+			intOrPercent: &intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "0%",
+			},
+			want: 5,
+		},
+		{
+			name:         "case7",
+			replicas:     6,
+			intOrPercent: &intstr.IntOrString{},
+			want:         2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/descheduler/controllers/migration/util/util_test.go
+++ b/pkg/descheduler/controllers/migration/util/util_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	sev1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -235,6 +236,61 @@ func TestFilterPodWithMaxEvictionCost(t *testing.T) {
 					},
 				},
 			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetMaxUnavailable(t *testing.T) {
+	tests := []struct {
+		name         string
+		replicas     int
+		intOrPercent *intstr.IntOrString
+		want         int
+	}{
+		{
+			name:     "case1",
+			replicas: 6,
+			intOrPercent: &intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "80%",
+			},
+			want: 4,
+		},
+		{
+			name:     "case2",
+			replicas: 6,
+			intOrPercent: &intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "150%",
+			},
+			want: 6,
+		},
+		{
+			name:     "case3",
+			replicas: 6,
+			intOrPercent: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 5,
+			},
+			want: 5,
+		},
+		{
+			name:     "case4",
+			replicas: 6,
+			intOrPercent: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 7,
+			},
+			want: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetMaxUnavailable(tt.replicas, tt.intOrPercent)
+			if err != nil {
+				t.Errorf("GetMaxUnavailable: %v", err)
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
bug fixed
in MigrationControllerArgs maxMigratingPerWorkload percentage parameter does not take effect

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how to verify it
run TestGetMaxUnavailable

### Ⅳ. Special notes for reviews

### V. Checklist
