### PR TITLE
koord-descheduler: accumulates the sum of system and Pod usage as node usage

### DIFF
--- a/pkg/descheduler/controllers/migration/filter.go
+++ b/pkg/descheduler/controllers/migration/filter.go
@@ -88,9 +88,10 @@ func (r *Reconciler) initFilters(args *deschedulerconfig.MigrationControllerArgs
 		excludedNamespaces = sets.NewString(args.Namespaces.Exclude...)
 	}
 
+	filterPlugin := defaultEvictor.(framework.FilterPlugin)
 	wrapFilterFuncs := podutil.WrapFilterFuncs(
 		util.FilterPodWithMaxEvictionCost,
-		defaultEvictor.(framework.FilterPlugin).Filter,
+		filterPlugin.Filter,
 		r.filterExpectedReplicas,
 	)
 	podFilter, err := podutil.NewOptions().

--- a/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
@@ -24,8 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 )
 
 var (
@@ -47,19 +45,6 @@ var (
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
 			},
-			nodeMetric: &slov1alpha1.NodeMetric{
-				Status: slov1alpha1.NodeMetricStatus{
-					NodeMetric: &slov1alpha1.NodeMetricInfo{
-						NodeUsage: slov1alpha1.ResourceMap{
-							ResourceList: corev1.ResourceList{
-								corev1.ResourceCPU:    *resource.NewMilliQuantity(1730, resource.DecimalSI),
-								corev1.ResourceMemory: *resource.NewQuantity(3038982964, resource.BinarySI),
-								corev1.ResourcePods:   *resource.NewQuantity(25, resource.BinarySI),
-							},
-						},
-					},
-				},
-			},
 			usage: map[corev1.ResourceName]*resource.Quantity{
 				corev1.ResourceCPU:    resource.NewMilliQuantity(1730, resource.DecimalSI),
 				corev1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
@@ -75,19 +60,6 @@ var (
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "node2"},
 			},
-			nodeMetric: &slov1alpha1.NodeMetric{
-				Status: slov1alpha1.NodeMetricStatus{
-					NodeMetric: &slov1alpha1.NodeMetricInfo{
-						NodeUsage: slov1alpha1.ResourceMap{
-							ResourceList: corev1.ResourceList{
-								corev1.ResourceCPU:    *resource.NewMilliQuantity(1220, resource.DecimalSI),
-								corev1.ResourceMemory: *resource.NewQuantity(3038982964, resource.BinarySI),
-								corev1.ResourcePods:   *resource.NewQuantity(11, resource.BinarySI),
-							},
-						},
-					},
-				},
-			},
 			usage: map[corev1.ResourceName]*resource.Quantity{
 				corev1.ResourceCPU:    resource.NewMilliQuantity(1220, resource.DecimalSI),
 				corev1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
@@ -102,19 +74,6 @@ var (
 					Allocatable: testNodeAllocatable,
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "node3"},
-			},
-			nodeMetric: &slov1alpha1.NodeMetric{
-				Status: slov1alpha1.NodeMetricStatus{
-					NodeMetric: &slov1alpha1.NodeMetricInfo{
-						NodeUsage: slov1alpha1.ResourceMap{
-							ResourceList: corev1.ResourceList{
-								corev1.ResourceCPU:    *resource.NewMilliQuantity(1530, resource.DecimalSI),
-								corev1.ResourceMemory: *resource.NewQuantity(5038982964, resource.BinarySI),
-								corev1.ResourcePods:   *resource.NewQuantity(20, resource.BinarySI),
-							},
-						},
-					},
-				},
 			},
 			usage: map[corev1.ResourceName]*resource.Quantity{
 				corev1.ResourceCPU:    resource.NewMilliQuantity(1530, resource.DecimalSI),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The `nodeMetric.Status.NodeMetric.NodeUsage` does not change immediately after some pods are evicted by the plugin, because by default nodeUsage is an average over 5 minutes.  So change to the sum of Pod utilization plus sysUsage as Node Usage.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #990 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
