### PR TITLE
koord-descheduler: ignore create pmj when pod.schedulerName is not koord-scheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -273,6 +273,6 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.24.15
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.15
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.15
-	sigs.k8s.io/descheduler => sigs.k8s.io/descheduler v0.26.1-0.20230216092500-02b1e8b8b9c1
+	sigs.k8s.io/descheduler => sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194
 	sigs.k8s.io/scheduler-plugins => sigs.k8s.io/scheduler-plugins v0.22.6
 )

--- a/go.sum
+++ b/go.sum
@@ -1979,8 +1979,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.37 h1:fAPTNEpzQMOLM
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.37/go.mod h1:vfnxT4FXNT8eGvO+xi/DsyC/qHmdujqwrUa1WSspCsk=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
-sigs.k8s.io/descheduler v0.26.1-0.20230216092500-02b1e8b8b9c1 h1:4u1i8qPZN26tP+9SGp8vSbib9ONN59meHTz342k82/4=
-sigs.k8s.io/descheduler v0.26.1-0.20230216092500-02b1e8b8b9c1/go.mod h1:/z7jjqyhgYDSd+LclGulcqX/JgfGIOTNB7ohFlGNQAQ=
+sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194 h1:xPrRjhoJr6pst13/3UHNwATYAsJROWcv+vvGRa+Fk1Q=
+sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194/go.mod h1:/z7jjqyhgYDSd+LclGulcqX/JgfGIOTNB7ohFlGNQAQ=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/pkg/descheduler/apis/config/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/types_pluginargs.go
@@ -104,6 +104,9 @@ type MigrationControllerArgs struct {
 	EvictionPolicy string
 	// DefaultDeleteOptions defines options when deleting migrated pods and preempted pods through the method specified by EvictionPolicy
 	DefaultDeleteOptions *metav1.DeleteOptions
+
+	// SchedulerName defines options to assign scheduler, koord-schuler by default.
+	SchedulerName string
 }
 
 type MigrationLimitObjectType string

--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -42,6 +42,7 @@ const (
 	defaultMigrationJobEvictionPolicy = migrationevictor.NativeEvictorName
 	defaultMigrationEvictQPS          = 10
 	defaultMigrationEvictBurst        = 1
+	defaultSchedulerName              = "koord-scheduler"
 )
 
 var (
@@ -217,6 +218,9 @@ func SetDefaults_MigrationControllerArgs(obj *MigrationControllerArgs) {
 	}
 	if obj.DefaultJobMode == "" {
 		obj.DefaultJobMode = string(defaultMigrationJobMode)
+	}
+	if obj.SchedulerName == "" {
+		obj.SchedulerName = defaultSchedulerName
 	}
 	if obj.DefaultJobTTL == nil {
 		obj.DefaultJobTTL = &metav1.Duration{Duration: defaultMigrationJobTTL}

--- a/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
@@ -98,6 +98,9 @@ type MigrationControllerArgs struct {
 	// Default is 5 minute
 	DefaultJobTTL *metav1.Duration `json:"defaultJobTTL,omitempty"`
 
+	// SchedulerName defines options to assign scheduler, koord-schuler by default.
+	SchedulerName string `json:"schedulerName,omitempty"`
+
 	// EvictQPS controls the number of evict per second
 	EvictQPS *config.Float64OrString `json:"evictQPS,omitempty"`
 	// EvictBurst is the maximum number of tokens

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -514,6 +514,7 @@ func autoConvert_v1alpha2_MigrationControllerArgs_To_config_MigrationControllerA
 	if err := v1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.DefaultJobTTL, &out.DefaultJobTTL, s); err != nil {
 		return err
 	}
+	out.SchedulerName = in.SchedulerName
 	out.EvictQPS = (*config.Float64OrString)(unsafe.Pointer(in.EvictQPS))
 	if err := v1.Convert_Pointer_int32_To_int32(&in.EvictBurst, &out.EvictBurst, s); err != nil {
 		return err
@@ -558,6 +559,7 @@ func autoConvert_config_MigrationControllerArgs_To_v1alpha2_MigrationControllerA
 	}
 	out.EvictionPolicy = in.EvictionPolicy
 	out.DefaultDeleteOptions = (*v1.DeleteOptions)(unsafe.Pointer(in.DefaultDeleteOptions))
+	out.SchedulerName = in.SchedulerName
 	return nil
 }
 

--- a/pkg/descheduler/controllers/migration/controller_test.go
+++ b/pkg/descheduler/controllers/migration/controller_test.go
@@ -1413,7 +1413,8 @@ func TestEvict(t *testing.T) {
 			},
 		},
 		Spec: corev1.PodSpec{
-			NodeName: "test-node-1",
+			NodeName:      "test-node-1",
+			SchedulerName: "koord-scheduler",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,

--- a/pkg/descheduler/controllers/migration/evict.go
+++ b/pkg/descheduler/controllers/migration/evict.go
@@ -44,6 +44,12 @@ func (r *Reconciler) Evict(ctx context.Context, pod *corev1.Pod, evictOptions fr
 		return false
 	}
 
+	if sev1alpha1.PodMigrationJobMode(r.args.DefaultJobMode) == sev1alpha1.PodMigrationJobModeReservationFirst &&
+		pod.Spec.SchedulerName != r.args.SchedulerName {
+		klog.Errorf("Pod %q can not be migrated by ReservationFirst mode because pod.schedulerName=%s but schuler of pmj controller assigned is %s", klog.KObj(pod), pod.Spec.SchedulerName, r.args.SchedulerName)
+		return false
+	}
+
 	err := CreatePodMigrationJob(ctx, pod, evictOptions, r.Client, r.args)
 	return err == nil
 }

--- a/pkg/descheduler/controllers/migration/filter.go
+++ b/pkg/descheduler/controllers/migration/filter.go
@@ -158,13 +158,10 @@ func (r *Reconciler) forEachAvailableMigrationJobs(listOpts *client.ListOptions,
 				break
 			}
 		}
-		if found {
-			if !handler(job) {
-				break
-			}
+		if found && !handler(job) {
+			break
 		}
 	}
-	return
 }
 
 func (r *Reconciler) filterExistingPodMigrationJob(pod *corev1.Pod) bool {
@@ -180,6 +177,7 @@ func (r *Reconciler) existingPodMigrationJob(pod *corev1.Pod, expectPhases ...se
 		}
 		return !existing
 	}, expectPhases...)
+
 	if !existing {
 		opts = &client.ListOptions{FieldSelector: fields.OneTermEqualSelector(fieldindex.IndexJobPodNamespacedName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))}
 		r.forEachAvailableMigrationJobs(opts, func(job *sev1alpha1.PodMigrationJob) bool {
@@ -215,10 +213,10 @@ func (r *Reconciler) filterMaxMigratingPerNode(pod *corev1.Pod) bool {
 	count := 0
 	for i := range podList.Items {
 		v := &podList.Items[i]
-		if v.UID != pod.UID && v.Spec.NodeName == pod.Spec.NodeName {
-			if r.existingPodMigrationJob(v, expectPhases...) {
-				count++
-			}
+		if v.UID != pod.UID &&
+			v.Spec.NodeName == pod.Spec.NodeName &&
+			r.existingPodMigrationJob(v, expectPhases...) {
+			count++
 		}
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
this pr fixed tow problems.
1. `koord-descheduler` should reject create pmj when pmj.mode is `ReservationFirst` and  pod.schedulerName is not koord-scheduler  detail in  https://github.com/koordinator-sh/koordinator/issues/1527 this issue.
2.  update `deschuler` in go.mod, because some bug have been fixed.  eg: https://github.com/kubernetes-sigs/descheduler/pull/1104/files 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
