### PR TITLE
koordlet: report CPUBasicInfo, adjust normalized cpu cgroups

### DIFF
--- a/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/podresource/pod_resource_collector_test.go
@@ -339,7 +339,9 @@ func Test_podResourceCollector_Run(t *testing.T) {
 	})
 	collector := c.(*podResourceCollector)
 	collector.started = atomic.NewBool(true)
-	collector.Setup(&framework.Context{})
+	collector.Setup(&framework.Context{
+		State: framework.NewSharedState(),
+	})
 	assert.True(t, collector.Enabled())
 	assert.True(t, collector.Started())
 	assert.NotPanics(t, func() {

--- a/pkg/koordlet/qosmanager/plugins/cgreconcile/cgroup_reconcile_test.go
+++ b/pkg/koordlet/qosmanager/plugins/cgreconcile/cgroup_reconcile_test.go
@@ -1304,10 +1304,10 @@ func assertCgroupResourceEqual(t *testing.T, expect, got []resourceexecutor.Reso
 		g, ok := got[i].(*resourceexecutor.CgroupResourceUpdater)
 		assert.Equal(t, true, ok, fmt.Sprintf("check for index %v", i))
 		// assert not support func arguments
-		e.SetUpdateFunc(nil, nil)
-		g.SetUpdateFunc(nil, nil)
+		e.WithUpdateFunc(nil).WithMergeUpdateFunc(nil)
+		g.WithUpdateFunc(nil).WithMergeUpdateFunc(nil)
 		// set expect eventhelper like reality
-		e.SeteventHelper(g.GeteventHelper())
+		e.SetEventHelper(g.GetEventHelper())
 		assert.Equal(t, e, g, fmt.Sprintf("check for index %v", i))
 	}
 }

--- a/pkg/koordlet/resourceexecutor/executor.go
+++ b/pkg/koordlet/resourceexecutor/executor.go
@@ -271,3 +271,12 @@ func (e *ResourceUpdateExecutorImpl) isUpdateErrIgnored(err error) bool {
 	}
 	return false
 }
+
+// NewTestResourceExecutor returns a new ResourceUpdateExecutorImpl for testing usage.
+// NOTE: Please DO NOT use it except unittests.
+func NewTestResourceExecutor() ResourceUpdateExecutor {
+	return &ResourceUpdateExecutorImpl{
+		ResourceCache: cache.NewCacheDefault(),
+		Config:        NewDefaultConfig(),
+	}
+}

--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/batchresource"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/cpunormalization"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/cpuset"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/gpu"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/groupidentity"
@@ -32,47 +33,55 @@ import (
 )
 
 const (
+	// GroupIdentity sets pod cpu group identity(bvt) according to QoS.
+	//
 	// owner: @zwzhang0107 @saintube
 	// alpha: v0.3
 	// beta: v1.1
-	//
-	// GroupIdentity set pod cpu group identity(bvt) according to QoS.
 	GroupIdentity featuregate.Feature = "GroupIdentity"
 
+	// CPUSetAllocator sets container cpuset according to allocate result from koord-scheduler for LSR/LS pods.
+	//
 	// owner: @saintube @zwzhang0107
 	// alpha: v0.3
 	// beta: v1.1
-	//
-	// CPUSetAllocator set container cpuset according to allocate result from koord-scheduler for LSR/LS pods.
 	CPUSetAllocator featuregate.Feature = "CPUSetAllocator"
 
+	// GPUEnvInject injects gpu allocated env info according to allocate result from koord-scheduler.
+	//
 	// owner: @ZYecho @jasonliu747
 	// alpha: v0.3
 	// beta: v1.1
-	//
-	// GPUEnvInject injects gpu allocated env info according to allocate result from koord-scheduler.
 	GPUEnvInject featuregate.Feature = "GPUEnvInject"
 
+	// BatchResource sets request and limits of cpu and memory on cgroup file according batch resources.
+	//
 	// owner: @saintube @zwzhang0107
 	// alpha: v1.1
-	//
-	// BatchResource set request and limits of cpu and memory on cgroup file.
 	BatchResource featuregate.Feature = "BatchResource"
+
+	// CPUNormalization adjusts cpu cgroups value for cpu normalized LS pod.
+	//
+	// owner: @saintube @zwzhang0107
+	// alpha: v1.4
+	CPUNormalization featuregate.Feature = "CPUNormalization"
 )
 
 var (
 	defaultRuntimeHooksFG = map[featuregate.Feature]featuregate.FeatureSpec{
-		GroupIdentity:   {Default: true, PreRelease: featuregate.Beta},
-		CPUSetAllocator: {Default: true, PreRelease: featuregate.Beta},
-		GPUEnvInject:    {Default: false, PreRelease: featuregate.Alpha},
-		BatchResource:   {Default: true, PreRelease: featuregate.Beta},
+		GroupIdentity:    {Default: true, PreRelease: featuregate.Beta},
+		CPUSetAllocator:  {Default: true, PreRelease: featuregate.Beta},
+		GPUEnvInject:     {Default: false, PreRelease: featuregate.Alpha},
+		BatchResource:    {Default: true, PreRelease: featuregate.Beta},
+		CPUNormalization: {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	runtimeHookPlugins = map[featuregate.Feature]HookPlugin{
-		GroupIdentity:   groupidentity.Object(),
-		CPUSetAllocator: cpuset.Object(),
-		GPUEnvInject:    gpu.Object(),
-		BatchResource:   batchresource.Object(),
+		GroupIdentity:    groupidentity.Object(),
+		CPUSetAllocator:  cpuset.Object(),
+		GPUEnvInject:     gpu.Object(),
+		BatchResource:    batchresource.Object(),
+		CPUNormalization: cpunormalization.Object(),
 	}
 )
 

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule.go
@@ -17,29 +17,87 @@ limitations under the License.
 package batchresource
 
 import (
-	"reflect"
+	"fmt"
+	"math"
+	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/reconciler"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/util/sloconfig"
 )
 
-type batchResourceRule struct {
-	enableCFSQuota bool
+const ratioDiffEpsilon = 0.01
+
+type Rule struct {
+	lock sync.RWMutex
+
+	enableCFSQuota        *bool    // default = true
+	cpuNormalizationRatio *float64 // default = -1, -1 means disabled
 }
 
-func (r *batchResourceRule) getEnableCFSQuota() bool {
-	if r == nil {
+func newRule() *Rule {
+	return &Rule{
+		enableCFSQuota:        nil,
+		cpuNormalizationRatio: nil,
+	}
+}
+
+// GetCFSQuotaScaleRatio returns
+// 1. if the cfs quota should be unlimited (-1 / max)
+// 2. the scale ratio for the cfs quota when the quota is limited (-1 means do not scale)
+func (r *Rule) GetCFSQuotaScaleRatio() (bool, float64) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	enabled := true
+	if r.enableCFSQuota != nil {
+		enabled = *r.enableCFSQuota
+	}
+	ratio := -1.0
+	if r.cpuNormalizationRatio != nil {
+		ratio = *r.cpuNormalizationRatio
+	}
+	if enabled {
+		return true, ratio
+	}
+	return false, -1
+}
+
+func (r *Rule) UpdateCFSQuotaEnabled(enabled bool) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.enableCFSQuota == nil {
+		r.enableCFSQuota = &enabled
 		return true
 	}
-	return r.enableCFSQuota
+	if *r.enableCFSQuota != enabled {
+		*r.enableCFSQuota = enabled
+		return true
+	}
+	return false
 }
 
-func (p *plugin) parseRule(mergedNodeSLOIf interface{}) (bool, error) {
+func (r *Rule) UpdateCPUNormalizationRatio(ratio float64) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.cpuNormalizationRatio == nil {
+		r.cpuNormalizationRatio = &ratio
+		return true
+	}
+	if math.Abs(*r.cpuNormalizationRatio-ratio) >= ratioDiffEpsilon {
+		*r.cpuNormalizationRatio = ratio
+		return true
+	}
+	return false
+}
+
+func (p *plugin) parseRuleForNodeSLO(mergedNodeSLOIf interface{}) (bool, error) {
 	mergedNodeSLO := mergedNodeSLOIf.(*slov1alpha1.NodeSLOSpec)
 
 	enableCFSQuota := true
@@ -50,19 +108,39 @@ func (p *plugin) parseRule(mergedNodeSLOIf interface{}) (bool, error) {
 		enableCFSQuota = false
 	}
 
-	rule := &batchResourceRule{
-		enableCFSQuota: enableCFSQuota,
+	isUpdated := p.rule.UpdateCFSQuotaEnabled(enableCFSQuota)
+	if isUpdated {
+		klog.V(4).Infof("runtime hook plugin %s update rule, new rule: CFSQuotaEnabled %v",
+			ruleNameForNodeSLO, enableCFSQuota)
 	}
-
-	updated := p.updateRule(rule)
-	klog.V(4).Infof("runtime hook plugin %s update rule %v, new rule %v", name, updated, rule)
-	return updated, nil
+	return isUpdated, nil
 }
 
-func (p *plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
-	r := p.getRule()
-	if r == nil {
-		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
+func (p *plugin) parseRuleForNodeMeta(nodeIf interface{}) (bool, error) {
+	node, ok := nodeIf.(*corev1.Node)
+	if !ok {
+		return false, fmt.Errorf("type input %T is not *Node", nodeIf)
+	}
+	if node == nil {
+		return false, fmt.Errorf("got nil node")
+	}
+
+	ratio, err := apiext.GetCPUNormalizationRatio(node)
+	if err != nil {
+		return false, fmt.Errorf("get cpu normalization ratio failed, err: %w", err)
+	}
+
+	isUpdated := p.rule.UpdateCPUNormalizationRatio(ratio)
+	if isUpdated {
+		klog.V(4).Infof("runtime hook plugin %s update rule, enabled %v, ratio %v",
+			ruleNameForNodeMeta, ratio != -1, ratio)
+	}
+	return isUpdated, nil
+}
+
+func (p *plugin) ruleUpdateCbForNodeSLO(pods []*statesinformer.PodMeta) error {
+	if p.rule == nil {
+		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", ruleNameForNodeSLO)
 		return nil
 	}
 	for _, podMeta := range pods {
@@ -70,48 +148,84 @@ func (p *plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		if podQOS != apiext.QoSBE {
 			continue
 		}
+
 		// pod-level
 		podCtx := &protocol.PodContext{}
 		podCtx.FromReconciler(podMeta)
 		if err := p.SetPodCFSQuota(podCtx); err != nil { // only need to change cfs quota
-			klog.V(4).Infof("failed to set pod cfs quota during callback %v, err: %v", name, err)
+			klog.V(4).Infof("failed to set pod cfs quota during callback %v, err: %v", ruleNameForNodeSLO, err)
 			continue
 		}
 		podCtx.ReconcilerDone(p.executor)
+
 		// container-level
 		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
 			containerCtx := &protocol.ContainerContext{}
 			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
 			if err := p.SetContainerCFSQuota(containerCtx); err != nil {
 				klog.V(4).Infof("failed to set container cfs quota during callback %v, container %v, err: %v",
-					name, containerStat.Name, err)
+					ruleNameForNodeSLO, containerStat.Name, err)
 				continue
 			}
 			containerCtx.ReconcilerDone(p.executor)
 		}
 		// TODO set for sandbox container
 	}
+
 	return nil
 }
 
-func (p *plugin) getRule() *batchResourceRule {
-	p.ruleRWMutex.RLock()
-	defer p.ruleRWMutex.RUnlock()
+func (p *plugin) ruleUpdateCbForNodeMeta(pods []*statesinformer.PodMeta) error {
+	// NOTE: if the ratio becomes bigger, scale top down, otherwise, scale bottom up
 	if p.rule == nil {
+		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", ruleNameForNodeMeta)
 		return nil
 	}
-	rule := *p.rule
-	return &rule
-}
+	filter := reconciler.PodQOSFilter()
+	var podUpdaters, containerUpdaters []resourceexecutor.ResourceUpdater
+	for _, podMeta := range pods {
+		if qos := apiext.QoSClass(filter.Filter(podMeta)); qos != apiext.QoSBE {
+			continue
+		}
 
-func (p *plugin) updateRule(newRule *batchResourceRule) bool {
-	p.ruleRWMutex.Lock()
-	defer p.ruleRWMutex.Unlock()
-	if !reflect.DeepEqual(newRule, p.rule) {
-		p.rule = newRule
-		return true
+		// pod-level
+		podCtx := &protocol.PodContext{}
+		podCtx.FromReconciler(podMeta)
+		if err := p.SetPodCFSQuota(podCtx); err != nil {
+			klog.V(4).Infof("failed to set pod cfs quota during callback %s, pod %s, err: %s",
+				ruleNameForNodeMeta, podMeta.Key(), err)
+			continue
+		}
+		podCtx.ReconcilerProcess(p.executor)
+		podUpdaters = append(podUpdaters, podCtx.GetUpdaters()...)
+		klog.V(6).Infof("got %v updaters for pod %s during callback %s",
+			len(podUpdaters), podMeta.Key(), ruleNameForNodeMeta)
+
+		// container-level
+		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+			containerCtx := &protocol.ContainerContext{}
+			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
+			if err := p.SetContainerCFSQuota(containerCtx); err != nil {
+				klog.V(4).Infof("failed to set container cfs quota during callback %s, container %s/%s, err: %s",
+					ruleNameForNodeMeta, podMeta.Key(), containerStat.Name, err)
+				continue
+			}
+			containerCtx.ReconcilerProcess(p.executor)
+			containerUpdaters = append(containerUpdaters, containerCtx.GetUpdaters()...)
+			klog.V(6).Infof("got %v updaters for container %s/%s during callback %s",
+				len(podUpdaters), podMeta.Key(), containerStat.Name, ruleNameForNodeMeta)
+		}
+		// ignore sandbox containers
 	}
-	return false
+
+	// NOTE: Update cgroups by the level since some resources like cfs quota requires the upper level value is no less
+	//       than the lower.
+	p.executor.LeveledUpdateBatch([][]resourceexecutor.ResourceUpdater{
+		podUpdaters,
+		containerUpdaters,
+	})
+
+	return nil
 }
 
 func getCPUSuppressPolicy(nodeSLOSpec *slov1alpha1.NodeSLOSpec) (bool, slov1alpha1.CPUSuppressPolicy) {

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
@@ -34,9 +34,47 @@ import (
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
-func Test_plugin_parseRule(t *testing.T) {
+func TestRule(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		r := newRule()
+		assert.NotNil(t, r)
+
+		// check the defaults
+		got, got1 := r.GetCFSQuotaScaleRatio()
+		assert.True(t, got)
+		assert.Equal(t, float64(-1), got1)
+
+		isUpdated := r.UpdateCFSQuotaEnabled(true)
+		assert.True(t, isUpdated)
+		got, _ = r.GetCFSQuotaScaleRatio()
+		assert.True(t, got)
+		isUpdated = r.UpdateCFSQuotaEnabled(true)
+		assert.False(t, isUpdated)
+		isUpdated = r.UpdateCFSQuotaEnabled(false)
+		assert.True(t, isUpdated)
+		got, _ = r.GetCFSQuotaScaleRatio()
+		assert.False(t, got)
+		isUpdated = r.UpdateCFSQuotaEnabled(true)
+		assert.True(t, isUpdated)
+		got, _ = r.GetCFSQuotaScaleRatio()
+		assert.True(t, got)
+
+		isUpdated = r.UpdateCPUNormalizationRatio(-1)
+		assert.True(t, isUpdated)
+		_, got1 = r.GetCFSQuotaScaleRatio()
+		assert.Equal(t, float64(-1), got1)
+		isUpdated = r.UpdateCPUNormalizationRatio(-1)
+		assert.False(t, isUpdated)
+		isUpdated = r.UpdateCPUNormalizationRatio(1.2)
+		assert.True(t, isUpdated)
+		_, got1 = r.GetCFSQuotaScaleRatio()
+		assert.Equal(t, 1.2, got1)
+	})
+}
+
+func Test_plugin_parseRuleForNodeSLO(t *testing.T) {
 	type fields struct {
-		rule *batchResourceRule
+		rule *Rule
 	}
 	type args struct {
 		mergedNodeSLO *slov1alpha1.NodeSLOSpec
@@ -47,18 +85,25 @@ func Test_plugin_parseRule(t *testing.T) {
 		args     args
 		want     bool
 		wantErr  bool
-		wantRule *batchResourceRule
+		wantRule *Rule
 	}{
 		{
-			name:    "initialize true",
+			name: "initialize true",
+			fields: fields{
+				rule: newRule(),
+			},
 			want:    true,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: true,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(true),
+				cpuNormalizationRatio: nil,
 			},
 		},
 		{
 			name: "initialize false",
+			fields: fields{
+				rule: newRule(),
+			},
 			args: args{
 				mergedNodeSLO: &slov1alpha1.NodeSLOSpec{
 					ResourceUsedThresholdWithBE: &slov1alpha1.ResourceThresholdStrategy{
@@ -69,15 +114,17 @@ func Test_plugin_parseRule(t *testing.T) {
 			},
 			want:    true,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: false,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(false),
+				cpuNormalizationRatio: nil,
 			},
 		},
 		{
 			name: "rule change to false",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: true,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(-1),
 				},
 			},
 			args: args{
@@ -90,15 +137,17 @@ func Test_plugin_parseRule(t *testing.T) {
 			},
 			want:    true,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: false,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(false),
+				cpuNormalizationRatio: pointer.Float64(-1),
 			},
 		},
 		{
 			name: "rule change to true",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: false,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(false),
+					cpuNormalizationRatio: pointer.Float64(-1),
 				},
 			},
 			args: args{
@@ -106,15 +155,17 @@ func Test_plugin_parseRule(t *testing.T) {
 			},
 			want:    true,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: true,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(true),
+				cpuNormalizationRatio: pointer.Float64(-1),
 			},
 		},
 		{
 			name: "rule not change as true",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: true,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(-1),
 				},
 			},
 			args: args{
@@ -122,15 +173,17 @@ func Test_plugin_parseRule(t *testing.T) {
 			},
 			want:    false,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: true,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(true),
+				cpuNormalizationRatio: pointer.Float64(-1),
 			},
 		},
 		{
 			name: "rule not change as false",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: false,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(false),
+					cpuNormalizationRatio: pointer.Float64(-1),
 				},
 			},
 			args: args{
@@ -143,8 +196,9 @@ func Test_plugin_parseRule(t *testing.T) {
 			},
 			want:    false,
 			wantErr: false,
-			wantRule: &batchResourceRule{
-				enableCFSQuota: false,
+			wantRule: &Rule{
+				enableCFSQuota:        pointer.Bool(false),
+				cpuNormalizationRatio: pointer.Float64(-1),
 			},
 		},
 	}
@@ -153,7 +207,7 @@ func Test_plugin_parseRule(t *testing.T) {
 			p := plugin{
 				rule: tt.fields.rule,
 			}
-			got, err := p.parseRule(tt.args.mergedNodeSLO)
+			got, err := p.parseRuleForNodeSLO(tt.args.mergedNodeSLO)
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantRule, p.rule)
@@ -161,7 +215,7 @@ func Test_plugin_parseRule(t *testing.T) {
 	}
 }
 
-func Test_plugin_ruleUpdateCb(t *testing.T) {
+func Test_plugin_ruleUpdateCbForNodeSLO(t *testing.T) {
 	testSpec := &apiext.ExtendedResourceSpec{
 		Containers: map[string]apiext.ExtendedResourceContainerSpec{
 			"container-0": {
@@ -179,7 +233,7 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 	testSpecBytes, err := json.Marshal(testSpec)
 	assert.NoError(t, err)
 	type fields struct {
-		rule *batchResourceRule
+		rule *Rule
 	}
 	type args struct {
 		pods []*statesinformer.PodMeta
@@ -206,8 +260,9 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 		{
 			name: "update no Batch pods",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: true,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: nil,
 				},
 			},
 			args: args{
@@ -239,8 +294,9 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 		{
 			name: "update a Batch pods",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: true,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: nil,
 				},
 			},
 			args: args{
@@ -296,8 +352,9 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 		{
 			name: "update a Batch pods for unset cfs quota",
 			fields: fields{
-				rule: &batchResourceRule{
-					enableCFSQuota: false,
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(false),
+					cpuNormalizationRatio: nil,
 				},
 			},
 			args: args{
@@ -373,7 +430,7 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 			defer func() { close(stop) }()
 			p.executor.Run(stop)
 
-			err := p.ruleUpdateCb(tt.args.pods)
+			err := p.ruleUpdateCbForNodeSLO(tt.args.pods)
 			assert.Equal(t, tt.wantErr, err != nil)
 			// init cgroups cpuset file
 			for i, podMeta := range tt.args.pods {
@@ -385,6 +442,490 @@ func Test_plugin_ruleUpdateCb(t *testing.T) {
 					assert.NoError(t, err, "container "+containerStat.Name)
 					assert.Equal(t, w.cfsQuota, helper.ReadCgroupFileContents(cgroupDir, sysutil.CPUCFSQuota))
 				}
+			}
+		})
+	}
+}
+
+func Test_plugin_parseRuleForNodeMeta(t *testing.T) {
+	tests := []struct {
+		name       string
+		field      *Rule
+		arg        interface{}
+		want       bool
+		wantErr    bool
+		wantField  bool
+		wantField1 float64
+	}{
+		{
+			name:       "got invalid type of input",
+			arg:        &slov1alpha1.NodeSLOSpec{},
+			want:       false,
+			wantErr:    true,
+			wantField:  true,
+			wantField1: -1,
+		},
+		{
+			name:       "got nil input",
+			arg:        (*corev1.Node)(nil),
+			want:       false,
+			wantErr:    true,
+			wantField:  true,
+			wantField1: -1,
+		},
+		{
+			name: "parse ratio failed",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						apiext.AnnotationCPUNormalizationRatio: "[}",
+					},
+				},
+			},
+			want:       false,
+			wantErr:    true,
+			wantField:  true,
+			wantField1: -1,
+		},
+		{
+			name: "update new ratio",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						apiext.AnnotationCPUNormalizationRatio: "1.10",
+					},
+				},
+			},
+			want:       true,
+			wantErr:    false,
+			wantField:  true,
+			wantField1: 1.1,
+		},
+		{
+			name: "ratio not changed",
+			field: &Rule{
+				cpuNormalizationRatio: pointer.Float64(1.1),
+			},
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						apiext.AnnotationCPUNormalizationRatio: "1.10",
+					},
+				},
+			},
+			want:       false,
+			wantErr:    false,
+			wantField:  true,
+			wantField1: 1.1,
+		},
+		{
+			name: "cfs quota disabled",
+			field: &Rule{
+				enableCFSQuota:        pointer.Bool(false),
+				cpuNormalizationRatio: pointer.Float64(1.1),
+			},
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						apiext.AnnotationCPUNormalizationRatio: "1.10",
+					},
+				},
+			},
+			want:       false,
+			wantErr:    false,
+			wantField:  false,
+			wantField1: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin()
+			if tt.field != nil {
+				p.rule = tt.field
+			}
+			got, gotErr := p.parseRuleForNodeMeta(tt.arg)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			gotCFSQuotaEnabled, gotRatio := p.rule.GetCFSQuotaScaleRatio()
+			assert.Equal(t, tt.wantField, gotCFSQuotaEnabled)
+			assert.Equal(t, tt.wantField1, gotRatio)
+		})
+	}
+}
+
+func Test_plugin_ruleUpdateCbForNodeMeta(t *testing.T) {
+	type fields struct {
+		rule    *Rule
+		prepare func(t *testing.T, helper *sysutil.FileTestUtil)
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		arg       []*statesinformer.PodMeta
+		wantErr   bool
+		wantCheck func(t *testing.T, helper *sysutil.FileTestUtil)
+	}{
+		{
+			name: "rule is uninitialized",
+			fields: fields{
+				rule: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no matched pod to reconcile",
+			fields: fields{
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(1.1),
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-terminated-pod",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodFailed,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reconcile a pod with larger ratio",
+			fields: fields{
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(1.2),
+				},
+				prepare: func(t *testing.T, helper *sysutil.FileTestUtil) {
+					sysutil.SetupCgroupPathFormatter(sysutil.Systemd)
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice", sysutil.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice", sysutil.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares, "1024")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-be-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSBE),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-be-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-be-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *sysutil.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice", sysutil.CPUCFSQuota)
+				assert.Equal(t, "83334", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice", sysutil.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota)
+				assert.Equal(t, "83334", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+			},
+		},
+		{
+			name: "reconcile a pod with small ratio",
+			fields: fields{
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(1.0), // previous 1.2
+				},
+				prepare: func(t *testing.T, helper *sysutil.FileTestUtil) {
+					sysutil.SetupCgroupPathFormatter(sysutil.Systemd)
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUCFSQuota, "83334")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.MemoryLimit, "1073741824")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota, "83334")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.MemoryLimit, "1073741824")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-be-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSBE),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-be-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-be-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *sysutil.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUCFSQuota)
+				assert.Equal(t, "100000", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				podMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.MemoryLimit)
+				assert.Equal(t, "1073741824", podMemoryLimit)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota)
+				assert.Equal(t, "100000", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+				containerMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.MemoryLimit)
+				assert.Equal(t, "1073741824", containerMemoryLimit)
+			},
+		},
+		{
+			name: "reconcile multi pods",
+			fields: fields{
+				rule: &Rule{
+					enableCFSQuota:        pointer.Bool(true),
+					cpuNormalizationRatio: pointer.Float64(1.2),
+				},
+				prepare: func(t *testing.T, helper *sysutil.FileTestUtil) {
+					sysutil.SetupCgroupPathFormatter(sysutil.Systemd)
+					// test-be-pod
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.MemoryLimit, "1073741824")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.MemoryLimit, "1073741824")
+					// test-be-pod-1
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.CPUCFSQuota, "200000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.CPUShares, "2048")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.MemoryLimit, "2147483648")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.CPUCFSQuota, "200000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.CPUShares, "2048")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.MemoryLimit, "2147483648")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-be-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSBE),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-be-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											apiext.BatchCPU:    resource.MustParse("1000"),
+											apiext.BatchMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-be-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-podxyz456.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-none-pod-1",
+							UID:  "xyz456",
+							Labels: map[string]string{
+								apiext.LabelPodQoS: string(apiext.QoSNone),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-none-container-1",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("4Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("4Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-none-container-1",
+									ContainerID: "containerd://testyyy",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *sysutil.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUCFSQuota)
+				assert.Equal(t, "83334", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				podMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice", sysutil.MemoryLimit)
+				assert.Equal(t, "1073741824", podMemoryLimit)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUCFSQuota)
+				assert.Equal(t, "83334", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+				containerMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc123.slice/cri-containerd-testxxx.scope", sysutil.MemoryLimit)
+				assert.Equal(t, "1073741824", containerMemoryLimit)
+				podCFSQuota1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.CPUCFSQuota)
+				assert.Equal(t, "200000", podCFSQuota1)
+				podCPUShares1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.CPUShares)
+				assert.Equal(t, "2048", podCPUShares1)
+				podMemoryLimit1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", sysutil.MemoryLimit)
+				assert.Equal(t, "2147483648", podMemoryLimit1)
+				containerCFSQuota1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.CPUCFSQuota)
+				assert.Equal(t, "200000", containerCFSQuota1)
+				containerCPUShares1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.CPUShares)
+				assert.Equal(t, "2048", containerCPUShares1)
+				containerMemoryLimit1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", sysutil.MemoryLimit)
+				assert.Equal(t, "2147483648", containerMemoryLimit1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := sysutil.NewFileTestUtil(t)
+			defer helper.Cleanup()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			if tt.fields.prepare != nil {
+				tt.fields.prepare(t, helper)
+			}
+			p := newPlugin()
+			p.executor = resourceexecutor.NewTestResourceExecutor()
+			p.executor.Run(stopCh)
+			p.rule = tt.fields.rule
+			gotErr := p.ruleUpdateCbForNodeMeta(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, helper)
 			}
 		})
 	}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpunormalization
+
+import (
+	"fmt"
+	"math"
+
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/reconciler"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/rule"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+	rmconfig "github.com/koordinator-sh/koordinator/pkg/runtimeproxy/config"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+const (
+	name        = "CPUNormalization"
+	description = "adjust cpu cgroups value for cpu normalized LS pod"
+)
+
+var podQOSConditions = []string{string(extension.QoSLS), string(extension.QoSNone)}
+
+type Plugin struct {
+	rule     *Rule
+	executor resourceexecutor.ResourceUpdateExecutor
+}
+
+var singleton *Plugin
+
+func Object() *Plugin {
+	if singleton == nil {
+		singleton = newPlugin()
+	}
+	return singleton
+}
+
+func newPlugin() *Plugin {
+	return &Plugin{
+		rule: newRule(),
+	}
+}
+
+func (p *Plugin) Register(op hooks.Options) {
+	klog.V(5).Infof("register hook %v", name)
+	rule.Register(name, description,
+		rule.WithParseFunc(statesinformer.RegisterTypeNodeMetadata, p.parseRule),
+		rule.WithUpdateCallback(p.ruleUpdateCb))
+	hooks.Register(rmconfig.PreRunPodSandbox, name, description+" (pod)", p.AdjustPodCFSQuota)
+	hooks.Register(rmconfig.PreCreateContainer, name, description+" (container)", p.AdjustContainerCFSQuota)
+	hooks.Register(rmconfig.PreUpdateContainerResources, name, description+" (container)", p.AdjustContainerCFSQuota)
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUCFSQuota, description+" (pod cfs quota)",
+		p.AdjustPodCFSQuota, reconciler.PodQOSFilter(), podQOSConditions...)
+	reconciler.RegisterCgroupReconciler(reconciler.ContainerLevel, sysutil.CPUCFSQuota, description+" (container cfs quota)",
+		p.AdjustContainerCFSQuota, reconciler.PodQOSFilter(), podQOSConditions...)
+	p.executor = op.Executor
+}
+
+func (p *Plugin) AdjustPodCFSQuota(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("pod protocol is nil for plugin %s", name)
+	}
+	if podCtx.Request.Resources == nil { // currently only reconciler mode provides Resources in ctx
+		return nil
+	}
+
+	if !isPodCPUShare(podCtx.Request.Labels, podCtx.Request.Annotations) {
+		return nil
+	}
+
+	return p.adjustPodCFSQuota(podCtx)
+}
+
+func (p *Plugin) AdjustContainerCFSQuota(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %s", name)
+	}
+	if containerCtx.Request.Resources == nil { // currently only reconciler mode provides Resources in ctx
+		return nil
+	}
+
+	if !isPodCPUShare(containerCtx.Request.PodLabels, containerCtx.Request.PodAnnotations) {
+		return nil
+	}
+
+	return p.adjustContainerCFSQuota(containerCtx)
+}
+
+func (p *Plugin) adjustPodCFSQuota(podCtx *protocol.PodContext) error {
+	if !p.rule.IsEnabled() {
+		return nil
+	}
+
+	originalCFSQuota := podCtx.Request.Resources.CFSQuota
+	if originalCFSQuota == nil || *originalCFSQuota <= 0 { // no need to scale when cgroup is unset
+		return nil
+	}
+
+	ratio := p.rule.GetCPUNormalizationRatio()
+	cfsQuota := *originalCFSQuota
+	if ratio > 1.0 {
+		cfsQuota = int64(math.Ceil(float64(*originalCFSQuota) / ratio))
+		klog.V(6).Infof("plugin %s adjusts pod %s/%s cfs quota from %d to %d",
+			name, podCtx.Request.PodMeta.Namespace, podCtx.Request.PodMeta.Name, *originalCFSQuota, cfsQuota)
+	}
+
+	podCtx.Response.Resources.CFSQuota = &cfsQuota
+	return nil
+}
+
+func (p *Plugin) adjustContainerCFSQuota(containerCtx *protocol.ContainerContext) error {
+	if !p.rule.IsEnabled() {
+		return nil
+	}
+
+	originalCFSQuota := containerCtx.Request.Resources.CFSQuota
+	if originalCFSQuota == nil || *originalCFSQuota <= 0 { // no need to scale when cgroup is unset
+		return nil
+	}
+
+	ratio := p.rule.GetCPUNormalizationRatio()
+	cfsQuota := *originalCFSQuota
+	if ratio > 1.0 {
+		cfsQuota = int64(math.Ceil(float64(*originalCFSQuota) / ratio))
+		klog.V(6).Infof("plugin %s adjusts container %s/%s/%s cfs quota from %d to %d", name,
+			containerCtx.Request.PodMeta.Namespace, containerCtx.Request.PodMeta.Name,
+			containerCtx.Request.ContainerMeta.Name, *originalCFSQuota, cfsQuota)
+	}
+
+	containerCtx.Response.Resources.CFSQuota = &cfsQuota
+	return nil
+}
+
+func isPodCPUShare(labels map[string]string, annotations map[string]string) bool {
+	if labels == nil { // considered None
+		return true
+	}
+
+	qosClass := extension.GetQoSClassByAttrs(labels, annotations)
+	// consider as LSR if pod is qos=None and has cpuset
+	if qosClass == extension.QoSNone && annotations != nil {
+		cpuset, _ := util.GetCPUSetFromPod(annotations)
+		if len(cpuset) > 0 {
+			return false
+		}
+	}
+
+	return qosClass == extension.QoSLS || qosClass == extension.QoSNone
+}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization_test.go
@@ -1,0 +1,560 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpunormalization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+)
+
+func TestPlugin(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		p := Object()
+		assert.NotNil(t, p)
+	})
+}
+
+func TestPlugin_Register(t *testing.T) {
+	t.Run("test not panic", func(t *testing.T) {
+		p := newPlugin()
+		p.Register(hooks.Options{})
+	})
+}
+
+func TestPluginAdjustPodCFSQuota(t *testing.T) {
+	type fields struct {
+		rule *Rule
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		arg       protocol.HooksProtocol
+		wantErr   bool
+		wantField protocol.HooksProtocol
+	}{
+		{
+			name:      "nil input",
+			arg:       (*protocol.PodContext)(nil),
+			wantErr:   true,
+			wantField: (*protocol.PodContext)(nil),
+		},
+		{
+			name: "no resources to adjust",
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{},
+			},
+		},
+		{
+			name: "skip non-cpushare pod",
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSBE),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSBE),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "rule disabled",
+			fields: fields{
+				rule: &Rule{
+					enable:   false,
+					curRatio: -1,
+				},
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "adjust correctly",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.2,
+				},
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(83334),
+					},
+				},
+			},
+		},
+		{
+			name: "adjust correctly 1",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.0,
+				},
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "skip illegal ratio",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 0,
+				},
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(100000),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin()
+			p.rule = tt.fields.rule
+			gotErr := p.AdjustPodCFSQuota(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assert.Equal(t, tt.wantField, tt.arg)
+		})
+	}
+}
+
+func TestPluginAdjustContainerCFSQuota(t *testing.T) {
+	type fields struct {
+		rule *Rule
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		arg       protocol.HooksProtocol
+		wantErr   bool
+		wantField protocol.HooksProtocol
+	}{
+		{
+			name:      "nil input",
+			arg:       (*protocol.ContainerContext)(nil),
+			wantErr:   true,
+			wantField: (*protocol.ContainerContext)(nil),
+		},
+		{
+			name: "no resources to adjust",
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{},
+			},
+		},
+		{
+			name: "skip non-cpushare container",
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSBE),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSBE),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "rule disabled",
+			fields: fields{
+				rule: &Rule{
+					enable:   false,
+					curRatio: -1,
+				},
+			},
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares: pointer.Int64(1024),
+						CFSQuota:  pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "adjust correctly",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.2,
+				},
+			},
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(83334),
+					},
+				},
+			},
+		},
+		{
+			name: "adjust correctly 1",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.0,
+				},
+			},
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(100000),
+					},
+				},
+			},
+		},
+		{
+			name: "skip illegal ratio",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 0,
+				},
+			},
+			arg: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.ContainerContext{
+				Request: protocol.ContainerRequest{
+					PodLabels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLS),
+					},
+					Resources: &protocol.Resources{
+						CPUShares:   pointer.Int64(1024),
+						CFSQuota:    pointer.Int64(100000),
+						MemoryLimit: pointer.Int64(2147483648),
+					},
+				},
+				Response: protocol.ContainerResponse{
+					Resources: protocol.Resources{
+						CFSQuota: pointer.Int64(100000),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin()
+			p.rule = tt.fields.rule
+			gotErr := p.AdjustContainerCFSQuota(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assert.Equal(t, tt.wantField, tt.arg)
+		})
+	}
+}
+
+func Test_isPodCPUShare(t *testing.T) {
+	type args struct {
+		labels      map[string]string
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "none pod is cpushare",
+			args: args{
+				labels:      nil,
+				annotations: nil,
+			},
+			want: true,
+		},
+		{
+			name: "none pod is cpushare",
+			args: args{
+				labels:      map[string]string{},
+				annotations: map[string]string{},
+			},
+			want: true,
+		},
+		{
+			name: "ls pod is cpushare",
+			args: args{
+				labels: map[string]string{
+					extension.LabelPodQoS: string(extension.QoSLS),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "lse pod is not cpushare",
+			args: args{
+				labels: map[string]string{
+					extension.LabelPodQoS: string(extension.QoSLSE),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "be pod is not cpushare",
+			args: args{
+				labels: map[string]string{
+					extension.LabelPodQoS: string(extension.QoSLSE),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "cpuset pod is considered not cpushare",
+			args: args{
+				labels: map[string]string{},
+				annotations: map[string]string{
+					extension.AnnotationResourceStatus: `{"cpuset": "2-3,34-35"}`,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPodCPUShare(tt.args.labels, tt.args.annotations)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpunormalization
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/reconciler"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+const ratioDiffEpsilon = 0.01
+
+type Rule struct {
+	lock     sync.RWMutex
+	enable   bool
+	curRatio float64
+}
+
+func newRule() *Rule {
+	return &Rule{
+		enable:   false,
+		curRatio: -1,
+	}
+}
+
+func (r *Rule) IsEnabled() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.enable
+}
+
+func (r *Rule) GetCPUNormalizationRatio() float64 {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.curRatio
+}
+
+func (r *Rule) UpdateRule(ratio float64) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	enabled := true
+	if ratio == -1 {
+		enabled = false
+	}
+	if r.enable == enabled && math.Abs(r.curRatio-ratio) < ratioDiffEpsilon {
+		return false
+	}
+	r.enable = enabled
+	r.curRatio = ratio
+	klog.V(6).Infof("update %s rule to [enable %v, curRatio %v]", name, enabled, ratio)
+	return true
+}
+
+func (p *Plugin) parseRule(nodeIf interface{}) (bool, error) {
+	node, ok := nodeIf.(*corev1.Node)
+	if !ok {
+		return false, fmt.Errorf("type input %T is not *Node", nodeIf)
+	}
+	if node == nil {
+		return false, fmt.Errorf("got nil node")
+	}
+
+	ratio, err := extension.GetCPUNormalizationRatio(node)
+	if err != nil {
+		return false, fmt.Errorf("get cpu normalization ratio failed, err: %w", err)
+	}
+
+	isUpdated := p.rule.UpdateRule(ratio)
+	if isUpdated {
+		klog.V(4).Infof("runtime hook plugin %s update rule, enabled %v, ratio %v", name, ratio != -1, ratio)
+	}
+	return isUpdated, nil
+}
+
+func (p *Plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
+	// NOTE: if the ratio becomes bigger, scale top down, otherwise, scale bottom up
+	r := p.rule
+	if r == nil {
+		klog.V(5).Infof("hook plugin rule is nil, nothing to do for plugin %v", name)
+		return nil
+	}
+	filter := reconciler.PodQOSFilter()
+	var podUpdaters, containerUpdaters []resourceexecutor.ResourceUpdater
+	for _, podMeta := range pods {
+		if qos := extension.QoSClass(filter.Filter(podMeta)); qos != extension.QoSLS && qos != extension.QoSNone {
+			continue
+		}
+		if !podMeta.IsRunningOrPending() {
+			continue
+		}
+
+		// pod-level
+		podCtx := &protocol.PodContext{}
+		podCtx.FromReconciler(podMeta)
+		if err := p.AdjustPodCFSQuota(podCtx); err != nil {
+			klog.V(4).Infof("failed to adjust pod resources during callback %s, pod %s, err: %s",
+				name, podMeta.Key(), err)
+			continue
+		}
+		podCtx.ReconcilerProcess(p.executor)
+		podUpdaters = append(podUpdaters, podCtx.GetUpdaters()...)
+		klog.V(6).Infof("got %v updaters for pod %s during callback %s", len(podUpdaters), podMeta.Key(), name)
+
+		// container-level
+		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+			containerCtx := &protocol.ContainerContext{}
+			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
+			if err := p.AdjustContainerCFSQuota(containerCtx); err != nil {
+				klog.V(4).Infof("failed to adjust container resources during callback %s, container %s/%s, err: %s",
+					name, podMeta.Key(), containerStat.Name, err)
+				continue
+			}
+			containerCtx.ReconcilerProcess(p.executor)
+			containerUpdaters = append(containerUpdaters, containerCtx.GetUpdaters()...)
+			klog.V(6).Infof("got %v updaters for container %s/%s during callback %s",
+				len(podUpdaters), podMeta.Key(), containerStat.Name, name)
+		}
+		// ignore sandbox containers
+	}
+
+	// NOTE: Update cgroups by the level since some resources like cfs quota requires the upper level value is no less
+	//       than the lower.
+	p.executor.LeveledUpdateBatch([][]resourceexecutor.ResourceUpdater{
+		podUpdaters,
+		containerUpdaters,
+	})
+
+	return nil
+}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
@@ -1,0 +1,507 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpunormalization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func TestRule(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		r := newRule()
+		enabled := r.IsEnabled()
+		assert.False(t, enabled)
+		ratio := r.GetCPUNormalizationRatio()
+		assert.Equal(t, float64(-1), ratio)
+		isUpdated := r.UpdateRule(1.1)
+		assert.True(t, isUpdated)
+		enabled = r.IsEnabled()
+		assert.True(t, enabled)
+		ratio = r.GetCPUNormalizationRatio()
+		assert.Equal(t, 1.1, ratio)
+		isUpdated = r.UpdateRule(1.1)
+		assert.False(t, isUpdated)
+	})
+}
+
+func TestPlugin_parseRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     *float64
+		arg       interface{}
+		want      bool
+		wantErr   bool
+		wantField float64
+	}{
+		{
+			name:      "got invalid type of input",
+			arg:       &slov1alpha1.NodeSLOSpec{},
+			want:      false,
+			wantErr:   true,
+			wantField: -1,
+		},
+		{
+			name:      "got nil input",
+			arg:       (*corev1.Node)(nil),
+			want:      false,
+			wantErr:   true,
+			wantField: -1,
+		},
+		{
+			name: "parse ratio failed",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationCPUNormalizationRatio: "[}",
+					},
+				},
+			},
+			want:      false,
+			wantErr:   true,
+			wantField: -1,
+		},
+		{
+			name: "update new ratio",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationCPUNormalizationRatio: "1.10",
+					},
+				},
+			},
+			want:      true,
+			wantErr:   false,
+			wantField: 1.1,
+		},
+		{
+			name:  "ratio not changed",
+			field: pointer.Float64(1.1),
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationCPUNormalizationRatio: "1.10",
+					},
+				},
+			},
+			want:      false,
+			wantErr:   false,
+			wantField: 1.1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin()
+			if tt.field != nil {
+				p.rule.UpdateRule(*tt.field)
+			}
+			got, gotErr := p.parseRule(tt.arg)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			gotRatio := p.rule.GetCPUNormalizationRatio()
+			assert.Equal(t, tt.wantField, gotRatio)
+		})
+	}
+}
+
+func TestPlugin_ruleUpdateCb(t *testing.T) {
+	type fields struct {
+		rule    *Rule
+		prepare func(t *testing.T, helper *system.FileTestUtil)
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		arg       []*statesinformer.PodMeta
+		wantErr   bool
+		wantCheck func(t *testing.T, helper *system.FileTestUtil)
+	}{
+		{
+			name: "rule is uninitialized",
+			fields: fields{
+				rule: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no matched pod to reconcile",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.1,
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-terminated-pod",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodFailed,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reconcile a pod with larger ratio",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.2,
+				},
+				prepare: func(t *testing.T, helper *system.FileTestUtil) {
+					system.SetupCgroupPathFormatter(system.Systemd)
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares, "1024")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-ls-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLS),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-ls-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-ls-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *system.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota)
+				assert.Equal(t, "83334", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota)
+				assert.Equal(t, "83334", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+			},
+		},
+		{
+			name: "reconcile a pod with small ratio",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.0, // previous 1.2
+				},
+				prepare: func(t *testing.T, helper *system.FileTestUtil) {
+					system.SetupCgroupPathFormatter(system.Systemd)
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota, "83334")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.MemoryLimit, "1073741824")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota, "83334")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.MemoryLimit, "1073741824")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-ls-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLS),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-ls-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-ls-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *system.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota)
+				assert.Equal(t, "100000", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				podMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.MemoryLimit)
+				assert.Equal(t, "1073741824", podMemoryLimit)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota)
+				assert.Equal(t, "100000", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+				containerMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.MemoryLimit)
+				assert.Equal(t, "1073741824", containerMemoryLimit)
+			},
+		},
+		{
+			name: "reconcile multi pods",
+			fields: fields{
+				rule: &Rule{
+					enable:   true,
+					curRatio: 1.2,
+				},
+				prepare: func(t *testing.T, helper *system.FileTestUtil) {
+					system.SetupCgroupPathFormatter(system.Systemd)
+					// test-ls-pod
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.MemoryLimit, "1073741824")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota, "100000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares, "1024")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.MemoryLimit, "1073741824")
+					// test-ls-none-pod
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.CPUCFSQuota, "200000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.CPUShares, "2048")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.MemoryLimit, "2147483648")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.CPUCFSQuota, "200000")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.CPUShares, "2048")
+					helper.WriteCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.MemoryLimit, "2147483648")
+				},
+			},
+			arg: []*statesinformer.PodMeta{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-lse-pod",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLSE),
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodPending,
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-podabc123.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-ls-pod",
+							UID:  "abc123",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSLS),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-ls-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("2Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-ls-container",
+									ContainerID: "containerd://testxxx",
+								},
+							},
+						},
+					},
+				},
+				{
+					CgroupDir: "/kubepods.slice/kubepods-podxyz456.slice/",
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-ls-none-pod",
+							UID:  "xyz456",
+							Labels: map[string]string{
+								extension.LabelPodQoS: string(extension.QoSNone),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-ls-none-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("4Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("4Gi"),
+										},
+									},
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "test-ls-none-container",
+									ContainerID: "containerd://testyyy",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, helper *system.FileTestUtil) {
+				podCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUCFSQuota)
+				assert.Equal(t, "83334", podCFSQuota)
+				podCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.CPUShares)
+				assert.Equal(t, "1024", podCPUShares)
+				podMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice", system.MemoryLimit)
+				assert.Equal(t, "1073741824", podMemoryLimit)
+				containerCFSQuota := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUCFSQuota)
+				assert.Equal(t, "83334", containerCFSQuota)
+				containerCPUShares := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.CPUShares)
+				assert.Equal(t, "1024", containerCPUShares)
+				containerMemoryLimit := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podabc123.slice/cri-containerd-testxxx.scope", system.MemoryLimit)
+				assert.Equal(t, "1073741824", containerMemoryLimit)
+				podCFSQuota1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.CPUCFSQuota)
+				assert.Equal(t, "166667", podCFSQuota1)
+				podCPUShares1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.CPUShares)
+				assert.Equal(t, "2048", podCPUShares1)
+				podMemoryLimit1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice", system.MemoryLimit)
+				assert.Equal(t, "2147483648", podMemoryLimit1)
+				containerCFSQuota1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.CPUCFSQuota)
+				assert.Equal(t, "166667", containerCFSQuota1)
+				containerCPUShares1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.CPUShares)
+				assert.Equal(t, "2048", containerCPUShares1)
+				containerMemoryLimit1 := helper.ReadCgroupFileContents("kubepods.slice/kubepods-podxyz456.slice/cri-containerd-testyyy.scope", system.MemoryLimit)
+				assert.Equal(t, "2147483648", containerMemoryLimit1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := system.NewFileTestUtil(t)
+			defer helper.Cleanup()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			if tt.fields.prepare != nil {
+				tt.fields.prepare(t, helper)
+			}
+			p := newPlugin()
+			p.executor = resourceexecutor.NewTestResourceExecutor()
+			p.executor.Run(stopCh)
+			p.rule = tt.fields.rule
+			gotErr := p.ruleUpdateCb(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, helper)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/nri/server.go
+++ b/pkg/koordlet/runtimehooks/nri/server.go
@@ -174,7 +174,7 @@ func (p *NriServer) CreateContainer(pod *api.PodSandbox, container *api.Containe
 		}
 	}
 
-	adjust, _, err := containerCtx.NriDone()
+	adjust, _, err := containerCtx.NriDone(p.options.Executor)
 	if err != nil {
 		klog.Errorf("containerCtx nri done failed: %v", err)
 		return nil, nil, nil
@@ -197,7 +197,7 @@ func (p *NriServer) UpdateContainer(pod *api.PodSandbox, container *api.Containe
 		}
 	}
 
-	_, update, err := containerCtx.NriDone()
+	_, update, err := containerCtx.NriDone(p.options.Executor)
 	if err != nil {
 		klog.Errorf("containerCtx nri done failed: %v", err)
 		return nil, nil

--- a/pkg/koordlet/runtimehooks/protocol/container_context_test.go
+++ b/pkg/koordlet/runtimehooks/protocol/container_context_test.go
@@ -139,6 +139,7 @@ func TestContainerContext_NriDone(t *testing.T) {
 					},
 					AddContainerEnvs: map[string]string{"test": "test"},
 				},
+				executor: resourceexecutor.NewTestResourceExecutor(),
 			},
 			want: &api.ContainerAdjustment{
 				Linux: &api.LinuxContainerAdjustment{
@@ -190,7 +191,7 @@ func TestContainerContext_NriDone(t *testing.T) {
 				Response: tt.fields.Response,
 				executor: tt.fields.executor,
 			}
-			got, got1, err := c.NriDone()
+			got, got1, err := c.NriDone(tt.fields.executor)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Protocol2NRI() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/koordlet/runtimehooks/protocol/pod_context_test.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context_test.go
@@ -119,9 +119,11 @@ func TestPodContext_NriDone(t *testing.T) {
 		args   args
 	}{
 		{
-			name:   "nri done",
-			fields: fields{},
-			args:   args{},
+			name: "nri done",
+			fields: fields{
+				executor: resourceexecutor.NewTestResourceExecutor(),
+			},
+			args: args{},
 		},
 	}
 	for _, tt := range tests {
@@ -131,6 +133,9 @@ func TestPodContext_NriDone(t *testing.T) {
 				Response: tt.fields.Response,
 				executor: tt.fields.executor,
 			}
+			newStopCh := make(chan struct{})
+			defer close(newStopCh)
+			p.executor.Run(newStopCh)
 			p.NriDone(tt.args.executor)
 		})
 	}

--- a/pkg/koordlet/runtimehooks/protocol/protocol.go
+++ b/pkg/koordlet/runtimehooks/protocol/protocol.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/api/v1/resource"
 
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
@@ -29,6 +30,8 @@ import (
 
 type HooksProtocol interface {
 	ReconcilerDone(executor resourceexecutor.ResourceUpdateExecutor)
+	Update()
+	GetUpdaters() []resourceexecutor.ResourceUpdater
 }
 
 type hooksProtocolBuilder struct {
@@ -76,51 +79,83 @@ func (r *Resources) IsOriginResSet() bool {
 	return r.CPUShares != nil || r.CFSQuota != nil || r.CPUSet != nil || r.MemoryLimit != nil
 }
 
-func injectCPUShares(cgroupParent string, cpuShares int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+func (r *Resources) FromPod(pod *corev1.Pod) {
+	requests, limits := resource.PodRequestsAndLimits(pod)
+	cpuShares := sysutil.MilliCPUToShares(requests.Cpu().MilliValue())
+	cfsQuota := sysutil.MilliCPUToQuota(limits.Cpu().MilliValue())
+	memoryLimit := limits.Memory().Value()
+	if memoryLimit <= 0 {
+		memoryLimit = -1
+	}
+	r.CPUShares = &cpuShares
+	r.CFSQuota = &cfsQuota
+	r.MemoryLimit = &memoryLimit
+}
+
+func (r *Resources) FromContainer(container *corev1.Container) {
+	if requests := container.Resources.Requests; requests != nil {
+		cpuShares := sysutil.MilliCPUToShares(requests.Cpu().MilliValue())
+		r.CPUShares = &cpuShares
+	} else {
+		cpuShares := sysutil.MilliCPUToShares(0)
+		r.CPUShares = &cpuShares
+	}
+	if limits := container.Resources.Limits; limits != nil {
+		cfsQuota := sysutil.MilliCPUToQuota(limits.Cpu().MilliValue())
+		r.CFSQuota = &cfsQuota
+		memoryLimit := limits.Memory().Value()
+		if memoryLimit <= 0 {
+			memoryLimit = -1
+		}
+		r.MemoryLimit = &memoryLimit
+	} else {
+		cfsQuota := sysutil.MilliCPUToQuota(0)
+		r.CFSQuota = &cfsQuota
+		memoryLimit := int64(-1)
+		r.MemoryLimit = &memoryLimit
+	}
+}
+
+func injectCPUShares(cgroupParent string, cpuShares int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) (resourceexecutor.ResourceUpdater, error) {
 	cpuShareStr := strconv.FormatInt(cpuShares, 10)
 	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSharesName, cgroupParent, cpuShareStr, a)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = e.Update(true, updater)
-	return err
+	return updater, nil
 }
 
-func injectCPUSet(cgroupParent string, cpuset string, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUSet(cgroupParent string, cpuset string, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) (resourceexecutor.ResourceUpdater, error) {
 	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUSetCPUSName, cgroupParent, cpuset, a)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = e.Update(true, updater)
-	return err
+	return updater, nil
 }
 
-func injectCPUQuota(cgroupParent string, cpuQuota int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUQuota(cgroupParent string, cpuQuota int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) (resourceexecutor.ResourceUpdater, error) {
 	cpuQuotaStr := strconv.FormatInt(cpuQuota, 10)
 	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, cgroupParent, cpuQuotaStr, a)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = e.Update(true, updater)
-	return err
+	return updater, nil
 }
 
-func injectMemoryLimit(cgroupParent string, memoryLimit int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectMemoryLimit(cgroupParent string, memoryLimit int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) (resourceexecutor.ResourceUpdater, error) {
 	memoryLimitStr := strconv.FormatInt(memoryLimit, 10)
 	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.MemoryLimitName, cgroupParent, memoryLimitStr, a)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = e.Update(true, updater)
-	return err
+	return updater, nil
 }
 
-func injectCPUBvt(cgroupParent string, bvtValue int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) error {
+func injectCPUBvt(cgroupParent string, bvtValue int64, a *audit.EventHelper, e resourceexecutor.ResourceUpdateExecutor) (resourceexecutor.ResourceUpdater, error) {
 	bvtValueStr := strconv.FormatInt(bvtValue, 10)
 	updater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupParent, bvtValueStr, a)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = e.Update(true, updater)
-	return err
+	return updater, nil
 }

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler.go
@@ -118,7 +118,7 @@ func (p *podQOSFilter) Filter(podMeta *statesinformer.PodMeta) string {
 	// consider as LSR if pod is qos=None and has cpuset
 	if qosClass == apiext.QoSNone && podMeta.Pod != nil && podMeta.Pod.Annotations != nil {
 		cpuset, _ := util.GetCPUSetFromPod(podMeta.Pod.Annotations)
-		if len(cpuset) >= 0 {
+		if len(cpuset) > 0 {
 			return string(apiext.QoSLSR)
 		}
 	}
@@ -142,7 +142,7 @@ type reconcileFunc func(protocol.HooksProtocol) error
 // conditions. A cgroup file of one level can have multiple reconcile functions with different filtered conditions.
 //
 //	e.g. pod-level cfs_quota can be registered both by cpuset hook and batchresource hook. While cpuset hook reconciles
-//	cfs_quota for LSE and LSR pods, batchresource reconciles pods of other QoS classes.
+//	cfs_quota for LSE and LSR pods, batchresource reconciles pods of BE QoS.
 //
 // TODO: support priority+qos filter.
 func RegisterCgroupReconciler(level ReconcilerLevel, cgroupFile system.Resource, description string,

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
@@ -180,7 +180,11 @@ func Test_reconciler_reconcilePodCgroup(t *testing.T) {
 		c := &reconciler{
 			podsMeta:   []*statesinformer.PodMeta{test.fields.podsMeta},
 			podUpdated: make(chan struct{}, 1),
+			executor:   resourceexecutor.NewTestResourceExecutor(),
 		}
+		newStopCh := make(chan struct{})
+		defer close(newStopCh)
+		c.executor.Run(newStopCh)
 		c.podUpdated <- struct{}{}
 		c.reconcilePodCgroup(stopCh)
 		assert.Equal(t, test.wants.wantPods, podLevelOutput, "pod reconciler should be equal")

--- a/pkg/koordlet/runtimehooks/rule/rule.go
+++ b/pkg/koordlet/runtimehooks/rule/rule.go
@@ -77,7 +77,7 @@ func find(name string) (*Rule, bool) {
 }
 
 func UpdateRules(ruleType statesinformer.RegisterType, ruleObj interface{}, podsMeta []*statesinformer.PodMeta) {
-	klog.V(3).Infof("applying %v rules with new %v, detail: %v",
+	klog.V(4).Infof("applying %v rules with new %v, detail: %v",
 		len(globalHookRules), ruleType.String(), util.DumpJSON(ruleObj))
 	for _, r := range globalHookRules {
 		if ruleType != r.parseRuleType {

--- a/pkg/koordlet/runtimehooks/runtimehooks.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks.go
@@ -136,7 +136,10 @@ func NewRuntimeHook(si statesinformer.StatesInformer, cfg *Config) (RuntimeHook,
 		"Update hooks rule can run callbacks if NodeSLO spec update",
 		rule.UpdateRules)
 	si.RegisterCallbacks(statesinformer.RegisterTypeNodeTopology, "runtime-hooks-rule-node-topo",
-		"Update hooks rule if NodeTopology infor update",
+		"Update hooks rule if NodeTopology info update",
+		rule.UpdateRules)
+	si.RegisterCallbacks(statesinformer.RegisterTypeNodeMetadata, "runtime-hooks-rule-node-metadata",
+		"Update hooks rule if Node metadata update",
 		rule.UpdateRules)
 	if err := s.Setup(); err != nil {
 		return nil, fmt.Errorf("failed to setup runtime hook server, error %v", err)

--- a/pkg/koordlet/statesinformer/impl/callback_runner.go
+++ b/pkg/koordlet/statesinformer/impl/callback_runner.go
@@ -42,17 +42,19 @@ func NewCallbackRunner() *callbackRunner {
 		statesinformer.RegisterTypeNodeSLOSpec:  make(chan UpdateCbCtx, 1),
 		statesinformer.RegisterTypeAllPods:      make(chan UpdateCbCtx, 1),
 		statesinformer.RegisterTypeNodeTopology: make(chan UpdateCbCtx, 1),
+		statesinformer.RegisterTypeNodeMetadata: make(chan UpdateCbCtx, 1),
 	}
 	c.stateUpdateCallbacks = map[statesinformer.RegisterType][]updateCallback{
 		statesinformer.RegisterTypeNodeSLOSpec:  {},
 		statesinformer.RegisterTypeAllPods:      {},
 		statesinformer.RegisterTypeNodeTopology: {},
+		statesinformer.RegisterTypeNodeMetadata: {},
 	}
 	return c
 }
 
-func (c *callbackRunner) Setup(s StatesInformer) {
-	c.statesInformer = s
+func (s *callbackRunner) Setup(i StatesInformer) {
+	s.statesInformer = i
 }
 
 func (s *callbackRunner) RegisterCallbacks(rType statesinformer.RegisterType, name, description string, callbackFn statesinformer.UpdateCbFn) {
@@ -134,6 +136,8 @@ func (s *callbackRunner) getObjByType(objType statesinformer.RegisterType, cbCtx
 		return &struct{}{}
 	case statesinformer.RegisterTypeNodeTopology:
 		return s.statesInformer.GetNodeTopo()
+	case statesinformer.RegisterTypeNodeMetadata:
+		return s.statesInformer.GetNode()
 	}
 	return nil
 }

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
@@ -248,6 +248,13 @@ func (s *nodeTopoInformer) calcNodeTopo() (*nodeTopologyStatus, error) {
 		return nil, fmt.Errorf("failed to calculate cpu topology, err: %v", err)
 	}
 
+	// get CPUBasicInfo
+	cpuBasicInfo := &nodeCPUInfo.BasicInfo
+	cpuBasicInfoJSON, err := json.Marshal(cpuBasicInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal cpu basic info, err: %v", err)
+	}
+
 	zoneList, err := s.calTopologyZoneList(nodeCPUInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate topology ZoneList, err: %v", err)
@@ -356,10 +363,12 @@ func (s *nodeTopoInformer) calcNodeTopo() (*nodeTopologyStatus, error) {
 		return nil, fmt.Errorf("failed to marshal cpushare pools of node, err: %v", err)
 	}
 
-	annotations := map[string]string{}
-	annotations[extension.AnnotationNodeCPUTopology] = string(cpuTopologyJSON)
-	annotations[extension.AnnotationNodeCPUSharedPools] = string(cpuSharePoolsJSON)
-	annotations[extension.AnnotationKubeletCPUManagerPolicy] = string(cpuManagerPolicyJSON)
+	annotations := map[string]string{
+		extension.AnnotationCPUBasicInfo:            string(cpuBasicInfoJSON),
+		extension.AnnotationNodeCPUTopology:         string(cpuTopologyJSON),
+		extension.AnnotationNodeCPUSharedPools:      string(cpuSharePoolsJSON),
+		extension.AnnotationKubeletCPUManagerPolicy: string(cpuManagerPolicyJSON),
+	}
 	if len(podAllocsJSON) != 0 {
 		annotations[extension.AnnotationNodeCPUAllocs] = string(podAllocsJSON)
 	}
@@ -616,6 +625,7 @@ func isEqualNRTAnnotations(oldAnno, newAnno map[string]string) (bool, string) {
 		newData interface{}
 	)
 	keys := []string{
+		extension.AnnotationCPUBasicInfo,
 		extension.AnnotationKubeletCPUManagerPolicy,
 		extension.AnnotationNodeCPUSharedPools,
 		extension.AnnotationNodeCPUTopology,

--- a/pkg/koordlet/util/container.go
+++ b/pkg/koordlet/util/container.go
@@ -63,11 +63,7 @@ func GetContainerCgroupPerfPath(podParentDir string, c *corev1.ContainerStatus) 
 
 func GetContainerBaseCFSQuota(container *corev1.Container) int64 {
 	cpuMilliLimit := util.GetContainerMilliCPULimit(container)
-	if cpuMilliLimit <= 0 {
-		return -1
-	} else {
-		return cpuMilliLimit * system.CFSBasePeriodValue / 1000
-	}
+	return system.MilliCPUToQuota(cpuMilliLimit)
 }
 
 // ParseContainerID parse container ID from the container base path.

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -278,6 +278,7 @@ var (
 	CPUAcctStatV2  = DefaultFactory.NewV2(CPUAcctStatName, CPUStatName)
 	CPUAcctUsageV2 = DefaultFactory.NewV2(CPUAcctUsageName, CPUStatName)
 	CPUBurstV2     = DefaultFactory.NewV2(CPUBurstName, CPUMaxBurstName).WithValidator(CPUMaxBurstValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	CPUBVTWarpNsV2 = DefaultFactory.NewV2(CPUBVTWarpNsName, CPUBVTWarpNsName).WithValidator(CPUBvtWarpNsValidator).WithCheckSupported(SupportedIfFileExists)
 
 	CPUAcctCPUPressureV2    = DefaultFactory.NewV2(CPUAcctCPUPressureName, CPUAcctCPUPressureName).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 	CPUAcctMemoryPressureV2 = DefaultFactory.NewV2(CPUAcctMemoryPressureName, CPUAcctMemoryPressureName).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
@@ -309,6 +310,7 @@ var (
 		CPUAcctStatV2,
 		CPUAcctUsageV2,
 		CPUBurstV2,
+		CPUBVTWarpNsV2,
 		CPUAcctCPUPressureV2,
 		CPUAcctMemoryPressureV2,
 		CPUAcctIOPressureV2,

--- a/pkg/koordlet/util/system/resctrl.go
+++ b/pkg/koordlet/util/system/resctrl.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	CPUInfoFileName       string = "cpuinfo"
-	KernelCmdlineFileName string = "cmdline"
-
 	ResctrlName string = "resctrl"
 
 	ResctrlDir string = "resctrl/"
@@ -59,7 +56,7 @@ var (
 )
 
 func isCPUSupportResctrl() (bool, error) {
-	isCatFlagSet, isMbaFlagSet, err := isResctrlAvailableByCpuInfo(filepath.Join(Conf.ProcRootDir, CPUInfoFileName))
+	isCatFlagSet, isMbaFlagSet, err := isResctrlAvailableByCpuInfo(GetCPUInfoPath())
 	if err != nil {
 		klog.Errorf("isResctrlAvailableByCpuInfo error: %v", err)
 		return false, err
@@ -70,7 +67,7 @@ func isCPUSupportResctrl() (bool, error) {
 }
 
 func isKernelSupportResctrl() (bool, error) {
-	if vendorID, err := GetVendorIDByCPUInfo(filepath.Join(Conf.ProcRootDir, CPUInfoFileName)); err == nil && vendorID == AMD_VENDOR_ID {
+	if vendorID, err := GetVendorIDByCPUInfo(GetCPUInfoPath()); err == nil && vendorID == AMD_VENDOR_ID {
 		// AMD CPU support resctrl by default
 		klog.V(4).Infof("isKernelSupportResctrl true, since the cpu vendor is %v, no need to check kernel command line", vendorID)
 		return true, nil

--- a/pkg/koordlet/util/system/resctrl_linux.go
+++ b/pkg/koordlet/util/system/resctrl_linux.go
@@ -88,7 +88,7 @@ func isResctrlAvailableByCpuInfo(path string) (bool, bool, error) {
 	return isCatFlagSet, isMbaFlagSet, nil
 }
 
-// return vendor_id like AuthenticAMD from cpu info, e.g.
+// GetVendorIDByCPUInfo returns vendor_id like AuthenticAMD from cpu info, e.g.
 // vendor_id       : AuthenticAMD
 // vendor_id       : GenuineIntel
 func GetVendorIDByCPUInfo(path string) (string, error) {

--- a/pkg/koordlet/util/system/system_file.go
+++ b/pkg/koordlet/util/system/system_file.go
@@ -31,13 +31,18 @@ import (
 )
 
 const (
-	ProcStatName    = "stat"
-	ProcMemInfoName = "meminfo"
-	SysctlSubDir    = "sys"
+	ProcStatName          = "stat"
+	ProcMemInfoName       = "meminfo"
+	SysctlSubDir          = "sys"
+	ProcCPUInfoName       = "cpuinfo"
+	KernelCmdlineFileName = "cmdline"
 
 	KernelSchedGroupIdentityEnable = "kernel/sched_group_identity_enabled"
 
 	SysNUMASubDir = "bus/node/devices"
+
+	SysCPUSMTActiveSubPath       = "devices/system/cpu/smt/active"
+	SysIntelPStateNoTurboSubPath = "devices/system/cpu/intel_pstate/no_turbo"
 )
 
 var (
@@ -95,6 +100,18 @@ func GetSysNUMADir() string {
 
 func GetNUMAMemInfoPath(numaNodeSubDir string) string {
 	return filepath.Join(Conf.SysRootDir, SysNUMASubDir, numaNodeSubDir, ProcMemInfoName)
+}
+
+func GetCPUInfoPath() string {
+	return filepath.Join(Conf.ProcRootDir, ProcCPUInfoName)
+}
+
+func GetSysCPUSMTActivePath() string {
+	return filepath.Join(Conf.SysRootDir, SysCPUSMTActiveSubPath)
+}
+
+func GetSysIntelPStateNoTurboPath() string {
+	return filepath.Join(Conf.SysRootDir, SysIntelPStateNoTurboSubPath)
 }
 
 func GetProcSysFilePath(file string) string {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: support CPU Normalization.

1. Report CPUBasicInfo onto NRT annotations.
2. Adjust cgroups cpu.cfs_quota_us for LS and BE (cpushare) pods according to the normalized ratio.
3. Fix a flaky test in pod_resource_collector.go.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Part of #1570.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
