### PR TITLE
koord-scheduler: optimize NUMA Topology Manager interface

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -405,8 +405,8 @@ func (ext *frameworkExtenderImpl) ForgetPod(pod *corev1.Pod) error {
 	return nil
 }
 
-func (ext *frameworkExtenderImpl) RunNUMATopologyManagerAllocate(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy, assume bool) *framework.Status {
-	return ext.topologyManager.Allocate(ctx, cycleState, pod, nodeName, numaNodes, policyType, assume)
+func (ext *frameworkExtenderImpl) RunNUMATopologyManagerAdmit(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy) *framework.Status {
+	return ext.topologyManager.Admit(ctx, cycleState, pod, nodeName, numaNodes, policyType)
 }
 
 func (ext *frameworkExtenderImpl) GetNUMATopologyHintProvider() []topologymanager.NUMATopologyHintProvider {

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -60,7 +60,7 @@ type FrameworkExtender interface {
 	RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
 	RunReservationScorePlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfos []*ReservationInfo, nodeName string) (PluginToReservationScores, *framework.Status)
 
-	RunNUMATopologyManagerAllocate(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy, assume bool) *framework.Status
+	RunNUMATopologyManagerAdmit(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy) *framework.Status
 
 	RunResizePod(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status
 }

--- a/pkg/scheduler/frameworkext/topologymanager/policy_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_test.go
@@ -42,7 +42,7 @@ func (m *mockNUMATopologyHintProvider) GetPodTopologyHints(ctx context.Context, 
 	return m.th, nil
 }
 
-func (m *mockNUMATopologyHintProvider) Allocate(ctx context.Context, cycleState *framework.CycleState, affinity NUMATopologyHint, pod *corev1.Pod, nodeName string, assume bool) *framework.Status {
+func (m *mockNUMATopologyHintProvider) Allocate(ctx context.Context, cycleState *framework.CycleState, affinity NUMATopologyHint, pod *corev1.Pod, nodeName string) *framework.Status {
 	return nil
 }
 

--- a/pkg/scheduler/frameworkext/topologymanager/store.go
+++ b/pkg/scheduler/frameworkext/topologymanager/store.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"sync"
+
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	affinityStateKey = "koordinator.sh/topology-affinity-store"
+)
+
+type Store struct {
+	affinityMap sync.Map
+}
+
+func InitStore(cycleState *framework.CycleState) {
+	cycleState.Write(affinityStateKey, &Store{})
+}
+
+func GetStore(cycleState *framework.CycleState) *Store {
+	s, err := cycleState.Read(affinityStateKey)
+	if err != nil {
+		return &Store{}
+	}
+	store := s.(*Store)
+	return store
+}
+
+func (s *Store) Clone() framework.StateData {
+	ss := &Store{}
+	s.affinityMap.Range(func(key, value any) bool {
+		ss.affinityMap.Store(key, value)
+		return true
+	})
+	return ss
+}
+
+func (s *Store) SetAffinity(nodeName string, affinity NUMATopologyHint) {
+	s.affinityMap.Store(nodeName, &affinity)
+}
+
+func (s *Store) GetAffinity(nodeName string) NUMATopologyHint {
+	val, ok := s.affinityMap.Load(nodeName)
+	if !ok {
+		return NUMATopologyHint{}
+	}
+	hint := val.(*NUMATopologyHint)
+	return *hint
+}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -236,6 +236,7 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 	}
 
 	cycleState.Write(stateKey, state)
+	topologymanager.InitStore(cycleState)
 	return nil, nil
 }
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -107,7 +107,7 @@ func (f *testSharedLister) Get(nodeName string) (*framework.NodeInfo, error) {
 }
 
 type frameworkHandleExtender struct {
-	frameworkext.ExtendedHandle
+	frameworkext.FrameworkExtender
 	*nrtfake.Clientset
 }
 
@@ -139,8 +139,8 @@ func newPluginTestSuit(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
 
 	proxyNew := frameworkext.PluginFactoryProxy(extenderFactory, func(configuration apiruntime.Object, f framework.Handle) (framework.Plugin, error) {
 		return New(configuration, &frameworkHandleExtender{
-			ExtendedHandle: f.(frameworkext.ExtendedHandle),
-			Clientset:      nrtClientSet,
+			FrameworkExtender: f.(frameworkext.FrameworkExtender),
+			Clientset:         nrtClientSet,
 		})
 	})
 

--- a/pkg/scheduler/plugins/nodenumaresource/topology_hint_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_hint_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+func TestReserveByNUMANode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				apiext.LabelNUMATopologyPolicy: string(apiext.NUMATopologyPolicySingleNUMANode),
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("104"),
+				corev1.ResourceMemory: resource.MustParse("256Gi"),
+			},
+		},
+	}
+	suit := newPluginTestSuit(t, []*corev1.Node{node})
+
+	p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+
+	pl.topologyOptionsManager.UpdateTopologyOptions(node.Name, func(options *TopologyOptions) {
+		options.CPUTopology = buildCPUTopologyForTest(2, 1, 26, 2)
+		options.NUMANodeResources = []NUMANodeResource{
+			{
+				Node: 0,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("52"),
+					corev1.ResourceMemory: resource.MustParse("128Gi"),
+				},
+			},
+			{
+				Node: 1,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("52"),
+					corev1.ResourceMemory: resource.MustParse("128Gi"),
+				},
+			},
+		}
+	})
+
+	cycleState := framework.NewCycleState()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "123456",
+			Namespace: "default",
+			Name:      "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	_, status := pl.PreFilter(context.TODO(), cycleState, pod)
+	assert.True(t, status.IsSuccess())
+
+	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(node.Name)
+	assert.NoError(t, err)
+	status = pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+	assert.True(t, status.IsSuccess())
+	pod.Spec.NodeName = node.Name
+	status = pl.Reserve(context.TODO(), cycleState, pod, node.Name)
+	assert.True(t, status.IsSuccess())
+	state, status := getPreFilterState(cycleState)
+	assert.True(t, status.IsSuccess())
+	expectPodAllocation := &PodAllocation{
+		UID:       pod.UID,
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+		NUMANodeResources: []NUMANodeResource{
+			{
+				Node: 0,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+	}
+	assert.Equal(t, expectPodAllocation, state.allocation)
+}

--- a/pkg/scheduler/plugins/nodenumaresource/topology_options_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_options_test.go
@@ -103,8 +103,8 @@ func TestTopologyOptionsManager(t *testing.T) {
 	assert.NotNil(t, topologyOptionsManager)
 
 	extendHandle := &frameworkHandleExtender{
-		ExtendedHandle: suit.Extender,
-		Clientset:      suit.NRTClientset,
+		FrameworkExtender: suit.Extender,
+		Clientset:         suit.NRTClientset,
 	}
 	nrtInformerFactory, err := initNRTInformerFactory(extendHandle)
 	assert.NoError(t, err)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Convert the Allocate method to Admit, which is only used to calculate the optimal topology Hint, and store the Best Hint of each node in the Store. In the subsequent Score, Reserve and other stages, the Hint of the node can be queried through the Store. Once a Hint is determined, it cannot be changed, otherwise it will conflict with future functions that support Reservation/Preemption on NUMA-Aware.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
