### PR TITLE
koord-scheduler: support required CPU bind policy

### DIFF
--- a/apis/extension/numa_aware.go
+++ b/apis/extension/numa_aware.go
@@ -55,6 +55,9 @@ const (
 
 // ResourceSpec describes extra attributes of the resource requirements.
 type ResourceSpec struct {
+	// RequiredCPUBindPolicy indicates that the CPU is allocated strictly
+	// according to the specified CPUBindPolicy, otherwise the scheduling fails
+	RequiredCPUBindPolicy CPUBindPolicy `json:"requiredCPUBindPolicy,omitempty"`
 	// PreferredCPUBindPolicy represents best-effort CPU bind policy.
 	PreferredCPUBindPolicy CPUBindPolicy `json:"preferredCPUBindPolicy,omitempty"`
 	// PreferredCPUExclusivePolicy represents best-effort CPU exclusive policy.

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -155,6 +155,12 @@ func ValidateDeviceShareArgs(path *field.Path, args *config.DeviceShareArgs) err
 
 func ValidateNodeNUMAResourceArgs(path *field.Path, args *config.NodeNUMAResourceArgs) error {
 	var allErrs field.ErrorList
+	if args.DefaultCPUBindPolicy != "" &&
+		args.DefaultCPUBindPolicy != config.CPUBindPolicyFullPCPUs &&
+		args.DefaultCPUBindPolicy != config.CPUBindPolicySpreadByPCPUs {
+		allErrs = append(allErrs, field.Invalid(path.Child("defaultCPUBindPolicy"), args.DefaultCPUBindPolicy, "must specified CPU bind policy FullPCPUs or SpreadByPCPUs"))
+	}
+
 	if args.ScoringStrategy != nil {
 		allErrs = append(allErrs, validateResources(args.ScoringStrategy.Resources, path.Child("resources"))...)
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
@@ -28,15 +28,17 @@ import (
 	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
-func TestAllocate(t *testing.T) {
+func TestResourceManagerAllocate(t *testing.T) {
 	tests := []struct {
-		name    string
-		pod     *corev1.Pod
-		options *ResourceOptions
-		want    *PodAllocation
-		wantErr bool
+		name      string
+		pod       *corev1.Pod
+		options   *ResourceOptions
+		allocated *PodAllocation
+		want      *PodAllocation
+		wantErr   bool
 	}{
 		{
 			name: "allocate with non-existing resources in NUMA",
@@ -86,6 +88,252 @@ func TestAllocate(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "allocate with required CPUBindPolicyFullPCPUs",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0-3"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicyFullPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("4-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0-3"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed to allocate with required CPUBindPolicyFullPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("1,3,5,7-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0,2,4,6"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("1,3,5,7-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0,2,4,6"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed to allocate with required CPUBindPolicySpreadByPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("4-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -110,7 +358,6 @@ func TestAllocate(t *testing.T) {
 					},
 				}
 			})
-			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
@@ -122,7 +369,354 @@ func TestAllocate(t *testing.T) {
 					},
 				},
 			}
+			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
+			if tt.allocated != nil {
+				resourceManager.Update(node.Name, tt.allocated)
+			}
 			got, err := resourceManager.Allocate(node, tt.pod, tt.options)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("wantErr %v but got %v", tt.wantErr, err != nil)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResourceManagerGetTopologyHint(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		options   *ResourceOptions
+		allocated *PodAllocation
+		want      map[string][]topologymanager.NUMATopologyHint
+		wantErr   bool
+	}{
+		{
+			name: "allocate with required CPUBindPolicyFullPCPUs",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(1)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicyFullPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("4-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed to allocate with required CPUBindPolicyFullPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicyFullPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("1,3,5,7-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(1)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("1,3,5,7-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed to allocate with required CPUBindPolicySpreadByPCPUs and allocated",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("4-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0)
+							return mask
+						}(),
+						Preferred: true,
+					},
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			tom := NewTopologyOptionsManager()
+			tom.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {
+				options.CPUTopology = buildCPUTopologyForTest(2, 1, 26, 2)
+				options.NUMANodeResources = []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("52"),
+							corev1.ResourceMemory: resource.MustParse("128Gi"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("52"),
+							corev1.ResourceMemory: resource.MustParse("128Gi"),
+						},
+					},
+				}
+			})
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("104"),
+						corev1.ResourceMemory: resource.MustParse("256Gi"),
+					},
+				},
+			}
+			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
+			if tt.allocated != nil {
+				resourceManager.Update(node.Name, tt.allocated)
+			}
+			got, err := resourceManager.GetTopologyHints(node, tt.pod, tt.options)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v but got %v", tt.wantErr, err != nil)
 			}

--- a/pkg/scheduler/plugins/nodenumaresource/scoring.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring.go
@@ -56,6 +56,9 @@ func (p *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, po
 	if !status.IsSuccess() {
 		return 0, status
 	}
+	if state.skip {
+		return 0, nil
+	}
 
 	nodeInfo, err := p.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
 	if err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Add `RequiredCPUBindPolicy` in `ResourceSpec`. `RequiredCPUBindPolicy` indicates that the CPU is allocated strictly according to the specified CPUBindPolicy, otherwise the scheduling fails.

`RequiredCPUBindPolicy` supports `FullPCPus` and `SpreadByPCPUs` policies.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
