### PR TITLE
koord-scheduler: ignore non-existing resources in NUMA Node

### DIFF
--- a/pkg/scheduler/frameworkext/topologymanager/manager.go
+++ b/pkg/scheduler/frameworkext/topologymanager/manager.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -60,7 +59,7 @@ func (m *topologyManager) Allocate(ctx context.Context, cycleState *framework.Cy
 	policy := createNUMATopologyPolicy(policyType, numaNodes)
 
 	bestHint, admit := m.calculateAffinity(ctx, cycleState, policy, pod, nodeName)
-	klog.V(5).Infof("Best TopologyHint for (pod: %v): %v", format.Pod(pod), bestHint)
+	klog.V(5).Infof("Best TopologyHint for (pod: %v): %v on node: %v", klog.KObj(pod), bestHint, nodeName)
 	if !admit {
 		return framework.NewStatus(framework.Unschedulable, "node(s) NUMA Topology affinity error")
 	}
@@ -87,7 +86,7 @@ func (m *topologyManager) accumulateProvidersHints(ctx context.Context, cycleSta
 		// Get the TopologyHints for a Pod from a provider.
 		hints, _ := provider.GetPodTopologyHints(ctx, cycleState, pod, nodeName)
 		providersHints = append(providersHints, hints)
-		klog.V(5).Infof("TopologyHints for pod '%v': %v", format.Pod(pod), hints)
+		klog.V(5).Infof("TopologyHints for pod '%v': %v on node: %v", klog.KObj(pod), hints, nodeName)
 	}
 	return providersHints
 }

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
+	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
+)
+
+func TestAllocate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		options *ResourceOptions
+		want    *PodAllocation
+		wantErr bool
+	}{
+		{
+			name: "allocate with non-existing resources in NUMA",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:  4,
+				requestCPUBind: false,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU:       resource.MustParse("4"),
+					apiext.ResourceGPUMemory: resource.MustParse("10Gi"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			want: &PodAllocation{
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with insufficient resources",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:  4,
+				requestCPUBind: false,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("54"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			tom := NewTopologyOptionsManager()
+			tom.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {
+				options.CPUTopology = buildCPUTopologyForTest(2, 1, 26, 2)
+				options.NUMANodeResources = []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("52"),
+							corev1.ResourceMemory: resource.MustParse("128Gi"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("52"),
+							corev1.ResourceMemory: resource.MustParse("128Gi"),
+						},
+					},
+				}
+			})
+			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("104"),
+						corev1.ResourceMemory: resource.MustParse("256Gi"),
+					},
+				},
+			}
+			got, err := resourceManager.Allocate(node, tt.pod, tt.options)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("wantErr %v but got %v", tt.wantErr, err != nil)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

At present, koordlet only reports cpu/memory in NodeResourceTopology. If a Pod requests resources from other resources, the Pod will not be able to be scheduled. So we should skip these non-existing resources.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
