### PR TITLE
koord-manager: add NUMA-level batch resources

### DIFF
--- a/pkg/slo-controller/noderesource/framework/extender_plugin.go
+++ b/pkg/slo-controller/noderesource/framework/extender_plugin.go
@@ -74,6 +74,7 @@ func UnregisterSetupExtender(name string) {
 // NodePreparePlugin implements node resource preparing for the calculated results.
 // For example, assign extended resources in the node allocatable.
 // It is invoked each time the controller tries updating the latest NodeResource object with calculated results.
+// NOTE: The Execute should be idempotent since it can be called multiple times in one reconciliation.
 type NodePreparePlugin interface {
 	Plugin
 	Execute(strategy *configuration.ColocationStrategy, node *corev1.Node, nr *NodeResource) error

--- a/pkg/slo-controller/noderesource/noderesource_controller_test.go
+++ b/pkg/slo-controller/noderesource/noderesource_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/koordinator-sh/koordinator/apis/configuration"
@@ -122,6 +123,9 @@ func Test_NodeResourceController_NodeMetricNotExist(t *testing.T) {
 
 	key := types.NamespacedName{Name: nodeName}
 	nodeReq := ctrl.Request{NamespacedName: key}
+
+	opt := framework.NewOption().WithClient(client).WithScheme(scheme).WithControllerBuilder(&builder.Builder{})
+	framework.RunSetupExtenders(opt)
 
 	result, err := r.Reconcile(ctx, nodeReq)
 	assert.NoError(t, err)

--- a/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"fmt"
+
+	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+var checkedNRTResourceSet = sets.NewString(string(corev1.ResourceCPU), string(corev1.ResourceMemory))
+
+var _ handler.EventHandler = &NRTHandler{}
+
+type NRTHandler struct {
+	syncContext *framework.SyncContext
+}
+
+func (h *NRTHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	nrt, ok := evt.Object.(*topologyv1alpha1.NodeResourceTopology)
+	if !ok {
+		return
+	}
+
+	if !isNRTResourcesCreated(nrt) {
+		return
+	}
+
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: nrt.Name,
+		},
+	})
+}
+
+func (h *NRTHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	nrtOld, okOld := evt.ObjectOld.(*topologyv1alpha1.NodeResourceTopology)
+	nrtNew, okNew := evt.ObjectNew.(*topologyv1alpha1.NodeResourceTopology)
+	if !okOld || !okNew {
+		return
+	}
+
+	if nrtOld.ResourceVersion == nrtNew.ResourceVersion {
+		return
+	}
+
+	if !isNRTResourcesChanged(nrtOld, nrtNew) {
+		return
+	}
+
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: nrtNew.Name,
+		},
+	})
+}
+
+func (h *NRTHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	nrt, ok := evt.Object.(*topologyv1alpha1.NodeResourceTopology)
+	if !ok {
+		return
+	}
+
+	if err := cleanupContextForNRT(h.syncContext, nrt); err != nil {
+		klog.V(4).InfoS("failed to cleanup syncContext for NRT", "node", nrt.Name, "err", err)
+	}
+}
+
+func (h *NRTHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+}
+
+func isNRTResourcesCreated(nrt *topologyv1alpha1.NodeResourceTopology) bool {
+	if len(nrt.Zones) <= 0 {
+		return false
+	}
+
+	// check if any zone has the target resource allocatable
+	for _, zone := range nrt.Zones {
+		for _, resourceInfo := range zone.Resources {
+			if checkedNRTResourceSet.Has(resourceInfo.Name) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isNRTResourcesChanged(nrtOld, nrtNew *topologyv1alpha1.NodeResourceTopology) bool {
+	// check if target resources not equal
+	return !util.IsZoneListResourceEqual(nrtOld.Zones, nrtNew.Zones, checkedNRTResourceSet.List()...)
+}
+
+func cleanupContextForNRT(syncContext *framework.SyncContext, nrt *topologyv1alpha1.NodeResourceTopology) error {
+	if syncContext == nil {
+		return fmt.Errorf("sync context not initialized")
+	}
+
+	// NRT name = node name
+	syncContext.Delete(util.GenerateNodeKey(&nrt.ObjectMeta))
+	return nil
+}

--- a/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler_test.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler_test.go
@@ -1,0 +1,789 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+)
+
+func Test_isNRTResourcesCreated(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *topologyv1alpha1.NodeResourceTopology
+		want bool
+	}{
+		{
+			name: "ignore empty zoneList",
+			arg:  &topologyv1alpha1.NodeResourceTopology{},
+			want: false,
+		},
+		{
+			name: "ignore zoneList which have no target resource",
+			arg: &topologyv1alpha1.NodeResourceTopology{
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "true when zoneList have target resources",
+			arg: &topologyv1alpha1.NodeResourceTopology{
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when zoneList have target resources 1",
+			arg: &topologyv1alpha1.NodeResourceTopology{
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNRTResourcesCreated(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_isNRTResourcesChanged(t *testing.T) {
+	type args struct {
+		nrtOld *topologyv1alpha1.NodeResourceTopology
+		nrtNew *topologyv1alpha1.NodeResourceTopology
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "false when objects are equal",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false when target resources unchanged",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "true when target resources added",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when target resources removed",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when target resources changed",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("15Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when zone with target resources added",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when zone with target resources removed",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "true when resources changed",
+			args: args{
+				nrtOld: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("20"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				nrtNew: &topologyv1alpha1.NodeResourceTopology{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Zones: topologyv1alpha1.ZoneList{
+						{
+							Name: "node-0",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("20"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "node-1",
+							Resources: topologyv1alpha1.ResourceInfoList{
+								{
+									Name:        string(corev1.ResourceCPU),
+									Allocatable: resource.MustParse("10"),
+								},
+								{
+									Name:        string(corev1.ResourceMemory),
+									Allocatable: resource.MustParse("20Gi"),
+								},
+								{
+									Name:        "other-resource",
+									Allocatable: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNRTResourcesChanged(tt.args.nrtOld, tt.args.nrtNew)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/slo-controller/noderesource/plugins/batchresource/util.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/util.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+func calculateBatchResourceByPolicy(strategy *configuration.ColocationStrategy, nodeAllocatable, nodeReserve,
+	systemUsed, podHPReq, podHPUsed corev1.ResourceList) (corev1.ResourceList, string, string) {
+	// Node(Batch).Alloc = Node.Total - Node.Reserved - System.Used - Pod(Prod/Mid).Used
+	batchAllocatableByUsage := quotav1.Max(quotav1.Subtract(quotav1.Subtract(quotav1.Subtract(
+		nodeAllocatable, nodeReserve), systemUsed), podHPUsed), util.NewZeroResourceList())
+
+	// Node(Batch).Alloc = Node.Total - Node.Reserved - Pod(Prod/Mid).Request
+	batchAllocatableByRequest := quotav1.Max(quotav1.Subtract(quotav1.Subtract(nodeAllocatable, nodeReserve),
+		podHPReq), util.NewZeroResourceList())
+
+	batchAllocatable := batchAllocatableByUsage
+	cpuMsg := fmt.Sprintf("batchAllocatable[CPU(Milli-Core)]:%v = nodeAllocatable:%v - nodeReservation:%v - systemUsage:%v - podHPUsed:%v",
+		batchAllocatable.Cpu().MilliValue(), nodeAllocatable.Cpu().MilliValue(), nodeReserve.Cpu().MilliValue(),
+		systemUsed.Cpu().MilliValue(), podHPUsed.Cpu().MilliValue())
+
+	var memMsg string
+	if strategy != nil && strategy.MemoryCalculatePolicy != nil && *strategy.MemoryCalculatePolicy == configuration.CalculateByPodRequest {
+		batchAllocatable[corev1.ResourceMemory] = *batchAllocatableByRequest.Memory()
+		memMsg = fmt.Sprintf("batchAllocatable[Mem(GB)]:%v = nodeAllocatable:%v - nodeReservation:%v - podHPRequest:%v",
+			batchAllocatable.Memory().ScaledValue(resource.Giga), nodeAllocatable.Memory().ScaledValue(resource.Giga),
+			nodeReserve.Memory().ScaledValue(resource.Giga), podHPReq.Memory().ScaledValue(resource.Giga))
+	} else { // use CalculatePolicy "usage" by default
+		memMsg = fmt.Sprintf("batchAllocatable[Mem(GB)]:%v = nodeAllocatable:%v - nodeReservation:%v - systemUsage:%v - podHPUsed:%v",
+			batchAllocatable.Memory().ScaledValue(resource.Giga), nodeAllocatable.Memory().ScaledValue(resource.Giga),
+			nodeReserve.Memory().ScaledValue(resource.Giga), systemUsed.Memory().ScaledValue(resource.Giga),
+			podHPUsed.Memory().ScaledValue(resource.Giga))
+	}
+
+	return batchAllocatable, cpuMsg, memMsg
+}
+
+func prepareNodeForResource(node *corev1.Node, nr *framework.NodeResource, name corev1.ResourceName) {
+	q := nr.Resources[name]
+	if q == nil || nr.Resets[name] { // if the specified resource has no quantity
+		delete(node.Status.Capacity, name)
+		delete(node.Status.Allocatable, name)
+		return
+	}
+
+	// amplify batch cpu according to cpu normalization ratio
+	if name == extension.BatchCPU {
+		ratio, err := getCPUNormalizationRatio(nr)
+		if err != nil {
+			klog.V(5).InfoS("failed to get cpu normalization ratio for node extended resources",
+				"node", node.Name, "err", err)
+		}
+		if ratio > 1.0 { // skip for invalid ratio
+			newQuantity := util.MultiplyMilliQuant(*q, ratio)
+			q = &newQuantity
+		}
+	}
+
+	// NOTE: extended resource would be validated as an integer, so it should be checked before the update
+	if _, ok := q.AsInt64(); !ok {
+		klog.V(4).InfoS("node resource's quantity is not int64 and will be rounded",
+			"node", node.Name, "resource", name, "original", *q, "rounded", q.Value())
+		q.Set(q.Value())
+	}
+	node.Status.Capacity[name] = *q
+	node.Status.Allocatable[name] = *q
+}
+
+// getPodMetricUsage gets pod usage from the PodMetricInfo
+func getPodMetricUsage(info *slov1alpha1.PodMetricInfo) corev1.ResourceList {
+	return getResourceListForCPUAndMemory(info.PodUsage.ResourceList)
+}
+
+// getPodNUMARequestAndUsage returns the pod request and usage on each NUMA nodes.
+// It averages the metrics over all sharepools when the pod does not allocate any sharepool or use all sharepools.
+func getPodNUMARequestAndUsage(pod *corev1.Pod, podRequest, podUsage corev1.ResourceList, numaNum int) ([]corev1.ResourceList, []corev1.ResourceList) {
+	// get pod NUMA allocation
+	var podAlloc *extension.ResourceStatus
+	if pod.Annotations == nil {
+		podAlloc = &extension.ResourceStatus{}
+	} else if podAllocFromAnnotations, err := extension.GetResourceStatus(pod.Annotations); err != nil {
+		podAlloc = &extension.ResourceStatus{}
+		klog.V(5).Infof("failed to get NUMA resource status of the pod %s, suppose it is LS, err: %s",
+			util.GetPodKey(pod), err)
+	} else {
+		podAlloc = podAllocFromAnnotations
+	}
+
+	// NOTE: For the pod which does not set NUMA-aware allocation policy, it has set particular cpuset cpus but may not
+	//       have NUMA allocation information in annotations. In this case, it can be inaccurate to average the
+	//       request/usage over all NUMA nodes.
+	podNUMARequest := make([]corev1.ResourceList, numaNum)
+	podNUMAUsage := make([]corev1.ResourceList, numaNum)
+
+	allocatedNUMAMap := map[int]struct{}{}
+	allocatedNUMANum := 0 // the number of allocated NUMA node
+	for _, numaResource := range podAlloc.NUMANodeResources {
+		allocatedNUMAMap[int(numaResource.Node)] = struct{}{}
+		// The invalid allocated NUMA ids will be ignored since it cannot be successfully bind on the node either.
+		if int(numaResource.Node) < numaNum && numaResource.Node >= 0 {
+			allocatedNUMANum++
+		}
+	}
+
+	if allocatedNUMANum <= 0 { // share all NUMAs
+		for i := 0; i < numaNum; i++ {
+			podNUMARequest[i] = divideResourceList(podRequest, float64(numaNum))
+			podNUMAUsage[i] = divideResourceList(podUsage, float64(numaNum))
+		}
+	} else {
+		for i := 0; i < numaNum; i++ {
+			_, ok := allocatedNUMAMap[i]
+			if !ok {
+				podNUMARequest[i] = util.NewZeroResourceList()
+				podNUMAUsage[i] = util.NewZeroResourceList()
+				continue
+			}
+
+			podNUMARequest[i] = divideResourceList(podRequest, float64(allocatedNUMANum))
+			podNUMAUsage[i] = divideResourceList(podUsage, float64(allocatedNUMANum))
+		}
+	}
+
+	return podNUMARequest, podNUMAUsage
+}
+
+func getPodUnknownNUMAUsage(podUsage corev1.ResourceList, numaNum int) []corev1.ResourceList {
+	if numaNum <= 0 {
+		return nil
+	}
+	podNUMAUsage := make([]corev1.ResourceList, numaNum)
+	for i := 0; i < numaNum; i++ {
+		podNUMAUsage[i] = divideResourceList(podUsage, float64(numaNum))
+	}
+	return podNUMAUsage
+}
+
+// getNodeAllocatable gets node allocatable and filters out non-CPU and non-Mem resources
+func getNodeAllocatable(node *corev1.Node) corev1.ResourceList {
+	return getResourceListForCPUAndMemory(node.Status.Allocatable)
+}
+
+// getNodeReservation gets node-level safe-guarding reservation with the node's allocatable
+func getNodeReservation(strategy *configuration.ColocationStrategy, nodeAllocatable corev1.ResourceList) corev1.ResourceList {
+	cpuReserveQuant := util.MultiplyMilliQuant(nodeAllocatable[corev1.ResourceCPU], getReserveRatio(*strategy.CPUReclaimThresholdPercent))
+	memReserveQuant := util.MultiplyQuant(nodeAllocatable[corev1.ResourceMemory], getReserveRatio(*strategy.MemoryReclaimThresholdPercent))
+
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    cpuReserveQuant,
+		corev1.ResourceMemory: memReserveQuant,
+	}
+}
+
+func divideResourceList(rl corev1.ResourceList, divisor float64) corev1.ResourceList {
+	if divisor == 0 {
+		return rl
+	}
+	divided := corev1.ResourceList{}
+	for resourceName, q := range rl {
+		divided[resourceName] = *resource.NewMilliQuantity(int64(math.Ceil(float64(q.MilliValue())/divisor)), q.Format)
+	}
+	return divided
+}
+
+func addZoneResourceList(a, b []corev1.ResourceList, zoneNum int) []corev1.ResourceList {
+	// assert len(a) == len(b) == zoneNum
+	result := make([]corev1.ResourceList, zoneNum)
+	for i := 0; i < zoneNum; i++ {
+		result[i] = quotav1.Add(a[i], b[i])
+	}
+	return result
+}
+
+func getResourceListForCPUAndMemory(rl corev1.ResourceList) corev1.ResourceList {
+	return quotav1.Mask(rl, []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory})
+}
+
+func mixResourceListCPUAndMemory(resourcesForCPU, resourcesForMemory corev1.ResourceList) corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    resourcesForCPU[corev1.ResourceCPU],
+		corev1.ResourceMemory: resourcesForMemory[corev1.ResourceMemory],
+	}
+}
+
+func minxZoneResourceListCPUAndMemory(resourcesForCPU, resourcesForMemory []corev1.ResourceList, zoneNum int) []corev1.ResourceList {
+	// assert len(a) == len(b) == zoneNum
+	result := make([]corev1.ResourceList, zoneNum)
+	for i := 0; i < zoneNum; i++ {
+		result[i] = mixResourceListCPUAndMemory(resourcesForCPU[i], resourcesForMemory[i])
+	}
+	return result
+}
+
+// getReserveRatio returns resource reserved ratio
+func getReserveRatio(reclaimThreshold int64) float64 {
+	return float64(100-reclaimThreshold) / 100.0
+}
+
+func updateNRTZoneListIfNeeded(node *corev1.Node, zoneList topologyv1alpha1.ZoneList, nr *framework.NodeResource, diffThreshold float64) bool {
+	ratio, err := getCPUNormalizationRatio(nr)
+	if err != nil {
+		klog.V(5).InfoS("failed to get cpu normalization ratio for zone resources",
+			"node", node.Name, "err", err)
+	}
+
+	needUpdate := false
+	for i := range zoneList {
+		zone := zoneList[i]
+		zoneResource, ok := nr.ZoneResources[zone.Name]
+		if !ok { // the resources of the zone should be reset
+			for _, resourceInfo := range zone.Resources {
+				if !updateNRTResourceSet.Has(resourceInfo.Name) {
+					continue
+				}
+				// FIXME: currently we set value to zero instead of deleting resource
+				if resourceInfo.Capacity.IsZero() && resourceInfo.Allocatable.IsZero() &&
+					resourceInfo.Available.IsZero() { // already reset
+					continue
+				}
+				needUpdate = true
+				resourceInfo.Capacity = *resource.NewQuantity(0, resourceInfo.Capacity.Format)
+				resourceInfo.Allocatable = *resource.NewQuantity(0, resourceInfo.Allocatable.Format)
+				resourceInfo.Available = *resource.NewQuantity(0, resourceInfo.Available.Format)
+				klog.V(6).InfoS("reset batch resource for zone", "node", node.Name,
+					"zone", zone.Name, "resource", resourceInfo.Name)
+			}
+		}
+
+		for resourceName := range zoneResource {
+			quantity := zoneResource[resourceName]
+
+			// amplify batch cpu according to cpu normalization ratio
+			if resourceName == extension.BatchCPU && ratio > 1.0 {
+				quantity = util.MultiplyMilliQuant(quantity, ratio)
+			}
+
+			oldHasResource := false
+			for j, resourceInfo := range zone.Resources {
+				if resourceInfo.Name == string(resourceName) { // old has the resource key
+					if util.IsQuantityDiff(resourceInfo.Capacity, quantity, diffThreshold) {
+						needUpdate = true
+						resourceInfo.Capacity = quantity
+					}
+					if util.IsQuantityDiff(resourceInfo.Allocatable, quantity, diffThreshold) {
+						needUpdate = true
+						resourceInfo.Allocatable = quantity
+					}
+					if util.IsQuantityDiff(resourceInfo.Available, quantity, diffThreshold) {
+						needUpdate = true
+						resourceInfo.Available = quantity
+					}
+					zone.Resources[j] = resourceInfo
+					oldHasResource = true
+					klog.V(6).InfoS("update batch resource for zone", "node", node.Name,
+						"zone", zone.Name, "resource", resourceName)
+					break
+				}
+			}
+			if !oldHasResource { // old has no resource key
+				needUpdate = true
+				zone.Resources = append(zone.Resources, topologyv1alpha1.ResourceInfo{
+					Name:        string(resourceName),
+					Capacity:    quantity,
+					Allocatable: quantity,
+					Available:   quantity,
+				})
+				sort.Slice(zone.Resources, func(p, q int) bool { // keep the resources order
+					return zone.Resources[p].Name < zone.Resources[q].Name
+				})
+				klog.V(6).InfoS("add batch resource for zone", "node", node.Name,
+					"zone", zone.Name, "resource", resourceName)
+			}
+		}
+
+		zoneList[i] = zone
+	}
+
+	return needUpdate
+}
+
+func getCPUNormalizationRatio(nr *framework.NodeResource) (float64, error) {
+	ratioStr, ok := nr.Annotations[extension.AnnotationCPUNormalizationRatio]
+	if !ok {
+		return -1, nil
+	}
+	ratio, err := strconv.ParseFloat(ratioStr, 64)
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse ratio in NodeResource, err: %w", err)
+	}
+	return ratio, nil
+}

--- a/pkg/slo-controller/noderesource/plugins/batchresource/util_test.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/util_test.go
@@ -1,0 +1,657 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
+)
+
+func Test_getPodMetricUsage(t *testing.T) {
+	type args struct {
+		info *slov1alpha1.PodMetricInfo
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceList
+	}{
+		{
+			name: "get correct scaled resource quantity",
+			args: args{
+				info: &slov1alpha1.PodMetricInfo{
+					PodUsage: slov1alpha1.ResourceMap{
+						ResourceList: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("10Gi"),
+							"unknown_resource":    resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			want: makeResourceList("4", "10Gi"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPodMetricUsage(tt.args.info)
+			testingCorrectResourceList(t, &tt.want, &got)
+		})
+	}
+}
+
+func Test_getResourceListForCPUAndMemory(t *testing.T) {
+	type args struct {
+		rl corev1.ResourceList
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceList
+	}{
+		{
+			name: "get correct scaled resource quantity",
+			args: args{
+				rl: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("40"),
+					corev1.ResourceMemory: resource.MustParse("80Gi"),
+					"unknown_resource":    resource.MustParse("10"),
+				},
+			},
+			want: makeResourceList("40", "80Gi"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getResourceListForCPUAndMemory(tt.args.rl)
+			testingCorrectResourceList(t, &tt.want, &got)
+		})
+	}
+}
+
+func Test_getNodeReservation(t *testing.T) {
+	type args struct {
+		strategy        *configuration.ColocationStrategy
+		nodeAllocatable corev1.ResourceList
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceList
+	}{
+		{
+			name: "get correct reserved node resource quantity",
+			args: args{
+				strategy: &configuration.ColocationStrategy{
+					Enable:                        pointer.Bool(true),
+					CPUReclaimThresholdPercent:    pointer.Int64(65),
+					MemoryReclaimThresholdPercent: pointer.Int64(65),
+					DegradeTimeMinutes:            pointer.Int64(15),
+					UpdateTimeThresholdSeconds:    pointer.Int64(300),
+					ResourceDiffThreshold:         pointer.Float64(0.1),
+				},
+				nodeAllocatable: makeResourceList("100", "100Gi"),
+			},
+			want: makeResourceList("35", "35Gi"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getNodeReservation(tt.args.strategy, tt.args.nodeAllocatable)
+			testingCorrectResourceList(t, &tt.want, &got)
+		})
+	}
+}
+
+func Test_getPodNUMARequestAndUsage(t *testing.T) {
+	type args struct {
+		pod        *corev1.Pod
+		podRequest corev1.ResourceList
+		podUsage   corev1.ResourceList
+		numaNum    int
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []corev1.ResourceList // request
+		want1 []corev1.ResourceList // usage
+	}{
+		{
+			name: "pod has no alloc status should have averaged result",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: makeResourceReq("4", "8Gi"),
+							},
+						},
+					},
+				},
+				podRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				podUsage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				numaNum: 2,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			want1: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+		{
+			name: "pod has no alloc status should have averaged result 1",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: makeResourceReq("1", "4Gi"),
+							},
+							{
+								Resources: makeResourceReq("1", "4Gi"),
+							},
+						},
+					},
+				},
+				podRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				podUsage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+				numaNum: 1,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			want1: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+			},
+		},
+		{
+			name: "pod allocate 2 NUMA nodes on 2 total nodes",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Annotations: map[string]string{
+							extension.AnnotationResourceStatus: `{"numaNodeResources": [{"node": 0}, {"node": 1}]}`,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: makeResourceReq("4", "8Gi"),
+							},
+						},
+					},
+				},
+				podRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				podUsage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				numaNum: 2,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			want1: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+		{
+			name: "pod allocate 1 NUMA nodes on 4 total nodes",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Annotations: map[string]string{
+							extension.AnnotationResourceStatus: `{"cpuset": "35-36,67-68", "numaNodeResources": [{"node": 1}]}`,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: makeResourceReq("4", "8Gi"),
+							},
+						},
+					},
+				},
+				podRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				podUsage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				numaNum: 4,
+			},
+			want: []corev1.ResourceList{
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				util.NewZeroResourceList(),
+				util.NewZeroResourceList(),
+			},
+			want1: []corev1.ResourceList{
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				util.NewZeroResourceList(),
+				util.NewZeroResourceList(),
+			},
+		},
+		{
+			name: "pod allocate 2 NUMA nodes on 4 total nodes",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Annotations: map[string]string{
+							extension.AnnotationResourceStatus: `{"cpuset": "35-36,67-68", "numaNodeResources": [{"node": 1}, {"node": 3}]}`,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: makeResourceReq("4", "8Gi"),
+							},
+						},
+					},
+				},
+				podRequest: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				podUsage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				numaNum: 4,
+			},
+			want: []corev1.ResourceList{
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			want1: []corev1.ResourceList{
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				util.NewZeroResourceList(),
+				{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := getPodNUMARequestAndUsage(tt.args.pod, tt.args.podRequest, tt.args.podUsage, tt.args.numaNum)
+			assertEqualNUMAResourceList(t, tt.want, got)
+			assertEqualNUMAResourceList(t, tt.want1, got1)
+		})
+	}
+}
+
+func Test_addZoneResourceList(t *testing.T) {
+	type args struct {
+		a       []corev1.ResourceList
+		b       []corev1.ResourceList
+		zoneNum int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.ResourceList
+	}{
+		{
+			name: "add zero",
+			args: args{
+				a: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+				b: []corev1.ResourceList{
+					{},
+					{},
+				},
+				zoneNum: 2,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		{
+			name: "add zero 1",
+			args: args{
+				a: []corev1.ResourceList{
+					util.NewZeroResourceList(),
+					util.NewZeroResourceList(),
+				},
+				b: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+				zoneNum: 2,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		{
+			name: "normal add",
+			args: args{
+				a: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					util.NewZeroResourceList(),
+					{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					util.NewZeroResourceList(),
+				},
+				b: []corev1.ResourceList{
+					{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+				zoneNum: 4,
+			},
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("3"),
+					corev1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("3"),
+					corev1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addZoneResourceList(tt.args.a, tt.args.b, tt.args.zoneNum)
+			assertEqualNUMAResourceList(t, tt.want, got)
+		})
+	}
+}
+
+func Test_getPodUnknownNUMAUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  corev1.ResourceList
+		arg1 int
+		want []corev1.ResourceList
+	}{
+		{
+			name: "no NUMA node resources",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			arg1: 0,
+			want: nil,
+		},
+		{
+			name: "average on one NUMA",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			arg1: 1,
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			name: "average on multiple NUMAs",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			arg1: 4,
+			want: []corev1.ResourceList{
+				{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPodUnknownNUMAUsage(tt.arg, tt.arg1)
+			assertEqualNUMAResourceList(t, tt.want, got)
+		})
+	}
+}
+
+func Test_divideResourceList(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  corev1.ResourceList
+		arg1 float64
+		want corev1.ResourceList
+	}{
+		{
+			name: "do not panic for divide by zero",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			arg1: 0,
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		{
+			name: "normal case",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			arg1: 2,
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		{
+			name: "normal case 1",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			arg1: 1,
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		{
+			name: "normal case 2",
+			arg: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("6Gi"),
+			},
+			arg1: 3,
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("667m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := divideResourceList(tt.arg, tt.arg1)
+			assert.True(t, util.IsResourceListEqualValue(tt.want, got))
+		})
+	}
+}
+
+func assertEqualNUMAResourceList(t *testing.T, want, got []corev1.ResourceList) {
+	assert.Equal(t, len(want), len(got))
+	for i := range want {
+		assert.True(t, util.IsResourceListEqualValue(want[i], got[i]))
+	}
+}

--- a/pkg/slo-controller/noderesource/plugins/cpunormalization/plugin_test.go
+++ b/pkg/slo-controller/noderesource/plugins/cpunormalization/plugin_test.go
@@ -22,7 +22,6 @@ import (
 	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -193,8 +192,6 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 }
 
 func TestPluginExecute(t *testing.T) {
-	testQuantity := resource.MustParse("8000m")
-	testQuantity1 := resource.MustParse("9600m")
 	type args struct {
 		node *corev1.Node
 		nr   *framework.NodeResource
@@ -272,76 +269,6 @@ func TestPluginExecute(t *testing.T) {
 						"xxx": "yyy",
 						extension.AnnotationCPUNormalizationRatio: "1.20",
 					},
-				},
-			},
-		},
-		{
-			name: "prepare ratio and mutate batch cpu",
-			args: args{
-				node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-node",
-					},
-				},
-				nr: &framework.NodeResource{
-					Resources: map[corev1.ResourceName]*resource.Quantity{
-						extension.BatchCPU: &testQuantity,
-					},
-					Annotations: map[string]string{
-						extension.AnnotationCPUNormalizationRatio: "1.20",
-					},
-				},
-			},
-			wantErr: false,
-			wantField: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node",
-					Annotations: map[string]string{
-						extension.AnnotationCPUNormalizationRatio: "1.20",
-					},
-				},
-			},
-			wantField1: &framework.NodeResource{
-				Resources: map[corev1.ResourceName]*resource.Quantity{
-					extension.BatchCPU: &testQuantity1,
-				},
-				Annotations: map[string]string{
-					extension.AnnotationCPUNormalizationRatio: "1.20",
-				},
-			},
-		},
-		{
-			name: "prepare ratio but failed to mutate batch cpu",
-			args: args{
-				node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-node",
-					},
-				},
-				nr: &framework.NodeResource{
-					Resources: map[corev1.ResourceName]*resource.Quantity{
-						extension.BatchCPU: &testQuantity,
-					},
-					Annotations: map[string]string{
-						extension.AnnotationCPUNormalizationRatio: "[}",
-					},
-				},
-			},
-			wantErr: true,
-			wantField: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node",
-					Annotations: map[string]string{
-						extension.AnnotationCPUNormalizationRatio: "[}",
-					},
-				},
-			},
-			wantField1: &framework.NodeResource{
-				Resources: map[corev1.ResourceName]*resource.Quantity{
-					extension.BatchCPU: &testQuantity,
-				},
-				Annotations: map[string]string{
-					extension.AnnotationCPUNormalizationRatio: "[}",
 				},
 			},
 		},

--- a/pkg/slo-controller/noderesource/plugins/midresource/plugin.go
+++ b/pkg/slo-controller/noderesource/plugins/midresource/plugin.go
@@ -188,8 +188,8 @@ func prepareNodeForResource(node *corev1.Node, nr *framework.NodeResource, name 
 		delete(node.Status.Allocatable, name)
 	} else {
 		if _, ok := q.AsInt64(); !ok {
-			klog.V(2).InfoS("node mid resource's quantity is not int64 and will be rounded",
-				"resource", name, "original", *q)
+			klog.V(4).InfoS("node mid resource's quantity is not int64 and will be rounded",
+				"node", node.Name, "resource", name, "original", *q, "rounded", q.Value())
 			q.Set(q.Value())
 		}
 		node.Status.Capacity[name] = *q

--- a/pkg/slo-controller/noderesource/plugins_profile.go
+++ b/pkg/slo-controller/noderesource/plugins_profile.go
@@ -45,6 +45,7 @@ var (
 	// SetupPlugins implement the setup for node resource plugin.
 	setupPlugins = []framework.SetupPlugin{
 		&cpunormalization.Plugin{},
+		&batchresource.Plugin{},
 	}
 	// NodePreparePlugin implements node resource preparing for the calculated results.
 	nodePreparePlugins = []framework.NodePreparePlugin{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. koord-manager:
    - batch resources support zone-level overcommitment.
    - Move the amplification according to the cpu normalization ratio inside the BatchResource plugin.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

NUMA-level batch resources should be updated on the NRT like:

```yaml
apiVersion: topology.node.k8s.io/v1alpha1
kind: NodeResourceTopology
metadata:
  annotations:
    kubelet.koordinator.sh/cpu-manager-policy: '{"policy":"none"}'
    node.koordinator.sh/be-cpu-shared-pools: '[{"socket":0,"node":0,"cpuset":"0-15"}]'
    node.koordinator.sh/cpu-basic-info: '{"cpuModel":"Intel(R) Xeon(R) Platinum XXX CPU @2.50GHz","hyperThreadEnabled":true, "turboEnabled":true, "vendorID":"GenuineIntel"}'
    node.koordinator.sh/cpu-shared-pools: '[{"socket":0,"node":0,"cpuset":"0-15"}]'
    node.koordinator.sh/cpu-topology: '{"detail":[{"id":0,"core":0,"socket":0,"node":0},{"id":1,"core":0,"socket":0,"node":0},{"id":2,"core":1,"socket":0,"node":0},{"id":3,"core":1,"socket":0,"node":0},{"id":4,"core":2,"socket":0,"node":0},{"id":5,"core":2,"socket":0,"node":0},{"id":6,"core":3,"socket":0,"node":0},{"id":7,"core":3,"socket":0,"node":0},{"id":8,"core":4,"socket":0,"node":0},{"id":9,"core":4,"socket":0,"node":0},{"id":10,"core":5,"socket":0,"node":0},{"id":11,"core":5,"socket":0,"node":0},{"id":12,"core":6,"socket":0,"node":0},{"id":13,"core":6,"socket":0,"node":0},{"id":14,"core":7,"socket":0,"node":0},{"id":15,"core":7,"socket":0,"node":0}]}'
    node.koordinator.sh/reservation: '{}'
    node.koordinator.sh/system-qos-resource: '{}'
  labels:
    app.kubernetes.io/managed-by: Koordinator
  name: test-node
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: true
    controller: true
    kind: Node
    name: test-node
topologyPolicies:
- None
zones:
- name: node-0
  resources:
  - allocatable: "16"
    available: "16"
    capacity: "16"
    name: cpu
  - allocatable: "6159"
    available: "6159"
    capacity: "6159"
    name: kubernetes.io/batch-cpu
  - allocatable: 32305492Ki
    available: 32305492Ki
    capacity: 32305492Ki
    name: kubernetes.io/batch-memory
  - allocatable: 64610984Ki
    available: 64610984Ki
    capacity: 64610984Ki
    name: memory
  type: Node
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
