### PR TITLE
koord-scheduler: support reservation score normalization

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -371,9 +371,19 @@ func (ext *frameworkExtenderImpl) RunReservationScorePlugins(ctx context.Context
 		}
 	}
 
-	// TODO: Should support score normalization
-	// TODO: Should support configure weight
+	for _, pl := range ext.reservationScorePlugins {
+		scoreExtensions := pl.ReservationScoreExtensions()
+		if scoreExtensions == nil {
+			continue
+		}
+		reservationScoreList := pluginToReservationScores[pl.Name()]
+		status := scoreExtensions.NormalizeReservationScore(ctx, cycleState, pod, reservationScoreList)
+		if !status.IsSuccess() {
+			return nil, framework.AsStatus(fmt.Errorf("running Normalize on Score plugins: %w", status.AsError()))
+		}
+	}
 
+	// TODO: Should support configure weight
 	for _, pl := range ext.reservationScorePlugins {
 		weight := 1
 		reservationScoreList := pluginToReservationScores[pl.Name()]

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -154,6 +154,16 @@ type PluginToReservationScores map[string]ReservationScoreList
 type ReservationScorePlugin interface {
 	framework.Plugin
 	ScoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) (int64, *framework.Status)
+	// ReservationScoreExtensions returns a ReservationScoreExtensions interface if it implements one, or nil if does not.
+	ReservationScoreExtensions() ReservationScoreExtensions
+}
+
+// ReservationScoreExtensions is an interface for Score extended functionality.
+type ReservationScoreExtensions interface {
+	// NormalizeReservationScore is called for all node scores produced by the same plugin's "ScoreReservation"
+	// method. A successful run of NormalizeReservationScore will update the scores list and return
+	// a success status.
+	NormalizeReservationScore(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, scores ReservationScoreList) *framework.Status
 }
 
 // ResizePodPlugin is an interface that resize the pod resource spec after reserve.

--- a/pkg/scheduler/frameworkext/normalize_score.go
+++ b/pkg/scheduler/frameworkext/normalize_score.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import "k8s.io/kubernetes/pkg/scheduler/framework"
+
+// DefaultReservationNormalizeScore generates a Normalize Score function that can normalize the
+// scores to [0, maxPriority]. If reverse is set to true, it reverses the scores by
+// subtracting it from maxPriority.
+func DefaultReservationNormalizeScore(maxPriority int64, reverse bool, scores ReservationScoreList) *framework.Status {
+	var maxCount int64
+	for i := range scores {
+		if scores[i].Score > maxCount {
+			maxCount = scores[i].Score
+		}
+	}
+
+	if maxCount == 0 {
+		if reverse {
+			for i := range scores {
+				scores[i].Score = maxPriority
+			}
+		}
+		return nil
+	}
+
+	for i := range scores {
+		score := scores[i].Score
+
+		score = maxPriority * score / maxCount
+		if reverse {
+			score = maxPriority - score
+		}
+
+		scores[i].Score = score
+	}
+	return nil
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -62,11 +62,12 @@ var (
 	_ framework.ReservePlugin   = &Plugin{}
 	_ framework.PreBindPlugin   = &Plugin{}
 
-	_ frameworkext.ResizePodPlugin          = &Plugin{}
-	_ frameworkext.ReservationRestorePlugin = &Plugin{}
-	_ frameworkext.ReservationFilterPlugin  = &Plugin{}
-	_ frameworkext.ReservationScorePlugin   = &Plugin{}
-	_ frameworkext.ReservationPreBindPlugin = &Plugin{}
+	_ frameworkext.ResizePodPlugin            = &Plugin{}
+	_ frameworkext.ReservationRestorePlugin   = &Plugin{}
+	_ frameworkext.ReservationFilterPlugin    = &Plugin{}
+	_ frameworkext.ReservationScorePlugin     = &Plugin{}
+	_ frameworkext.ReservationScoreExtensions = &Plugin{}
+	_ frameworkext.ReservationPreBindPlugin   = &Plugin{}
 )
 
 type Plugin struct {

--- a/pkg/scheduler/plugins/deviceshare/scoring.go
+++ b/pkg/scheduler/plugins/deviceshare/scoring.go
@@ -104,6 +104,14 @@ func (p *Plugin) ScoreReservation(ctx context.Context, cycleState *framework.Cyc
 	return p.scoreWithNominatedReservation(state, restoreState, nodeDeviceInfo, nodeName, pod, preemptible, reservationInfo)
 }
 
+func (p *Plugin) ReservationScoreExtensions() frameworkext.ReservationScoreExtensions {
+	return p
+}
+
+func (p *Plugin) NormalizeReservationScore(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, scores frameworkext.ReservationScoreList) *framework.Status {
+	return frameworkext.DefaultReservationNormalizeScore(frameworkext.MaxReservationScore, false, scores)
+}
+
 // deviceResourceStrategyTypeMap maps strategy to scorer implementation
 var deviceResourceStrategyTypeMap = map[schedulerconfig.ScoringStrategyType]scorer{
 	schedulerconfig.LeastAllocated: func(args *schedulerconfig.DeviceShareArgs) *resourceAllocationScorer {

--- a/pkg/scheduler/plugins/reservation/scoring.go
+++ b/pkg/scheduler/plugins/reservation/scoring.go
@@ -149,6 +149,10 @@ func (pl *Plugin) ScoreReservation(ctx context.Context, cycleState *framework.Cy
 	return scoreReservation(pod, rInfo), nil
 }
 
+func (pl *Plugin) ReservationScoreExtensions() frameworkext.ReservationScoreExtensions {
+	return nil
+}
+
 func findMostPreferredReservationByOrder(rOnNode []*frameworkext.ReservationInfo) (*frameworkext.ReservationInfo, int64) {
 	var selectOrder int64 = math.MaxInt64
 	var highOrder *frameworkext.ReservationInfo


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The plugin DeviceShare supports scoring reservation with multi resources, and returned the score exceed the MaxReservationScore(100), so koord-scheduler should normalize the scores after plugins scored the reservation.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1613 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
