### PR TITLE
koordlet: resource qos config supports SYSTEM qos

### DIFF
--- a/pkg/koordlet/qosmanager/helpers/property.go
+++ b/pkg/koordlet/qosmanager/helpers/property.go
@@ -36,13 +36,15 @@ func GetPodResourceQoSByQoSClass(pod *corev1.Pod, strategy *slov1alpha1.Resource
 		resourceQoS = strategy.LSClass
 	case apiext.QoSBE:
 		resourceQoS = strategy.BEClass
+	case apiext.QoSSystem:
+		resourceQoS = strategy.SystemClass
 	default:
 		// should never reach here
 	}
 	return resourceQoS
 }
 
-// getKubeQoSResourceQoSByQoSClass gets pod config by mapping kube qos into koordinator qos.
+// GetKubeQoSResourceQoSByQoSClass gets pod config by mapping kube qos into koordinator qos.
 // https://koordinator.sh/docs/core-concepts/qos/#koordinator-qos-vs-kubernetes-qos
 func GetKubeQoSResourceQoSByQoSClass(qosClass corev1.PodQOSClass, strategy *slov1alpha1.ResourceQOSStrategy) *slov1alpha1.ResourceQOS {
 	// NOTE: only used for static qos resource calculation here, and it may be incorrect mapping for dynamic qos

--- a/pkg/koordlet/qosmanager/helpers/property_test.go
+++ b/pkg/koordlet/qosmanager/helpers/property_test.go
@@ -66,6 +66,14 @@ func Test_getPodResourceQoSByQoSClass(t *testing.T) {
 			},
 			want: testutil.DefaultQOSStrategy().BEClass,
 		},
+		{
+			name: "get qos=SYSTEM config",
+			args: args{
+				pod:      testutil.MockTestPodWithQOS(corev1.PodQOSBurstable, apiext.QoSSystem).Pod,
+				strategy: testutil.DefaultQOSStrategy(),
+			},
+			want: testutil.DefaultQOSStrategy().SystemClass,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/koordlet/qosmanager/plugins/cgreconcile/cgroup_reconcile.go
+++ b/pkg/koordlet/qosmanager/plugins/cgreconcile/cgroup_reconcile.go
@@ -100,7 +100,7 @@ func (m *cgroupResourcesReconcile) reconcile() {
 	nodeSLO := m.statesInformer.GetNodeSLO()
 	if nodeSLO == nil || nodeSLO.Spec.ResourceQOSStrategy == nil {
 		// do nothing if nodeSLO == nil || nodeSLO.Spec.ResourceQOSStrategy == nil
-		klog.Warning("nodeSLO or nodeSLO.Spec.ResourceQOSStrategy is nil %v", util.DumpJSON(nodeSLO))
+		klog.Warningf("nodeSLO or nodeSLO.Spec.ResourceQOSStrategy is nil %v", util.DumpJSON(nodeSLO))
 		return
 	}
 

--- a/pkg/util/sloconfig/nodeslo_config.go
+++ b/pkg/util/sloconfig/nodeslo_config.go
@@ -72,6 +72,10 @@ func DefaultCPUQOS(qos apiext.QoSClass) *slov1alpha1.CPUQOS {
 		cpuQOS = &slov1alpha1.CPUQOS{
 			GroupIdentity: pointer.Int64(-1),
 		}
+	case apiext.QoSSystem:
+		cpuQOS = &slov1alpha1.CPUQOS{
+			GroupIdentity: pointer.Int64(0),
+		}
 	default:
 		klog.Infof("cpu qos has no auto config for qos %s", qos)
 	}
@@ -98,6 +102,12 @@ func DefaultResctrlQOS(qos apiext.QoSClass) *slov1alpha1.ResctrlQOS {
 		resctrlQOS = &slov1alpha1.ResctrlQOS{
 			CATRangeStartPercent: pointer.Int64(0),
 			CATRangeEndPercent:   pointer.Int64(30),
+			MBAPercent:           pointer.Int64(100),
+		}
+	case apiext.QoSSystem:
+		resctrlQOS = &slov1alpha1.ResctrlQOS{
+			CATRangeStartPercent: pointer.Int64(0),
+			CATRangeEndPercent:   pointer.Int64(100),
 			MBAPercent:           pointer.Int64(100),
 		}
 	default:
@@ -155,6 +165,18 @@ func DefaultMemoryQOS(qos apiext.QoSClass) *slov1alpha1.MemoryQOS {
 			Priority:          pointer.Int64(0),
 			OomKillGroup:      pointer.Int64(0),
 		}
+	case apiext.QoSSystem:
+		memoryQOS = &slov1alpha1.MemoryQOS{
+			MinLimitPercent:   pointer.Int64(0),
+			LowLimitPercent:   pointer.Int64(0),
+			ThrottlingPercent: pointer.Int64(0),
+			WmarkRatio:        pointer.Int64(0),
+			WmarkScalePermill: pointer.Int64(50),
+			WmarkMinAdj:       pointer.Int64(0),
+			PriorityEnable:    pointer.Int64(0),
+			Priority:          pointer.Int64(0),
+			OomKillGroup:      pointer.Int64(0),
+		}
 	default:
 		klog.V(5).Infof("memory qos has no auto config for qos %s", qos)
 	}
@@ -203,6 +225,20 @@ func DefaultResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 			MemoryQOS: &slov1alpha1.MemoryQOSCfg{
 				Enable:    pointer.Bool(false),
 				MemoryQOS: *DefaultMemoryQOS(apiext.QoSBE),
+			},
+		},
+		SystemClass: &slov1alpha1.ResourceQOS{
+			CPUQOS: &slov1alpha1.CPUQOSCfg{
+				Enable: pointer.Bool(false),
+				CPUQOS: *DefaultCPUQOS(apiext.QoSSystem),
+			},
+			ResctrlQOS: &slov1alpha1.ResctrlQOSCfg{
+				Enable:     pointer.Bool(false),
+				ResctrlQOS: *DefaultResctrlQOS(apiext.QoSSystem),
+			},
+			MemoryQOS: &slov1alpha1.MemoryQOSCfg{
+				Enable:    pointer.Bool(false),
+				MemoryQOS: *DefaultMemoryQOS(apiext.QoSSystem),
 			},
 		},
 	}
@@ -257,9 +293,10 @@ func NoneMemoryQOS() *slov1alpha1.MemoryQOS {
 // NoneResourceQOSStrategy indicates the qos strategy with all qos
 func NoneResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 	return &slov1alpha1.ResourceQOSStrategy{
-		LSRClass: NoneResourceQOS(apiext.QoSLSR),
-		LSClass:  NoneResourceQOS(apiext.QoSLS),
-		BEClass:  NoneResourceQOS(apiext.QoSBE),
+		LSRClass:    NoneResourceQOS(apiext.QoSLSR),
+		LSClass:     NoneResourceQOS(apiext.QoSLS),
+		BEClass:     NoneResourceQOS(apiext.QoSBE),
+		SystemClass: NoneResourceQOS(apiext.QoSSystem),
 	}
 }
 

--- a/pkg/util/sloconfig/nodeslo_config_test.go
+++ b/pkg/util/sloconfig/nodeslo_config_test.go
@@ -39,9 +39,10 @@ func Test_DefaultNodeSLOSpecConfig(t *testing.T) {
 
 func Test_NoneResourceQOSStrategy(t *testing.T) {
 	expect := &slov1alpha1.ResourceQOSStrategy{
-		LSRClass: NoneResourceQOS(apiext.QoSLSR),
-		LSClass:  NoneResourceQOS(apiext.QoSLS),
-		BEClass:  NoneResourceQOS(apiext.QoSBE),
+		LSRClass:    NoneResourceQOS(apiext.QoSLSR),
+		LSClass:     NoneResourceQOS(apiext.QoSLS),
+		BEClass:     NoneResourceQOS(apiext.QoSBE),
+		SystemClass: NoneResourceQOS(apiext.QoSSystem),
 	}
 	got := NoneResourceQOSStrategy()
 	assert.Equal(t, expect, got)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: Add the ResourceQOS configurations for qos=SYSTEM pods.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

When a pod reclaims its QoSClass as SYSTEM, the current ResourceQOS strategy can fail to parse the config for the pod since there is no SYSTEM class config defined. Especially, it can cause panic when CgroupReconcile is enabled and a SYSTEM pod is running on the node.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
