### PR TITLE
koord-scheduler: fix deletion of Reservation in concurrent scenarios

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -243,7 +243,7 @@ func Test_addReservationToCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sched := frameworkext.NewFakeScheduler()
-			addReservationToCache(sched, tt.obj)
+			addReservationToSchedulerCache(sched, tt.obj)
 			pod, err := sched.GetPod(&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: tt.obj.GetUID(),
@@ -542,7 +542,7 @@ func Test_updateReservationInCache(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reservation.SetReservationCache(&fakeReservationCache{})
 			sched := frameworkext.NewFakeScheduler()
-			updateReservationInCache(sched, tt.oldObj, tt.newObj)
+			updateReservationInSchedulerCache(sched, tt.oldObj, tt.newObj)
 			pod, err := sched.GetPod(&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: tt.newObj.GetUID(),
@@ -665,7 +665,7 @@ func Test_deleteReservationFromCache(t *testing.T) {
 			if reservationutil.ValidateReservation(tt.obj) == nil {
 				sched.AddPod(reservationutil.NewReservePod(tt.obj))
 			}
-			deleteReservationFromCache(sched, tt.obj)
+			deleteReservationFromSchedulerCache(sched, tt.obj)
 			pod, err := sched.GetPod(&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: tt.obj.GetUID(),

--- a/pkg/scheduler/plugins/reservation/cache.go
+++ b/pkg/scheduler/plugins/reservation/cache.go
@@ -114,6 +114,18 @@ func (cache *reservationCache) updateReservation(newR *schedulingv1alpha1.Reserv
 	}
 }
 
+func (cache *reservationCache) updateReservationIfExists(newR *schedulingv1alpha1.Reservation) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	rInfo := cache.reservationInfos[newR.UID]
+	if rInfo != nil {
+		rInfo.UpdateReservation(newR)
+		if newR.Status.NodeName != "" {
+			cache.updateReservationsOnNode(newR.Status.NodeName, newR.UID)
+		}
+	}
+}
+
 func (cache *reservationCache) DeleteReservation(r *schedulingv1alpha1.Reservation) *frameworkext.ReservationInfo {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()

--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -47,8 +47,8 @@ func (h *reservationEventHandler) OnAdd(obj interface{}) {
 	}
 	if reservationutil.IsReservationActive(r) {
 		h.cache.updateReservation(r)
+		klog.V(4).InfoS("add reservation into reservationCache", "reservation", klog.KObj(r))
 	}
-	klog.V(5).InfoS("reservation cache add", "reservation", klog.KObj(r))
 }
 
 func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -63,8 +63,8 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 	if reservationutil.IsReservationActive(newR) || reservationutil.IsReservationFailed(newR) || reservationutil.IsReservationSucceeded(newR) {
 		h.cache.updateReservation(newR)
+		klog.V(4).InfoS("update reservation into reservationCache", "reservation", klog.KObj(newR))
 	}
-	klog.V(5).InfoS("reservation cache update", "reservation", klog.KObj(newR))
 }
 
 func (h *reservationEventHandler) OnDelete(obj interface{}) {
@@ -91,6 +91,6 @@ func (h *reservationEventHandler) OnDelete(obj interface{}) {
 		r = r.DeepCopy()
 		r.Status.Phase = schedulingv1alpha1.ReservationFailed
 	}
-	h.cache.updateReservation(r)
-	klog.V(5).InfoS("reservation cache delete", "reservation", klog.KObj(r))
+	h.cache.updateReservationIfExists(r)
+	klog.V(4).InfoS("got delete reservation event but just update it if exists", "reservation", klog.KObj(r))
 }

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -71,7 +71,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 	processNode := func(i int) {
 		nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(allNodes[i])
 		if err != nil {
-			errCh.SendErrorWithCancel(err, cancel)
+			klog.Warningf("Failed to get NodeInfo of %s during reservation's BeforePreFilter, err: %v", allNodes[i], err)
 			return
 		}
 		node := nodeInfo.Node()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fix deletion of Reservation in concurrent scenarios. 
When deleting one Reservation, maybe the event handler of plugin `Reservation` got event after the `deleteReservationFromSchedulerCache` in `pkg/scheduler/frameworkext/eventhandlers`, so the deleted ReservationInfo re-added into the ReservationCache.
And optimize the log about reservation to help diagnose.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1436

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
