### PR TITLE
koord-manager: improve batch resource calculation with system metrics

### DIFF
--- a/pkg/slo-controller/noderesource/resource_calculator.go
+++ b/pkg/slo-controller/noderesource/resource_calculator.go
@@ -59,12 +59,12 @@ func (r *NodeResourceReconciler) resetNodeResource(node *corev1.Node, message st
 func (r *NodeResourceReconciler) calculateNodeResource(node *corev1.Node,
 	nodeMetric *slov1alpha1.NodeMetric, podList *corev1.PodList) *framework.NodeResource {
 	nr := framework.NewNodeResource()
-	metrics := &framework.ResourceMetrics{
+	resourceMetrics := &framework.ResourceMetrics{
 		NodeMetric: nodeMetric,
 	}
 
 	strategy := sloconfig.GetNodeColocationStrategy(r.cfgCache.GetCfgCopy(), node)
-	framework.RunResourceCalculateExtenders(nr, strategy, node, podList, metrics)
+	framework.RunResourceCalculateExtenders(nr, strategy, node, podList, resourceMetrics)
 
 	return nr
 }

--- a/pkg/slo-controller/noderesource/resource_calculator_test.go
+++ b/pkg/slo-controller/noderesource/resource_calculator_test.go
@@ -338,6 +338,12 @@ func Test_calculateNodeResource(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("55G"),
 								},
 							},
+							SystemUsage: slov1alpha1.ResourceMap{
+								ResourceList: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("7"),
+									corev1.ResourceMemory: resource.MustParse("12G"),
+								},
+							},
 						},
 						PodsMetric: []*slov1alpha1.PodMetricInfo{
 							{
@@ -540,6 +546,12 @@ func Test_calculateNodeResource(t *testing.T) {
 								ResourceList: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("50"),
 									corev1.ResourceMemory: resource.MustParse("55G"),
+								},
+							},
+							SystemUsage: slov1alpha1.ResourceMap{
+								ResourceList: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("7"),
+									corev1.ResourceMemory: resource.MustParse("12G"),
 								},
 							},
 						},
@@ -746,6 +758,12 @@ func Test_calculateNodeResource(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("55G"),
 								},
 							},
+							SystemUsage: slov1alpha1.ResourceMap{
+								ResourceList: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("7"),
+									corev1.ResourceMemory: resource.MustParse("12G"),
+								},
+							},
 						},
 						PodsMetric: []*slov1alpha1.PodMetricInfo{
 							{
@@ -945,6 +963,12 @@ func Test_calculateNodeResource(t *testing.T) {
 								ResourceList: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("50"),
 									corev1.ResourceMemory: resource.MustParse("55G"),
+								},
+							},
+							SystemUsage: slov1alpha1.ResourceMap{
+								ResourceList: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("7"),
+									corev1.ResourceMemory: resource.MustParse("12G"),
 								},
 							},
 						},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-manager: Improve the calculation of the batch resource allocatable with the newly-added system metrics.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixes #1427.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

Please note that the calculated allocatable can be lower than the real result at the nodeMetric reported time. It becomes accurate when there are no more pods terminated or newly-scheduled between the nodeMetric reported time and the controller calculating time.

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
