### PR TITLE
koord-scheduler: supports plugins to adjust reservation reusable resources

### DIFF
--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -51,6 +51,12 @@ const (
 	//
 	// DisablePodDisruptionBudgetInformer is used to disable PodDisruptionBudget informer
 	DisablePodDisruptionBudgetInformer featuregate.Feature = "DisablePodDisruptionBudgetInformer"
+
+	// owner: @joseph
+	// alpha: v0.1
+	//
+	// ResizePod is used to enable resize pod feature
+	ResizePod featuregate.Feature = "ResizePod"
 )
 
 var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -58,6 +64,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	DisableCSIStorageCapacityInformer:  {Default: false, PreRelease: featuregate.Alpha},
 	CompatiblePodDisruptionBudget:      {Default: false, PreRelease: featuregate.Alpha},
 	DisablePodDisruptionBudgetInformer: {Default: false, PreRelease: featuregate.Alpha},
+	ResizePod:                          {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -61,6 +61,8 @@ type FrameworkExtender interface {
 	RunReservationScorePlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfos []*ReservationInfo, nodeName string) (PluginToReservationScores, *framework.Status)
 
 	RunNUMATopologyManagerAllocate(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy, assume bool) *framework.Status
+
+	RunResizePod(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status
 }
 
 // SchedulingTransformer is the parent type for all the custom transformer plugins.
@@ -152,6 +154,12 @@ type PluginToReservationScores map[string]ReservationScoreList
 type ReservationScorePlugin interface {
 	framework.Plugin
 	ScoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) (int64, *framework.Status)
+}
+
+// ResizePodPlugin is an interface that resize the pod resource spec after reserve.
+// If you want to use the feature, must enable the feature gate ResizePod=true
+type ResizePodPlugin interface {
+	ResizePod(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status
 }
 
 var (

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -59,6 +59,10 @@ func TestNominateReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
 		},
 	}
 	reservation2C4G := &schedulingv1alpha1.Reservation{
@@ -85,6 +89,10 @@ func TestNominateReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
 		},
 	}
 	tests := []struct {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -638,7 +638,9 @@ func (pl *Plugin) Bind(ctx context.Context, cycleState *framework.CycleState, po
 
 		// mark reservation as available
 		reservation = reservation.DeepCopy()
-		reservationutil.SetReservationAvailable(reservation, nodeName)
+		if err = reservationutil.SetReservationAvailable(reservation, nodeName); err != nil {
+			return err
+		}
 		_, err = pl.client.Reservations().UpdateStatus(context.TODO(), reservation, metav1.UpdateOptions{})
 		if err != nil {
 			klog.V(4).ErrorS(err, "failed to update reservation", "reservation", klog.KObj(reservation))

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -61,6 +61,10 @@ func TestScore(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
 		},
 	}
 	reservation2C4G := &schedulingv1alpha1.Reservation{
@@ -87,6 +91,10 @@ func TestScore(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
 		},
 	}
 
@@ -280,6 +288,10 @@ func TestScoreWithOrder(t *testing.T) {
 			Status: schedulingv1alpha1.ReservationStatus{
 				Phase:    schedulingv1alpha1.ReservationAvailable,
 				NodeName: fmt.Sprintf("test-node-%d", i),
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
 			},
 		}
 	}
@@ -391,6 +403,10 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
 		},
 	}
 	reservation2C4G := &schedulingv1alpha1.Reservation{
@@ -417,6 +433,10 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
 		},
 	}
 	otherNodeReservation4C8G := reservation4C8G.DeepCopy()

--- a/pkg/scheduler/plugins/reservation/service_test.go
+++ b/pkg/scheduler/plugins/reservation/service_test.go
@@ -77,6 +77,10 @@ func TestQueryNodeReservations(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReasonReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
 		},
 	}
 	pl.reservationCache.updateReservation(reservation)

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -182,6 +182,10 @@ func TestRestoreReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("12"),
+				corev1.ResourceMemory: resource.MustParse("24Gi"),
+			},
 		},
 	}
 	pods = append(pods, reservationutil.NewReservePod(unmatchedReservation))
@@ -241,6 +245,10 @@ func TestRestoreReservation(t *testing.T) {
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
 			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
 		},
 	}
 	pods = append(pods, reservationutil.NewReservePod(matchedReservation))

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -22,44 +22,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/pointer"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
-
-func TestNewReservePod(t *testing.T) {
-	t.Run("test not panic", func(t *testing.T) {
-		r := &schedulingv1alpha1.Reservation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "reserve-pod-0",
-			},
-			Spec: schedulingv1alpha1.ReservationSpec{
-				Template: &corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "reserve-pod-0",
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "test-node-0",
-					},
-				},
-				Owners: []schedulingv1alpha1.ReservationOwner{
-					{
-						Object: &corev1.ObjectReference{
-							Kind: "Pod",
-							Name: "test-pod-0",
-						},
-					},
-				},
-				TTL: &metav1.Duration{Duration: 30 * time.Minute},
-			},
-		}
-		reservePod := NewReservePod(r)
-		assert.NotNil(t, reservePod)
-		assert.NotNil(t, reservePod.Spec.Priority)
-		assert.True(t, IsReservePod(reservePod))
-	})
-}
 
 func TestIsReservationActive(t *testing.T) {
 	t.Run("test not panic", func(t *testing.T) {
@@ -466,6 +436,312 @@ func Test_matchReservationOwners(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := MatchReservationOwners(tt.args.pod, tt.args.r.Spec.Owners)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSetReservationAvailable(t *testing.T) {
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "reserve-pod-0",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reserve-pod-0",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"test-resource": *resource.NewQuantity(100, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resizeAllocatable := corev1.ResourceList{
+		"test-resource": *resource.NewQuantity(100, resource.DecimalSI),
+	}
+
+	availableReservation := reservation.DeepCopy()
+	availableReservation.Status.Phase = schedulingv1alpha1.ReservationAvailable
+	availableReservation.Status.Allocatable = resizeAllocatable
+	availableReservation.Status.NodeName = "test-node"
+	availableReservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{
+			Type:               schedulingv1alpha1.ReservationConditionScheduled,
+			Status:             schedulingv1alpha1.ConditionStatusTrue,
+			Reason:             schedulingv1alpha1.ReasonReservationScheduled,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		},
+		{
+			Type:               schedulingv1alpha1.ReservationConditionReady,
+			Status:             schedulingv1alpha1.ConditionStatusTrue,
+			Reason:             schedulingv1alpha1.ReasonReservationAvailable,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	resizedReservation := reservation.DeepCopy()
+	assert.NoError(t, UpdateReservationResizeAllocatable(resizedReservation, resizeAllocatable))
+	resizedAvailableReservation := availableReservation.DeepCopy()
+	assert.NoError(t, UpdateReservationResizeAllocatable(resizedAvailableReservation, resizeAllocatable))
+	resizedAvailableReservation.Status.Allocatable = resizeAllocatable
+
+	tests := []struct {
+		name            string
+		reservation     *schedulingv1alpha1.Reservation
+		wantReservation *schedulingv1alpha1.Reservation
+	}{
+		{
+			name:            "pending reservation to available",
+			reservation:     reservation,
+			wantReservation: availableReservation,
+		},
+		{
+			name:            "reservation with resize allocatable",
+			reservation:     resizedReservation,
+			wantReservation: resizedAvailableReservation,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(t, SetReservationAvailable(tt.reservation, "test-node"))
+		})
+	}
+}
+
+func TestReservePod(t *testing.T) {
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "reserve-pod-0",
+			Labels: map[string]string{
+				"test-label": "666",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "888",
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reserve-pod-0",
+					Namespace: "test",
+					Labels: map[string]string{
+						"test-label":  "111",
+						"other-label": "1",
+					},
+					Annotations: map[string]string{
+						"test-annotation":  "222",
+						"other-annotation": "2",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:      "test-node",
+					SchedulerName: "koord-scheduler",
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"test-resource": *resource.NewQuantity(100, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"test-resource": *resource.NewQuantity(10, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						"test-resource": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: "test-node",
+			Allocatable: corev1.ResourceList{
+				"test-resource": *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+
+	expectReservePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       reservation.UID,
+			Name:      GetReservationKey(reservation),
+			Namespace: "test",
+			Labels: map[string]string{
+				"test-label":  "666",
+				"other-label": "1",
+			},
+			Annotations: map[string]string{
+				"test-annotation":         "888",
+				"other-annotation":        "2",
+				AnnotationReservePod:      "true",
+				AnnotationReservationName: reservation.Name,
+				AnnotationReservationNode: reservation.Status.NodeName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      "test-node",
+			SchedulerName: "koord-scheduler",
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+				},
+				{
+					Name: "__internal_fake_container__",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"test-resource": *resource.NewQuantity(200, resource.DecimalSI),
+						},
+						Limits: corev1.ResourceList{
+							"test-resource": *resource.NewQuantity(200, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			Priority: pointer.Int32(0),
+			InitContainers: []corev1.Container{
+				{
+					Name:      "test-init-container",
+					Resources: corev1.ResourceRequirements{},
+				},
+			},
+			Overhead: nil,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		reservation    *schedulingv1alpha1.Reservation
+		wantReservePod *corev1.Pod
+	}{
+		{
+			name:           "convert to reserve pod",
+			reservation:    reservation,
+			wantReservePod: expectReservePod,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reservePod := NewReservePod(tt.reservation)
+			assert.Equal(t, tt.wantReservePod, reservePod)
+		})
+	}
+}
+
+func TestReservationRequests(t *testing.T) {
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "reserve-pod-0",
+			Labels: map[string]string{
+				"test-label": "666",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "888",
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reserve-pod-0",
+					Namespace: "test",
+					Labels: map[string]string{
+						"test-label":  "111",
+						"other-label": "1",
+					},
+					Annotations: map[string]string{
+						"test-annotation":  "222",
+						"other-annotation": "2",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:      "test-node",
+					SchedulerName: "koord-scheduler",
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"test-resource": *resource.NewQuantity(100, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"test-resource": *resource.NewQuantity(10, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						"test-resource": *resource.NewQuantity(10, resource.DecimalSI),
+					},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationPending,
+		},
+	}
+
+	resizeAllocatableReservation := reservation.DeepCopy()
+	resizeAllocatableReservation.Status.NodeName = "test-node"
+	resizeAllocatableReservation.Status.Phase = schedulingv1alpha1.ReservationAvailable
+	resizeAllocatableReservation.Status.Allocatable = corev1.ResourceList{
+		"test-resource": *resource.NewQuantity(200, resource.DecimalSI),
+	}
+
+	tests := []struct {
+		name        string
+		reservation *schedulingv1alpha1.Reservation
+		want        corev1.ResourceList
+	}{
+		{
+			name:        "request from PodTemplateSpec",
+			reservation: reservation,
+			want: corev1.ResourceList{
+				"test-resource": *resource.NewQuantity(110, resource.DecimalSI),
+			},
+		},
+		{
+			name:        "request from status allocatable",
+			reservation: resizeAllocatableReservation,
+			want: corev1.ResourceList{
+				"test-resource": *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReservationRequests(tt.reservation)
+			assert.True(t, equality.Semantic.DeepEqual(tt.want, got))
 		})
 	}
 }

--- a/test/e2e/scheduling/deviceshare.go
+++ b/test/e2e/scheduling/deviceshare.go
@@ -107,7 +107,9 @@ var _ = SIGDescribe("DeviceShare", func() {
 			numPods := totalGPU.Value() / 50
 
 			ginkgo.By(fmt.Sprintf("Create %d pods", numPods))
-			requests := reservationutil.ReservationRequests(reservation)
+			requests := corev1.ResourceList{
+				apiext.ResourceGPU: resource.MustParse("50"),
+			}
 			replicas := numPods
 			rsConfig := pauseRSConfig{
 				Replicas: int32(replicas),
@@ -202,7 +204,9 @@ var _ = SIGDescribe("DeviceShare", func() {
 			reservation = waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
 
 			ginkgo.By("Create 1 pods that matched reservation")
-			requests := reservationutil.ReservationRequests(reservation)
+			requests := corev1.ResourceList{
+				apiext.ResourceGPU: resource.MustParse("50"),
+			}
 			rsConfig := pauseRSConfig{
 				Replicas: int32(1),
 				PodConfig: pausePodConfig{
@@ -328,7 +332,9 @@ var _ = SIGDescribe("DeviceShare", func() {
 				reservation = waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
 
 				ginkgo.By("Create 1 pods allocated from reservation")
-				requests := reservationutil.ReservationRequests(reservation)
+				requests := corev1.ResourceList{
+					apiext.ResourceGPU: resource.MustParse("50"),
+				}
 				rsConfig := pauseRSConfig{
 					Replicas: int32(1),
 					PodConfig: pausePodConfig{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Plugins like DeviceShare will add additional normalized resources after the scheduling is successful, and there may be more resources than Pod expects to apply for. In the Reservation scenario, these need to be backfilled to the Reservation and be perceived by subsequent links, so as to complete similar scenarios. resource reuse. This PR is to solve this problem.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
