### PR TITLE
koordlet: support qos for out-of-band applications

### DIFF
--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -18,6 +18,7 @@ package runtimehooks
 
 import (
 	"flag"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -95,7 +96,7 @@ type Config struct {
 	RuntimeHookDisableStages        []string
 	RuntimeHooksNRI                 bool
 	RuntimeHooksNRISocketPath       string
-	FeatureGates                    map[string]bool // Deprecated
+	RuntimeHookReconcileInterval    time.Duration
 }
 
 func NewDefaultConfig() *Config {
@@ -109,7 +110,7 @@ func NewDefaultConfig() *Config {
 		RuntimeHookDisableStages:        []string{},
 		RuntimeHooksNRI:                 true,
 		RuntimeHooksNRISocketPath:       "nri/nri.sock",
-		FeatureGates:                    map[string]bool{},
+		RuntimeHookReconcileInterval:    10 * time.Second,
 	}
 }
 
@@ -122,7 +123,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.RuntimeHookHostEndpoint, "runtime-hooks-host-endpoint", c.RuntimeHookHostEndpoint, "host endpoint of runtime proxy")
 	fs.Var(cliflag.NewStringSlice(&c.RuntimeHookDisableStages), "runtime-hooks-disable-stages", "disable stages for runtime hooks")
 	fs.BoolVar(&c.RuntimeHooksNRI, "enable-nri-runtime-hook", c.RuntimeHooksNRI, "enable/disable runtime hooks nri mode")
-	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "runtime-hooks", "Deprecated because all settings have been moved to --feature-gates parameters")
+	fs.DurationVar(&c.RuntimeHookReconcileInterval, "runtime-hooks-reconcile-interval", c.RuntimeHookReconcileInterval, "reconcile interval for each plugins")
 }
 
 func init() {

--- a/pkg/koordlet/runtimehooks/config_test.go
+++ b/pkg/koordlet/runtimehooks/config_test.go
@@ -19,6 +19,7 @@ package runtimehooks
 import (
 	"flag"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -36,7 +37,7 @@ func Test_NewDefaultConfig(t *testing.T) {
 		RuntimeHookDisableStages:        []string{},
 		RuntimeHooksNRI:                 true,
 		RuntimeHooksNRISocketPath:       "nri/nri.sock",
-		FeatureGates:                    map[string]bool{},
+		RuntimeHookReconcileInterval:    10 * time.Second,
 	}
 	defaultConfig := NewDefaultConfig()
 	assert.Equal(t, expectConfig, defaultConfig)

--- a/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/rule_test.go
@@ -430,7 +430,7 @@ func Test_plugin_ruleUpdateCbForNodeSLO(t *testing.T) {
 			defer func() { close(stop) }()
 			p.executor.Run(stop)
 
-			err := p.ruleUpdateCbForNodeSLO(tt.args.pods)
+			err := p.ruleUpdateCbForNodeSLO(&statesinformer.CallbackTarget{Pods: tt.args.pods})
 			assert.Equal(t, tt.wantErr, err != nil)
 			// init cgroups cpuset file
 			for i, podMeta := range tt.args.pods {
@@ -922,7 +922,10 @@ func Test_plugin_ruleUpdateCbForNodeMeta(t *testing.T) {
 			p.executor = resourceexecutor.NewTestResourceExecutor()
 			p.executor.Run(stopCh)
 			p.rule = tt.fields.rule
-			gotErr := p.ruleUpdateCbForNodeMeta(tt.arg)
+			target := &statesinformer.CallbackTarget{
+				Pods: tt.arg,
+			}
+			gotErr := p.ruleUpdateCbForNodeMeta(target)
 			assert.Equal(t, tt.wantErr, gotErr != nil)
 			if tt.wantCheck != nil {
 				tt.wantCheck(t, helper)

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule.go
@@ -95,7 +95,11 @@ func (p *Plugin) parseRule(nodeIf interface{}) (bool, error) {
 	return isUpdated, nil
 }
 
-func (p *Plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
+func (p *Plugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
+	if target == nil {
+		klog.Warningf("callback target is nil")
+		return nil
+	}
 	// NOTE: if the ratio becomes bigger, scale top down, otherwise, scale bottom up
 	r := p.rule
 	if r == nil {
@@ -104,7 +108,7 @@ func (p *Plugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 	}
 	filter := reconciler.PodQOSFilter()
 	var podUpdaters, containerUpdaters []resourceexecutor.ResourceUpdater
-	for _, podMeta := range pods {
+	for _, podMeta := range target.Pods {
 		if qos := extension.QoSClass(filter.Filter(podMeta)); qos != extension.QoSLS && qos != extension.QoSNone {
 			continue
 		}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
@@ -497,7 +497,10 @@ func TestPlugin_ruleUpdateCb(t *testing.T) {
 			p.executor = resourceexecutor.NewTestResourceExecutor()
 			p.executor.Run(stopCh)
 			p.rule = tt.fields.rule
-			gotErr := p.ruleUpdateCb(tt.arg)
+			target := &statesinformer.CallbackTarget{
+				Pods: tt.arg,
+			}
+			gotErr := p.ruleUpdateCb(target)
 			assert.Equal(t, tt.wantErr, gotErr != nil)
 			if tt.wantCheck != nil {
 				tt.wantCheck(t, helper)

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
@@ -74,6 +74,8 @@ func (p *cpusetPlugin) Register(op hooks.Options) {
 	reconciler.RegisterCgroupReconciler(reconciler.SandboxLevel, sysutil.CPUSet,
 		"set sandbox container cpuset for be pod is specified",
 		p.SetContainerCPUSet, reconciler.PodQOSFilter(), bePodQOSConditions...)
+	reconciler.RegisterHostAppReconciler(sysutil.CPUSet, "set host application cpuset",
+		p.SetHostAppCPUSet, &reconciler.ReconcilerOption{})
 	p.executor = op.Executor
 }
 
@@ -98,7 +100,7 @@ func (p *cpusetPlugin) SetContainerCPUSetAndUnsetCFS(proto protocol.HooksProtoco
 }
 
 func (p *cpusetPlugin) SetContainerCPUSet(proto protocol.HooksProtocol) error {
-	containerCtx := proto.(*protocol.ContainerContext)
+	containerCtx, _ := proto.(*protocol.ContainerContext)
 	if containerCtx == nil {
 		return fmt.Errorf("container protocol is nil for plugin %v", name)
 	}
@@ -130,10 +132,36 @@ func (p *cpusetPlugin) SetContainerCPUSet(proto protocol.HooksProtocol) error {
 		klog.V(5).Infof("get cpuset %v for container %v/%v from rule", *cpusetValue,
 			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name)
 	} else {
-		klog.V(5).Infof("get empty cpuset for container %v/%v from rule", *cpusetValue,
+		klog.V(5).Infof("get empty cpuset for container %v/%v from rule",
 			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name)
 	}
 	containerCtx.Response.Resources.CPUSet = cpusetValue
+	return nil
+}
+
+func (p *cpusetPlugin) SetHostAppCPUSet(proto protocol.HooksProtocol) error {
+	hostAppCtx, _ := proto.(*protocol.HostAppContext)
+	if hostAppCtx == nil {
+		return fmt.Errorf("host application protocol is nil for plugin %v", name)
+	}
+
+	r := p.getRule()
+	if r == nil {
+		klog.V(5).Infof("hook plugin rule is nil, do nothing for plugin %v", name)
+		return nil
+	}
+	hostAppReq := hostAppCtx.Request
+	cpusetValue, err := r.getHostAppCpuset(&hostAppReq)
+	if err != nil {
+		return err
+	}
+	if cpusetValue != nil {
+		klog.V(5).Infof("get cpuset %v for host application %v from rule", *cpusetValue,
+			hostAppReq.Name)
+	} else {
+		klog.V(5).Infof("get empty cpuset for host application %v from rule", hostAppReq.Name)
+	}
+	hostAppCtx.Response.Resources.CPUSet = cpusetValue
 	return nil
 }
 

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -125,6 +125,21 @@ func (r *cpusetRule) getContainerCPUSet(containerReq *protocol.ContainerRequest)
 	}
 }
 
+func (r *cpusetRule) getHostAppCpuset(hostAppReq *protocol.HostAppRequest) (*string, error) {
+	if hostAppReq == nil {
+		return nil, nil
+	}
+	if hostAppReq.QOSClass != ext.QoSLS {
+		return nil, fmt.Errorf("only LS is supported for host application %v", hostAppReq.Name)
+	}
+	allSharePoolCPUs := make([]string, 0, len(r.sharePools))
+	for _, nodeSharePool := range r.sharePools {
+		allSharePoolCPUs = append(allSharePoolCPUs, nodeSharePool.CPUSet)
+	}
+	klog.V(6).Infof("get cpuset from all share pool for host application %v", hostAppReq.Name)
+	return pointer.String(strings.Join(allSharePoolCPUs, ",")), nil
+}
+
 func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 	nodeTopo, ok := nodeTopoIf.(*topov1alpha1.NodeResourceTopology)
 	if !ok {
@@ -167,8 +182,12 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 	return updated, nil
 }
 
-func (p *cpusetPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
-	for _, podMeta := range pods {
+func (p *cpusetPlugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
+	if target == nil {
+		klog.Warningf("callback target is nil")
+		return nil
+	}
+	for _, podMeta := range target.Pods {
 		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
 			containerCtx := &protocol.ContainerContext{}
 			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
@@ -189,6 +208,15 @@ func (p *cpusetPlugin) ruleUpdateCb(pods []*statesinformer.PodMeta) error {
 		sandboxContainerCtx.ReconcilerDone(p.executor)
 		klog.V(5).Infof("set cpuset finished pod sandbox %v/%v",
 			sandboxContainerCtx.Request.PodMeta.String(), sandboxContainerCtx.Request.ContainerMeta.ID)
+	}
+	for _, hostApp := range target.HostApplications {
+		hostCtx := protocol.HooksProtocolBuilder.HostApp(&hostApp)
+		if err := p.SetHostAppCPUSet(hostCtx); err != nil {
+			klog.Warningf("set host application %v cpuset value failed, error %v", hostApp.Name, err)
+		} else {
+			hostCtx.ReconcilerDone(p.executor)
+			klog.V(5).Infof("set host application %v cpuset value finished", hostApp.Name)
+		}
 	}
 	return nil
 }

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cpuset
 
 import (
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
@@ -26,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	ext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
@@ -581,7 +584,7 @@ func Test_cpusetPlugin_parseRule(t *testing.T) {
 	}
 }
 
-func Test_cpusetPlugin_ruleUpdateCb(t *testing.T) {
+func Test_cpusetPlugin_ruleUpdateCbForPods(t *testing.T) {
 	type testPod struct {
 		pod       *corev1.Pod
 		sandboxID string
@@ -723,7 +726,11 @@ func Test_cpusetPlugin_ruleUpdateCb(t *testing.T) {
 			for _, podMeta := range podUIDMetas {
 				podMetas = append(podMetas, podMeta)
 			}
-			if err := p.ruleUpdateCb(podMetas); (err != nil) != tt.wantErr {
+			target := &statesinformer.CallbackTarget{
+				Pods: podMetas,
+			}
+
+			if err := p.ruleUpdateCb(target); (err != nil) != tt.wantErr {
 				t.Errorf("ruleUpdateCb() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -743,6 +750,211 @@ func Test_cpusetPlugin_ruleUpdateCb(t *testing.T) {
 				assert.Equal(t, tt.wants.sandboxCPUSet[string(podMeta.Pod.UID)], gotCPUSet,
 					"sandbox cpuset after callback should be equal")
 			}
+		})
+	}
+}
+
+func Test_cpusetRule_getHostAppCpuset(t *testing.T) {
+	type fields struct {
+		sharePools []ext.CPUSharedPool
+	}
+	type args struct {
+		hostAppReq *protocol.HostAppRequest
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *string
+		wantErr bool
+	}{
+		{
+			name: "get nil result with nil request",
+			fields: fields{
+				sharePools: nil,
+			},
+			args: args{
+				hostAppReq: nil,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "get nil result with bad request qos",
+			fields: fields{
+				sharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "0-7",
+					},
+					{
+						Socket: 1,
+						Node:   0,
+						CPUSet: "8-15",
+					},
+				},
+			},
+			args: args{
+				hostAppReq: &protocol.HostAppRequest{
+					Name:         "test-app",
+					QOSClass:     ext.QoSLSR,
+					CgroupParent: "",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "get cpuset result with ls qos request",
+			fields: fields{
+				sharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "0-7",
+					},
+					{
+						Socket: 1,
+						Node:   0,
+						CPUSet: "8-15",
+					},
+				},
+			},
+			args: args{
+				hostAppReq: &protocol.HostAppRequest{
+					Name:         "test-app",
+					QOSClass:     ext.QoSLS,
+					CgroupParent: "",
+				},
+			},
+			want:    pointer.String("0-7,8-15"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &cpusetRule{
+				sharePools: tt.fields.sharePools,
+			}
+			got, err := r.getHostAppCpuset(tt.args.hostAppReq)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHostAppCpuset() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getHostAppCpuset() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_cpusetPlugin_ruleUpdateCbForHostApp(t *testing.T) {
+	type fields struct {
+		rule     *cpusetRule
+		executor resourceexecutor.ResourceUpdateExecutor
+	}
+	type args struct {
+		hostApp slov1alpha1.HostApplicationSpec
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantCPUSet string
+		wantErr    bool
+	}{
+		{
+			name: "set cpuset for host application",
+			fields: fields{
+				rule: &cpusetRule{
+					sharePools: []ext.CPUSharedPool{
+						{
+							Socket: 0,
+							Node:   0,
+							CPUSet: "0-7",
+						},
+						{
+							Socket: 1,
+							Node:   0,
+							CPUSet: "8-15",
+						},
+					},
+				},
+			},
+			args: args{
+				hostApp: slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSLS,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						ParentDir:    "test-ls",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			wantCPUSet: "0-7,8-15",
+			wantErr:    false,
+		},
+		{
+			name: "set empty cpuset for LSR host application",
+			fields: fields{
+				rule: &cpusetRule{
+					sharePools: []ext.CPUSharedPool{
+						{
+							Socket: 0,
+							Node:   0,
+							CPUSet: "0-7",
+						},
+						{
+							Socket: 1,
+							Node:   0,
+							CPUSet: "8-15",
+						},
+					},
+				},
+			},
+			args: args{
+				hostApp: slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSLSR,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						ParentDir:    "test-ls",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			wantCPUSet: "",
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testHelper := system.NewFileTestUtil(t)
+			testApp := tt.args.hostApp
+			if testApp.CgroupPath == nil ||
+				(testApp.CgroupPath.Base != "" && testApp.CgroupPath.Base != slov1alpha1.CgroupBaseTypeRoot) {
+				t.Errorf("only cgroup root dir is suupported")
+			}
+
+			cgroupDir := filepath.Join(testApp.CgroupPath.ParentDir, testApp.CgroupPath.RelativePath)
+			initCPUSet(cgroupDir, "", testHelper)
+			p := &cpusetPlugin{
+				rule:     tt.fields.rule,
+				executor: resourceexecutor.NewResourceUpdateExecutor(),
+			}
+			stop := make(chan struct{})
+			defer func() { close(stop) }()
+			p.executor.Run(stop)
+
+			target := &statesinformer.CallbackTarget{
+				HostApplications: []slov1alpha1.HostApplicationSpec{tt.args.hostApp},
+			}
+			if err := p.ruleUpdateCb(target); (err != nil) != tt.wantErr {
+				t.Errorf("ruleUpdateCb() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			gotCPUSet := getCPUSet(cgroupDir, testHelper)
+			assert.Equal(t, tt.wantCPUSet, gotCPUSet)
 		})
 	}
 }

--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/bvt.go
@@ -59,6 +59,8 @@ func (b *bvtPlugin) Register(op hooks.Options) {
 		b.SetPodBvtValue, reconciler.NoneFilter())
 	reconciler.RegisterCgroupReconciler(reconciler.KubeQOSLevel, sysutil.CPUBVTWarpNs, "reconcile kubeqos level cpu bvt value",
 		b.SetKubeQOSBvtValue, reconciler.NoneFilter())
+	reconciler.RegisterHostAppReconciler(sysutil.CPUBVTWarpNs, "reconcile host application cpu bvt value",
+		b.SetHostAppBvtValue, &reconciler.ReconcilerOption{})
 	b.executor = op.Executor
 }
 

--- a/pkg/koordlet/runtimehooks/protocol/host_qos_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/host_qos_context.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	ext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+)
+
+const (
+	hostLSCgroupDir = "host-latency-sensitive"
+	hostBECgroupDir = "host-best-effort"
+)
+
+func getHostCgroupRelativePath(hostAppSpec *slov1alpha1.HostApplicationSpec) string {
+	if hostAppSpec == nil {
+		return ""
+	}
+	if hostAppSpec.CgroupPath == nil {
+		cgroupBaseDir := ""
+		switch hostAppSpec.QoS {
+		case ext.QoSLSE, ext.QoSLSR, ext.QoSLS:
+			cgroupBaseDir = hostLSCgroupDir
+		case ext.QoSBE:
+			cgroupBaseDir = hostBECgroupDir
+			// empty string for QoSNone as default
+		}
+		return filepath.Join(cgroupBaseDir, hostAppSpec.Name)
+	} else {
+		cgroupBaseDir := ""
+		switch hostAppSpec.CgroupPath.Base {
+		case slov1alpha1.CgroupBaseTypeKubepods:
+			cgroupBaseDir = util.GetPodQoSRelativePath(corev1.PodQOSGuaranteed)
+		case slov1alpha1.CgroupBaseTypeKubeBurstable:
+			cgroupBaseDir = util.GetPodQoSRelativePath(corev1.PodQOSBurstable)
+		case slov1alpha1.CgroupBaseTypeKubeBesteffort:
+			cgroupBaseDir = util.GetPodQoSRelativePath(corev1.PodQOSBestEffort)
+			// empty string for CgroupBaseTypeRoot as default
+		}
+		return filepath.Join(cgroupBaseDir, hostAppSpec.CgroupPath.ParentDir, hostAppSpec.CgroupPath.RelativePath)
+	}
+}
+
+type HostAppRequest struct {
+	Name         string
+	QOSClass     ext.QoSClass
+	CgroupParent string
+}
+
+func (r *HostAppRequest) FromReconciler(hostAppSpec *slov1alpha1.HostApplicationSpec) {
+	r.Name = hostAppSpec.Name
+	r.QOSClass = hostAppSpec.QoS
+	r.CgroupParent = getHostCgroupRelativePath(hostAppSpec)
+}
+
+type HostAppResponse struct {
+	Resources Resources
+}
+
+type HostAppContext struct {
+	Request  HostAppRequest
+	Response HostAppResponse
+	executor resourceexecutor.ResourceUpdateExecutor
+	updaters []resourceexecutor.ResourceUpdater
+}
+
+func (c *HostAppContext) FromReconciler(hostAppSpec *slov1alpha1.HostApplicationSpec) {
+	c.Request.FromReconciler(hostAppSpec)
+}
+
+func (c *HostAppContext) ReconcilerProcess(executor resourceexecutor.ResourceUpdateExecutor) {
+	if c.executor == nil {
+		c.executor = executor
+	}
+	c.injectForOrigin()
+	c.injectForExt()
+}
+
+func (c *HostAppContext) ReconcilerDone(executor resourceexecutor.ResourceUpdateExecutor) {
+	c.ReconcilerProcess(executor)
+	c.Update()
+}
+
+func (c *HostAppContext) GetUpdaters() []resourceexecutor.ResourceUpdater {
+	return c.updaters
+}
+
+func (c *HostAppContext) Update() {
+	klog.V(5).Infof("")
+	c.executor.UpdateBatch(true, c.updaters...)
+	c.updaters = nil
+}
+
+func (c *HostAppContext) injectForOrigin() {
+	// If CPUSet is not nil and is not an empty string, set cpuset
+	if c.Response.Resources.CPUSet != nil && *c.Response.Resources.CPUSet != "" {
+		eventHelper := audit.V(3).Group(c.Request.Name).Reason("runtime-hooks").Message(
+			"set host application cpuset to %v", *c.Response.Resources.CPUSet)
+		updater, err := injectCPUSet(c.Request.CgroupParent, *c.Response.Resources.CPUSet, eventHelper, c.executor)
+		if err != nil {
+			klog.Infof("set host application %v cpuset %v on cgroup parent %v failed, error %v",
+				c.Request.Name, *c.Response.Resources.CPUSet, c.Request.CgroupParent, err)
+		} else {
+			c.updaters = append(c.updaters, updater)
+			klog.V(5).Infof("set host application %v cpuset %v on cgroup parent %v",
+				c.Request.Name, *c.Response.Resources.CPUSet, c.Request.CgroupParent)
+		}
+	}
+}
+
+func (c *HostAppContext) injectForExt() {
+	if c.Response.Resources.CPUBvt != nil {
+		eventHelper := audit.V(3).Group(c.Request.Name).Reason("runtime-hooks").Message(
+			"set host application bvt to %v", *c.Response.Resources.CPUBvt)
+		updater, err := injectCPUBvt(c.Request.CgroupParent, *c.Response.Resources.CPUBvt, eventHelper, c.executor)
+		if err != nil {
+			klog.Infof("set host application %v bvt %v on cgroup parent %v failed, error %v", c.Request.Name,
+				*c.Response.Resources.CPUBvt, c.Request.CgroupParent, err)
+		} else {
+			c.updaters = append(c.updaters, updater)
+			klog.V(5).Infof("set host application %v bvt %v on cgroup parent %v", c.Request.Name,
+				*c.Response.Resources.CPUBvt, c.Request.CgroupParent)
+		}
+	}
+}

--- a/pkg/koordlet/runtimehooks/protocol/host_qos_context_test.go
+++ b/pkg/koordlet/runtimehooks/protocol/host_qos_context_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	ext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+)
+
+func Test_getHostCgroupRelativePath(t *testing.T) {
+	type args struct {
+		hostAppSpec *slov1alpha1.HostApplicationSpec
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "nil host app",
+			args: args{
+				hostAppSpec: nil,
+			},
+			want: "",
+		},
+		{
+			name: "ls app with no cgroup",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "ls-app",
+					QoS:  ext.QoSLS,
+				},
+			},
+			want: filepath.Join(hostLSCgroupDir, "ls-app"),
+		},
+		{
+			name: "be app with no cgroup",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "be-app",
+					QoS:  ext.QoSBE,
+				},
+			},
+			want: filepath.Join(hostBECgroupDir, "be-app"),
+		},
+		{
+			name: "app with cgroup root base",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSLS,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						Base:         slov1alpha1.CgroupBaseTypeRoot,
+						ParentDir:    "host-ls-app",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			want: filepath.Join("", "host-ls-app", "test-app"),
+		},
+		{
+			name: "app with kubepods cgroup base",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSLS,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						Base:         slov1alpha1.CgroupBaseTypeKubepods,
+						ParentDir:    "host-ls-app",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			want: filepath.Join(util.GetPodQoSRelativePath(corev1.PodQOSGuaranteed), "host-ls-app", "test-app"),
+		},
+		{
+			name: "app with burstable cgroup base",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSLS,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						Base:         slov1alpha1.CgroupBaseTypeKubeBurstable,
+						ParentDir:    "host-ls-app",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			want: filepath.Join(util.GetPodQoSRelativePath(corev1.PodQOSBurstable), "host-ls-app", "test-app"),
+		},
+		{
+			name: "app with besteffort cgroup base",
+			args: args{
+				hostAppSpec: &slov1alpha1.HostApplicationSpec{
+					Name: "test-app",
+					QoS:  ext.QoSBE,
+					CgroupPath: &slov1alpha1.CgroupPath{
+						Base:         slov1alpha1.CgroupBaseTypeKubeBesteffort,
+						ParentDir:    "host-be-app",
+						RelativePath: "test-app",
+					},
+				},
+			},
+			want: filepath.Join(util.GetPodQoSRelativePath(corev1.PodQOSBestEffort), "host-be-app", "test-app"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHostCgroupRelativePath(tt.args.hostAppSpec); got != tt.want {
+				t.Errorf("getHostCgroupRelativePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/protocol/protocol.go
+++ b/pkg/koordlet/runtimehooks/protocol/protocol.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
@@ -39,6 +40,7 @@ type hooksProtocolBuilder struct {
 	Pod       func(podMeta *statesinformer.PodMeta) HooksProtocol
 	Sandbox   func(podMeta *statesinformer.PodMeta) HooksProtocol
 	Container func(podMeta *statesinformer.PodMeta, containerName string) HooksProtocol
+	HostApp   func(hostAppSpec *slov1alpha1.HostApplicationSpec) HooksProtocol
 }
 
 var HooksProtocolBuilder = hooksProtocolBuilder{
@@ -60,6 +62,11 @@ var HooksProtocolBuilder = hooksProtocolBuilder{
 	Container: func(podMeta *statesinformer.PodMeta, containerName string) HooksProtocol {
 		c := &ContainerContext{}
 		c.FromReconciler(podMeta, containerName, false)
+		return c
+	},
+	HostApp: func(hostAppSpec *slov1alpha1.HostApplicationSpec) HooksProtocol {
+		c := &HostAppContext{}
+		c.FromReconciler(hostAppSpec)
 		return c
 	},
 }

--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"reflect"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+var globalHostAppReconcilers = struct {
+	hostApps []*hostAppReconciler
+}{}
+
+type hostAppReconciler struct {
+	resourceFile system.Resource
+	description  string
+	fn           reconcileFunc
+}
+
+func RegisterHostAppReconciler(resource system.Resource, description string, fn reconcileFunc, opt *ReconcilerOption) {
+	for _, r := range globalHostAppReconcilers.hostApps {
+		if resource.ResourceType() == r.resourceFile.ResourceType() {
+			klog.Fatal("%v file already registered by %v", resource.ResourceType(), r.description)
+		}
+	}
+
+	r := &hostAppReconciler{
+		resourceFile: resource,
+		description:  description,
+		fn:           fn,
+	}
+	globalHostAppReconcilers.hostApps = append(globalHostAppReconcilers.hostApps, r)
+}
+
+type ReconcilerOption struct {
+	// TODO mv filter and condition
+}
+
+type hostReconciler struct {
+	appMutex          sync.RWMutex
+	hostAppMap        map[string]*slov1alpha1.HostApplicationSpec
+	appUpdated        chan struct{}
+	executor          resourceexecutor.ResourceUpdateExecutor
+	reconcileInterval time.Duration
+}
+
+func NewHostAppReconciler(ctx Context) Reconciler {
+	r := &hostReconciler{
+		appUpdated:        make(chan struct{}, 1),
+		executor:          ctx.Executor,
+		reconcileInterval: ctx.ReconcileInterval,
+	}
+	ctx.StatesInformer.RegisterCallbacks(statesinformer.RegisterTypeNodeSLOSpec, "host-app-reconciler",
+		"Reconcile cgroup files if host app updated", r.appRefreshCallback)
+	return r
+}
+
+func (r *hostReconciler) Run(stopCh <-chan struct{}) error {
+	go r.doHostAppCgroup(stopCh)
+	go r.reconcile(stopCh)
+	klog.V(1).Infof("start host application reconciler successfully")
+	return nil
+}
+
+func (r *hostReconciler) reconcile(stopCh <-chan struct{}) {
+	timer := time.NewTicker(r.reconcileInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			if len(r.appUpdated) == 0 {
+				r.appUpdated <- struct{}{}
+				klog.V(5).Infof("reconcile host application with %v interval", r.reconcileInterval.String())
+			}
+			timer.Reset(r.reconcileInterval)
+		case <-stopCh:
+			klog.V(1).Infof("stop reconcile for host application")
+		}
+	}
+}
+
+func (r *hostReconciler) appRefreshCallback(t statesinformer.RegisterType, mergedNodeSLOSpecIf interface{},
+	target *statesinformer.CallbackTarget) {
+	if target == nil {
+		klog.Warningf("callback target is nil")
+		return
+	}
+	updated := r.parseHostApp(target.HostApplications)
+	if !updated {
+		klog.V(4).Infof("host application in node slo is not updated, no need to reconcile")
+		return
+	}
+	if len(r.appUpdated) == 0 {
+		r.appUpdated <- struct{}{}
+	}
+}
+
+func (r *hostReconciler) parseHostApp(hostApps []slov1alpha1.HostApplicationSpec) bool {
+	newHostAppMap := make(map[string]*slov1alpha1.HostApplicationSpec, len(hostApps))
+	for _, app := range hostApps {
+		newHostAppMap[app.Name] = app.DeepCopy()
+	}
+	updated := r.updateHostApp(newHostAppMap)
+	klog.V(4).Infof("host application updated=%v with new %v", updated, newHostAppMap)
+	return updated
+}
+
+func (r *hostReconciler) updateHostApp(hostAppMap map[string]*slov1alpha1.HostApplicationSpec) bool {
+	r.appMutex.Lock()
+	defer r.appMutex.Unlock()
+	if !reflect.DeepEqual(hostAppMap, r.hostAppMap) {
+		r.hostAppMap = hostAppMap
+		return true
+	}
+	return false
+}
+
+func (r *hostReconciler) getHostApps() map[string]*slov1alpha1.HostApplicationSpec {
+	r.appMutex.RLock()
+	defer r.appMutex.RUnlock()
+	result := make(map[string]*slov1alpha1.HostApplicationSpec, len(r.hostAppMap))
+	for k, v := range r.hostAppMap {
+		result[k] = v.DeepCopy()
+	}
+	return result
+}
+
+func (r *hostReconciler) doHostAppCgroup(stopCh <-chan struct{}) {
+	for {
+		select {
+		case <-r.appUpdated:
+			hostApps := r.getHostApps()
+			for name, app := range hostApps {
+				for _, appReconciler := range globalHostAppReconcilers.hostApps {
+					hostCtx := protocol.HooksProtocolBuilder.HostApp(app)
+					if err := appReconciler.fn(hostCtx); err != nil {
+						klog.Warningf("calling host reconcile function %v failed, erro %v", appReconciler.description, err)
+					} else {
+						hostCtx.ReconcilerDone(r.executor)
+						klog.V(5).Infof("calling host reconcile function %v for app %v finished", appReconciler.description, name)
+					}
+				}
+			}
+		case <-stopCh:
+			klog.V(1).Infof("stop reconcile host app cgroup")
+			return
+		}
+	}
+}

--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/cache"
+
+	ext "github.com/koordinator-sh/koordinator/apis/extension"
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	mock_statesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/mockstatesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func Test_hostReconciler_parseHostAppAndGet(t *testing.T) {
+	type fields struct {
+		hostAppMap map[string]*slov1alpha1.HostApplicationSpec
+	}
+	type args struct {
+		hostApps []slov1alpha1.HostApplicationSpec
+	}
+	type wants struct {
+		hostApp map[string]*slov1alpha1.HostApplicationSpec
+		updated bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "update app with new",
+			fields: fields{
+				hostAppMap: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name:       "test-app",
+						CgroupPath: nil,
+					},
+				},
+			},
+			args: args{
+				hostApps: []slov1alpha1.HostApplicationSpec{
+					{
+						Name:       "new-app",
+						CgroupPath: nil,
+					},
+				},
+			},
+			wants: wants{
+				hostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"new-app": {
+						Name:       "new-app",
+						CgroupPath: nil,
+					},
+				},
+				updated: true,
+			},
+		},
+		{
+			name: "update app with same",
+			fields: fields{
+				hostAppMap: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name:       "test-app",
+						CgroupPath: nil,
+					},
+				},
+			},
+			args: args{
+				hostApps: []slov1alpha1.HostApplicationSpec{
+					{
+						Name:       "test-app",
+						CgroupPath: nil,
+					},
+				},
+			},
+			wants: wants{
+				hostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name:       "test-app",
+						CgroupPath: nil,
+					},
+				},
+				updated: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &hostReconciler{
+				hostAppMap: tt.fields.hostAppMap,
+			}
+			gotUpdated := r.parseHostApp(tt.args.hostApps)
+			assert.Equal(t, tt.wants.updated, gotUpdated)
+			if gotUpdated {
+				gotApps := r.getHostApps()
+				assert.Equal(t, tt.wants.hostApp, gotApps)
+			}
+		})
+	}
+}
+
+func Test_hostReconciler_doHostAppCgroup(t *testing.T) {
+	stopCh := make(chan struct{}, 1)
+	stopFn := func() {
+		close(stopCh)
+	}
+
+	hostAppOutput := map[string]string{}
+	hostAppReconcilerGetQoSFn := func(proto protocol.HooksProtocol) error {
+		appCtx := proto.(*protocol.HostAppContext)
+		qos := appCtx.Request.QOSClass
+		hostAppOutput[appCtx.Request.Name] = string(qos)
+		stopFn()
+		return nil
+	}
+	badReconcilerFn := func(proto protocol.HooksProtocol) error {
+		return fmt.Errorf("mock reconcile error")
+	}
+
+	type fields struct {
+		hostAppMap     map[string]*slov1alpha1.HostApplicationSpec
+		registerFn     reconcileFunc
+		registerFnDesc string
+	}
+	type wants struct {
+		hostAppOutput map[string]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		wants  wants
+	}{
+		{
+			name: "reconcile host app to get qos",
+			fields: fields{
+				hostAppMap: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+						QoS:  ext.QoSLS,
+					},
+				},
+				registerFn:     hostAppReconcilerGetQoSFn,
+				registerFnDesc: "get host app qos",
+			},
+			wants: wants{
+				hostAppOutput: map[string]string{
+					"test-app": string(ext.QoSLS),
+				},
+			},
+		},
+		{
+			name: "reconcile host app with error",
+			fields: fields{
+				hostAppMap: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+						QoS:  ext.QoSLS,
+					},
+				},
+				registerFn:     badReconcilerFn,
+				registerFnDesc: "get host app qos",
+			},
+			wants: wants{
+				hostAppOutput: map[string]string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &hostReconciler{
+				hostAppMap: tt.fields.hostAppMap,
+				appUpdated: make(chan struct{}, 1),
+				executor:   resourceexecutor.NewResourceUpdateExecutor(),
+			}
+			RegisterHostAppReconciler(system.CPUBVTWarpNs, tt.fields.registerFnDesc, tt.fields.registerFn, &ReconcilerOption{})
+			defer func() {
+				globalHostAppReconcilers.hostApps = []*hostAppReconciler{}
+				hostAppOutput = map[string]string{}
+			}()
+			r.appUpdated <- struct{}{}
+			r.doHostAppCgroup(stopCh)
+			assert.Equal(t, tt.wants.hostAppOutput, hostAppOutput)
+
+		})
+	}
+}
+
+func Test_hostReconciler_appRefreshCallback(t *testing.T) {
+	type args struct {
+		target         *statesinformer.CallbackTarget
+		currentHostApp map[string]*slov1alpha1.HostApplicationSpec
+	}
+	type wants struct {
+		hostApp    map[string]*slov1alpha1.HostApplicationSpec
+		appUpdated bool
+	}
+	tests := []struct {
+		name  string
+		args  args
+		wants wants
+	}{
+		{
+			name: "update app with new",
+			args: args{
+				target: &statesinformer.CallbackTarget{
+					HostApplications: []slov1alpha1.HostApplicationSpec{
+						{
+							Name: "new-app",
+						},
+					},
+				},
+				currentHostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+					},
+				},
+			},
+			wants: wants{
+				hostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"new-app": {
+						Name: "new-app",
+					},
+				},
+				appUpdated: true,
+			},
+		},
+		{
+			name: "update app with old",
+			args: args{
+				target: &statesinformer.CallbackTarget{
+					HostApplications: []slov1alpha1.HostApplicationSpec{
+						{
+							Name: "test-app",
+						},
+					},
+				},
+				currentHostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+					},
+				},
+			},
+			wants: wants{
+				hostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+					},
+				},
+				appUpdated: false,
+			},
+		},
+		{
+			name: "update app with nil",
+			args: args{
+				target: nil,
+				currentHostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+					},
+				},
+			},
+			wants: wants{
+				hostApp: map[string]*slov1alpha1.HostApplicationSpec{
+					"test-app": {
+						Name: "test-app",
+					},
+				},
+				appUpdated: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &hostReconciler{
+				appUpdated: make(chan struct{}, 1),
+				hostAppMap: tt.args.currentHostApp,
+			}
+			r.appRefreshCallback(statesinformer.RegisterTypeNodeSLOSpec, nil, tt.args.target)
+			assert.Equal(t, tt.wants.hostApp, r.getHostApps())
+			assert.Equal(t, tt.wants.appUpdated, len(r.appUpdated) == 1)
+		})
+	}
+}
+
+func Test_hostReconciler_reconcile(t *testing.T) {
+	r := &hostReconciler{
+		appUpdated:        make(chan struct{}, 1),
+		reconcileInterval: time.Second,
+	}
+	stopCh := make(chan struct{}, 1)
+	defer close(stopCh)
+	go r.reconcile(stopCh)
+	checkAppUpdated := func() bool {
+		return len(r.appUpdated) == 1
+	}
+	assert.True(t, cache.WaitForCacheSync(stopCh, checkAppUpdated))
+}
+
+func TestNewHostAppReconciler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	si := mock_statesinformer.NewMockStatesInformer(ctrl)
+	si.EXPECT().RegisterCallbacks(statesinformer.RegisterTypeNodeSLOSpec, gomock.Any(), gomock.Any(), gomock.Any())
+	ctx := Context{
+		StatesInformer:    si,
+		Executor:          resourceexecutor.NewResourceUpdateExecutor(),
+		ReconcileInterval: time.Second,
+	}
+	r := NewHostAppReconciler(ctx)
+	stop := make(chan struct{}, 1)
+	defer close(stop)
+	assert.NoError(t, r.Run(stop))
+}

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler_test.go
@@ -222,7 +222,9 @@ func Test_reconciler_podRefreshCallback(t *testing.T) {
 			c := &reconciler{
 				podUpdated: make(chan struct{}, 1),
 			}
-			c.podRefreshCallback(statesinformer.RegisterTypeAllPods, nil, tt.args.podsMeta)
+			c.podRefreshCallback(statesinformer.RegisterTypeAllPods, nil, &statesinformer.CallbackTarget{
+				Pods: tt.args.podsMeta,
+			})
 			assert.Equal(t, c.podsMeta, tt.args.podsMeta, "callback update pod meta")
 		})
 	}
@@ -233,11 +235,11 @@ func TestNewReconciler(t *testing.T) {
 	defer ctrl.Finish()
 	si := mock_statesinformer.NewMockStatesInformer(ctrl)
 	si.EXPECT().RegisterCallbacks(statesinformer.RegisterTypeAllPods, gomock.Any(), gomock.Any(), gomock.Any())
-	op := Options{
+	ctx := Context{
 		StatesInformer: si,
 		Executor:       resourceexecutor.NewResourceUpdateExecutor(),
 	}
-	r := NewReconciler(op)
+	r := NewReconciler(ctx)
 	nr := r.(*reconciler)
 	stopCh := make(chan struct{}, 1)
 	stopCh <- struct{}{}

--- a/pkg/koordlet/runtimehooks/rule/rule.go
+++ b/pkg/koordlet/runtimehooks/rule/rule.go
@@ -37,7 +37,7 @@ type Rule struct {
 }
 
 type ParseRuleFn func(interface{}) (bool, error)
-type UpdateCbFn func(pods []*statesinformer.PodMeta) error
+type UpdateCbFn func(target *statesinformer.CallbackTarget) error
 type SysSupportFn func() bool
 
 var globalHookRules map[string]*Rule
@@ -56,9 +56,9 @@ func Register(name, description string, injectOpts ...InjectOption) *Rule {
 	return r
 }
 
-func (r *Rule) runUpdateCallbacks(pods []*statesinformer.PodMeta) {
+func (r *Rule) runUpdateCallbacks(target *statesinformer.CallbackTarget) {
 	for _, callbackFn := range r.callbacks {
-		if err := callbackFn(pods); err != nil {
+		if err := callbackFn(target); err != nil {
 			cbName := runtime.FuncForPC(reflect.ValueOf(callbackFn).Pointer()).Name()
 			klog.Warningf("executing %s callback function %s failed, error %v", r.name, cbName)
 		}
@@ -76,7 +76,7 @@ func find(name string) (*Rule, bool) {
 	return newRule, false
 }
 
-func UpdateRules(ruleType statesinformer.RegisterType, ruleObj interface{}, podsMeta []*statesinformer.PodMeta) {
+func UpdateRules(ruleType statesinformer.RegisterType, ruleObj interface{}, targets *statesinformer.CallbackTarget) {
 	klog.V(4).Infof("applying %v rules with new %v, detail: %v",
 		len(globalHookRules), ruleType.String(), util.DumpJSON(ruleObj))
 	for _, r := range globalHookRules {
@@ -96,8 +96,9 @@ func UpdateRules(ruleType statesinformer.RegisterType, ruleObj interface{}, pods
 			continue
 		}
 		if updated {
-			klog.V(3).Infof("rule %s is updated, run update callback for all %v pods", r.name, len(podsMeta))
-			r.runUpdateCallbacks(podsMeta)
+			klog.V(3).Infof("rule %s is updated, run update callback for all %v pods and %v host applications",
+				r.name, len(targets.Pods), len(targets.HostApplications))
+			r.runUpdateCallbacks(targets)
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/runtimehooks_test.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks_test.go
@@ -19,6 +19,7 @@ package runtimehooks
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,7 @@ func Test_runtimeHook_Run(t *testing.T) {
 					RuntimeHookDisableStages:        []string{"PreRunPodSandbox"},
 					RuntimeHookConfigFilePath:       tmpDir,
 					RuntimeHooksNRI:                 true,
+					RuntimeHookReconcileInterval:    time.Second,
 				},
 				fg: map[string]bool{
 					string(GroupIdentity):   false,
@@ -72,6 +74,7 @@ func Test_runtimeHook_Run(t *testing.T) {
 					RuntimeHookDisableStages:        []string{"PreRunPodSandbox"},
 					RuntimeHookConfigFilePath:       tmpDir,
 					RuntimeHooksNRI:                 true,
+					RuntimeHookReconcileInterval:    time.Second,
 				},
 				fg: map[string]bool{
 					string(GroupIdentity):   false,
@@ -94,6 +97,7 @@ func Test_runtimeHook_Run(t *testing.T) {
 					RuntimeHookDisableStages:        []string{"PreRunPodSandbox"},
 					RuntimeHookConfigFilePath:       tmpDir,
 					RuntimeHooksNRI:                 true,
+					RuntimeHookReconcileInterval:    time.Second,
 				},
 				fg: map[string]bool{
 					string(GroupIdentity):   true,
@@ -117,7 +121,9 @@ func Test_runtimeHook_Run(t *testing.T) {
 			stop := make(chan struct{})
 
 			go func() { close(stop) }()
-			err = r.Run(stop)
+			assert.NotPanics(t, func() {
+				err = r.Run(stop)
+			})
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/koordlet/statesinformer/api.go
+++ b/pkg/koordlet/statesinformer/api.go
@@ -70,13 +70,17 @@ func (r RegisterType) String() string {
 		return "RegisterTypeNodeTopology"
 	case RegisterTypeNodeMetadata:
 		return "RegisterNodeMetadata"
-
 	default:
 		return "RegisterTypeUnknown"
 	}
 }
 
-type UpdateCbFn func(t RegisterType, obj interface{}, pods []*PodMeta)
+type CallbackTarget struct {
+	Pods             []*PodMeta
+	HostApplications []slov1alpha1.HostApplicationSpec
+}
+
+type UpdateCbFn func(t RegisterType, obj interface{}, target *CallbackTarget)
 
 type StatesInformer interface {
 	Run(stopCh <-chan struct{}) error

--- a/pkg/koordlet/statesinformer/impl/callback_runner.go
+++ b/pkg/koordlet/statesinformer/impl/callback_runner.go
@@ -95,10 +95,15 @@ func (s *callbackRunner) runCallbacks(objType statesinformer.RegisterType, obj i
 		klog.Errorf("states informer callbacks type %v not exist", objType.String())
 		return
 	}
-	pods := s.statesInformer.GetAllPods()
+	callbackTarget := &statesinformer.CallbackTarget{
+		Pods: s.statesInformer.GetAllPods(),
+	}
+	if nodeSLO := s.statesInformer.GetNodeSLO(); nodeSLO != nil {
+		callbackTarget.HostApplications = nodeSLO.Spec.HostApplications
+	}
 	for _, c := range callbacks {
 		klog.V(5).Infof("start running callback function %v for type %v", c.name, objType.String())
-		c.fn(objType, obj, pods)
+		c.fn(objType, obj, callbackTarget)
 	}
 }
 

--- a/pkg/koordlet/statesinformer/impl/callback_runner_test.go
+++ b/pkg/koordlet/statesinformer/impl/callback_runner_test.go
@@ -33,9 +33,13 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 		name        string
 		description string
 	}
+	type wants struct {
+		callbackRunSucceec bool
+	}
 	tests := []struct {
-		name string
-		args args
+		name  string
+		args  args
+		wants wants
 	}{
 		{
 			name: "register RegisterTypeNodeSLOSpec and run",
@@ -43,6 +47,9 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 				objType:     statesinformer.RegisterTypeNodeSLOSpec,
 				name:        "set-bool-var",
 				description: "set test bool var as true",
+			},
+			wants: wants{
+				callbackRunSucceec: true,
 			},
 		},
 		{
@@ -52,6 +59,9 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 				name:        "set-bool-var",
 				description: "set test bool var as true",
 			},
+			wants: wants{
+				callbackRunSucceec: true,
+			},
 		},
 		{
 			name: "register RegisterTypeNodeSLOSpec and run",
@@ -60,12 +70,15 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 				name:        "set-bool-var",
 				description: "set test bool var as true",
 			},
+			wants: wants{
+				callbackRunSucceec: true,
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testVar := pointer.Bool(false)
-			callbackFn := func(t statesinformer.RegisterType, obj interface{}, pods []*statesinformer.PodMeta) {
+			callbackFn := func(t statesinformer.RegisterType, obj interface{}, target *statesinformer.CallbackTarget) {
 				*testVar = true
 			}
 			si := &callbackRunner{
@@ -90,7 +103,7 @@ func TestRegisterCallbacksAndRun(t *testing.T) {
 			si.RegisterCallbacks(tt.args.objType, tt.args.name, tt.args.description, callbackFn)
 			si.getObjByType(tt.args.objType, UpdateCbCtx{})
 			si.runCallbacks(tt.args.objType, &slov1alpha1.NodeSLO{})
-			assert.Equal(t, *testVar, true)
+			assert.Equal(t, *testVar, tt.wants.callbackRunSucceec)
 		})
 	}
 }
@@ -124,7 +137,7 @@ func Test_statesInformer_startCallbackRunners(t *testing.T) {
 				nodeSLO:     nodeSLO,
 				name:        "get value from node slo label",
 				description: "get value from node slo label",
-				fn: func(t statesinformer.RegisterType, obj interface{}, pods []*statesinformer.PodMeta) {
+				fn: func(t statesinformer.RegisterType, obj interface{}, target *statesinformer.CallbackTarget) {
 					output <- nodeSLO.Labels["test-label-key"]
 					stopCh <- struct{}{}
 				},

--- a/pkg/slo-controller/nodeslo/nodeslo_controller.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_controller.go
@@ -107,6 +107,14 @@ func (r *NodeSLOReconciler) getNodeSLOSpec(node *corev1.Node, oldSpec *slov1alph
 		metrics.RecordNodeSLOSpecParseCount(true, "getSystemConfigSpec")
 	}
 
+	nodeSLOSpec.HostApplications, err = getHostApplicationConfig(node, &sloCfg.HostAppCfgMerged)
+	if err != nil {
+		metrics.RecordNodeSLOSpecParseCount(false, "getHostApplicationConfig")
+		klog.Warningf("getHostApplicationConfig(): failed to get hostApplicationConfig spec for node %s,error: %v", node.Name, err)
+	} else {
+		metrics.RecordNodeSLOSpecParseCount(true, "getHostApplicationConfig")
+	}
+
 	nodeSLOSpec.Extensions = getExtensionsConfigSpec(node, oldSpec, &sloCfg.ExtensionCfgMerged)
 
 	return nodeSLOSpec, nil
@@ -119,7 +127,7 @@ func (r *NodeSLOReconciler) getNodeSLOSpec(node *corev1.Node, oldSpec *slov1alph
 
 func (r *NodeSLOReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// reconcile for 2 things:
-	//   1. ensuring the NodeSLO exists iff the Node exists
+	//   1. ensuring the NodeSLO exists if the Node exists
 	//   2. update NodeSLO Spec
 	_ = log.FromContext(ctx, "node-slo-reconciler", req.NamespacedName)
 

--- a/pkg/slo-controller/nodeslo/nodeslo_controller_test.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_controller_test.go
@@ -114,6 +114,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 				ResourceQOSStrategy:         &slov1alpha1.ResourceQOSStrategy{},
 				CPUBurstStrategy:            sloconfig.DefaultCPUBurstStrategy(),
 				SystemStrategy:              sloconfig.DefaultSystemStrategy(),
+				HostApplications:            []slov1alpha1.HostApplicationSpec{},
 				Extensions:                  testingExtensions,
 			},
 			wantErr: false,
@@ -143,6 +144,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 				ResourceQOSStrategy:         &slov1alpha1.ResourceQOSStrategy{},
 				CPUBurstStrategy:            sloconfig.DefaultCPUBurstStrategy(),
 				SystemStrategy:              sloconfig.DefaultSystemStrategy(),
+				HostApplications:            []slov1alpha1.HostApplicationSpec{},
 				Extensions:                  testingExtensions,
 			},
 			wantErr: false,
@@ -171,6 +173,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 				ResourceQOSStrategy:         &slov1alpha1.ResourceQOSStrategy{},
 				CPUBurstStrategy:            sloconfig.DefaultCPUBurstStrategy(),
 				SystemStrategy:              sloconfig.DefaultSystemStrategy(),
+				HostApplications:            []slov1alpha1.HostApplicationSpec{},
 				Extensions:                  testingExtensions,
 			},
 			wantErr: false,
@@ -210,6 +213,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 				ResourceQOSStrategy:         testingResourceQOSStrategy,
 				CPUBurstStrategy:            sloconfig.DefaultCPUBurstStrategy(),
 				SystemStrategy:              sloconfig.DefaultSystemStrategy(),
+				HostApplications:            []slov1alpha1.HostApplicationSpec{},
 				Extensions:                  testingExtensions,
 			},
 			wantErr: false,
@@ -249,6 +253,7 @@ func TestNodeSLOReconciler_initNodeSLO(t *testing.T) {
 				ResourceQOSStrategy:         testingResourceQOSStrategyOld,
 				CPUBurstStrategy:            sloconfig.DefaultCPUBurstStrategy(),
 				SystemStrategy:              sloconfig.DefaultSystemStrategy(),
+				HostApplications:            []slov1alpha1.HostApplicationSpec{},
 				Extensions:                  testingExtensions,
 			},
 			wantErr: false,
@@ -314,8 +319,9 @@ func TestNodeSLOReconciler_Reconcile(t *testing.T) {
   }
 }
 `,
-			configuration.CPUBurstConfigKey: "{\"clusterStrategy\":{\"cfsQuotaBurstPeriodSeconds\":60}}",
-			configuration.SystemConfigKey:   "{\"clusterStrategy\":{\"minFreeKbytesFactor\":150,\"watermarkScaleFactor\":150}}",
+			configuration.CPUBurstConfigKey:        "{\"clusterStrategy\":{\"cfsQuotaBurstPeriodSeconds\":60}}",
+			configuration.SystemConfigKey:          "{\"clusterStrategy\":{\"minFreeKbytesFactor\":150,\"watermarkScaleFactor\":150}}",
+			configuration.HostApplicationConfigKey: "{\"applications\": [{\"name\": \"test-app\"}]}",
 		},
 	}
 	testingResourceThresholdStrategy := sloconfig.DefaultResourceThresholdStrategy()
@@ -337,6 +343,12 @@ func TestNodeSLOReconciler_Reconcile(t *testing.T) {
 	testingSystemStrategy := sloconfig.DefaultSystemStrategy()
 	testingSystemStrategy.MinFreeKbytesFactor = pointer.Int64(150)
 
+	testingHostApplication := []slov1alpha1.HostApplicationSpec{
+		{
+			Name: "test-app",
+		},
+	}
+
 	testingExtensionsMap := *getDefaultExtensionStrategy()
 	testingExtensionsIfMap, err := getExtensionsIfMap(testingExtensionsMap)
 	if err != nil {
@@ -348,6 +360,7 @@ func TestNodeSLOReconciler_Reconcile(t *testing.T) {
 		ResourceQOSStrategy:         testingResourceQOSStrategy,
 		CPUBurstStrategy:            testingCPUBurstStrategy,
 		SystemStrategy:              testingSystemStrategy,
+		HostApplications:            testingHostApplication,
 		Extensions:                  testingExtensionsIfMap,
 	}
 	nodeReq := ctrl.Request{NamespacedName: types.NamespacedName{Name: testingNode.Name}}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Support QoS parameters setting for host application.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
https://github.com/koordinator-sh/koordinator/issues/1639

### Ⅲ. Describe how to verify it

1. create configmap with the followings:

```yaml
apiVersion: v1
data:
  colocation-config: |
    {
      "enable": true
    }
  host-application-config: |
    {
      "applications": [
        {
          "name": "nginx",
          "priority": "koord-prod",
          "qos": "LS",
          "cgroupPath": {
            "base": "CgroupRoot",
            "parentDir": "host-latency-sensitive/",
            "relativePath": "nginx/"
          }
        }
      ]
    }
  resource-qos-config: |
    {
      "clusterStrategy": {
        "lsClass": {
          "cpuQOS": {
            "enable": true,
            "groupIdentity": 2
          }
        },
        "beClass": {
          "cpuQOS": {
            "enable": true,
            "groupIdentity": -1
          }
        }
      }
    }
kind: ConfigMap
metadata:
  name: slo-controller-config
  namespace: koordinator-system
```

2. run processes under `/sys/fs/cgroup/cpu/host-latency-sensitive/nginx/` and `/sys/fs/cgroup/cpuset/host-latency-sensitive/nginx/` group
cpuset.cpus and cpuset.mems must be pre set

3. the content of `/sys/fs/cgroup/cpu/host-latency-sensitive/nginx/cpu.bvt_warp_ns` should be 2, and the content of `/sys/fs/cgroup/cpuset/host-latency-sensitive/nginx/` should be equal to cpushare pool


### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
