### PR TITLE
koord-scheduler: numa-aware scheduling supports scoring

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -2,6 +2,8 @@ vendor
 pkg/descheduler
 pkg/descheduler/controllers/migration/controllerfinder
 pkg/scheduler/plugins/coscheduling
+pkg/scheduler/plugins/nodenumaresource/least_allocated.go
+pkg/scheduler/plugins/nodenumaresource/most_allocated.go
 pkg/scheduler/frameworkext/topologymanager/policy.go
 pkg/scheduler/frameworkext/topologymanager/policy_test.go
 pkg/scheduler/frameworkext/topologymanager/policy_best_effort.go

--- a/pkg/scheduler/frameworkext/topologymanager/policy.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy.go
@@ -96,7 +96,7 @@ func filterProvidersHints(providersHints []map[string][]NUMATopologyHint) [][]NU
 	for _, hints := range providersHints {
 		// If hints is nil, insert a single, preferred any-numa hint into allProviderHints.
 		if len(hints) == 0 {
-			klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with any resource")
+			klog.V(5).Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with any resource")
 			allProviderHints = append(allProviderHints, []NUMATopologyHint{{nil, true}})
 			continue
 		}
@@ -104,13 +104,13 @@ func filterProvidersHints(providersHints []map[string][]NUMATopologyHint) [][]NU
 		// Otherwise, accumulate the hints for each resource type into allProviderHints.
 		for resource := range hints {
 			if hints[resource] == nil {
-				klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with resource '%s'", resource)
+				klog.V(5).Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with resource '%s'", resource)
 				allProviderHints = append(allProviderHints, []NUMATopologyHint{{nil, true}})
 				continue
 			}
 
 			if len(hints[resource]) == 0 {
-				klog.Infof("[topologymanager] Hint Provider has no possible NUMA affinities for resource '%s'", resource)
+				klog.V(5).Infof("[topologymanager] Hint Provider has no possible NUMA affinities for resource '%s'", resource)
 				allProviderHints = append(allProviderHints, []NUMATopologyHint{{nil, false}})
 				continue
 			}

--- a/pkg/scheduler/plugins/nodenumaresource/least_allocated.go
+++ b/pkg/scheduler/plugins/nodenumaresource/least_allocated.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The Koordinator Authors.
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// leastResourceScorer favors nodes with fewer requested resources.
+// It calculates the percentage of memory, CPU and other resources requested by pods scheduled on the node, and
+// prioritizes based on the minimum of the average of the fraction of requested to capacity.
+//
+// Details:
+// (cpu((capacity-requested)*MaxNodeScore*cpuWeight/capacity) + memory((capacity-requested)*MaxNodeScore*memoryWeight/capacity) + ...)/weightSum
+func leastResourceScorer(resToWeightMap resourceToWeightMap) func(resourceToValueMap, resourceToValueMap) int64 {
+	return func(requested, allocable resourceToValueMap) int64 {
+		var nodeScore, weightSum int64
+		for resource := range requested {
+			weight := resToWeightMap[resource]
+			resourceScore := leastRequestedScore(requested[resource], allocable[resource])
+			nodeScore += resourceScore * weight
+			weightSum += weight
+		}
+		if weightSum == 0 {
+			return 0
+		}
+		return nodeScore / weightSum
+	}
+}
+
+// The unused capacity is calculated on a scale of 0-MaxNodeScore
+// 0 being the lowest priority and `MaxNodeScore` being the highest.
+// The more unused resources the higher the score is.
+func leastRequestedScore(requested, capacity int64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		return 0
+	}
+
+	return ((capacity - requested) * framework.MaxNodeScore) / capacity
+}

--- a/pkg/scheduler/plugins/nodenumaresource/most_allocated.go
+++ b/pkg/scheduler/plugins/nodenumaresource/most_allocated.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Koordinator Authors.
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// mostResourceScorer favors nodes with most requested resources.
+// It calculates the percentage of memory and CPU requested by pods scheduled on the node, and prioritizes
+// based on the maximum of the average of the fraction of requested to capacity.
+//
+// Details:
+// (cpu(MaxNodeScore * sum(requested) / capacity) + memory(MaxNodeScore * sum(requested) / capacity)) / weightSum
+func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allocable resourceToValueMap) int64 {
+	return func(requested, allocable resourceToValueMap) int64 {
+		var nodeScore, weightSum int64
+		for resource := range requested {
+			weight := resToWeightMap[resource]
+			resourceScore := mostRequestedScore(requested[resource], allocable[resource])
+			nodeScore += resourceScore * weight
+			weightSum += weight
+		}
+		if weightSum == 0 {
+			return 0
+		}
+		return nodeScore / weightSum
+	}
+}
+
+// The used capacity is calculated on a scale of 0-MaxNodeScore (MaxNodeScore is
+// constant with value set to 100).
+// 0 being the lowest priority and 100 being the highest.
+// The more resources are used the higher the score is. This function
+// is almost a reversed version of noderesources.leastRequestedScore.
+func mostRequestedScore(requested, capacity int64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		// `requested` might be greater than `capacity` because pods with no
+		// requests get minimum values.
+		requested = capacity
+	}
+
+	return (requested * framework.MaxNodeScore) / capacity
+}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -680,7 +680,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   50,
+			wantScore:   25,
 		},
 		{
 			name: "score with satisfied node FullPCPUs",
@@ -695,7 +695,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   100,
+			wantScore:   50,
 		},
 		{
 			name: "score with full empty node SpreadByPCPUs",
@@ -710,7 +710,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   100,
+			wantScore:   25,
 		},
 		{
 			name: "score with exceed socket FullPCPUs",
@@ -725,7 +725,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   0,
+			wantScore:   100,
 		},
 		{
 			name: "score with satisfied socket FullPCPUs",
@@ -740,7 +740,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 2, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   33,
+			wantScore:   50,
 		},
 		{
 			name: "score with full empty socket SpreadByPCPUs",
@@ -755,7 +755,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   100,
+			wantScore:   25,
 		},
 		{
 			name: "score with Node NUMA Allocate Strategy",
@@ -773,7 +773,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   50,
+			wantScore:   12,
 		},
 		{
 			name: "score with Node CPU Bind Policy",
@@ -791,12 +791,15 @@ func TestPlugin_Score(t *testing.T) {
 			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
 			pod:         &corev1.Pod{},
 			want:        nil,
-			wantScore:   100,
+			wantScore:   50,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
+			totalCPUs := 96
+			if tt.cpuTopology != nil {
+				totalCPUs = tt.cpuTopology.CPUDetails.CPUs().Size()
+			}
 			nodes := []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -805,7 +808,7 @@ func TestPlugin_Score(t *testing.T) {
 					},
 					Status: corev1.NodeStatus{
 						Allocatable: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("96"),
+							corev1.ResourceCPU:    *resource.NewMilliQuantity(int64(totalCPUs*1000), resource.DecimalSI),
 							corev1.ResourceMemory: resource.MustParse("512Gi"),
 						},
 					},

--- a/pkg/scheduler/plugins/nodenumaresource/scoring.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	schedconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+// resourceStrategyTypeMap maps strategy to scorer implementation
+var resourceStrategyTypeMap = map[schedulingconfig.ScoringStrategyType]scorer{
+	schedulingconfig.LeastAllocated: func(args *schedulingconfig.NodeNUMAResourceArgs) *resourceAllocationScorer {
+		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
+		return &resourceAllocationScorer{
+			Name:                string(schedconfig.LeastAllocated),
+			scorer:              leastResourceScorer(resToWeightMap),
+			resourceToWeightMap: resToWeightMap,
+		}
+	},
+	schedulingconfig.MostAllocated: func(args *schedulingconfig.NodeNUMAResourceArgs) *resourceAllocationScorer {
+		resToWeightMap := resourcesToWeightMap(args.ScoringStrategy.Resources)
+		return &resourceAllocationScorer{
+			Name:                string(schedconfig.MostAllocated),
+			scorer:              mostResourceScorer(resToWeightMap),
+			resourceToWeightMap: resToWeightMap,
+		}
+	},
+}
+
+func (p *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) (int64, *framework.Status) {
+	state, status := getPreFilterState(cycleState)
+	if !status.IsSuccess() {
+		return 0, status
+	}
+
+	nodeInfo, err := p.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
+	if err != nil {
+		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
+	}
+	node := nodeInfo.Node()
+
+	topologyOptions := p.topologyOptionsManager.GetTopologyOptions(node.Name)
+	if state.requestCPUBind && (topologyOptions.CPUTopology == nil || !topologyOptions.CPUTopology.IsValid()) {
+		return 0, nil
+	}
+
+	resourceOptions, err := p.getResourceOptions(cycleState, state, node, pod, topologymanager.NUMATopologyHint{})
+	if err != nil {
+		return 0, nil
+	}
+
+	policyType := getNUMATopologyPolicy(node.Labels, topologyOptions.NUMATopologyPolicy)
+	if policyType != extension.NUMATopologyPolicyNone {
+		store := topologymanager.GetStore(cycleState)
+		affinity := store.GetAffinity(nodeName)
+		podAllocation, status := p.allocateByHint(ctx, cycleState, affinity, pod, nodeName, false)
+		if !status.IsSuccess() {
+			return 0, nil
+		}
+
+		totalAllocatable, totalAllocated, allocatedCPUSets := p.calculateAllocatableRequestByNUMA(node.Name, resourceOptions.requests, podAllocation, topologyOptions)
+		if state.requestCPUBind {
+			// NOTE(joseph):
+			totalAllocated[corev1.ResourceCPU] = *resource.NewMilliQuantity(int64(allocatedCPUSets*1000), resource.DecimalSI)
+		}
+		return p.scorer.score(totalAllocated, totalAllocatable)
+	}
+
+	if state.requestCPUBind {
+		podAllocation, err := p.resourceManager.Allocate(node, pod, resourceOptions)
+		if err != nil {
+			return 0, nil
+		}
+		allocatedCPUSets := p.calculateRequestedCPUSets(nodeName, podAllocation)
+		allocated := corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewMilliQuantity(int64(allocatedCPUSets)*1000, resource.DecimalSI),
+		}
+		allocatable := corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewMilliQuantity(nodeInfo.Allocatable.MilliCPU, resource.DecimalSI),
+		}
+		return p.scorer.score(allocated, allocatable)
+	}
+
+	return 0, nil
+}
+
+func (p *Plugin) calculateAllocatableRequestByNUMA(
+	nodeName string,
+	requests corev1.ResourceList,
+	podAllocation *PodAllocation,
+	topologyOptions TopologyOptions,
+) (totalAllocatable, totalAllocated corev1.ResourceList, allocatedCPUSets int) {
+	nodeAllocation := p.resourceManager.GetNodeAllocation(nodeName)
+	nodeAllocation.lock.RLock()
+	defer nodeAllocation.lock.RUnlock()
+
+	totalAllocatable = corev1.ResourceList{}
+	totalAllocated = corev1.ResourceList{}
+
+	var nodes []int
+	for _, v := range podAllocation.NUMANodeResources {
+		nodes = append(nodes, v.Node)
+		allocated := nodeAllocation.allocatedResources[v.Node]
+		if allocated != nil {
+			util.AddResourceList(totalAllocated, allocated.Resources)
+		}
+		for _, vv := range topologyOptions.NUMANodeResources {
+			if vv.Node == v.Node {
+				util.AddResourceList(totalAllocatable, vv.Resources)
+				break
+			}
+		}
+	}
+	util.AddResourceList(totalAllocated, requests)
+	allocatedCPUSets = podAllocation.CPUSet.Union(nodeAllocation.allocatedCPUs.CPUsInNUMANodes(nodes...)).Size()
+	return
+}
+
+func (p *Plugin) calculateRequestedCPUSets(nodeName string, podAllocation *PodAllocation) int {
+	nodeAllocation := p.resourceManager.GetNodeAllocation(nodeName)
+	nodeAllocation.lock.RLock()
+	defer nodeAllocation.lock.RUnlock()
+
+	return podAllocation.CPUSet.Union(nodeAllocation.allocatedCPUs.CPUs()).Size()
+}
+
+func (p *Plugin) ScoreExtensions() framework.ScoreExtensions {
+	return nil
+}
+
+// resourceToWeightMap contains resource name and weight.
+type resourceToWeightMap map[corev1.ResourceName]int64
+
+// scorer is decorator for resourceAllocationScorer
+type scorer func(args *schedulingconfig.NodeNUMAResourceArgs) *resourceAllocationScorer
+
+// resourceAllocationScorer contains information to calculate resource allocation score.
+type resourceAllocationScorer struct {
+	Name                string
+	scorer              func(requested, allocatable resourceToValueMap) int64
+	resourceToWeightMap resourceToWeightMap
+}
+
+// resourceToValueMap is keyed with resource name and valued with quantity.
+type resourceToValueMap map[corev1.ResourceName]int64
+
+// score will use `scorer` function to calculate the score.
+func (r *resourceAllocationScorer) score(totalRequested, totalAllocatable corev1.ResourceList) (int64, *framework.Status) {
+	if r.resourceToWeightMap == nil {
+		return 0, framework.NewStatus(framework.Error, "resources not found")
+	}
+
+	requested := make(resourceToValueMap)
+	allocatable := make(resourceToValueMap)
+	for resourceName := range r.resourceToWeightMap {
+		alloc, req := getResourceQuantity(totalAllocatable, resourceName), getResourceQuantity(totalRequested, resourceName)
+		if alloc != 0 {
+			// Only fill the extended resource entry when it's non-zero.
+			allocatable[resourceName], requested[resourceName] = alloc, req
+		}
+	}
+	score := r.scorer(requested, allocatable)
+	return score, nil
+}
+
+func getResourceQuantity(m corev1.ResourceList, resourceName corev1.ResourceName) int64 {
+	quantity := m[resourceName]
+	if quantity.IsZero() {
+		return 0
+	}
+	switch resourceName {
+	case corev1.ResourceCPU:
+		return quantity.MilliValue()
+	default:
+		return quantity.Value()
+	}
+}
+
+// resourcesToWeightMap make weightmap from resources spec
+func resourcesToWeightMap(resources []schedconfig.ResourceSpec) resourceToWeightMap {
+	resourceToWeightMap := make(resourceToWeightMap)
+	for _, resourceSpec := range resources {
+		resourceToWeightMap[corev1.ResourceName(resourceSpec.Name)] = resourceSpec.Weight
+	}
+	return resourceToWeightMap
+}

--- a/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apiresource "k8s.io/kubernetes/pkg/api/v1/resource"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+)
+
+func TestScore(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodes          []*corev1.Node
+		numaNodeCounts map[string]int
+		requestedPod   *corev1.Pod
+		existingPods   []*corev1.Pod
+		expectedScores framework.NodeScoreList
+		strategy       *schedulerconfig.ScoringStrategy
+	}{
+		{
+			name: "single numa nodes score",
+			nodes: []*corev1.Node{
+				st.MakeNode().Name("test-node-1").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
+					Obj(),
+				st.MakeNode().Name("test-node-2").
+					Capacity(map[corev1.ResourceName]string{"cpu": "64", "memory": "128Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
+					Obj(),
+			},
+			numaNodeCounts: map[string]int{
+				"test-node-1": 2,
+				"test-node-2": 1,
+			},
+			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "21", "memory": "40Gi"}).Obj(),
+			strategy: &schedulerconfig.ScoringStrategy{
+				Type: schedulerconfig.MostAllocated,
+				Resources: []config.ResourceSpec{
+					{
+						Name:   string(corev1.ResourceCPU),
+						Weight: 1,
+					},
+					{
+						Name:   string(corev1.ResourceMemory),
+						Weight: 1,
+					},
+				},
+			},
+			expectedScores: []framework.NodeScore{
+				{
+					Name:  "test-node-1",
+					Score: 35,
+				},
+				{
+					Name:  "test-node-2",
+					Score: 0,
+				},
+			},
+		},
+		{
+			name: "restricted numa nodes score",
+			nodes: []*corev1.Node{
+				st.MakeNode().Name("test-node-1").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-2").
+					Capacity(map[corev1.ResourceName]string{"cpu": "64", "memory": "128Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+			},
+			numaNodeCounts: map[string]int{
+				"test-node-1": 2,
+				"test-node-2": 1,
+			},
+			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "54", "memory": "40Gi"}).Obj(),
+			strategy: &schedulerconfig.ScoringStrategy{
+				Type: schedulerconfig.MostAllocated,
+				Resources: []config.ResourceSpec{
+					{
+						Name:   string(corev1.ResourceCPU),
+						Weight: 1,
+					},
+					{
+						Name:   string(corev1.ResourceMemory),
+						Weight: 1,
+					},
+				},
+			},
+			expectedScores: []framework.NodeScore{
+				{
+					Name:  "test-node-1",
+					Score: 33,
+				},
+				{
+					Name:  "test-node-2",
+					Score: 57,
+				},
+			},
+		},
+		{
+			name: "restricted numa nodes score with same capacity",
+			nodes: []*corev1.Node{
+				st.MakeNode().Name("test-node-1").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-2").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+			},
+			numaNodeCounts: map[string]int{
+				"test-node-1": 2,
+				"test-node-2": 2,
+			},
+			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "54", "memory": "40Gi"}).Obj(),
+			strategy: &schedulerconfig.ScoringStrategy{
+				Type: schedulerconfig.MostAllocated,
+				Resources: []config.ResourceSpec{
+					{
+						Name:   string(corev1.ResourceCPU),
+						Weight: 1,
+					},
+					{
+						Name:   string(corev1.ResourceMemory),
+						Weight: 1,
+					},
+				},
+			},
+			expectedScores: []framework.NodeScore{
+				{
+					Name:  "test-node-1",
+					Score: 33,
+				},
+				{
+					Name:  "test-node-2",
+					Score: 33,
+				},
+			},
+		},
+		{
+			name: "single numa nodes score with same capacity but different requested",
+			nodes: []*corev1.Node{
+				st.MakeNode().Name("test-node-1").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-2").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-3").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+			},
+			numaNodeCounts: map[string]int{
+				"test-node-1": 2,
+				"test-node-2": 2,
+				"test-node-3": 2,
+			},
+			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "4", "memory": "40Gi"}).Obj(),
+			existingPods: []*corev1.Pod{
+				st.MakePod().Node("test-node-1").Req(map[corev1.ResourceName]string{"cpu": "4", "memory": "8Gi"}).Obj(),
+				st.MakePod().Node("test-node-2").Req(map[corev1.ResourceName]string{"cpu": "8", "memory": "32Gi"}).Obj(),
+				st.MakePod().Node("test-node-3").Req(map[corev1.ResourceName]string{"cpu": "32", "memory": "40Gi"}).Obj(),
+			},
+			strategy: &schedulerconfig.ScoringStrategy{
+				Type: schedulerconfig.MostAllocated,
+				Resources: []config.ResourceSpec{
+					{
+						Name:   string(corev1.ResourceCPU),
+						Weight: 1,
+					},
+					{
+						Name:   string(corev1.ResourceMemory),
+						Weight: 1,
+					},
+				},
+			},
+			expectedScores: []framework.NodeScore{
+				{
+					Name:  "test-node-1",
+					Score: 26,
+				},
+				{
+					Name:  "test-node-2",
+					Score: 39,
+				},
+				{
+					Name:  "test-node-3",
+					Score: 65,
+				},
+			},
+		},
+		{
+			name: "single numa nodes score with same capacity but different requested and LSR",
+			nodes: []*corev1.Node{
+				st.MakeNode().Name("test-node-1").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-2").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+				st.MakeNode().Name("test-node-3").
+					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Obj(),
+			},
+			numaNodeCounts: map[string]int{
+				"test-node-1": 2,
+				"test-node-2": 2,
+				"test-node-3": 2,
+			},
+			requestedPod: st.MakePod().
+				Label(apiext.LabelPodQoS, string(apiext.QoSLSR)).
+				Priority(apiext.PriorityProdValueMax).
+				Req(map[corev1.ResourceName]string{"cpu": "4", "memory": "40Gi"}).
+				Obj(),
+			existingPods: []*corev1.Pod{
+				st.MakePod().Node("test-node-1").Req(map[corev1.ResourceName]string{"cpu": "4", "memory": "8Gi"}).Obj(),
+				st.MakePod().Node("test-node-1").UID("123").Label(apiext.LabelPodQoS, string(apiext.QoSLSR)).
+					Priority(apiext.PriorityProdValueMax).Req(map[corev1.ResourceName]string{"cpu": "4", "memory": "8Gi"}).Obj(),
+				st.MakePod().Node("test-node-2").Req(map[corev1.ResourceName]string{"cpu": "8", "memory": "32Gi"}).Obj(),
+				st.MakePod().Node("test-node-2").UID("123").Label(apiext.LabelPodQoS, string(apiext.QoSLSR)).
+					Priority(apiext.PriorityProdValueMax).Req(map[corev1.ResourceName]string{"cpu": "8", "memory": "32Gi"}).Obj(),
+				st.MakePod().Node("test-node-3").Req(map[corev1.ResourceName]string{"cpu": "16", "memory": "40Gi"}).Obj(),
+				st.MakePod().Node("test-node-3").UID("123").Label(apiext.LabelPodQoS, string(apiext.QoSLSR)).
+					Priority(apiext.PriorityProdValueMax).Req(map[corev1.ResourceName]string{"cpu": "16", "memory": "40Gi"}).Obj(),
+			},
+			strategy: &schedulerconfig.ScoringStrategy{
+				Type: schedulerconfig.MostAllocated,
+				Resources: []config.ResourceSpec{
+					{
+						Name:   string(corev1.ResourceCPU),
+						Weight: 1,
+					},
+					{
+						Name:   string(corev1.ResourceMemory),
+						Weight: 1,
+					},
+				},
+			},
+			expectedScores: []framework.NodeScore{
+				{
+					Name:  "test-node-1",
+					Score: 29,
+				},
+				{
+					Name:  "test-node-2",
+					Score: 52,
+				},
+				{
+					Name:  "test-node-3",
+					Score: 65,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, tt.nodes)
+			if tt.strategy != nil {
+				suit.nodeNUMAResourceArgs.ScoringStrategy = tt.strategy
+			}
+			p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			for _, node := range tt.nodes {
+				count := tt.numaNodeCounts[node.Name]
+				if count > 0 {
+					cpusPerNUMANode := node.Status.Allocatable.Cpu().MilliValue() / int64(count)
+					memoryPerNUMANode := node.Status.Allocatable.Memory().Value() / int64(count)
+					pl.topologyOptionsManager.UpdateTopologyOptions(node.Name, func(options *TopologyOptions) {
+						cores := node.Status.Allocatable.Cpu().MilliValue() / 1000 / 2 / int64(count)
+						options.CPUTopology = buildCPUTopologyForTest(count, 1, int(cores), 2)
+						for i := 0; i < count; i++ {
+							options.NUMANodeResources = append(options.NUMANodeResources, NUMANodeResource{
+								Node: i,
+								Resources: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(cpusPerNUMANode, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memoryPerNUMANode, resource.BinarySI),
+								}})
+						}
+					})
+				}
+			}
+			for _, v := range tt.existingPods {
+				builder := cpuset.NewCPUSetBuilder()
+				if AllowUseCPUSet(v) {
+					requests, _ := apiresource.PodRequestsAndLimits(v)
+					cpuCount := int(requests.Cpu().MilliValue() / 1000)
+					for i := 0; i < cpuCount; i++ {
+						builder.Add(i)
+					}
+				}
+				pl.resourceManager.Update(v.Spec.NodeName, &PodAllocation{
+					UID:       v.UID,
+					Namespace: v.Namespace,
+					Name:      v.Name,
+					CPUSet:    builder.Result(),
+					NUMANodeResources: []NUMANodeResource{
+						{
+							Node:      0,
+							Resources: v.Spec.Containers[0].Resources.Requests,
+						},
+					},
+				})
+			}
+
+			cycleState := framework.NewCycleState()
+			_, status := pl.PreFilter(context.TODO(), cycleState, tt.requestedPod)
+			assert.True(t, status.IsSuccess())
+
+			var gotScores framework.NodeScoreList
+			for _, n := range tt.nodes {
+				nodeInfo, err := suit.Handle.SnapshotSharedLister().NodeInfos().Get(n.Name)
+				assert.NoError(t, err)
+				status = pl.Filter(context.TODO(), cycleState, tt.requestedPod, nodeInfo)
+				assert.True(t, status.IsSuccess())
+				score, status := p.(framework.ScorePlugin).Score(context.TODO(), cycleState, tt.requestedPod, n.Name)
+				assert.True(t, status.IsSuccess())
+				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
+			}
+			assert.Equal(t, tt.expectedScores, gotScores)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/nodenumaresource/topology_hint.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_hint.go
@@ -90,11 +90,11 @@ func (p *Plugin) allocateByHint(ctx context.Context, cycleState *framework.Cycle
 
 	resourceOptions, err := p.getResourceOptions(cycleState, state, node, pod, affinity)
 	if err != nil {
-		return nil, framework.AsStatus(err)
+		return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
 	}
 	result, err := p.resourceManager.Allocate(node, pod, resourceOptions)
 	if err != nil {
-		return nil, framework.AsStatus(err)
+		return nil, framework.NewStatus(framework.Unschedulable, err.Error())
 	}
 	if assume {
 		p.resourceManager.Update(nodeName, result)

--- a/pkg/scheduler/plugins/nodenumaresource/util.go
+++ b/pkg/scheduler/plugins/nodenumaresource/util.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+)
+
+func GetDefaultNUMAAllocateStrategy(pluginArgs *schedulingconfig.NodeNUMAResourceArgs) schedulingconfig.NUMAAllocateStrategy {
+	numaAllocateStrategy := schedulingconfig.NUMAMostAllocated
+	if pluginArgs != nil && pluginArgs.ScoringStrategy != nil && pluginArgs.ScoringStrategy.Type == schedulingconfig.LeastAllocated {
+		numaAllocateStrategy = schedulingconfig.NUMALeastAllocated
+	}
+	return numaAllocateStrategy
+}
+
+func GetNUMAAllocateStrategy(node *corev1.Node, defaultNUMAtAllocateStrategy schedulingconfig.NUMAAllocateStrategy) schedulingconfig.NUMAAllocateStrategy {
+	numaAllocateStrategy := defaultNUMAtAllocateStrategy
+	if val := schedulingconfig.NUMAAllocateStrategy(node.Labels[extension.LabelNodeNUMAAllocateStrategy]); val != "" {
+		numaAllocateStrategy = val
+	}
+	return numaAllocateStrategy
+}
+
+func AllowUseCPUSet(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	qosClass := extension.GetPodQoSClassRaw(pod)
+	priorityClass := extension.GetPodPriorityClassWithDefault(pod)
+	return (qosClass == extension.QoSLSE || qosClass == extension.QoSLSR) && priorityClass == extension.PriorityProd
+}
+
+func getNUMATopologyPolicy(nodeLabels map[string]string, kubeletTopologyManagerPolicy extension.NUMATopologyPolicy) extension.NUMATopologyPolicy {
+	policyType := extension.GetNodeNUMATopologyPolicy(nodeLabels)
+	if policyType != extension.NUMATopologyPolicyNone {
+		return policyType
+	}
+	return kubeletTopologyManagerPolicy
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does 

Rewrite the scoring algorithm of the plugin `NodeNUMAResource` to support NUMA-aware scheduling scenarios.
The original scoring algorithm only considered CPUSet, but now we need to consider resources in more dimensions and resource allocation in the NUMA Node dimension.
The new scoring algorithm is as compatible as possible with the original scoring algorithm:
- If the Pod is allocated on a node whose NUMATopologyPolicy is not none, the scoring algorithm will sum the requests of all pods and sum the available allocations of the used NUMA nodes. If the current Pod also requests a CPUSet, the sum of the requests in the CPU resource dimension is equal to the already allocated CPUSet on the node plus the currently requested CPUSet, and finally uses the LeastAllocated/MostAllocated strategy for scoring.
- If the node's NUMATopologyPolicy is none, and the pod requests a bound CPU, use LeastAllocated/MostAllocated to score only the requested CPUSet and the available CPU.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

part of #228

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
