### PR TITLE
CI: fix goreleaser.yaml for the deprecated replacement field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,8 +25,16 @@ archives:
     format: binary
     builds:
       - koord-runtime-proxy
-    replacements:
-      amd64: x86_64
+    # Default template: https://goreleaser.com/customization/archive/
+    name_template: >-
+      {{ .Binary }}_
+      {{ .Version }}_
+      {{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_
+      {{ . }}{{ end }}
+      {{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the runtime-proxy release error since the latest version of the goreleaser does not support `archieve.replacement` field anymore.

![image](https://github.com/koordinator-sh/koordinator/assets/21831156/5c2c50ed-1b4e-42fd-8fe9-62b0dd9417dc)

https://goreleaser.com/deprecations/#archivesreplacements

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
