### PR TITLE
koord-scheduler: invalidate nodeDevice when deleting Device CRD object

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_handler.go
+++ b/pkg/scheduler/plugins/deviceshare/device_handler.go
@@ -73,6 +73,13 @@ func (n *nodeDeviceCache) onDeviceDelete(obj interface{}) {
 	default:
 		return
 	}
-	n.removeNodeDevice(device.Name)
-	klog.V(4).InfoS("device cache deleted", "Device", klog.KObj(device))
+
+	//
+	// The user may accidentally delete the Device CRD object,
+	// and then the Device CRD object will be recreated by koordlet/DevicePlugin.
+	// During this period, the internal state can only be marked as invalid,
+	// otherwise the GPU may be repeatedly allocated to different Pods.
+	//
+	n.invalidateNodeDevice(device)
+	klog.V(4).InfoS("device invalided", "Device", klog.KObj(device))
 }

--- a/pkg/scheduler/plugins/deviceshare/device_handler_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_handler_test.go
@@ -377,7 +377,22 @@ func Test_nodeDeviceCache_onDeviceDelete(t *testing.T) {
 			deviceCache: &nodeDeviceCache{
 				nodeDeviceInfos: generateFakeNodeDeviceInfos(),
 			},
-			wantCache: map[string]*nodeDevice{},
+			wantCache: map[string]*nodeDevice{
+				"test-node-1": {
+					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{},
+						},
+					},
+					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {
+							1: corev1.ResourceList{},
+						},
+					},
+					deviceUsed:  map[schedulingv1alpha1.DeviceType]deviceResources{},
+					allocateSet: map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]deviceResources{},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -461,6 +461,7 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 	deviceCache := newNodeDeviceCache()
 	registerDeviceEventHandler(deviceCache, extendedHandle.KoordinatorSharedInformerFactory())
 	registerPodEventHandler(deviceCache, handle.SharedInformerFactory(), extendedHandle.KoordinatorSharedInformerFactory())
+	go deviceCache.gcNodeDevice(context.TODO(), handle.SharedInformerFactory(), defaultGCPeriod)
 
 	allocatorOpts := AllocatorOptions{
 		SharedInformerFactory:      extendedHandle.SharedInformerFactory(),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The user may accidentally delete the Device CRD object, and then the Device CRD object will be recreated by koordlet/DevicePlugin. During this period, the internal state can only be marked as invalid, otherwise the GPU may be repeatedly allocated to different Pods.

And the DeviceShare plugin will start a GC thread to GC the remaining NodeDevice objects that are no longer present.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1186

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
