### PR TITLE
apis: add moduleID in Device CRD

### DIFF
--- a/apis/scheduling/v1alpha1/device_types.go
+++ b/apis/scheduling/v1alpha1/device_types.go
@@ -38,6 +38,8 @@ type DeviceInfo struct {
 	UUID string `json:"id,omitempty"`
 	// Minor represents the Minor number of Device, starting from 0
 	Minor *int32 `json:"minor,omitempty"`
+	// ModuleID represents the physical id of Device
+	ModuleID *int32 `json:"moduleID,omitempty"`
 	// Type represents the type of device
 	Type DeviceType `json:"type,omitempty"`
 	// Health indicates whether the device is normal

--- a/apis/scheduling/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/scheduling/v1alpha1/zz_generated.deepcopy.go
@@ -104,6 +104,11 @@ func (in *DeviceInfo) DeepCopyInto(out *DeviceInfo) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ModuleID != nil {
+		in, out := &in.ModuleID, &out.ModuleID
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make(v1.ResourceList, len(*in))

--- a/config/crd/bases/scheduling.koordinator.sh_devices.yaml
+++ b/config/crd/bases/scheduling.koordinator.sh_devices.yaml
@@ -47,6 +47,10 @@ spec:
                         from 0
                       format: int32
                       type: integer
+                    moduleID:
+                      description: ModuleID represents the physical id of Device
+                      format: int32
+                      type: integer
                     resources:
                       additionalProperties:
                         anyOf:

--- a/config/crd/bases/slo.koordinator.sh_nodemetrics.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodemetrics.yaml
@@ -90,6 +90,11 @@ spec:
                                         of Device, starting from 0
                                       format: int32
                                       type: integer
+                                    moduleID:
+                                      description: ModuleID represents the physical
+                                        id of Device
+                                      format: int32
+                                      type: integer
                                     resources:
                                       additionalProperties:
                                         anyOf:
@@ -144,6 +149,11 @@ spec:
                                         of Device, starting from 0
                                       format: int32
                                       type: integer
+                                    moduleID:
+                                      description: ModuleID represents the physical
+                                        id of Device
+                                      format: int32
+                                      type: integer
                                     resources:
                                       additionalProperties:
                                         anyOf:
@@ -191,6 +201,11 @@ spec:
                                 starting from 0
                               format: int32
                               type: integer
+                            moduleID:
+                              description: ModuleID represents the physical id of
+                                Device
+                              format: int32
+                              type: integer
                             resources:
                               additionalProperties:
                                 anyOf:
@@ -234,6 +249,11 @@ spec:
                             minor:
                               description: Minor represents the Minor number of Device,
                                 starting from 0
+                              format: int32
+                              type: integer
+                            moduleID:
+                              description: ModuleID represents the physical id of
+                                Device
                               format: int32
                               type: integer
                             resources:
@@ -293,6 +313,11 @@ spec:
                                   Device, starting from 0
                                 format: int32
                                 type: integer
+                              moduleID:
+                                description: ModuleID represents the physical id of
+                                  Device
+                                format: int32
+                                type: integer
                               resources:
                                 additionalProperties:
                                   anyOf:
@@ -341,6 +366,11 @@ spec:
                             minor:
                               description: Minor represents the Minor number of Device,
                                 starting from 0
+                              format: int32
+                              type: integer
+                            moduleID:
+                              description: ModuleID represents the physical id of
+                                Device
                               format: int32
                               type: integer
                             resources:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Some advanced GPUs require allocation according to the combination relationship of ModuleID to obtain the best communication efficiency.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
