### PR TITLE
koord-scheduler: deviceshare plugin skips handling nodes without device cr

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -293,7 +293,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 
 	nodeDeviceInfo := p.nodeDeviceCache.getNodeDevice(node.Name, false)
 	if nodeDeviceInfo == nil {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice)
+		return nil
 	}
 
 	reservationRestoreState := getReservationRestoreState(cycleState)
@@ -343,7 +343,7 @@ func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.Cy
 
 	nodeDeviceInfo := p.nodeDeviceCache.getNodeDevice(nodeName, false)
 	if nodeDeviceInfo == nil {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice)
+		return nil
 	}
 
 	preemptible := appendAllocated(nil, restoreState.mergedUnmatchedUsed, state.preemptibleDevices[nodeName])
@@ -372,7 +372,7 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, 
 
 	nodeDeviceInfo := p.nodeDeviceCache.getNodeDevice(nodeName, false)
 	if nodeDeviceInfo == nil {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice)
+		return nil
 	}
 
 	reservationRestoreState := getReservationRestoreState(cycleState)

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -718,7 +718,7 @@ func Test_Plugin_Filter(t *testing.T) {
 			pod:             &corev1.Pod{},
 			nodeDeviceCache: newNodeDeviceCache(),
 			nodeInfo:        testNodeInfo,
-			want:            framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice),
+			want:            nil,
 		},
 		{
 			name: "insufficient device resource 1",
@@ -1595,7 +1595,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 				nodeName: "test-node",
 			},
 			wants: wants{
-				status: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrMissingDevice),
+				status: nil,
 			},
 		},
 		{


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
background:
Initially, gpu scheduling was implemented through the gpu device plugin, and after switching to koord-scheduler scheduling, the pod could not be scheduled, prompts that no device resources.

reason:
The gpu node doesn't have a koordlet, but it does report gpu info to node.status via the device plugin, so it can be scheduled by default-scheduler. But koord-scheduler's deviceshare plugin intercepts scheduling pod because there are no device resources.

resolve:
deviceshare skips handling nodes without device

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
