### PR TITLE
koordlet: report system resource usage in node metric

### DIFF
--- a/pkg/koordlet/metriccache/metric_resources.go
+++ b/pkg/koordlet/metriccache/metric_resources.go
@@ -20,16 +20,23 @@ var (
 	defaultMetricFactory = NewMetricFactory()
 
 	// define all kinds of MetricResource
-	NodeCPUUsageMetric          = defaultMetricFactory.New(NodeMetricCPUUsage)
-	NodeMemoryUsageMetric       = defaultMetricFactory.New(NodeMetricMemoryUsage)
-	NodeGPUCoreUsageMetric      = defaultMetricFactory.New(NodeMetricGPUCoreUsage).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
-	NodeGPUMemUsageMetric       = defaultMetricFactory.New(NodeMetricGPUMemUsage).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
-	NodeGPUTotalMetric          = defaultMetricFactory.New(NodeMetricGPUMemTotal).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
-	PodCPUUsageMetric           = defaultMetricFactory.New(PodMetricCPUUsage).withPropertySchema(MetricPropertyPodUID)
-	PodMemUsageMetric           = defaultMetricFactory.New(PodMetricMemoryUsage).withPropertySchema(MetricPropertyPodUID)
-	PodCPUThrottledMetric       = defaultMetricFactory.New(PodMetricCPUThrottled).withPropertySchema(MetricPropertyPodUID)
-	PodGPUCoreUsageMetric       = defaultMetricFactory.New(PodMetricGPUCoreUsage).withPropertySchema(MetricPropertyPodUID, MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
-	PodGPUMemUsageMetric        = defaultMetricFactory.New(PodMetricGPUMemUsage).withPropertySchema(MetricPropertyPodUID, MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+	NodeCPUUsageMetric     = defaultMetricFactory.New(NodeMetricCPUUsage)
+	NodeMemoryUsageMetric  = defaultMetricFactory.New(NodeMetricMemoryUsage)
+	NodeGPUCoreUsageMetric = defaultMetricFactory.New(NodeMetricGPUCoreUsage).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+	NodeGPUMemUsageMetric  = defaultMetricFactory.New(NodeMetricGPUMemUsage).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+	NodeGPUMemTotalMetric  = defaultMetricFactory.New(NodeMetricGPUMemTotal).withPropertySchema(MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+
+	// define system resource usage as independent metric, although this can be calculate by node-sum(pod), but the time series are
+	// unaligned across different type of metric, which makes it hard to aggregate.
+	SystemCPUUsageMetric    = defaultMetricFactory.New(SysMetricCPUUsage)
+	SystemMemoryUsageMetric = defaultMetricFactory.New(SysMetricMemoryUsage)
+
+	PodCPUUsageMetric     = defaultMetricFactory.New(PodMetricCPUUsage).withPropertySchema(MetricPropertyPodUID)
+	PodMemUsageMetric     = defaultMetricFactory.New(PodMetricMemoryUsage).withPropertySchema(MetricPropertyPodUID)
+	PodCPUThrottledMetric = defaultMetricFactory.New(PodMetricCPUThrottled).withPropertySchema(MetricPropertyPodUID)
+	PodGPUCoreUsageMetric = defaultMetricFactory.New(PodMetricGPUCoreUsage).withPropertySchema(MetricPropertyPodUID, MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+	PodGPUMemUsageMetric  = defaultMetricFactory.New(PodMetricGPUMemUsage).withPropertySchema(MetricPropertyPodUID, MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)
+
 	ContainerCPUUsageMetric     = defaultMetricFactory.New(ContainerMetricCPUUsage).withPropertySchema(MetricPropertyContainerID)
 	ContainerMemUsageMetric     = defaultMetricFactory.New(ContainerMetricMemoryUsage).withPropertySchema(MetricPropertyContainerID)
 	ContainerGPUCoreUsageMetric = defaultMetricFactory.New(ContainerMetricGPUCoreUsage).withPropertySchema(MetricPropertyContainerID, MetricPropertyGPUMinor, MetricPropertyGPUDeviceUUID)

--- a/pkg/koordlet/metriccache/metric_types.go
+++ b/pkg/koordlet/metriccache/metric_types.go
@@ -42,6 +42,9 @@ const (
 	NodeMetricGPUMemUsage  MetricKind = "node_gpu_memory_usage"
 	NodeMetricGPUMemTotal  MetricKind = "node_gpu_memory_total"
 
+	SysMetricCPUUsage    MetricKind = "sys_cpu_usage"
+	SysMetricMemoryUsage MetricKind = "sys_memory_usage"
+
 	// NodeBE
 	NodeMetricBE MetricKind = "node_be"
 

--- a/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
@@ -303,6 +303,9 @@ total_unevictable 0
 					CollectorName: tt.fields.podFilterOption,
 				},
 			})
+			collector.Setup(&framework.Context{
+				State: framework.NewSharedState(),
+			})
 			c := collector.(*podResourceCollector)
 			tt.fields.initPodLastStat(c.lastPodCPUStat)
 			tt.fields.initContainerLastStat(c.lastContainerCPUStat)

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysresource
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+const (
+	CollectorName = "SystemResourceCollector"
+
+	metricOutdatedIntervalRatio = 3
+)
+
+var (
+	timeNow = time.Now
+)
+
+type systemResourceCollector struct {
+	collectInterval time.Duration
+	started         *atomic.Bool
+	appendableDB    metriccache.Appendable
+	sharedState     *framework.SharedState
+}
+
+func New(opt *framework.Options) framework.Collector {
+	return &systemResourceCollector{
+		collectInterval: opt.Config.CollectResUsedInterval,
+		started:         atomic.NewBool(false),
+		appendableDB:    opt.MetricCache,
+	}
+}
+
+func (s *systemResourceCollector) Enabled() bool {
+	return true
+}
+
+func (s *systemResourceCollector) Setup(c *framework.Context) {
+	s.sharedState = c.State
+}
+
+func (s *systemResourceCollector) Run(stopCh <-chan struct{}) {
+	dependencyStarted := func() bool {
+		if cpu, memory := s.sharedState.GetNodeUsage(); cpu == nil || memory == nil {
+			return false
+		}
+		if cpu, memory := s.sharedState.GetPodsUsageByCollector(); len(cpu) == 0 || len(memory) == 0 {
+			return false
+		}
+		return true
+	}
+	if !cache.WaitForCacheSync(stopCh, dependencyStarted) {
+		klog.Fatal("time out waiting for other collector started")
+	}
+	go wait.Until(s.collectSysResUsed, s.collectInterval, stopCh)
+}
+
+func (s *systemResourceCollector) Started() bool {
+	return s.started.Load()
+}
+
+func (s *systemResourceCollector) collectSysResUsed() {
+	klog.V(6).Info("collectSysResUsed start")
+
+	// get node resource usage
+	validTime := timeNow().Add(-s.collectInterval * metricOutdatedIntervalRatio)
+	nodeCPU, nodeMemory := s.sharedState.GetNodeUsage()
+	if nodeCPU == nil || nodeMemory == nil {
+		klog.Warningf("node resource cpu %v or memory %v is empty during collect system usage", nodeCPU, nodeMemory)
+		return
+	}
+	if nodeCPU.Timestamp.Before(validTime) || nodeMemory.Timestamp.Before(validTime) {
+		klog.Warningf("node resource metric is timeout, valid time %v, metric time is %v and %v",
+			validTime.String(), nodeCPU.Timestamp.String(), nodeMemory.Timestamp.String())
+		return
+	}
+
+	// get all pod resource usage
+	podsCPUUsage, podsMemoryUsage, err := s.getAllPodsResourceUsage()
+	if err != nil {
+		klog.Warningf("get all pods resource usage failed, error %v", err)
+		return
+	}
+
+	// calculate system resource usage
+	systemCPUUsage := util.MaxFloat64(nodeCPU.Value-podsCPUUsage, 0)
+	systemMemoryUsage := util.MaxFloat64(nodeMemory.Value-podsMemoryUsage, 0)
+	collectTime := nodeCPU.Timestamp
+	systemCPUMetric, err := metriccache.SystemCPUUsageMetric.GenerateSample(nil, collectTime, systemCPUUsage)
+	if err != nil {
+		klog.Warningf("generate system cpu metric failed, err %v", err)
+		return
+	}
+	systemMemoryMetric, err := metriccache.SystemMemoryUsageMetric.GenerateSample(nil, collectTime, systemMemoryUsage)
+	if err != nil {
+		klog.Warningf("generate system memory metric failed, err %v", err)
+		return
+	}
+
+	// commit metric sample
+	appender := s.appendableDB.Appender()
+	if err := appender.Append([]metriccache.MetricSample{systemCPUMetric, systemMemoryMetric}); err != nil {
+		klog.ErrorS(err, "append system metrics error")
+		return
+	}
+	if err := appender.Commit(); err != nil {
+		klog.ErrorS(err, "commit system metrics error")
+		return
+	}
+
+	klog.V(4).Infof("collect system resource usage finished, cpu %v, memory %v", systemCPUUsage, systemMemoryUsage)
+	s.started.Store(true)
+}
+
+func (s *systemResourceCollector) getAllPodsResourceUsage() (cpuCore float64, memory float64, err error) {
+	validTime := timeNow().Add(-s.collectInterval * metricOutdatedIntervalRatio)
+	podCPUByCollector, podMemoryByCollector := s.sharedState.GetPodsUsageByCollector()
+	if len(podCPUByCollector) == 0 || len(podMemoryByCollector) == 0 {
+		err = fmt.Errorf("pod resource cpu %v or memory %v is empty during collect system usage", podCPUByCollector, podMemoryByCollector)
+		return
+	}
+	for collector, podCPU := range podCPUByCollector {
+		if podCPU.Timestamp.Before(validTime) {
+			err = fmt.Errorf("pod collector %v cpu resource metric is timeout, valid time %v, metric time is %v",
+				collector, validTime.String(), podCPU.Timestamp.String())
+			return
+		}
+		cpuCore += podCPU.Value
+	}
+	for collector, podMemory := range podMemoryByCollector {
+		if podMemory.Timestamp.Before(validTime) {
+			err = fmt.Errorf("pod collector %v memory resource metric is timeout, valid time %v, metric time is %v",
+				collector, validTime.String(), podMemory.Timestamp.String())
+			return
+		}
+		memory += podMemory.Value
+	}
+	return
+}

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysresource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
+	testNow := time.Now()
+	timeNow = func() time.Time {
+		return testNow
+	}
+	config := framework.NewDefaultConfig()
+	type usageField struct {
+		ts     time.Time
+		cpu    float64
+		memory float64
+	}
+	type fields struct {
+		nodeUsage *usageField
+		podUsage  map[string]usageField
+	}
+	type want struct {
+		systemCPU    *float64
+		systemMemory *float64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name:   "node metric not exist",
+			fields: fields{},
+			want:   want{},
+		},
+		{
+			name: "pod metric not exist",
+			fields: fields{
+				nodeUsage: &usageField{
+					ts:     timeNow(),
+					cpu:    1,
+					memory: 1024,
+				},
+			},
+			want: want{},
+		},
+		{
+			name: "node metric outdated",
+			fields: fields{
+				nodeUsage: &usageField{
+					ts:     timeNow().Add(-config.CollectResUsedInterval * metricOutdatedIntervalRatio * 2),
+					cpu:    1,
+					memory: 1024,
+				},
+				podUsage: map[string]usageField{
+					"test-collector": {
+						ts:     timeNow(),
+						cpu:    0.5,
+						memory: 512,
+					},
+				},
+			},
+			want: want{},
+		},
+		{
+			name: "pod metric outdated",
+			fields: fields{
+				nodeUsage: &usageField{
+					ts:     timeNow(),
+					cpu:    1,
+					memory: 1024,
+				},
+				podUsage: map[string]usageField{
+					"test-collector": {
+						ts:     timeNow().Add(-config.CollectResUsedInterval * metricOutdatedIntervalRatio * 2),
+						cpu:    0.5,
+						memory: 512,
+					},
+				},
+			},
+			want: want{},
+		},
+		{
+			name: "one pod collector",
+			fields: fields{
+				nodeUsage: &usageField{
+					ts:     timeNow(),
+					cpu:    1,
+					memory: 1024,
+				},
+				podUsage: map[string]usageField{
+					"test-collector": {
+						ts:     timeNow(),
+						cpu:    0.5,
+						memory: 512,
+					},
+				},
+			},
+			want: want{
+				systemCPU:    pointer.Float64(0.5),
+				systemMemory: pointer.Float64(512),
+			},
+		},
+		{
+			name: "two pod collectors",
+			fields: fields{
+				nodeUsage: &usageField{
+					ts:     timeNow(),
+					cpu:    2,
+					memory: 2048,
+				},
+				podUsage: map[string]usageField{
+					"test-collector1": {
+						ts:     timeNow(),
+						cpu:    0.5,
+						memory: 512,
+					},
+					"test-collector2": {
+						ts:     timeNow(),
+						cpu:    1,
+						memory: 512,
+					},
+				},
+			},
+			want: want{
+				systemCPU:    pointer.Float64(0.5),
+				systemMemory: pointer.Float64(1024),
+			},
+		},
+	}
+	for _, tt := range tests {
+		helper := system.NewFileTestUtil(t)
+
+		metricCache, err := metriccache.NewMetricCache(&metriccache.Config{
+			TSDBPath:              t.TempDir(),
+			TSDBEnablePromMetrics: false,
+		})
+		assert.NoError(t, err)
+
+		t.Run(tt.name, func(t *testing.T) {
+			si := New(&framework.Options{
+				Config:      config,
+				MetricCache: metricCache,
+			})
+			si.Setup(&framework.Context{
+				State: framework.NewSharedState(),
+			})
+			s := si.(*systemResourceCollector)
+			if tt.fields.nodeUsage != nil {
+				s.sharedState.UpdateNodeUsage(
+					metriccache.Point{Timestamp: tt.fields.nodeUsage.ts, Value: tt.fields.nodeUsage.cpu},
+					metriccache.Point{Timestamp: tt.fields.nodeUsage.ts, Value: tt.fields.nodeUsage.memory},
+				)
+			}
+			for collector, pod := range tt.fields.podUsage {
+				s.sharedState.UpdatePodUsage(collector,
+					metriccache.Point{Timestamp: pod.ts, Value: pod.cpu},
+					metriccache.Point{Timestamp: pod.ts, Value: pod.memory},
+				)
+			}
+			s.collectSysResUsed()
+
+			querier, err := metricCache.Querier(timeNow().Add(-s.collectInterval*metricOutdatedIntervalRatio), timeNow())
+			assert.NoError(t, err)
+
+			cpuResult, err := testQuery(querier, metriccache.SystemCPUUsageMetric, nil)
+			assert.NoError(t, err)
+			if tt.want.systemCPU == nil {
+				assert.Equal(t, 0, cpuResult.Count())
+			} else {
+				cpuValue, aggregateErr := cpuResult.Value(metriccache.AggregationTypeLast)
+				assert.NoError(t, aggregateErr)
+				assert.Equal(t, *tt.want.systemCPU, cpuValue)
+			}
+			memoryResult, err := testQuery(querier, metriccache.SystemMemoryUsageMetric, nil)
+			assert.NoError(t, err)
+			if tt.want.systemMemory == nil {
+				assert.Equal(t, 0, memoryResult.Count())
+			} else {
+				memoryValue, aggregateErr := memoryResult.Value(metriccache.AggregationTypeLast)
+				assert.NoError(t, aggregateErr)
+				assert.Equal(t, *tt.want.systemMemory, memoryValue)
+			}
+		})
+		err = metricCache.Close()
+		assert.NoError(t, err)
+		helper.Cleanup()
+	}
+}
+
+func testQuery(querier metriccache.Querier, resource metriccache.MetricResource, properties map[metriccache.MetricProperty]string) (metriccache.AggregateResult, error) {
+	queryMeta, err := resource.BuildQueryMeta(properties)
+	if err != nil {
+		return nil, err
+	}
+	aggregateResult := metriccache.DefaultAggregateResultFactory.New(queryMeta)
+	if err = querier.Query(queryMeta, nil, aggregateResult); err != nil {
+		return nil, err
+	}
+	return aggregateResult, nil
+}
+
+func Test_systemResourceCollector_Enabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		s := &systemResourceCollector{}
+		if got := s.Enabled(); !got {
+			t.Errorf("Enabled() = %v", got)
+		}
+	})
+}
+
+func Test_systemResourceCollector_Started(t *testing.T) {
+	type fields struct {
+		started *atomic.Bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "started",
+			fields: fields{
+				started: atomic.NewBool(true),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &systemResourceCollector{
+				started: tt.fields.started,
+			}
+			if got := s.Started(); got != tt.want {
+				t.Errorf("Started() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_systemResourceCollector_Run(t *testing.T) {
+	type fields struct {
+		sharedState *framework.SharedState
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "node has not synced",
+			fields: fields{
+				sharedState: &framework.SharedState{
+					LatestMetric: framework.LatestMetric{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		metricCache, err := metriccache.NewMetricCache(&metriccache.Config{
+			TSDBPath:              t.TempDir(),
+			TSDBEnablePromMetrics: false,
+		})
+
+		assert.NoError(t, err)
+		t.Run(tt.name, func(t *testing.T) {
+			s := &systemResourceCollector{
+				collectInterval: time.Second,
+				appendableDB:    metricCache,
+				sharedState:     framework.NewSharedState(),
+			}
+			s.sharedState.UpdateNodeUsage(metriccache.Point{Timestamp: time.Now(), Value: 1},
+				metriccache.Point{Timestamp: time.Now(), Value: 1024})
+			s.sharedState.UpdatePodUsage("pod-collector",
+				metriccache.Point{Timestamp: time.Now(), Value: 0.5},
+				metriccache.Point{Timestamp: time.Now(), Value: 512})
+
+			stopCh := make(chan struct{}, 1)
+			close(stopCh)
+			assert.NotPanics(t, func() {
+				s.Run(stopCh)
+			})
+			err = metricCache.Close()
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/koordlet/metricsadvisor/framework/context.go
+++ b/pkg/koordlet/metricsadvisor/framework/context.go
@@ -17,14 +17,18 @@ limitations under the License.
 package framework
 
 import (
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
 )
 
 type Context struct {
 	DeviceCollectors map[string]DeviceCollector
 	Collectors       map[string]Collector
+	State            *SharedState
 }
 
 func DeviceCollectorsStarted(devices map[string]DeviceCollector) bool {
@@ -52,4 +56,63 @@ type CPUStat struct {
 	CPUTick   uint64
 	CPUUsage  uint64
 	Timestamp time.Time
+}
+
+// SharedState is for sharing infos across collectors, for example the system resource collector use the result of
+// pod and node resource collector for calculating system usage
+type SharedState struct {
+	LatestMetric
+}
+
+func NewSharedState() *SharedState {
+	return &SharedState{
+		LatestMetric: LatestMetric{
+			podsCPUByCollector:    make(map[string]metriccache.Point),
+			podsMemoryByCollector: make(map[string]metriccache.Point),
+		},
+	}
+}
+
+type LatestMetric struct {
+	nodeMutex  sync.RWMutex
+	nodeCPU    *metriccache.Point
+	nodeMemory *metriccache.Point
+
+	podMutex              sync.RWMutex
+	podsCPUByCollector    map[string]metriccache.Point
+	podsMemoryByCollector map[string]metriccache.Point
+}
+
+func (r *SharedState) UpdateNodeUsage(cpu, memory metriccache.Point) {
+	r.nodeMutex.Lock()
+	defer r.nodeMutex.Unlock()
+	r.nodeCPU = &cpu
+	r.nodeMemory = &memory
+}
+
+func (r *SharedState) UpdatePodUsage(collectorName string, cpu, memory metriccache.Point) {
+	r.podMutex.Lock()
+	defer r.podMutex.Unlock()
+	r.podsCPUByCollector[collectorName] = cpu
+	r.podsMemoryByCollector[collectorName] = memory
+}
+
+func (r *SharedState) GetNodeUsage() (cpu, memory *metriccache.Point) {
+	r.nodeMutex.RLock()
+	defer r.nodeMutex.RUnlock()
+	return r.nodeCPU, r.nodeMemory
+}
+
+func (r *SharedState) GetPodsUsageByCollector() (cpu, memory map[string]metriccache.Point) {
+	r.podMutex.RLock()
+	defer r.podMutex.RUnlock()
+	podsCPU := map[string]metriccache.Point{}
+	podsMemory := map[string]metriccache.Point{}
+	for collector, val := range r.podsCPUByCollector {
+		podsCPU[collector] = val
+	}
+	for collector, val := range r.podsMemoryByCollector {
+		podsMemory[collector] = val
+	}
+	return podsCPU, podsMemory
 }

--- a/pkg/koordlet/metricsadvisor/framework/context_test.go
+++ b/pkg/koordlet/metricsadvisor/framework/context_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+)
+
+func TestSharedState_UpdateNodeUsage(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		cpu    metriccache.Point
+		memory metriccache.Point
+	}
+	type want struct {
+		cpu    metriccache.Point
+		memory metriccache.Point
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "add node point",
+			args: args{
+				cpu: metriccache.Point{
+					Timestamp: now,
+					Value:     1,
+				},
+				memory: metriccache.Point{
+					Timestamp: now,
+					Value:     1024,
+				},
+			},
+			want: want{
+				cpu: metriccache.Point{
+					Timestamp: now,
+					Value:     1,
+				},
+				memory: metriccache.Point{
+					Timestamp: now,
+					Value:     1024,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSharedState()
+			r.UpdateNodeUsage(tt.args.cpu, tt.args.memory)
+			gotCPU, gotMemory := r.GetNodeUsage()
+			assert.Equal(t, tt.want.cpu, *gotCPU)
+			assert.Equal(t, tt.want.memory, *gotMemory)
+		})
+	}
+}
+
+func TestSharedState_UpdatePodUsage(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		collectorName string
+		cpu           metriccache.Point
+		memory        metriccache.Point
+	}
+	type want struct {
+		cpu    map[string]metriccache.Point
+		memory map[string]metriccache.Point
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "update pod usage",
+			args: args{
+				collectorName: "test-collector",
+				cpu: metriccache.Point{
+					Timestamp: now,
+					Value:     1,
+				},
+				memory: metriccache.Point{
+					Timestamp: now,
+					Value:     1024,
+				},
+			},
+			want: want{
+				cpu: map[string]metriccache.Point{
+					"test-collector": {
+						Timestamp: now,
+						Value:     1,
+					},
+				},
+				memory: map[string]metriccache.Point{
+					"test-collector": {
+						Timestamp: now,
+						Value:     1024,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSharedState()
+			r.UpdatePodUsage(tt.args.collectorName, tt.args.cpu, tt.args.memory)
+			gotCPU, gotMemory := r.GetPodsUsageByCollector()
+			assert.Equal(t, tt.want.cpu, gotCPU)
+			assert.Equal(t, tt.want.memory, gotMemory)
+		})
+	}
+}

--- a/pkg/koordlet/metricsadvisor/metrics_advisor.go
+++ b/pkg/koordlet/metricsadvisor/metrics_advisor.go
@@ -49,6 +49,7 @@ func NewMetricAdvisor(cfg *framework.Config, statesInformer statesinformer.State
 	ctx := &framework.Context{
 		DeviceCollectors: make(map[string]framework.DeviceCollector, len(devicePlugins)),
 		Collectors:       make(map[string]framework.Collector, len(collectorPlugins)),
+		State:            framework.NewSharedState(),
 	}
 	for name, device := range devicePlugins {
 		ctx.DeviceCollectors[name] = device(opt)

--- a/pkg/koordlet/metricsadvisor/metrics_advisor_test.go
+++ b/pkg/koordlet/metricsadvisor/metrics_advisor_test.go
@@ -200,10 +200,16 @@ unevictable 0
 			statesInformer := mock_statesinformer.NewMockStatesInformer(ctrl)
 			metricCache := mock_metriccache.NewMockMetricCache(ctrl)
 
-			c := NewMetricAdvisor(&framework.Config{
+			ci := NewMetricAdvisor(&framework.Config{
 				CollectResUsedInterval:     1 * time.Second,
 				CollectNodeCPUInfoInterval: 1 * time.Second,
 			}, statesInformer, metricCache)
+			c := ci.(*metricAdvisor)
+			c.context.State.UpdateNodeUsage(metriccache.Point{Timestamp: time.Now(), Value: 1},
+				metriccache.Point{Timestamp: time.Now(), Value: 1024})
+			c.context.State.UpdatePodUsage("pod-collector",
+				metriccache.Point{Timestamp: time.Now(), Value: 0.5},
+				metriccache.Point{Timestamp: time.Now(), Value: 512})
 
 			statesInformer.EXPECT().GetAllPods().Return([]*statesinformer.PodMeta{{
 				CgroupDir: testPodMetaDir,

--- a/pkg/koordlet/metricsadvisor/plugins_profile.go
+++ b/pkg/koordlet/metricsadvisor/plugins_profile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/performance"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/podresource"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/podthrottled"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/sysresource"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/devices/gpu"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
 )
@@ -43,6 +44,7 @@ var (
 		podresource.CollectorName:     podresource.New,
 		podthrottled.CollectorName:    podthrottled.New,
 		performance.CollectorName:     performance.New,
+		sysresource.CollectorName:     sysresource.New,
 	}
 
 	podFilters = map[string]framework.PodFilter{

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -76,6 +76,20 @@ func MaxInt64(i, j int64) int64 {
 	return j
 }
 
+func MinFloat64(i, j float64) float64 {
+	if i < j {
+		return i
+	}
+	return j
+}
+
+func MaxFloat64(i, j float64) float64 {
+	if i > j {
+		return i
+	}
+	return j
+}
+
 func RetryOnConflictOrTooManyRequests(fn func() error) error {
 	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return errors.IsConflict(err) || errors.IsTooManyRequests(err)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -258,3 +258,12 @@ func Test_GeneratePodPatch(t *testing.T) {
 		t.Errorf("expect patchBytes: %q, got: %q", patchAnnotation, annotation)
 	}
 }
+
+func TestMinFloat64(t *testing.T) {
+	big := 2.0
+	small := 1.0
+	gotMin := MinFloat64(big, small)
+	assert.Equal(t, small, gotMin)
+	gotMax := MaxFloat64(big, small)
+	assert.Equal(t, big, gotMax)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Update system usage in node metric crd.
Add system usage collector in metric advisor. Read latest usage of node and pods from share state in context and calculate system usage, then saves in metric cache.
Although this can be calculate by node-sum(pod) from metric cache, but the time series are unaligned across different type of metric, which makes it hard to aggregate.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#991

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
