### PR TITLE
apis: add priority-class compatible label

### DIFF
--- a/apis/extension/constants.go
+++ b/apis/extension/constants.go
@@ -29,6 +29,10 @@ const (
 
 	LabelPodQoS      = DomainPrefix + "qosClass"
 	LabelPodPriority = DomainPrefix + "priority"
+	// LabelPodPriorityClass is used to revise those Pods that are already running and have Priority set, so that
+	// Koordinator can be smoothly deployed to the running cluster. If you don't have a running Pod with
+	// PriorityClass set, don't set this field specifically.
+	LabelPodPriorityClass = DomainPrefix + "priority-class"
 
 	LabelManagedBy = "app.kubernetes.io/managed-by"
 )

--- a/apis/extension/priority.go
+++ b/apis/extension/priority.go
@@ -48,8 +48,25 @@ var (
 	PriorityFreeValueMin int32 = 3000
 )
 
+func GetPodPriorityClassByName(priorityClass string) PriorityClass {
+	p := PriorityClass(priorityClass)
+
+	switch p {
+	case PriorityProd, PriorityMid, PriorityBatch, PriorityFree:
+		return p
+	}
+
+	return PriorityNone
+}
+
 func GetPriorityClass(pod *corev1.Pod) PriorityClass {
-	if pod == nil || pod.Spec.Priority == nil {
+	if pod == nil {
+		return PriorityNone
+	}
+	if p, ok := pod.Labels[LabelPodPriorityClass]; ok {
+		return GetPodPriorityClassByName(p)
+	}
+	if pod.Spec.Priority == nil {
 		return PriorityNone
 	}
 	return getPriorityClassByPriority(pod.Spec.Priority)

--- a/apis/extension/priority_utils.go
+++ b/apis/extension/priority_utils.go
@@ -34,6 +34,8 @@ func GetPodPriorityClassWithDefault(pod *corev1.Pod) PriorityClass {
 
 // GetPodPriorityClassWithQoS returns the default PriorityClass according to its QoSClass when the pod does not specify
 // a PriorityClass explicitly.
+// Note that this is only a derivation of the default value, and the reverse is not true. For example, PriorityMid
+// can also be combined with QoSLS.
 func GetPodPriorityClassWithQoS(qos QoSClass) PriorityClass {
 	switch qos {
 	case QoSSystem, QoSLSE, QoSLSR, QoSLS:

--- a/apis/extension/priority_utils_test.go
+++ b/apis/extension/priority_utils_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func toIntPointer(i int32) *int32 {
+	return &i
+}
+
+func TestGetPriorityClass(t *testing.T) {
+	testCases := []struct {
+		pod      *v1.Pod
+		expected PriorityClass
+	}{
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityProdValueMin + PriorityProdValueMax) / 2),
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityBatchValueMin + PriorityBatchValueMax) / 2),
+				},
+			},
+			expected: PriorityBatch,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPriorityClass: string(PriorityProd),
+					},
+				},
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityBatchValueMin + PriorityBatchValueMax) / 2),
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPriorityClass: "unknown",
+					},
+				},
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityBatchValueMin + PriorityBatchValueMax) / 2),
+				},
+			},
+			expected: PriorityNone,
+		},
+	}
+
+	for _, tc := range testCases {
+		p := GetPriorityClass(tc.pod)
+		if p != tc.expected {
+			t.Errorf("unexpected priority class, expected %v actual %v", tc.expected, p)
+		}
+	}
+}
+
+func TestGetPodPriorityClassWithDefault(t *testing.T) {
+	testCases := []struct {
+		pod      *v1.Pod
+		expected PriorityClass
+	}{
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityProdValueMin + PriorityProdValueMax) / 2),
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPriorityClass: string(PriorityProd),
+					},
+				},
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityBatchValueMin + PriorityBatchValueMax) / 2),
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodQoS: string(QoSLSR),
+					},
+				},
+				Spec: v1.PodSpec{
+					Priority: toIntPointer((PriorityBatchValueMin + PriorityBatchValueMax) / 2),
+				},
+			},
+			expected: PriorityBatch,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodQoS: string(QoSLSR),
+					},
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodQoS: string(QoSBE),
+					},
+				},
+			},
+			expected: PriorityBatch,
+		},
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("100"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("200"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("100"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: PriorityProd,
+		},
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "abc",
+						},
+					},
+				},
+			},
+			expected: PriorityBatch,
+		},
+	}
+
+	for _, tc := range testCases {
+		p := GetPodPriorityClassWithDefault(tc.pod)
+		if p != tc.expected {
+			t.Errorf("unexpected priority class, expected %v actual %v", tc.expected, p)
+		}
+	}
+}

--- a/docs/proposals/api-machinery/20230707-add-compatibility-interface-for-priority-class.md
+++ b/docs/proposals/api-machinery/20230707-add-compatibility-interface-for-priority-class.md
@@ -1,0 +1,105 @@
+---
+title: Add compatibility interface for priority class
+authors:
+- "@hormes"
+reviews:
+- "@eahydra"
+- "@saintube"
+- "@zwzhang0107"
+- "@jasonliu747"
+---
+
+# Add compatibility interface for priority class
+
+## Table of Contents
+
+- [Add compatibility interface for priority class](#add-compatibility-interface-for-priority-class)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals/Future Work](#non-goalsfuture-work)
+  - [Proposal](#proposal)
+    - [User Stories](#user-stories)
+    - [Implementation](#implementation)
+  - [Alternatives](#alternatives)
+  - [Unsolved Problems](#unsolved-problems)
+  - [Implementation History](#implementation-history)
+
+## Summary
+
+Provide a solution using Koordinator PriorityClass for already running a large number of Pod clusters by adding a label `koordinator.sh/priority-class`.
+
+## Motivation
+
+Koordinator defines a set of specifications on top of kubernetes priority class, and extends a dimension of to support fine-grained colocation(see [Koordinator Priority Class](https://koordinator.sh/docs/architecture/priority)). 
+If your cluster follows Koordinator's best practice to build the entire scheduling system from initialization, then everything will be very natural. 
+
+Then, the actual situation is that before install Koordinator, a large number of clusters have been running for a period of time, and have its own Priority Class definition and supporting operating system.
+In order to be better compatible with usage habits and at the same time obtain the scheduling capability of Koordinator bound to PriorityClass, we need a compatible solution to support this situation.
+
+### Goals
+
+1. Provides a solution using Koordinator PriorityClass for already running a large number of Pod clusters.
+
+### Non-Goals/Future Work
+
+1. Provide an alternative API for PriorityClass.
+
+## Proposal
+
+### User Stories
+
+The user has already run a large number of Pods, and the PriorityClass conflicts with the Koordinator declaration.
+For example, the PriorityClass is declared as follows:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: user-defined-priority-class
+value: 5000
+description: "This priority class should be used for prod service pods only."
+```
+
+Then create many Pods like this:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent
+  priorityClassName: user-defined-priority-class
+```
+
+When users install Koordinator, they cannot adjust all these Pods at once (affecting business stability), and hope that
+there is a way to regulate these Pods into the best practice category of Koordinator.
+
+### Implementation
+
+1. Defines a new label `koordinator.sh/priority-class` to compatible with Pods that are already running.
+2. When a user install Koordinator, find a way to label the existing Pods with this label. There is a default value inference mechanism for unlabeled Koordinator, but please do not rely on it.
+3. When Koordinator calculates the priorityclass, priority-class is obtained according to the label firstly. If the Pod declares the label, the label will be used(even if the value is not recognized).
+
+## Alternatives
+
+Provide a feature-gate to express whether to enable the compatibility mode. The compatibility mode is defined as follows:
+- All priority classes are based on the obtained label and are no longer calculated based on Priority
+
+The reason why this method is not used is that PriorityClass is actually used to describe Priority. If it is completely described in a label loosely coupled manner, the Priority between different PriorityClasses will be confused, which is not conducive to long-term business operations. Long-term use on k8s has compatibility and stability risks.
+
+
+## Unsolved Problems
+
+1. When there are two situations of PriorityClass declared by label and inferred by Priority at the same time, the Prod Pod Priority may be lower than the Batch Pod Priority. Users need to pay attention to the preemptive declaration relationship in the corresponding PriorityClass configuration and the possible Priority flipped. (Koord-scheduler supports the process of disabling high-priority to low-priority preemption to support user grayscale switching).
+
+## Implementation History
+
+- 2023-07-07: Initialize proposal for review


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Provide a solution using Koordinator PriorityClass for already running a large number of Pods clusters by adding a label `koordinator.sh/priority-class`.
