### PR TITLE
koord-scheduler: DeviceShare plugin supports scoring

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -207,4 +207,6 @@ type DeviceShareArgs struct {
 
 	// Allocator indicates the expected allocator to use
 	Allocator string
+	// ScoringStrategy selects the device resource scoring strategy.
+	ScoringStrategy *ScoringStrategy
 }

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
 )
 
 var (
@@ -156,5 +158,20 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	}
 	if obj.ControllerWorkers == nil {
 		obj.ControllerWorkers = pointer.Int64(int64(defaultControllerWorkers))
+	}
+}
+
+func SetDefaults_DeviceShareArgs(obj *DeviceShareArgs) {
+	if obj.ScoringStrategy == nil {
+		obj.ScoringStrategy = &ScoringStrategy{
+			// By default, LeastAllocate is used to ensure high availability of applications
+			Type: LeastAllocated,
+			Resources: []schedconfig.ResourceSpec{
+				{
+					Name:   string(extension.ResourceGPUMemoryRatio),
+					Weight: 1,
+				},
+			},
+		}
 	}
 }

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -203,4 +203,6 @@ type DeviceShareArgs struct {
 
 	// Allocator indicates the expected allocator to use
 	Allocator string `json:"allocator,omitempty"`
+	// ScoringStrategy selects the device resource scoring strategy.
+	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -153,6 +153,7 @@ func Convert_config_CoschedulingArgs_To_v1beta2_CoschedulingArgs(in *config.Cosc
 
 func autoConvert_v1beta2_DeviceShareArgs_To_config_DeviceShareArgs(in *DeviceShareArgs, out *config.DeviceShareArgs, s conversion.Scope) error {
 	out.Allocator = in.Allocator
+	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	return nil
 }
 
@@ -163,6 +164,7 @@ func Convert_v1beta2_DeviceShareArgs_To_config_DeviceShareArgs(in *DeviceShareAr
 
 func autoConvert_config_DeviceShareArgs_To_v1beta2_DeviceShareArgs(in *config.DeviceShareArgs, out *DeviceShareArgs, s conversion.Scope) error {
 	out.Allocator = in.Allocator
+	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -72,6 +72,11 @@ func (in *CoschedulingArgs) DeepCopyObject() runtime.Object {
 func (in *DeviceShareArgs) DeepCopyInto(out *DeviceShareArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.ScoringStrategy != nil {
+		in, out := &in.ScoringStrategy, &out.ScoringStrategy
+		*out = new(ScoringStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.defaults.go
@@ -30,6 +30,7 @@ import (
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&CoschedulingArgs{}, func(obj interface{}) { SetObjectDefaults_CoschedulingArgs(obj.(*CoschedulingArgs)) })
+	scheme.AddTypeDefaultingFunc(&DeviceShareArgs{}, func(obj interface{}) { SetObjectDefaults_DeviceShareArgs(obj.(*DeviceShareArgs)) })
 	scheme.AddTypeDefaultingFunc(&ElasticQuotaArgs{}, func(obj interface{}) { SetObjectDefaults_ElasticQuotaArgs(obj.(*ElasticQuotaArgs)) })
 	scheme.AddTypeDefaultingFunc(&LoadAwareSchedulingArgs{}, func(obj interface{}) { SetObjectDefaults_LoadAwareSchedulingArgs(obj.(*LoadAwareSchedulingArgs)) })
 	scheme.AddTypeDefaultingFunc(&NodeNUMAResourceArgs{}, func(obj interface{}) { SetObjectDefaults_NodeNUMAResourceArgs(obj.(*NodeNUMAResourceArgs)) })
@@ -39,6 +40,10 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_CoschedulingArgs(in *CoschedulingArgs) {
 	SetDefaults_CoschedulingArgs(in)
+}
+
+func SetObjectDefaults_DeviceShareArgs(in *DeviceShareArgs) {
+	SetDefaults_DeviceShareArgs(in)
 }
 
 func SetObjectDefaults_ElasticQuotaArgs(in *ElasticQuotaArgs) {

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -67,6 +67,11 @@ func (in *CoschedulingArgs) DeepCopyObject() runtime.Object {
 func (in *DeviceShareArgs) DeepCopyInto(out *DeviceShareArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.ScoringStrategy != nil {
+		in, out := &in.ScoringStrategy, &out.ScoringStrategy
+		*out = new(ScoringStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_cache_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_test.go
@@ -257,7 +257,7 @@ func Test_nodeDevice_allocateGPU(t *testing.T) {
 			},
 		},
 	}
-	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible)
+	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible, nil)
 	assert.NoError(t, err)
 	expectAllocations := apiext.DeviceAllocations{
 		schedulingv1alpha1.GPU: {
@@ -277,7 +277,7 @@ func Test_nodeDevice_allocateGPU(t *testing.T) {
 		apiext.ResourceGPUCore:        resource.MustParse("200"),
 		apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
 	}
-	allocateResult, err = nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible)
+	allocateResult, err = nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible, nil)
 	assert.NoError(t, err)
 	expectAllocations = allocations
 	assert.True(t, equality.Semantic.DeepEqual(expectAllocations, allocateResult))
@@ -354,7 +354,7 @@ func Test_nodeDevice_failedPreemptGPUFromReservation(t *testing.T) {
 			},
 		},
 	}
-	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible)
+	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, preemptible, nil)
 	assert.EqualError(t, err, fmt.Sprintf("node does not have enough %v", schedulingv1alpha1.GPU))
 	assert.Nil(t, allocateResult)
 }
@@ -376,7 +376,7 @@ func Test_nodeDevice_allocateGPUWithUnhealthyInstance(t *testing.T) {
 		apiext.ResourceGPUCore:        resource.MustParse("50"),
 		apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
 	}
-	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, nil)
+	allocateResult, err := nd.tryAllocateDevice(podRequests, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	expectAllocations := apiext.DeviceAllocations{
 		schedulingv1alpha1.GPU: {
@@ -454,7 +454,7 @@ func Test_nodeDevice_allocateRDMA(t *testing.T) {
 			apiext.ResourceRDMA: resource.MustParse("100"),
 		},
 	}
-	err := nd.tryAllocateDeviceByType(podRequests, schedulingv1alpha1.RDMA, nil, nil, allocateResult, nil, preemptible)
+	err := nd.tryAllocateByDeviceType(podRequests, schedulingv1alpha1.RDMA, nil, nil, allocateResult, nil, preemptible, nil)
 	assert.NoError(t, err)
 	expectAllocations := apiext.DeviceAllocations{
 		schedulingv1alpha1.RDMA: {
@@ -472,7 +472,7 @@ func Test_nodeDevice_allocateRDMA(t *testing.T) {
 		apiext.ResourceRDMA: resource.MustParse("200"),
 	}
 	allocateResult = apiext.DeviceAllocations{}
-	err = nd.tryAllocateDeviceByType(podRequests, schedulingv1alpha1.RDMA, nil, nil, allocateResult, nil, preemptible)
+	err = nd.tryAllocateByDeviceType(podRequests, schedulingv1alpha1.RDMA, nil, nil, allocateResult, nil, preemptible, nil)
 	assert.NoError(t, err)
 	expectAllocations = allocations
 	assert.True(t, equality.Semantic.DeepEqual(expectAllocations, allocateResult))

--- a/pkg/scheduler/plugins/deviceshare/device_resources_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_resources_test.go
@@ -59,7 +59,15 @@ func Test_sortDeviceResourcesByMinor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sortDeviceResourcesByMinor(tt.resources, sets.NewInt(tt.preferred...))
+			var r []deviceResourceMinorPair
+			for minor, resources := range tt.resources {
+				r = append(r, deviceResourceMinorPair{
+					minor:     minor,
+					resources: resources,
+					score:     0,
+				})
+			}
+			got := sortDeviceResourcesByMinor(r, sets.NewInt(tt.preferred...))
 			var orders []int
 			for _, v := range got {
 				orders = append(orders, v.minor)

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -31,14 +31,13 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 func Test_Plugin_ReservationRestore(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(&config.DeviceShareArgs{}, suit.Framework)
+	p, err := suit.proxyNew(getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)
 
@@ -664,6 +663,7 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 				&corev1.Pod{},
 				basicPreemptible,
 				tt.requiredFromReservation,
+				nil,
 			)
 			assert.Equal(t, tt.wantStatus, status)
 			assert.Equal(t, tt.wantResult, result)

--- a/pkg/scheduler/plugins/deviceshare/scoring.go
+++ b/pkg/scheduler/plugins/deviceshare/scoring.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+	schedconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+
+	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+)
+
+func (pl *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) (int64, *framework.Status) {
+	state, status := getPreFilterState(cycleState)
+	if !status.IsSuccess() {
+		return 0, status
+	}
+	if state.skip {
+		return 0, nil
+	}
+
+	nodeDeviceInfo := pl.nodeDeviceCache.getNodeDevice(nodeName, false)
+	if nodeDeviceInfo == nil {
+		return 0, framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice)
+	}
+
+	reservationRestoreState := getReservationRestoreState(cycleState)
+	restoreState := reservationRestoreState.getNodeState(nodeName)
+	preemptible := appendAllocated(nil, restoreState.mergedUnmatchedUsed, state.preemptibleDevices[nodeName])
+
+	nodeDeviceInfo.lock.RLock()
+	defer nodeDeviceInfo.lock.RUnlock()
+
+	reservationInfo := frameworkext.GetNominatedReservation(cycleState, nodeName)
+	if reservationInfo != nil {
+		score, status := pl.scoreWithNominatedReservation(state, restoreState, nodeDeviceInfo, nodeName, pod, preemptible, reservationInfo)
+		if status.IsSuccess() {
+			return score, nil
+		}
+		klog.ErrorS(status.AsError(), "Failed to scoreWithNominatedReservation of DeviceShare",
+			"pod", klog.KObj(pod), "reservation", klog.KObj(reservationInfo), "node", nodeName)
+	}
+
+	preemptible = appendAllocated(preemptible, restoreState.mergedMatchedAllocatable)
+	score, err := pl.allocator.Score(nodeName, pod, state.podRequests, nodeDeviceInfo, nil, preemptible, pl.scorer)
+	if err != nil {
+		klog.ErrorS(status.AsError(), "Failed to score of DeviceShare",
+			"pod", klog.KObj(pod), "reservation", klog.KObj(reservationInfo), "node", nodeName)
+		return 0, framework.AsStatus(err)
+	}
+	return score, nil
+}
+
+func (pl *Plugin) ScoreExtensions() framework.ScoreExtensions {
+	return pl
+}
+
+func (pl *Plugin) NormalizeScore(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, scores framework.NodeScoreList) *framework.Status {
+	return pluginhelper.DefaultNormalizeScore(framework.MaxNodeScore, false, scores)
+}
+
+func (pl *Plugin) ScoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) (int64, *framework.Status) {
+	state, status := getPreFilterState(cycleState)
+	if !status.IsSuccess() {
+		return 0, status
+	}
+	if state.skip {
+		return 0, nil
+	}
+
+	reservationRestoreState := getReservationRestoreState(cycleState)
+	restoreState := reservationRestoreState.getNodeState(nodeName)
+
+	nodeDeviceInfo := pl.nodeDeviceCache.getNodeDevice(nodeName, false)
+	if nodeDeviceInfo == nil {
+		return 0, framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice)
+	}
+
+	preemptible := appendAllocated(nil, restoreState.mergedUnmatchedUsed, state.preemptibleDevices[nodeName])
+
+	nodeDeviceInfo.lock.RLock()
+	defer nodeDeviceInfo.lock.RUnlock()
+
+	return pl.scoreWithNominatedReservation(state, restoreState, nodeDeviceInfo, nodeName, pod, preemptible, reservationInfo)
+}
+
+// deviceResourceStrategyTypeMap maps strategy to scorer implementation
+var deviceResourceStrategyTypeMap = map[schedulerconfig.ScoringStrategyType]scorer{
+	schedulerconfig.LeastAllocated: func(args *schedulerconfig.DeviceShareArgs) *resourceAllocationScorer {
+		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
+		return &resourceAllocationScorer{
+			Name:                string(schedconfig.LeastAllocated),
+			scorer:              leastResourceScorer(resToWeightMap),
+			resourceToWeightMap: resToWeightMap,
+		}
+	},
+	schedulerconfig.MostAllocated: func(args *schedulerconfig.DeviceShareArgs) *resourceAllocationScorer {
+		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
+		return &resourceAllocationScorer{
+			Name:                string(schedconfig.MostAllocated),
+			scorer:              mostResourceScorer(resToWeightMap),
+			resourceToWeightMap: resToWeightMap,
+		}
+	},
+}
+
+// resourceToWeightMap contains resource name and weight.
+type resourceToWeightMap map[corev1.ResourceName]int64
+
+// scorer is decorator for resourceAllocationScorer
+type scorer func(args *schedulerconfig.DeviceShareArgs) *resourceAllocationScorer
+
+// resourceAllocationScorer contains information to calculate resource allocation score.
+type resourceAllocationScorer struct {
+	Name                string
+	scorer              func(requested, allocatable resourceToValueMap) int64
+	resourceToWeightMap resourceToWeightMap
+}
+
+// resourceToValueMap is keyed with resource name and valued with quantity.
+type resourceToValueMap map[corev1.ResourceName]int64
+
+// scoreDevice will use `scorer` function to calculate the scoreDevice.
+func (r *resourceAllocationScorer) scoreDevice(podRequest corev1.ResourceList, total, free corev1.ResourceList) int64 {
+	if r.resourceToWeightMap == nil {
+		return 0
+	}
+
+	requested := make(resourceToValueMap)
+	allocatable := make(resourceToValueMap)
+	for resourceName := range r.resourceToWeightMap {
+		totalQuantity := total[resourceName]
+		if !totalQuantity.IsZero() {
+			used := totalQuantity.DeepCopy()
+			used.Sub(free[resourceName])
+			req := podRequest[resourceName]
+			req.Add(used)
+			allocatable[resourceName], requested[resourceName] = totalQuantity.Value(), req.Value()
+		}
+	}
+
+	score := r.scorer(requested, allocatable)
+	return score
+}
+
+func (r *resourceAllocationScorer) scoreNode(podRequest corev1.ResourceList, totalDeviceResources, freeDeviceResources deviceResources) int64 {
+	if r.resourceToWeightMap == nil {
+		return 0
+	}
+
+	requested := make(resourceToValueMap)
+	allocatable := make(resourceToValueMap)
+	for resourceName := range r.resourceToWeightMap {
+		var total resource.Quantity
+		for _, deviceRes := range totalDeviceResources {
+			total.Add(deviceRes[resourceName])
+		}
+		if total.IsZero() {
+			continue
+		}
+		var free resource.Quantity
+		for _, deviceRes := range freeDeviceResources {
+			free.Add(deviceRes[resourceName])
+		}
+
+		if total.Cmp(free) >= 0 {
+			req := total.DeepCopy()
+			req.Sub(free)
+			req.Add(podRequest[resourceName])
+			allocatable[resourceName], requested[resourceName] = total.Value(), req.Value()
+		}
+	}
+
+	score := r.scorer(requested, allocatable)
+	return score
+}
+
+// resourcesToWeightMap make weightmap from resources spec
+func resourcesToWeightMap(resources []schedconfig.ResourceSpec) resourceToWeightMap {
+	resourceToWeightMap := make(resourceToWeightMap)
+	for _, resource := range resources {
+		resourceToWeightMap[corev1.ResourceName(resource.Name)] = resource.Weight
+	}
+	return resourceToWeightMap
+}
+
+func leastResourceScorer(resToWeightMap resourceToWeightMap) func(resourceToValueMap, resourceToValueMap) int64 {
+	return func(requested, allocatable resourceToValueMap) int64 {
+		var nodeScore, weightSum int64
+		for resource := range requested {
+			weight := resToWeightMap[resource]
+			resourceScore := leastRequestedScore(requested[resource], allocatable[resource])
+			nodeScore += resourceScore * weight
+			weightSum += weight
+		}
+		if weightSum == 0 {
+			return 0
+		}
+		return nodeScore / weightSum
+	}
+}
+
+func leastRequestedScore(requested, capacity int64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		return 0
+	}
+
+	return ((capacity - requested) * framework.MaxNodeScore) / capacity
+}
+
+func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allocable resourceToValueMap) int64 {
+	return func(requested, allocatable resourceToValueMap) int64 {
+		var nodeScore, weightSum int64
+		for resource := range requested {
+			weight := resToWeightMap[resource]
+			resourceScore := mostRequestedScore(requested[resource], allocatable[resource])
+			nodeScore += resourceScore * weight
+			weightSum += weight
+		}
+		if weightSum == 0 {
+			return 0
+		}
+		return nodeScore / weightSum
+	}
+}
+
+func mostRequestedScore(requested, capacity int64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		// `requested` might be greater than `capacity` because pods with no
+		// requests get minimum values.
+		requested = capacity
+	}
+
+	return (requested * framework.MaxNodeScore) / capacity
+}

--- a/pkg/scheduler/plugins/deviceshare/service.go
+++ b/pkg/scheduler/plugins/deviceshare/service.go
@@ -26,14 +26,14 @@ import (
 
 var _ services.APIServiceProvider = &Plugin{}
 
-func (p *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
+func (pl *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 	group.GET("/nodeDeviceSummaries", func(c *gin.Context) {
-		allNodeDeviceSummary := p.getAllNodeDeviceSummary()
+		allNodeDeviceSummary := pl.getAllNodeDeviceSummary()
 		c.JSON(http.StatusOK, allNodeDeviceSummary)
 	})
 	group.GET("/nodeDeviceSummaries/:name", func(c *gin.Context) {
 		nodeName := c.Param("name")
-		nodeDeviceSummary, exist := p.getNodeDeviceSummary(nodeName)
+		nodeDeviceSummary, exist := pl.getNodeDeviceSummary(nodeName)
 		if !exist {
 			services.ResponseErrorMessage(c, http.StatusNotFound, "cannot find node %s", nodeName)
 			return

--- a/pkg/scheduler/plugins/deviceshare/service_test.go
+++ b/pkg/scheduler/plugins/deviceshare/service_test.go
@@ -33,12 +33,11 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 )
 
 func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(&config.DeviceShareArgs{}, suit.Framework)
+	p, err := suit.proxyNew(getDefaultArgs(), suit.Framework)
 	assert.NotNil(t, p)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The DeviceShare plugin in koord-scheduler supports multiple resource APIs such as `nvidia.com/gpu`, `koordinator.sh/gpu-memory`, `koordinator.sh/gpu-memory-ratio` and `koordinator.sh/gpu` - core, etc. Therefore, a user can create some Pods on the same node using the above resource API, and the DeviceShare plugin will normalize the resource request to "koordinator.sh/gpu-memory" etc., for example, convert "nvidia.com/gpu=1" to "koordinator .sh/gpu-core=100" and "koordinator.sh/gpu-memory-ratio=100", this normalization behavior breaks the "NodeResourceFit" scoring algorithm.

In addition, in the GPU Share scenario, multiple Pods may run on one GPU device instance. This usage method can improve resource utilization and reduce costs, but it also has the risk of reducing the high availability of applications. Therefore, it is necessary to provide the ability to spread at the device instance level.

In order to solve these problems, a new field `scoreStrategy` is added in the plug-in configuration DeviceShareArgs to support users to customize different scoring strategies. The two most common strategies are currently supported: MostAllocated and LeastAllocated. LeastAllocated is used by default.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1457

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
