### PR TITLE
koord-scheduler: fix missing IsParent when rebuild tree

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -359,6 +359,7 @@ func (gqm *GroupQuotaManager) buildSubParGroupTopoNoLock() {
 				Name: topoNode.quotaInfo.ParentName,
 			})
 		}
+		parQuotaTopoNode.quotaInfo.IsParent = true
 		topoNode.parQuotaTopoNode = parQuotaTopoNode
 		parQuotaTopoNode.addChildGroupQuotaInfo(topoNode)
 	}

--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
@@ -1210,3 +1210,25 @@ func TestGetPodName(t *testing.T) {
 	assert.Equal(t, pod1.Name, getPodName(pod1, nil))
 	assert.Equal(t, pod1.Name, getPodName(nil, pod1))
 }
+
+func TestGroupQuotaManager_IsParent(t *testing.T) {
+	gqm := NewGroupQuotaManagerForTest()
+
+	gqm.UpdateClusterTotalResource(createResourceList(50, 50))
+
+	qi1 := createQuota("1", extension.RootQuotaName, 40, 40, 10, 10)
+	qi2 := createQuota("2", "1", 40, 40, 10, 10)
+	gqm.UpdateQuota(qi1, false)
+
+	qi1Info := gqm.GetQuotaInfoByName("1")
+	assert.False(t, qi1Info.IsParent)
+
+	gqm.UpdateQuota(qi2, false)
+
+	qi1Info = gqm.GetQuotaInfoByName("1")
+	assert.True(t, qi1Info.IsParent)
+
+	qi2Info := gqm.GetQuotaInfoByName("2")
+	assert.False(t, qi2Info.IsParent)
+
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fix IsParent in the quota tree rebuild

some parent quotas has no is-parent label. we should fix it in the rebuild phase

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
