### PR TITLE
koord-scheduler: use the sum of Pods and system usage as node usage

### DIFF
--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -200,13 +200,13 @@ func (p *Plugin) filterNodeUsage(node *corev1.Node, nodeMetric *slov1alpha1.Node
 		// TODO(joseph): maybe we should estimate the Pod that just be scheduled that have not reported
 		var nodeUsage *slov1alpha1.ResourceMap
 		if filterProfile.AggregatedUsage != nil {
-			nodeUsage = getTargetAggregatedUsage(
+			nodeUsage = getAggregatedNodeUsage(
 				nodeMetric,
 				filterProfile.AggregatedUsage.UsageAggregatedDuration,
 				filterProfile.AggregatedUsage.UsageAggregationType,
 			)
 		} else {
-			nodeUsage = &nodeMetric.Status.NodeMetric.NodeUsage
+			nodeUsage = getNodeUsage(nodeMetric)
 		}
 		if nodeUsage == nil {
 			continue
@@ -310,9 +310,9 @@ func (p *Plugin) Score(ctx context.Context, state *framework.CycleState, pod *co
 		if nodeMetric.Status.NodeMetric != nil {
 			var nodeUsage *slov1alpha1.ResourceMap
 			if scoreWithAggregation(p.args.Aggregated) {
-				nodeUsage = getTargetAggregatedUsage(nodeMetric, &p.args.Aggregated.ScoreAggregatedDuration, p.args.Aggregated.ScoreAggregationType)
+				nodeUsage = getAggregatedNodeUsage(nodeMetric, &p.args.Aggregated.ScoreAggregatedDuration, p.args.Aggregated.ScoreAggregationType)
 			} else {
-				nodeUsage = &nodeMetric.Status.NodeMetric.NodeUsage
+				nodeUsage = getNodeUsage(nodeMetric)
 			}
 			if nodeUsage != nil {
 				for resourceName, quantity := range nodeUsage.ResourceList {
@@ -357,7 +357,7 @@ func (p *Plugin) estimatedAssignedPodUsed(nodeName string, nodeMetric *slov1alph
 			missedLatestUpdateTime(assignInfo.timestamp, nodeMetricUpdateTime) ||
 			stillInTheReportInterval(assignInfo.timestamp, nodeMetricUpdateTime, nodeMetricReportInterval) ||
 			(scoreWithAggregation(p.args.Aggregated) &&
-				getTargetAggregatedUsage(nodeMetric, &p.args.Aggregated.ScoreAggregatedDuration, p.args.Aggregated.ScoreAggregationType) == nil) {
+				getAggregatedNodeUsage(nodeMetric, &p.args.Aggregated.ScoreAggregatedDuration, p.args.Aggregated.ScoreAggregationType) == nil) {
 			estimated, err := p.estimator.EstimatePod(assignInfo.pod)
 			if err != nil {
 				continue


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The `nodeMetric.Status.NodeMetric.NodeUsage` does not change immediately after some pods are deleted, because by default nodeUsage is an average over 5 minutes. So change to the sum of Pod utilization plus sysUsage as Node Usage.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

part of #990 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
