### PR TITLE
all: fix GetPriorityClass with default

### DIFF
--- a/apis/extension/priority.go
+++ b/apis/extension/priority.go
@@ -68,7 +68,7 @@ func GetPodPriorityClassByName(priorityClass string) PriorityClass {
 	return PriorityNone
 }
 
-func GetPriorityClass(pod *corev1.Pod) PriorityClass {
+func GetPodPriorityClassRaw(pod *corev1.Pod) PriorityClass {
 	if pod == nil {
 		return PriorityNone
 	}

--- a/apis/extension/priority_utils.go
+++ b/apis/extension/priority_utils.go
@@ -24,7 +24,7 @@ var DefaultPriorityClass = PriorityNone
 
 // GetPodPriorityClassWithDefault gets the pod's PriorityClass with the default config.
 func GetPodPriorityClassWithDefault(pod *corev1.Pod) PriorityClass {
-	priorityClass := GetPriorityClass(pod)
+	priorityClass := GetPodPriorityClassRaw(pod)
 	if priorityClass != PriorityNone {
 		return priorityClass
 	}

--- a/apis/extension/priority_utils_test.go
+++ b/apis/extension/priority_utils_test.go
@@ -78,7 +78,7 @@ func TestGetPriorityClass(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		p := GetPriorityClass(tc.pod)
+		p := GetPodPriorityClassRaw(tc.pod)
 		if p != tc.expected {
 			t.Errorf("unexpected priority class, expected %v actual %v", tc.expected, p)
 		}

--- a/apis/extension/qos_utils.go
+++ b/apis/extension/qos_utils.go
@@ -30,7 +30,7 @@ var QoSClassForGuaranteed = QoSLSR
 
 // GetPodQoSClassWithDefault gets the pod's QoSClass with the default config.
 func GetPodQoSClassWithDefault(pod *corev1.Pod) QoSClass {
-	qosClass := GetPodQoSClass(pod)
+	qosClass := GetPodQoSClassRaw(pod)
 	if qosClass != QoSNone {
 		return qosClass
 	}
@@ -54,7 +54,7 @@ func GetPodQoSClassWithKubeQoS(kubeQOS corev1.PodQOSClass) QoSClass {
 	return QoSNone
 }
 
-func GetPodQoSClass(pod *corev1.Pod) QoSClass {
+func GetPodQoSClassRaw(pod *corev1.Pod) QoSClass {
 	if pod == nil || pod.Labels == nil {
 		return QoSNone
 	}

--- a/apis/extension/qos_utils_test.go
+++ b/apis/extension/qos_utils_test.go
@@ -69,7 +69,7 @@ func TestGetPodQoSClass(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetPodQoSClass(tt.arg)
+			got := GetPodQoSClassRaw(tt.arg)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/descheduler/utils/sorter/pod.go
+++ b/pkg/descheduler/utils/sorter/pod.go
@@ -78,8 +78,8 @@ func KubernetesQoSClass(p1, p2 *corev1.Pod) int {
 
 // KoordinatorQoSClass compares pods by the Koordinator QoSClass
 func KoordinatorQoSClass(p1, p2 *corev1.Pod) int {
-	qos1 := koordQoSClassOrder[extension.GetPodQoSClass(p1)]
-	qos2 := koordQoSClassOrder[extension.GetPodQoSClass(p2)]
+	qos1 := koordQoSClassOrder[extension.GetPodQoSClassWithDefault(p1)]
+	qos2 := koordQoSClassOrder[extension.GetPodQoSClassWithDefault(p2)]
 	if qos1 == qos2 {
 		return 0
 	}
@@ -91,8 +91,8 @@ func KoordinatorQoSClass(p1, p2 *corev1.Pod) int {
 
 // KoordinatorPriorityClass compares pods by the Koordinator PriorityClass
 func KoordinatorPriorityClass(p1, p2 *corev1.Pod) int {
-	priorityClass1 := koordPriorityClassOrder[extension.GetPriorityClass(p1)]
-	priorityClass2 := koordPriorityClassOrder[extension.GetPriorityClass(p2)]
+	priorityClass1 := koordPriorityClassOrder[extension.GetPodPriorityClassWithDefault(p1)]
+	priorityClass2 := koordPriorityClassOrder[extension.GetPodPriorityClassWithDefault(p2)]
 	if priorityClass1 == priorityClass2 {
 		return 0
 	}

--- a/pkg/descheduler/utils/sorter/pod_test.go
+++ b/pkg/descheduler/utils/sorter/pod_test.go
@@ -130,7 +130,7 @@ func TestSortPods(t *testing.T) {
 		corev1.ResourcePods:   1,
 	}
 	SortPodsByUsage(pods, podMetrics, nodeAllocatableMap, resourceToWeightMap)
-	expectedPodsOrder := []string{"test-18", "test-19", "test-17", "test-16", "test-15", "test-21", "test-20", "test-23", "test-22", "test-9", "test-8", "test-2", "test-3", "test-7", "test-4", "test-6", "test-5", "test-1", "test-11", "test-10", "test-12", "test-13", "test-14"}
+	expectedPodsOrder := []string{"test-1", "test-12", "test-18", "test-19", "test-17", "test-16", "test-15", "test-21", "test-20", "test-23", "test-22", "test-9", "test-8", "test-11", "test-10", "test-13", "test-14", "test-2", "test-3", "test-7", "test-4", "test-6", "test-5"}
 	var podsOrder []string
 	for _, v := range pods {
 		podsOrder = append(podsOrder, v.Name)

--- a/pkg/koordlet/metricsadvisor/collectors/beresource/be_resource_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/beresource/be_resource_collector.go
@@ -155,7 +155,7 @@ func (b *beResourceCollector) getBECPURequestSum() resource.Quantity {
 	requestSum := int64(0)
 	for _, podMeta := range b.statesInformer.GetAllPods() {
 		pod := podMeta.Pod
-		if apiext.GetPodQoSClass(pod) == apiext.QoSBE {
+		if apiext.GetPodQoSClassRaw(pod) == apiext.QoSBE {
 			podCPUReq := util.GetPodBEMilliCPURequest(pod)
 			if podCPUReq > 0 {
 				requestSum += podCPUReq

--- a/pkg/koordlet/resmanager/blkio_reconcile.go
+++ b/pkg/koordlet/resmanager/blkio_reconcile.go
@@ -164,7 +164,7 @@ func (b *BlkIOReconcile) reconcile() {
 	// pods
 	podsMeta := b.resmanager.statesInformer.GetAllPods()
 	for _, podMeta := range podsMeta {
-		if extension.GetPodQoSClass(podMeta.Pod) == extension.QoSNone {
+		if extension.GetPodQoSClassRaw(podMeta.Pod) == extension.QoSNone {
 			// ignore unknown qos pods
 			continue
 		}

--- a/pkg/koordlet/resmanager/cgroup_reconcile.go
+++ b/pkg/koordlet/resmanager/cgroup_reconcile.go
@@ -233,7 +233,7 @@ func (m *CgroupResourcesReconcile) calculatePodResources(pod *corev1.Pod, parent
 		var memRequest int64
 		// memory.min, memory.low: just sum all containers' memory requests; regard as no memory protection when any
 		// of containers does not set request
-		if apiext.GetPodQoSClass(pod) != apiext.QoSBE {
+		if apiext.GetPodQoSClassRaw(pod) != apiext.QoSBE {
 			podRequest := util.GetPodRequest(pod)
 			memRequest = podRequest.Memory().Value()
 		} else {
@@ -279,7 +279,7 @@ func (m *CgroupResourcesReconcile) calculateContainerResources(container *corev1
 		// resources calculated with container spec
 		var memRequest int64
 		var memLimit int64
-		if apiext.GetPodQoSClass(pod) != apiext.QoSBE {
+		if apiext.GetPodQoSClassRaw(pod) != apiext.QoSBE {
 			memRequest = container.Resources.Requests.Memory().Value()
 			memLimit = util.GetContainerMemoryByteLimit(container)
 		} else {
@@ -402,7 +402,7 @@ func updateCgroupSummaryForQoS(summary *cgroupResourceSummary, pod *corev1.Pod, 
 	// `memory.low` for qos := sum(requests of pod with the qos * lowLimitPercent); if factor is nil, set kernel default
 	var memRequest int64
 	// if any container's memory request is not set, just consider it as zero
-	if apiext.GetPodQoSClass(pod) != apiext.QoSBE {
+	if apiext.GetPodQoSClassRaw(pod) != apiext.QoSBE {
 		podRequest := util.GetPodRequest(pod)
 		memRequest = podRequest.Memory().Value()
 	} else {

--- a/pkg/koordlet/resmanager/cpu_burst.go
+++ b/pkg/koordlet/resmanager/cpu_burst.go
@@ -273,7 +273,7 @@ func (b *CPUBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 	sharePoolCPUCoresTotal := float64(nodeCPUCoresTotal)
 	sharePoolCPUCoresUsage := nodeCPUCoresUsage
 	for _, podMeta := range podsMeta {
-		podQOS := apiext.GetPodQoSClass(podMeta.Pod)
+		podQOS := apiext.GetPodQoSClassRaw(podMeta.Pod)
 		// exclude LSE/LSR pod cpu from cpu share pool
 		if podQOS == apiext.QoSLSE || podQOS == apiext.QoSLSR {
 			podRequest := util.GetPodRequest(podMeta.Pod)

--- a/pkg/koordlet/resmanager/cpu_evict.go
+++ b/pkg/koordlet/resmanager/cpu_evict.go
@@ -180,7 +180,7 @@ func (c *CPUEvictor) getPodEvictInfoAndSort(beMetric *metriccache.BECPUResourceM
 
 	for _, podMeta := range c.resmanager.statesInformer.GetAllPods() {
 		pod := podMeta.Pod
-		if apiext.GetPodQoSClass(pod) == apiext.QoSBE {
+		if apiext.GetPodQoSClassRaw(pod) == apiext.QoSBE {
 
 			bePodInfo := &podEvictCPUInfo{pod: podMeta.Pod}
 			queryMeta, err := metriccache.PodCPUUsageMetric.BuildQueryMeta(metriccache.MetricPropertiesFunc.Pod(string(pod.UID)))

--- a/pkg/koordlet/resmanager/cpu_suppress.go
+++ b/pkg/koordlet/resmanager/cpu_suppress.go
@@ -127,7 +127,7 @@ func (r *CPUSuppress) calculateBESuppressCPU(node *corev1.Node, nodeMetric float
 		if !ok {
 			klog.Warningf("podMetric not included in the podMetas %v", podUID)
 		}
-		if !ok || (apiext.GetPodQoSClass(podMeta.Pod) != apiext.QoSBE && util.GetKubeQosClass(podMeta.Pod) != corev1.PodQOSBestEffort) {
+		if !ok || (apiext.GetPodQoSClassRaw(podMeta.Pod) != apiext.QoSBE && util.GetKubeQosClass(podMeta.Pod) != corev1.PodQOSBestEffort) {
 			// NOTE: consider non-BE pods and podMeta-missing pods as LS
 			podNoneBEUsedCPU.Add(*resource.NewMilliQuantity(int64(podMetric*1000), resource.DecimalSI))
 		}
@@ -336,7 +336,7 @@ func (r *CPUSuppress) adjustByCPUSet(cpusetQuantity *resource.Quantity, nodeCPUI
 			continue
 		}
 		for _, cpuID := range set.ToSliceNoSort() {
-			cpuIdToPool[int32(cpuID)] = apiext.GetPodQoSClass(podMeta.Pod)
+			cpuIdToPool[int32(cpuID)] = apiext.GetPodQoSClassRaw(podMeta.Pod)
 		}
 	}
 
@@ -458,7 +458,7 @@ func (r *CPUSuppress) recoverCPUSetIfNeed(maxDepth int) {
 		if err != nil {
 			continue
 		}
-		if apiext.GetPodQoSClass(podMeta.Pod) != apiext.QoSLSE {
+		if apiext.GetPodQoSClassRaw(podMeta.Pod) != apiext.QoSLSE {
 			continue
 		}
 		if alloc.CPUSet == "" {

--- a/pkg/koordlet/resmanager/memory_evict.go
+++ b/pkg/koordlet/resmanager/memory_evict.go
@@ -163,7 +163,7 @@ func (m *MemoryEvictor) getSortedBEPodInfos(podMetricMap map[string]float64) []*
 	var bePodInfos []*podInfo
 	for _, podMeta := range m.resManager.statesInformer.GetAllPods() {
 		pod := podMeta.Pod
-		if extension.GetPodQoSClass(pod) == extension.QoSBE {
+		if extension.GetPodQoSClassRaw(pod) == extension.QoSBE {
 			info := &podInfo{
 				pod:     pod,
 				memUsed: podMetricMap[string(pod.UID)],

--- a/pkg/koordlet/resmanager/resctrl_reconcile.go
+++ b/pkg/koordlet/resmanager/resctrl_reconcile.go
@@ -84,7 +84,7 @@ func (r *ResctrlReconcile) RunInit(stopCh <-chan struct{}) error {
 }
 
 func getPodResctrlGroup(pod *corev1.Pod) string {
-	podQoS := extension.GetPodQoSClass(pod)
+	podQoS := extension.GetPodQoSClassRaw(pod)
 	switch podQoS {
 	case extension.QoSLSR:
 		return LSRResctrlGroup
@@ -392,7 +392,7 @@ func (r *ResctrlReconcile) reconcileResctrlGroups(qosStrategy *slov1alpha1.Resou
 		// only extension-QoS-specified pod are considered
 		podQoSCfg := getPodResourceQoSByQoSClass(pod, qosStrategy, r.resManager.config)
 		if podQoSCfg.ResctrlQOS.Enable == nil || !(*podQoSCfg.ResctrlQOS.Enable) {
-			klog.V(5).Infof("pod %v with qos %v disabled resctrl", util.GetPodKey(pod), extension.GetPodQoSClass(pod))
+			klog.V(5).Infof("pod %v with qos %v disabled resctrl", util.GetPodKey(pod), extension.GetPodQoSClassRaw(pod))
 			continue
 		}
 

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
@@ -66,7 +66,7 @@ func (p *plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		return nil
 	}
 	for _, podMeta := range pods {
-		podQOS := apiext.GetPodQoSClass(podMeta.Pod)
+		podQOS := apiext.GetPodQoSClassRaw(podMeta.Pod)
 		if podQOS != apiext.QoSBE {
 			continue
 		}

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
@@ -144,7 +144,7 @@ func (b *bvtPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		}
 	}
 	for _, podMeta := range pods {
-		podQOS := ext.GetPodQoSClass(podMeta.Pod)
+		podQOS := ext.GetPodQoSClassRaw(podMeta.Pod)
 		podKubeQOS := podMeta.Pod.Status.QOSClass
 		podBvt := r.getPodBvtValue(podQOS, podKubeQOS)
 		podCgroupPath := podMeta.CgroupDir

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler.go
@@ -113,7 +113,7 @@ func (p *podQOSFilter) Name() string {
 }
 
 func (p *podQOSFilter) Filter(podMeta *statesinformer.PodMeta) string {
-	qosClass := apiext.GetPodQoSClass(podMeta.Pod)
+	qosClass := apiext.GetPodQoSClassRaw(podMeta.Pod)
 
 	// consider as LSR if pod is qos=None and has cpuset
 	if qosClass == apiext.QoSNone && podMeta.Pod != nil && podMeta.Pod.Annotations != nil {

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
@@ -387,7 +387,7 @@ func (s *nodeTopoInformer) calGuaranteedCpu(usedCPUs map[int32]*extension.CPUInf
 	managedPods := make(map[types.UID]struct{})
 	for _, podMeta := range s.podsInformer.GetAllPods() {
 		pods[podMeta.Pod.UID] = podMeta
-		qosClass := extension.GetPodQoSClass(podMeta.Pod)
+		qosClass := extension.GetPodQoSClassRaw(podMeta.Pod)
 		if qosClass == extension.QoSLS || qosClass == extension.QoSBE {
 			managedPods[podMeta.Pod.UID] = struct{}{}
 			continue

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -60,7 +60,7 @@ func (e *DefaultEstimator) EstimatePod(pod *corev1.Pod) (map[corev1.ResourceName
 func estimatedPodUsed(pod *corev1.Pod, resourceWeights map[corev1.ResourceName]int64, scalingFactors map[corev1.ResourceName]int64) map[corev1.ResourceName]int64 {
 	requests, limits := resourceapi.PodRequestsAndLimits(pod)
 	estimatedUsed := make(map[corev1.ResourceName]int64)
-	priorityClass := extension.GetPriorityClass(pod)
+	priorityClass := extension.GetPodPriorityClassWithDefault(pod)
 	for resourceName := range resourceWeights {
 		realResourceName := extension.TranslateResourceNameByPriorityClass(priorityClass, resourceName)
 		estimatedUsed[resourceName] = estimatedUsedByResource(requests, limits, realResourceName, scalingFactors[resourceName])

--- a/pkg/scheduler/plugins/loadaware/helper.go
+++ b/pkg/scheduler/plugins/loadaware/helper.go
@@ -160,7 +160,7 @@ func buildPodMetricMap(podLister corev1listers.PodLister, nodeMetric *slov1alpha
 		if err != nil {
 			continue
 		}
-		if filterProdPod && extension.GetPriorityClass(pod) != extension.PriorityProd {
+		if filterProdPod && extension.GetPodPriorityClassWithDefault(pod) != extension.PriorityProd {
 			continue
 		}
 		name := getPodNamespacedName(podMetric.Namespace, podMetric.Name)

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -149,7 +149,7 @@ func (p *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *c
 	}
 
 	filterProfile := generateUsageThresholdsFilterProfile(node, p.args)
-	if len(filterProfile.ProdUsageThresholds) > 0 && extension.GetPriorityClass(pod) == extension.PriorityProd {
+	if len(filterProfile.ProdUsageThresholds) > 0 && extension.GetPodPriorityClassWithDefault(pod) == extension.PriorityProd {
 		status := p.filterProdUsage(node, nodeMetric, filterProfile.ProdUsageThresholds)
 		if !status.IsSuccess() {
 			return status
@@ -290,7 +290,7 @@ func (p *Plugin) Score(ctx context.Context, state *framework.CycleState, pod *co
 		return 0, nil
 	}
 
-	prodPod := extension.GetPriorityClass(pod) == extension.PriorityProd && p.args.ScoreAccordingProdUsage
+	prodPod := extension.GetPodPriorityClassWithDefault(pod) == extension.PriorityProd && p.args.ScoreAccordingProdUsage
 	podMetrics := buildPodMetricMap(p.podLister, nodeMetric, prodPod)
 
 	estimatedUsed, err := p.estimator.EstimatePod(pod)
@@ -348,7 +348,7 @@ func (p *Plugin) estimatedAssignedPodUsed(nodeName string, nodeMetric *slov1alph
 	p.podAssignCache.lock.RLock()
 	defer p.podAssignCache.lock.RUnlock()
 	for _, assignInfo := range p.podAssignCache.podInfoItems[nodeName] {
-		if filterProdPod && extension.GetPriorityClass(assignInfo.pod) != extension.PriorityProd {
+		if filterProdPod && extension.GetPodPriorityClassWithDefault(assignInfo.pod) != extension.PriorityProd {
 			continue
 		}
 		podName := getPodNamespacedName(assignInfo.pod.Namespace, assignInfo.pod.Name)

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -229,8 +229,8 @@ func AllowUseCPUSet(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
 	}
-	qosClass := extension.GetPodQoSClass(pod)
-	priorityClass := extension.GetPriorityClass(pod)
+	qosClass := extension.GetPodQoSClassRaw(pod)
+	priorityClass := extension.GetPodPriorityClassWithDefault(pod)
 	return (qosClass == extension.QoSLSE || qosClass == extension.QoSLSR) && priorityClass == extension.PriorityProd
 }
 

--- a/pkg/util/pod_qos_utils.go
+++ b/pkg/util/pod_qos_utils.go
@@ -38,7 +38,7 @@ func IsPodCfsQuotaNeedUnset(annotations map[string]string) (bool, error) {
 
 // IsPodCPUBurstable checks if cpu burst is allowed for the pod.
 func IsPodCPUBurstable(pod *corev1.Pod) bool {
-	qosClass := apiext.GetPodQoSClass(pod)
+	qosClass := apiext.GetPodQoSClassRaw(pod)
 	return qosClass != apiext.QoSLSR && qosClass != apiext.QoSLSE && qosClass != apiext.QoSBE
 }
 

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile.go
@@ -218,7 +218,7 @@ func (h *PodMutatingHandler) doMutateByColocationProfile(ctx context.Context, po
 }
 
 func (h *PodMutatingHandler) mutatePodResourceSpec(pod *corev1.Pod) error {
-	priorityClass := extension.GetPriorityClass(pod)
+	priorityClass := extension.GetPodPriorityClassWithDefault(pod)
 	if priorityClass == extension.PriorityNone || priorityClass == extension.PriorityProd {
 		return nil
 	}

--- a/pkg/webhook/pod/validating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/validating/cluster_colocation_profile_test.go
@@ -187,7 +187,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantReason:  fmt.Sprintf(`spec.priority: Invalid value: %q: field is immutable`, extension.GetPriorityClass(&corev1.Pod{})),
+			wantReason:  fmt.Sprintf(`spec.priority: Invalid value: %q: field is immutable`, extension.GetPodPriorityClassRaw(&corev1.Pod{})),
 		},
 		{
 			name:      "validate koordinator priority",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. Koordinator is using PriorityClass to make a lot of logical judgments, which need to consider compatible scenarios (default value)
2. Renamed GetPriorityClass and GetQoSClass at the same time to avoid misuse
