### PR TITLE
koord-scheduler: run plugin transformers in configured order

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -358,7 +358,6 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		frameworkext.WithServicesEngine(cc.ServicesEngine),
 		frameworkext.WithKoordinatorClientSet(cc.KoordinatorClient),
 		frameworkext.WithKoordinatorSharedInformerFactory(cc.KoordinatorSharedInformerFactory),
-		frameworkext.WithDefaultTransformers(frameworkext.DefaultTransformers...),
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -402,9 +401,10 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	}
 
 	// extend framework to hook run plugin functions
-	for k := range sched.Profiles {
+	for k, fwk := range sched.Profiles {
 		extender := frameworkExtenderFactory.GetExtender(k)
 		if extender != nil {
+			extender.SetConfiguredPlugins(fwk.ListPlugins())
 			sched.Profiles[k] = extender
 		}
 	}

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -28,17 +28,10 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
 )
 
-var DefaultTransformers []SchedulingTransformer
-
-func RegisterDefaultTransformers(transformers ...SchedulingTransformer) {
-	DefaultTransformers = append(DefaultTransformers, transformers...)
-}
-
 type extendedHandleOptions struct {
 	servicesEngine                   *services.Engine
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
-	defaultTransformers              []SchedulingTransformer
 }
 
 type Option func(*extendedHandleOptions)
@@ -61,16 +54,9 @@ func WithKoordinatorSharedInformerFactory(informerFactory koordinatorinformers.S
 	}
 }
 
-func WithDefaultTransformers(transformers ...SchedulingTransformer) Option {
-	return func(options *extendedHandleOptions) {
-		options.defaultTransformers = transformers
-	}
-}
-
 type FrameworkExtenderFactory struct {
 	controllerMaps                   *ControllersMap
 	servicesEngine                   *services.Engine
-	defaultTransformers              []SchedulingTransformer
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
 	profiles                         map[string]FrameworkExtender
@@ -91,7 +77,6 @@ func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, 
 	return &FrameworkExtenderFactory{
 		controllerMaps:                   NewControllersMap(),
 		servicesEngine:                   handleOptions.servicesEngine,
-		defaultTransformers:              handleOptions.defaultTransformers,
 		koordinatorClientSet:             handleOptions.koordinatorClientSet,
 		koordinatorSharedInformerFactory: handleOptions.koordinatorSharedInformerFactory,
 		profiles:                         map[string]FrameworkExtender{},

--- a/pkg/scheduler/frameworkext/framework_extender_factory_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory_test.go
@@ -41,7 +41,6 @@ func TestExtenderFactory(t *testing.T) {
 		WithServicesEngine(services.NewEngine(gin.New())),
 		WithKoordinatorClientSet(koordClientSet),
 		WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
-		WithDefaultTransformers(&TestTransformer{index: 1}),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, factory)
@@ -49,7 +48,7 @@ func TestExtenderFactory(t *testing.T) {
 	assert.Equal(t, koordSharedInformerFactory, factory.KoordinatorSharedInformerFactory())
 
 	proxyNew := PluginFactoryProxy(factory, func(args runtime.Object, f framework.Handle) (framework.Plugin, error) {
-		return &TestTransformer{index: 2}, nil
+		return &TestTransformer{index: 1}, nil
 	})
 	registeredPlugins := []schedulertesting.RegisterPluginFunc{
 		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -69,7 +68,7 @@ func TestExtenderFactory(t *testing.T) {
 	extender := factory.GetExtender("koord-scheduler")
 	assert.NotNil(t, extender)
 	impl := extender.(*frameworkExtenderImpl)
-	assert.Len(t, impl.preFilterTransformers, 2)
-	assert.Len(t, impl.filterTransformers, 2)
-	assert.Len(t, impl.scoreTransformers, 2)
+	assert.Len(t, impl.preFilterTransformers, 1)
+	assert.Len(t, impl.filterTransformers, 1)
+	assert.Len(t, impl.scoreTransformers, 1)
 }

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	schedconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -48,6 +49,8 @@ type ExtendedHandle interface {
 type FrameworkExtender interface {
 	framework.Framework
 	ExtendedHandle
+
+	SetConfiguredPlugins(plugins *schedconfig.Plugins)
 
 	RunReservationExtensionPreRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status
 	RunReservationExtensionRestoreReservation(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, matched []*ReservationInfo, unmatched []*ReservationInfo, nodeInfo *framework.NodeInfo) (PluginToReservationRestoreStates, *framework.Status)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Executing plugin transformers in the order of configuration can better handle some special scenarios, such as checking certain conditions before Reservation.BeforePreFilter to end scheduling early.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
