### PR TITLE
koordlet: fix the cpu.shares conversion on cgroups-v2

### DIFF
--- a/pkg/koordlet/resourceexecutor/reader_test.go
+++ b/pkg/koordlet/resourceexecutor/reader_test.go
@@ -576,19 +576,19 @@ func TestCgroupReader_ReadCPUShares(t *testing.T) {
 			args: args{
 				parentDir: "/kubepods.slice",
 			},
-			want:    10,
+			want:    2,
 			wantErr: false,
 		},
 		{
 			name: "parse v2 value successfully 1",
 			fields: fields{
 				UseCgroupsV2:   true,
-				CPUWeightValue: "100",
+				CPUWeightValue: "39",
 			},
 			args: args{
 				parentDir: "/kubepods.slice",
 			},
-			want:    1024,
+			want:    998,
 			wantErr: false,
 		},
 		{

--- a/pkg/koordlet/util/system/cgroup2_test.go
+++ b/pkg/koordlet/util/system/cgroup2_test.go
@@ -340,13 +340,13 @@ func TestConvertCPUWeightToShares(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			input:    50,
-			expected: 512,
+			input:    1,
+			expected: 2,
 			wantErr:  false,
 		},
 		{
 			input:    10000,
-			expected: 102400,
+			expected: 262144,
 			wantErr:  false,
 		},
 		{
@@ -358,9 +358,8 @@ func TestConvertCPUWeightToShares(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			input:    -1,
-			expected: 2,
-			wantErr:  true,
+			input:   -1,
+			wantErr: true,
 		},
 	}
 
@@ -390,17 +389,22 @@ func TestConvertCPUSharesToWeight(t *testing.T) {
 	}{
 		{
 			input:    "1000",
-			expected: 97, // 1000 * 100 / 1024 = 97
+			expected: 39, // 1 + (1000 - 2) * 9999 / 262142 = 39
 			wantErr:  false,
 		},
 		{
 			input:    "1024",
-			expected: 100, // 1024 * 100 / 1024 = 100
+			expected: 39, // 1 + (1024 - 2) * 9999 / 262142 = 39
 			wantErr:  false,
 		},
 		{
-			input:    "512",
-			expected: 50, // 512 * 100 / 1024 = 50
+			input:    "2",
+			expected: 1, // 1 + (2 - 2) * 9999 / 262142 = 1
+			wantErr:  false,
+		},
+		{
+			input:    "262144",
+			expected: 10000, // 1 + (262144 - 2) * 9999 / 262142 = 10000
 			wantErr:  false,
 		},
 		{
@@ -409,12 +413,12 @@ func TestConvertCPUSharesToWeight(t *testing.T) {
 		},
 		{
 			input:    "2000",
-			expected: 195, // 2000 * 100 / 1024 = 195
+			expected: 77, // 1 + (77 - 2) * 9999 / 262142 = 77
 			wantErr:  false,
 		},
 		{
 			input:    "50000",
-			expected: 4882, // 50000 * 100 / 1024 = 4882
+			expected: 1908, // 1 + (50000 - 2) * 9999 / 262142 = 1908
 			wantErr:  false,
 		},
 		{

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -119,6 +119,7 @@ const (
 	CFSBasePeriodValue int64 = 100000
 	CFSQuotaMinValue   int64 = 1000 // min value except `-1`
 	CPUSharesMinValue  int64 = 2
+	CPUSharesMaxValue  int64 = 262144
 	CPUWeightMinValue  int64 = 1
 	CPUWeightMaxValue  int64 = 10000
 
@@ -171,7 +172,7 @@ const (
 var (
 	NaturalInt64Validator = &RangeValidator{min: 0, max: math.MaxInt64}
 
-	CPUSharesValidator                      = &RangeValidator{min: CPUSharesMinValue, max: math.MaxInt64}
+	CPUSharesValidator                      = &RangeValidator{min: CPUSharesMinValue, max: CPUSharesMaxValue}
 	CPUBurstValidator                       = &RangeValidator{min: 0, max: 100 * 10 * 100000}
 	CPUBvtWarpNsValidator                   = &RangeValidator{min: -1, max: 2}
 	CPUWeightValidator                      = &RangeValidator{min: CPUWeightMinValue, max: CPUWeightMaxValue}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: fix the value conversion between `cpu.shares` and `cpu.weights` (cgroups-v2), use the same conversion as the kubelet.

link: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
