### PR TITLE
koord-manager: add leader elect resource lock arg

### DIFF
--- a/cmd/koord-manager/main.go
+++ b/cmd/koord-manager/main.go
@@ -57,6 +57,7 @@ func main() {
 	var healthProbeAddr string
 	var enableLeaderElection, enablePprof bool
 	var leaderElectionNamespace string
+	var leaderElectResourceLock string
 	var namespace string
 	var syncPeriodStr string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -64,6 +65,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true, "Whether you need to enable leader election.")
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "koordinator-system",
 		"This determines the namespace in which the leader election configmap will be created, it will use in-cluster namespace if empty.")
+	flag.StringVar(&leaderElectResourceLock, "leader-elect-resource-lock", resourcelock.ConfigMapsLeasesResourceLock,
+		"The leader election resource lock for controller manager. e.g. 'leases', 'configmaps', 'endpoints', 'endpointsleases', 'configmapsleases'")
 	flag.StringVar(&namespace, "namespace", "",
 		"Namespace if specified restricts the manager's cache to watch objects in the desired namespace. Defaults to all namespaces.")
 	flag.BoolVar(&enablePprof, "enable-pprof", true, "Enable pprof for controller manager.")
@@ -115,7 +118,7 @@ func main() {
 		LeaderElection:             enableLeaderElection,
 		LeaderElectionID:           "koordinator-manager",
 		LeaderElectionNamespace:    leaderElectionNamespace,
-		LeaderElectionResourceLock: resourcelock.ConfigMapsLeasesResourceLock,
+		LeaderElectionResourceLock: leaderElectResourceLock,
 		Namespace:                  namespace,
 		SyncPeriod:                 syncPeriod,
 		NewClient:                  utilclient.NewClient,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-manager: add a leader election resource lock argument.

It is helpful when we want to migrate the leader election lock mode of the deployed koord-manager from the old `configmaps` into new `leases`.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
