### PR TITLE
koordlet: report be cpu share pool and set cpuset if specified

### DIFF
--- a/apis/extension/numa_aware.go
+++ b/apis/extension/numa_aware.go
@@ -43,6 +43,9 @@ const (
 	// AnnotationNodeCPUSharedPools describes the CPU Shared Pool defined by Koordinator.
 	// The shared pool is mainly used by Koordinator LS Pods or K8s Burstable Pods.
 	AnnotationNodeCPUSharedPools = NodeDomainPrefix + "/cpu-shared-pools"
+	// AnnotationNodeBECPUSharedPools describes the CPU Shared Pool defined by Koordinator.
+	// The shared pool is mainly used by Koordinator BE Pods or K8s Besteffort Pods.
+	AnnotationNodeBECPUSharedPools = NodeDomainPrefix + "/be-cpu-shared-pools"
 
 	// LabelNodeCPUBindPolicy constrains how to bind CPU logical CPUs when scheduling.
 	LabelNodeCPUBindPolicy = NodeDomainPrefix + "/cpu-bind-policy"
@@ -279,6 +282,19 @@ func GetNodeCPUSharePools(nodeTopoAnnotations map[string]string) ([]CPUSharedPoo
 		return nil, err
 	}
 	return cpuSharePools, nil
+}
+
+func GetNodeBECPUSharePools(nodeTopoAnnotations map[string]string) ([]CPUSharedPool, error) {
+	var beCPUSharePools []CPUSharedPool
+	data, ok := nodeTopoAnnotations[AnnotationNodeBECPUSharedPools]
+	if !ok {
+		return beCPUSharePools, nil
+	}
+	err := json.Unmarshal([]byte(data), &beCPUSharePools)
+	if err != nil {
+		return nil, err
+	}
+	return beCPUSharePools, nil
 }
 
 func GetKubeletCPUManagerPolicy(annotations map[string]string) (*KubeletCPUManagerPolicy, error) {

--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -46,6 +46,13 @@ const (
 	BECPUSuppress featuregate.Feature = "BECPUSuppress"
 
 	// owner: @zwzhang0107 @saintube
+	// alpha: v1.4
+	//
+	// BECPUManager manages cpuset of best-effort pod, this feature cannot work with BECPUSuppress together
+	// TODO use BECPUManager to replace BECPUSuppress for advanced cpu management for be pods
+	BECPUManager featuregate.Feature = "BECPUManager"
+
+	// owner: @zwzhang0107 @saintube
 	// alpha: v0.4
 	//
 	// BECPUEvict evicts best-effort pod when they lack of resource.
@@ -128,6 +135,7 @@ var (
 		AuditEvents:            {Default: false, PreRelease: featuregate.Alpha},
 		AuditEventsHTTPHandler: {Default: false, PreRelease: featuregate.Alpha},
 		BECPUSuppress:          {Default: true, PreRelease: featuregate.Beta},
+		BECPUManager:           {Default: false, PreRelease: featuregate.Alpha},
 		BECPUEvict:             {Default: false, PreRelease: featuregate.Alpha},
 		BEMemoryEvict:          {Default: false, PreRelease: featuregate.Alpha},
 		CPUBurst:               {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler.go
@@ -165,7 +165,7 @@ func RegisterCgroupReconciler(level ReconcilerLevel, cgroupFile system.Resource,
 		for _, condition := range conditions {
 			if _, ok := r.fn[condition]; ok {
 				klog.Fatalf("%v of level %v is already registered with condition %v by %v, cannot change by %v",
-					cgroupFile.ResourceType, level, condition, r.description, description)
+					cgroupFile.ResourceType(), level, condition, r.description, description)
 			}
 
 			r.fn[condition] = fn


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Report be cpu share pool in annotation of NodeResourceTopo
Set cpuset according to specified numa node id for BE pod is scheduler specified.

BECPUSuppress should not work together with BECPUManager.
If both enabled, CPUSuppress will recover cpuset on all level for be pod does not specified numa node, and let be cpu set hook handle the others


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
