### PR TITLE
koord-manager: allow quotas that are not bound to pods to become parent nodes

### DIFF
--- a/docs/proposals/scheduling/20220722-multi-hierarchy-elastic-quota-management.md
+++ b/docs/proposals/scheduling/20220722-multi-hierarchy-elastic-quota-management.md
@@ -371,7 +371,7 @@ spec:
 We introduce a new label on the pod to associate pod with quota group:
 ```yaml
 labels:
-  quota.scheduling.koordinator.sh/quota-name: "test1"
+  quota.scheduling.koordinator.sh/name: "test1"
 ```
 
 if pod's don't have the label, we will follow [Elastic Quota](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/kep/9-capacity-scheduling/README.md#goals)
@@ -379,9 +379,9 @@ using namespace to associate pod with quota group.
 
 ### Compatibility
 We are fully compatible with [Elastic Quota](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/kep/9-capacity-scheduling/README.md#goals) 's interface.
-If pod's don't have the "quota-name" label, we will use the namespace to associate pod with quota group. If the pod has 
-the "quota-name" label, we will use it to associate pod with quota group instead of namespace. If we can't find the 
-matched quota group, we force the pod to associate with the "default-group". 
+If pod's don't have the "name" label, we will use the namespace to associate pod with quota group. If the pod has the "name" label, 
+we will use it to associate pod with quota group instead of namespace. If we can't find the matched quota group, we force the pod to 
+associate with the "default-group". 
 
 ## Unsolved Problems
 Please see Non-goals/Future work.

--- a/pkg/util/fieldindex/register.go
+++ b/pkg/util/fieldindex/register.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
 )
 
 var registerOnce sync.Once
@@ -50,6 +52,21 @@ var indexDescriptors = []fieldIndexDescriptor{
 				return []string{}
 			}
 			return []string{pod.Spec.NodeName}
+		},
+	},
+	{
+		description: "index pod by label.QuotaName",
+		obj:         &corev1.Pod{},
+		field:       "label.quotaName",
+		indexerFunc: func(obj client.Object) []string {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				return []string{}
+			}
+			if len(pod.Labels) == 0 || pod.Labels[extension.LabelQuotaName] == "" {
+				return []string{}
+			}
+			return []string{pod.Labels[extension.LabelQuotaName]}
 		},
 	},
 }

--- a/pkg/webhook/elasticquota/quota_topology.go
+++ b/pkg/webhook/elasticquota/quota_topology.go
@@ -66,7 +66,7 @@ func (qt *quotaTopology) ValidAddQuota(quota *v1alpha1.ElasticQuota) error {
 	}
 
 	quotaInfo := NewQuotaInfoFromQuota(quota)
-	if err := qt.validateQuotaTopology(nil, quotaInfo); err != nil {
+	if err := qt.validateQuotaTopology(nil, quotaInfo, nil); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func (qt *quotaTopology) ValidUpdateQuota(oldQuota, newQuota *v1alpha1.ElasticQu
 	}
 
 	newQuotaInfo := NewQuotaInfoFromQuota(newQuota)
-	if err := qt.validateQuotaTopology(oldQuotaInfo, newQuotaInfo); err != nil {
+	if err := qt.validateQuotaTopology(oldQuotaInfo, newQuotaInfo, oldQuota); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Relax the limit of IsParent change. 
If quota is not bound to pods, it can become parent node. 
If quota doesn't have children, it can become child node.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
