### PR TITLE
koord-scheduler: framework extension executes handler after handling scheduling errors

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -420,7 +420,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		frameworkExtenderFactory.KoordinatorClientSet(),
 		frameworkExtenderFactory.KoordinatorSharedInformerFactory(),
 	)
-	frameworkExtenderFactory.RegisterErrorHandler(reservationErrorHandler)
+	frameworkExtenderFactory.RegisterErrorHandlerFilters(reservationErrorHandler, nil)
 
 	return &cc, sched, frameworkExtenderFactory, nil
 }

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -50,7 +50,7 @@ func MakeReservationErrorHandler(
 	schedAdapter frameworkext.Scheduler,
 	koordClientSet koordclientset.Interface,
 	koordSharedInformerFactory koordinatorinformers.SharedInformerFactory,
-) frameworkext.ErrorHandler {
+) frameworkext.PreErrorHandlerFilter {
 	reservationLister := koordSharedInformerFactory.Scheduling().V1alpha1().Reservations().Lister()
 	reservationErrorFn := makeReservationErrorFunc(schedAdapter, reservationLister)
 	return func(podInfo *framework.QueuedPodInfo, schedulingErr error) bool {
@@ -395,7 +395,7 @@ func deleteReservationFromSchedulerCache(sched frameworkext.Scheduler, obj inter
 			klog.V(4).InfoS("Successfully delete reservation from SchedulerCache", "reservation", klog.KObj(r))
 		}
 
-		sched.GetSchedulingQueue().MoveAllToActiveOrBackoffQueue(frameworkext.AssignedPodDelete)
+		sched.GetSchedulingQueue().MoveAllToActiveOrBackoffQueue(frameworkext.AssignedPodDelete, nil)
 	}
 }
 

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -41,7 +41,10 @@ type ExtendedHandle interface {
 	Scheduler() Scheduler
 	KoordinatorClientSet() koordinatorclientset.Interface
 	KoordinatorSharedInformerFactory() koordinatorinformers.SharedInformerFactory
-	RegisterErrorHandler(handler ErrorHandler)
+	// RegisterErrorHandlerFilters supports registering custom PreErrorHandlerFilter and PostErrorHandlerFilter to intercept scheduling errors.
+	// If PreErrorHandlerFilter returns true, the k8s scheduler's default error handler and other handlers will not be called.
+	// After handling scheduling errors, will execute PostErrorHandlerFilter, and if return true, other custom handlers will not be called.
+	RegisterErrorHandlerFilters(preFilter PreErrorHandlerFilter, afterFilter PostErrorHandlerFilter)
 	RegisterForgetPodHandler(handler ForgetPodHandler)
 	ForgetPod(pod *corev1.Pod) error
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The framework extension executes handlers after handling scheduling errors to gain the opportunity to affect the scheduling queue.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
