### PR TITLE
koordlet: revise BECPUEvict, RdtResctrl, CPUSetAllocator and system collector

### DIFF
--- a/apis/slo/v1alpha1/nodeslo_types.go
+++ b/apis/slo/v1alpha1/nodeslo_types.go
@@ -209,6 +209,13 @@ const (
 	CPUCfsQuotaPolicy CPUSuppressPolicy = "cfsQuota"
 )
 
+type CPUEvictPolicy string
+
+const (
+	EvictByRealLimitPolicy   CPUEvictPolicy = "evictByRealLimit"
+	EvictByAllocatablePolicy CPUEvictPolicy = "evictByAllocatable"
+)
+
 type ResourceThresholdStrategy struct {
 	// whether the strategy is enabled, default = false
 	Enable *bool `json:"enable,omitempty"`
@@ -241,6 +248,9 @@ type ResourceThresholdStrategy struct {
 	// when avg(cpuusage) > CPUEvictThresholdPercent, will start to evict pod by cpu,
 	// and avg(cpuusage) is calculated based on the most recent CPUEvictTimeWindowSeconds data
 	CPUEvictTimeWindowSeconds *int64 `json:"cpuEvictTimeWindowSeconds,omitempty" validate:"omitempty,gt=0"`
+	// CPUEvictPolicy defines the policy for the BECPUEvict feature.
+	// Default: `evictByRealLimit`.
+	CPUEvictPolicy CPUEvictPolicy `json:"cpuEvictPolicy,omitempty"`
 }
 
 // ResctrlQOSCfg stores node-level config of resctrl qos

--- a/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
@@ -1181,6 +1181,10 @@ spec:
                       then start to calculate the resources need to be released.
                     format: int64
                     type: integer
+                  cpuEvictPolicy:
+                    description: 'CPUEvictPolicy defines the policy for the BECPUEvict
+                      feature. Default: `evictByRealLimit`.'
+                    type: string
                   cpuEvictTimeWindowSeconds:
                     description: when avg(cpuusage) > CPUEvictThresholdPercent, will
                       start to evict pod by cpu, and avg(cpuusage) is calculated based

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
@@ -73,7 +73,7 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 			name: "node metric outdated",
 			fields: fields{
 				nodeUsage: &usageField{
-					ts:     timeNow().Add(-config.CollectResUsedInterval * metricOutdatedIntervalRatio * 2),
+					ts:     timeNow().Add(-config.CollectSysMetricOutdatedInterval * 2),
 					cpu:    1,
 					memory: 1024,
 				},
@@ -97,7 +97,7 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 				},
 				podUsage: map[string]usageField{
 					"test-collector": {
-						ts:     timeNow().Add(-config.CollectResUsedInterval * metricOutdatedIntervalRatio * 2),
+						ts:     timeNow().Add(-config.CollectSysMetricOutdatedInterval * 2),
 						cpu:    0.5,
 						memory: 512,
 					},
@@ -185,7 +185,7 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 			}
 			s.collectSysResUsed()
 
-			querier, err := metricCache.Querier(timeNow().Add(-s.collectInterval*metricOutdatedIntervalRatio), timeNow())
+			querier, err := metricCache.Querier(timeNow().Add(-s.outdatedInterval), timeNow())
 			assert.NoError(t, err)
 
 			cpuResult, err := testQuery(querier, metriccache.SystemCPUUsageMetric, nil)

--- a/pkg/koordlet/metricsadvisor/framework/config.go
+++ b/pkg/koordlet/metricsadvisor/framework/config.go
@@ -27,27 +27,30 @@ const (
 )
 
 type Config struct {
-	CollectResUsedInterval         time.Duration
-	CollectNodeCPUInfoInterval     time.Duration
-	CollectNodeStorageInfoInterval time.Duration
-	CPICollectorInterval           time.Duration
-	PSICollectorInterval           time.Duration
-	CPICollectorTimeWindow         time.Duration
+	CollectResUsedInterval           time.Duration
+	CollectSysMetricOutdatedInterval time.Duration
+	CollectNodeCPUInfoInterval       time.Duration
+	CollectNodeStorageInfoInterval   time.Duration
+	CPICollectorInterval             time.Duration
+	PSICollectorInterval             time.Duration
+	CPICollectorTimeWindow           time.Duration
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		CollectResUsedInterval:         1 * time.Second,
-		CollectNodeCPUInfoInterval:     60 * time.Second,
-		CollectNodeStorageInfoInterval: 1 * time.Second,
-		CPICollectorInterval:           60 * time.Second,
-		PSICollectorInterval:           10 * time.Second,
-		CPICollectorTimeWindow:         10 * time.Second,
+		CollectResUsedInterval:           1 * time.Second,
+		CollectSysMetricOutdatedInterval: 10 * time.Second,
+		CollectNodeCPUInfoInterval:       60 * time.Second,
+		CollectNodeStorageInfoInterval:   1 * time.Second,
+		CPICollectorInterval:             60 * time.Second,
+		PSICollectorInterval:             10 * time.Second,
+		CPICollectorTimeWindow:           10 * time.Second,
 	}
 }
 
 func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.CollectResUsedInterval, "collect-res-used-interval", c.CollectResUsedInterval, "Collect node/pod resource usage interval. Minimum interval is 1 second. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
+	fs.DurationVar(&c.CollectSysMetricOutdatedInterval, "collect-sys-metric-outdated-interval", c.CollectSysMetricOutdatedInterval, "Collecy system metrics outdated interval. Node or pods metrics whose timestamps are before the interval will be ignored.")
 	fs.DurationVar(&c.CollectNodeCPUInfoInterval, "collect-node-cpu-info-interval", c.CollectNodeCPUInfoInterval, "Collect node cpu info interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.DurationVar(&c.CollectNodeStorageInfoInterval, "collect-node-storage-info-interval", c.CollectNodeStorageInfoInterval, "Collect node storage info interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.DurationVar(&c.CPICollectorInterval, "cpi-collector-interval", c.CPICollectorInterval, "Collect cpi interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")

--- a/pkg/koordlet/metricsadvisor/framework/config_test.go
+++ b/pkg/koordlet/metricsadvisor/framework/config_test.go
@@ -26,12 +26,13 @@ import (
 
 func Test_NewDefaultConfig(t *testing.T) {
 	expectConfig := &Config{
-		CollectResUsedInterval:         1 * time.Second,
-		CollectNodeCPUInfoInterval:     60 * time.Second,
-		CollectNodeStorageInfoInterval: 1 * time.Second,
-		CPICollectorInterval:           60 * time.Second,
-		PSICollectorInterval:           10 * time.Second,
-		CPICollectorTimeWindow:         10 * time.Second,
+		CollectResUsedInterval:           1 * time.Second,
+		CollectSysMetricOutdatedInterval: 10 * time.Second,
+		CollectNodeCPUInfoInterval:       60 * time.Second,
+		CollectNodeStorageInfoInterval:   1 * time.Second,
+		CPICollectorInterval:             60 * time.Second,
+		PSICollectorInterval:             10 * time.Second,
+		CPICollectorTimeWindow:           10 * time.Second,
 	}
 	defaultConfig := NewDefaultConfig()
 	assert.Equal(t, expectConfig, defaultConfig)
@@ -41,6 +42,7 @@ func Test_InitFlags(t *testing.T) {
 	cmdArgs := []string{
 		"",
 		"--collect-res-used-interval=3s",
+		"--collect-sys-metric-outdated-interval=9s",
 		"--collect-node-cpu-info-interval=90s",
 		"--collect-node-storage-info-interval=4s",
 		"--cpi-collector-interval=90s",
@@ -50,12 +52,13 @@ func Test_InitFlags(t *testing.T) {
 	fs := flag.NewFlagSet(cmdArgs[0], flag.ExitOnError)
 
 	type fields struct {
-		CollectResUsedInterval         time.Duration
-		CollectNodeCPUInfoInterval     time.Duration
-		CollectNodeStorageInfoInterval time.Duration
-		CPICollectorInterval           time.Duration
-		PSICollectorInterval           time.Duration
-		CPICollectorTimeWindow         time.Duration
+		CollectResUsedInterval           time.Duration
+		CollectSysMetricOutdatedInterval time.Duration
+		CollectNodeCPUInfoInterval       time.Duration
+		CollectNodeStorageInfoInterval   time.Duration
+		CPICollectorInterval             time.Duration
+		PSICollectorInterval             time.Duration
+		CPICollectorTimeWindow           time.Duration
 	}
 	type args struct {
 		fs *flag.FlagSet
@@ -68,12 +71,13 @@ func Test_InitFlags(t *testing.T) {
 		{
 			name: "not default",
 			fields: fields{
-				CollectResUsedInterval:         3 * time.Second,
-				CollectNodeCPUInfoInterval:     90 * time.Second,
-				CollectNodeStorageInfoInterval: 4 * time.Second,
-				CPICollectorInterval:           90 * time.Second,
-				PSICollectorInterval:           5 * time.Second,
-				CPICollectorTimeWindow:         15 * time.Second,
+				CollectResUsedInterval:           3 * time.Second,
+				CollectSysMetricOutdatedInterval: 9 * time.Second,
+				CollectNodeCPUInfoInterval:       90 * time.Second,
+				CollectNodeStorageInfoInterval:   4 * time.Second,
+				CPICollectorInterval:             90 * time.Second,
+				PSICollectorInterval:             5 * time.Second,
+				CPICollectorTimeWindow:           15 * time.Second,
 			},
 			args: args{fs: fs},
 		},
@@ -81,16 +85,18 @@ func Test_InitFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			raw := &Config{
-				CollectResUsedInterval:         tt.fields.CollectResUsedInterval,
-				CollectNodeCPUInfoInterval:     tt.fields.CollectNodeCPUInfoInterval,
-				CollectNodeStorageInfoInterval: tt.fields.CollectNodeStorageInfoInterval,
-				CPICollectorInterval:           tt.fields.CPICollectorInterval,
-				PSICollectorInterval:           tt.fields.PSICollectorInterval,
-				CPICollectorTimeWindow:         tt.fields.CPICollectorTimeWindow,
+				CollectResUsedInterval:           tt.fields.CollectResUsedInterval,
+				CollectSysMetricOutdatedInterval: tt.fields.CollectSysMetricOutdatedInterval,
+				CollectNodeCPUInfoInterval:       tt.fields.CollectNodeCPUInfoInterval,
+				CollectNodeStorageInfoInterval:   tt.fields.CollectNodeStorageInfoInterval,
+				CPICollectorInterval:             tt.fields.CPICollectorInterval,
+				PSICollectorInterval:             tt.fields.PSICollectorInterval,
+				CPICollectorTimeWindow:           tt.fields.CPICollectorTimeWindow,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)
-			tt.args.fs.Parse(cmdArgs[1:])
+			err := tt.args.fs.Parse(cmdArgs[1:])
+			assert.NoError(t, err)
 			assert.Equal(t, raw, c)
 		})
 	}

--- a/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile_test.go
+++ b/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile_test.go
@@ -457,6 +457,44 @@ func Test_getPodCgroupNewTaskIds(t *testing.T) {
 			},
 			want: []int32{122454, 123111, 128912},
 		},
+		{
+			name: "successfully get task ids from the sandbox container",
+			fields: fields{
+				containerParentDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podp0.slice/cri-containerd-abc.scope",
+				containerTasksStr:  "122450\n122454\n123111\n128912",
+				useCgroupsV2:       true,
+			},
+			args: args{
+				podMeta: &statesinformer.PodMeta{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod0",
+							UID:  "p0",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "container0",
+								},
+							},
+						},
+						Status: corev1.PodStatus{
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:        "container0",
+									ContainerID: "containerd://c0",
+								},
+							},
+						},
+					},
+					CgroupDir: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podp0.slice",
+				},
+				tasksMap: map[int32]struct{}{
+					122450: {},
+				},
+			},
+			want: []int32{122454, 123111, 128912},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/koordlet/qosmanager/qosmanager.go
+++ b/pkg/koordlet/qosmanager/qosmanager.go
@@ -113,7 +113,7 @@ func (r *qosManager) Run(stopCh <-chan struct{}) error {
 	}
 
 	for name, strategy := range r.context.Strategies {
-		klog.V(4).Infof("reaady to start qos strategy %v", name)
+		klog.V(4).Infof("ready to start qos strategy %v", name)
 		if !strategy.Enabled() {
 			klog.V(4).Infof("qos strategy %v is not enabled, skip running", name)
 			continue

--- a/pkg/koordlet/resourceexecutor/cgroup.go
+++ b/pkg/koordlet/resourceexecutor/cgroup.go
@@ -126,7 +126,7 @@ func cgroupFileRead(cgroupTaskDir string, r sysutil.Resource) (string, error) {
 	}
 
 	filePath := r.Path(cgroupTaskDir)
-	klog.V(5).Infof("read %s", filePath)
+	klog.V(6).Infof("read %s", filePath)
 
 	data, err := os.ReadFile(filePath)
 	return strings.Trim(string(data), "\n"), err
@@ -153,7 +153,7 @@ func readCgroupAndParseInt64(parentDir string, r sysutil.Resource) (int64, error
 func readCgroupAndParseUint64(parentDir string, r sysutil.Resource) (uint64, error) {
 	s, err := cgroupFileRead(parentDir, r)
 	if err != nil {
-		return 0, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return 0, err
 	}
 
 	// "max" means unlimited
@@ -173,7 +173,7 @@ func readCgroupAndParseUint64(parentDir string, r sysutil.Resource) (uint64, err
 func readCgroupAndParseInt32Slice(parentDir string, r sysutil.Resource) ([]int32, error) {
 	s, err := cgroupFileRead(parentDir, r)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 
 	// content: "%d\n%d\n%d\n..."

--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -101,7 +101,7 @@ func (r *CgroupV1Reader) ReadCPUSet(parentDir string) (*cpuset.CPUSet, error) {
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 
 	v, err := cpuset.Parse(s)
@@ -126,7 +126,7 @@ func (r *CgroupV1Reader) ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, err
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// content: "nr_periods 0\nnr_throttled 0\nthrottled_time 0\n..."
 	v, err := sysutil.ParseCPUStatRaw(s)
@@ -159,7 +159,7 @@ func (r *CgroupV1Reader) ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRa
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// content: `...total_inactive_anon $total_inactive_anon\ntotal_active_anon $total_active_anon\n
 	//           total_inactive_file $total_inactive_file\ntotal_active_file $total_active_file\n
@@ -178,7 +178,7 @@ func (r *CgroupV1Reader) ReadMemoryNumaStat(parentDir string) ([]sysutil.NumaMem
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// `total=42227 N0=42184 N1=...\nfile=40094 N0=40126 N1=...\nanon=2133 N0=2058 N1=...\nunevictable=0 N0=0\n...`
 	// the unit is page
@@ -229,7 +229,7 @@ func (r *CgroupV2Reader) ReadCPUPeriod(parentDir string) (int64, error) {
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return -1, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return -1, err
 	}
 
 	// content: "max 100000", "100000 100000"
@@ -263,7 +263,7 @@ func (r *CgroupV2Reader) ReadCPUSet(parentDir string) (*cpuset.CPUSet, error) {
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 
 	v, err := cpuset.Parse(s)
@@ -280,7 +280,7 @@ func (r *CgroupV2Reader) ReadCPUAcctUsage(parentDir string) (uint64, error) {
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return 0, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return 0, err
 	}
 	// content: "usage_usec 1000000\nuser_usec 800000\nsystem_usec 200000\n..."
 	v, err := sysutil.ParseCPUAcctUsageV2(s)
@@ -297,7 +297,7 @@ func (r *CgroupV2Reader) ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, err
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// content: "...\nnr_periods 0\nnr_throttled 0\nthrottled_usec 0\n..."
 	v, err := sysutil.ParseCPUStatRawV2(s)
@@ -322,7 +322,7 @@ func (r *CgroupV2Reader) ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRa
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// content: `anon 0\nfile 0\nkernel_stack 0\n...inactive_anon 0\nactive_anon 0\n...`
 	v, err := sysutil.ParseMemoryStatRawV2(s)
@@ -339,7 +339,7 @@ func (r *CgroupV2Reader) ReadMemoryNumaStat(parentDir string) ([]sysutil.NumaMem
 	}
 	s, err := cgroupFileRead(parentDir, resource)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read cgroup file, err: %v", err)
+		return nil, err
 	}
 	// `anon N0=193236992 N1=...\nfile N0=1367764992 N1=...`
 	// the unit is byte, 2Kbyte -> a page

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
@@ -618,6 +618,60 @@ func Test_reportNodeTopology(t *testing.T) {
 			},
 		},
 	}
+	oldZones1 := topologyv1alpha1.ZoneList{
+		{
+			Name: "fake-name",
+			Type: util.NodeZoneType,
+		},
+		{
+			Name: "node-0",
+			Type: util.NodeZoneType,
+			Resources: topologyv1alpha1.ResourceInfoList{
+				{
+					Name:        "cpu",
+					Capacity:    *resource.NewQuantity(2, resource.DecimalSI),
+					Allocatable: *resource.NewQuantity(2, resource.DecimalSI),
+					Available:   *resource.NewQuantity(2, resource.DecimalSI),
+				},
+				{
+					Name:        "gpu",
+					Capacity:    *resource.NewQuantity(1, resource.DecimalSI),
+					Allocatable: *resource.NewQuantity(1, resource.DecimalSI),
+					Available:   *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				{
+					Name:        "memory",
+					Capacity:    *resource.NewQuantity(269755191296, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(269755191296, resource.BinarySI),
+					Available:   *resource.NewQuantity(269755191296, resource.BinarySI),
+				},
+			},
+		},
+		{
+			Name: "node-1",
+			Type: util.NodeZoneType,
+			Resources: topologyv1alpha1.ResourceInfoList{
+				{
+					Name:        "cpu",
+					Capacity:    *resource.NewQuantity(2, resource.DecimalSI),
+					Allocatable: *resource.NewQuantity(2, resource.DecimalSI),
+					Available:   *resource.NewQuantity(2, resource.DecimalSI),
+				},
+				{
+					Name:        "gpu",
+					Capacity:    *resource.NewQuantity(1, resource.DecimalSI),
+					Allocatable: *resource.NewQuantity(1, resource.DecimalSI),
+					Available:   *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				{
+					Name:        "memory",
+					Capacity:    *resource.NewQuantity(269754368000, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(269754368000, resource.BinarySI),
+					Available:   *resource.NewQuantity(269754368000, resource.BinarySI),
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		name                            string
@@ -752,6 +806,31 @@ func Test_reportNodeTopology(t *testing.T) {
 				},
 			},
 			oldZoneList: &oldZones,
+			expectedKubeletCPUManagerPolicy: extension.KubeletCPUManagerPolicy{
+				Policy:       "static",
+				ReservedCPUs: "0-1",
+			},
+			expectedCPUBasicInfo:     string(expectedCPUBasicInfoBytes),
+			expectedCPUSharedPool:    expectedCPUSharedPool,
+			expectedBECPUSharedPool:  expectedBECPUSharedPool,
+			expectedCPUTopology:      expectedCPUTopology,
+			expectedNodeReservation:  "{}",
+			expectedSystemQOS:        "{}",
+			expectedTopologyPolicies: expectedTopologyPolices,
+			expectedZones:            mergedZones,
+		},
+		{
+			name:   "report topology and trim expired zone",
+			config: NewDefaultConfig(),
+			kubeletStub: &testKubeletStub{
+				config: &kubeletconfiginternal.KubeletConfiguration{
+					CPUManagerPolicy: "static",
+					KubeReserved: map[string]string{
+						"cpu": "2000m",
+					},
+				},
+			},
+			oldZoneList: &oldZones1,
 			expectedKubeletCPUManagerPolicy: extension.KubeletCPUManagerPolicy{
 				Policy:       "static",
 				ReservedCPUs: "0-1",

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
@@ -270,6 +270,7 @@ func Test_mergeSLOSpecResourceUsedThresholdWithBE(t *testing.T) {
 		CPUSuppressThresholdPercent: pointer.Int64(80),
 		MemoryEvictThresholdPercent: pointer.Int64(70),
 		CPUSuppressPolicy:           slov1alpha1.CPUSetPolicy,
+		CPUEvictPolicy:              slov1alpha1.EvictByRealLimitPolicy,
 	}
 	type args struct {
 		defaultSpec *slov1alpha1.ResourceThresholdStrategy
@@ -307,6 +308,7 @@ func Test_mergeSLOSpecResourceUsedThresholdWithBE(t *testing.T) {
 				CPUSuppressThresholdPercent: pointer.Int64(80),
 				MemoryEvictThresholdPercent: pointer.Int64(75),
 				CPUSuppressPolicy:           slov1alpha1.CPUSetPolicy,
+				CPUEvictPolicy:              slov1alpha1.EvictByRealLimitPolicy,
 			},
 		},
 		{

--- a/pkg/koordlet/util/cpuinfo.go
+++ b/pkg/koordlet/util/cpuinfo.go
@@ -136,6 +136,10 @@ func getCPUTurboEnabled() (bool, error) {
 	// TODO: In the current version, only intel cpu is collected turbo status. The other vendors' interfaces are not
 	//       supported yet. We may check the frequency in the future.
 	turboDisabledPath := system.GetSysIntelPStateNoTurboPath()
+	if !system.FileExists(turboDisabledPath) {
+		klog.V(5).Infof("abort to read %s, file not exist", turboDisabledPath)
+		return false, nil
+	}
 	out, err := os.ReadFile(turboDisabledPath)
 	if err == nil {
 		disabled, err := strconv.Atoi(strings.TrimSpace(strings.Trim(string(out), "\n")))

--- a/pkg/koordlet/util/system/resctrl_linux.go
+++ b/pkg/koordlet/util/system/resctrl_linux.go
@@ -26,6 +26,8 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+
+	"k8s.io/klog/v2"
 )
 
 // MountResctrlSubsystem mounts resctrl fs under the sysFSRoot to enable the kernel feature on supported environment
@@ -33,21 +35,21 @@ import (
 // features should be enabled in kernel configurations and kernel commandline.
 // For more info, please see https://github.com/intel/intel-cmt-cat/wiki/resctrl
 func MountResctrlSubsystem() (bool, error) {
-	schemataPath := GetResctrlSchemataFilePath("")
 	// use schemata path to check since the subsystem root dir could keep exist when unmounted
-	_, err := os.Stat(schemataPath)
+	err := CheckResctrlSchemataValid()
 	if err == nil {
 		return false, nil
 	}
+	klog.V(5).Infof("check resctrl schemata before mounted, err: %s", err)
 	subsystemPath := GetResctrlSubsystemDirPath()
 	err = syscall.Mount(ResctrlName, subsystemPath, ResctrlName, syscall.MS_RELATIME, "")
 	if err != nil {
 		return false, err
 	}
-	_, err = os.Stat(schemataPath)
+	err = CheckResctrlSchemataValid()
 	if err != nil {
-		return false, fmt.Errorf("resctrl subsystem is mounted, but path %s does not exist, err: %s",
-			subsystemPath, err)
+		return false, fmt.Errorf("resctrl subsystem %s is mounted, but schemata %s is still invalid, err: %s",
+			subsystemPath, ResctrlSchemata.Path(""), err)
 	}
 	return true, nil
 }

--- a/pkg/koordlet/util/system/util_test_tool.go
+++ b/pkg/koordlet/util/system/util_test_tool.go
@@ -19,7 +19,7 @@ package system
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -73,11 +73,12 @@ func NewFileTestUtil(t *testing.T) *FileTestUtil {
 	tempDir := t.TempDir()
 	HostSystemInfo.IsAnolisOS = true
 
-	Conf.ProcRootDir = path.Join(tempDir, "proc")
+	Conf.ProcRootDir = filepath.Join(tempDir, "proc")
 	err := os.MkdirAll(Conf.ProcRootDir, 0777)
 	assert.NoError(t, err)
 	Conf.CgroupRootDir = tempDir
 	Conf.SysRootDir = tempDir
+	Conf.SysFSRootDir = filepath.Join(tempDir, "fs")
 	Conf.VarRunRootDir = tempDir
 
 	initSupportConfigs()
@@ -119,7 +120,7 @@ func (c *FileTestUtil) SetValidateResource(enabled bool) {
 func (c *FileTestUtil) MkDirAll(testDir string) {
 	dir := testDir
 	if !strings.Contains(dir, c.TempDir) {
-		dir = path.Join(c.TempDir, testDir)
+		dir = filepath.Join(c.TempDir, testDir)
 	}
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		c.t.Fatal(err)
@@ -130,9 +131,9 @@ func (c *FileTestUtil) MkDirAll(testDir string) {
 func (c *FileTestUtil) CreateFile(testFilePath string) {
 	filePath := testFilePath
 	if !strings.Contains(filePath, c.TempDir) {
-		filePath = path.Join(c.TempDir, testFilePath)
+		filePath = filepath.Join(c.TempDir, testFilePath)
 	}
-	dir, _ := path.Split(filePath)
+	dir, _ := filepath.Split(filePath)
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		c.t.Fatal(err)
 	}
@@ -145,7 +146,7 @@ func (c *FileTestUtil) CreateFile(testFilePath string) {
 func (c *FileTestUtil) WriteFileContents(testFilePath, contents string) {
 	filePath := testFilePath
 	if !strings.Contains(filePath, c.TempDir) {
-		filePath = path.Join(c.TempDir, testFilePath)
+		filePath = filepath.Join(c.TempDir, testFilePath)
 	}
 	if !FileExists(filePath) {
 		c.CreateFile(testFilePath)
@@ -160,7 +161,7 @@ func (c *FileTestUtil) WriteFileContents(testFilePath, contents string) {
 func (c *FileTestUtil) ReadFileContents(testFilePath string) string {
 	filePath := testFilePath
 	if !strings.Contains(filePath, c.TempDir) {
-		filePath = path.Join(c.TempDir, testFilePath)
+		filePath = filepath.Join(c.TempDir, testFilePath)
 	}
 	contents, err := os.ReadFile(filePath)
 	if err != nil {
@@ -170,8 +171,8 @@ func (c *FileTestUtil) ReadFileContents(testFilePath string) string {
 }
 
 func (c *FileTestUtil) CreateProcSubFile(fileRelativePath string) {
-	file := path.Join(Conf.ProcRootDir, fileRelativePath)
-	dir, _ := path.Split(file)
+	file := filepath.Join(Conf.ProcRootDir, fileRelativePath)
+	dir, _ := filepath.Split(file)
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		c.t.Fatal(err)
 	}
@@ -181,7 +182,7 @@ func (c *FileTestUtil) CreateProcSubFile(fileRelativePath string) {
 }
 
 func (c *FileTestUtil) WriteProcSubFileContents(relativeFilePath string, contents string) {
-	file := path.Join(Conf.ProcRootDir, relativeFilePath)
+	file := filepath.Join(Conf.ProcRootDir, relativeFilePath)
 	if !FileExists(file) {
 		c.CreateProcSubFile(relativeFilePath)
 	}
@@ -192,7 +193,7 @@ func (c *FileTestUtil) WriteProcSubFileContents(relativeFilePath string, content
 }
 
 func (c *FileTestUtil) ReadProcSubFileContents(relativeFilePath string) string {
-	file := path.Join(Conf.ProcRootDir, relativeFilePath)
+	file := filepath.Join(Conf.ProcRootDir, relativeFilePath)
 	contents, err := os.ReadFile(file)
 	if err != nil {
 		c.t.Fatal(err)
@@ -205,7 +206,7 @@ func (c *FileTestUtil) CreateCgroupFile(taskDir string, r Resource) {
 	c.SetCgroupsV2(IsCgroupV2Resource(r))
 
 	filePath := GetCgroupFilePath(taskDir, r)
-	dir, _ := path.Split(filePath)
+	dir, _ := filepath.Split(filePath)
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		c.t.Fatal(err)
 	}

--- a/pkg/util/resource_test.go
+++ b/pkg/util/resource_test.go
@@ -474,3 +474,596 @@ func TestZoneListTransform(t *testing.T) {
 		})
 	}
 }
+
+func TestIsZoneListResourceEqual(t *testing.T) {
+	type args struct {
+		a v1alpha1.ZoneList
+		b v1alpha1.ZoneList
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "objects are equal",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "resources unchanged",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "target resources added",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "target resources removed",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "target resources changed",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("15Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "zone with target resources added",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "zone with target resources removed",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "resources changed",
+			args: args{
+				a: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("20"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				b: v1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("20"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "node-1",
+						Resources: v1alpha1.ResourceInfoList{
+							{
+								Name:        string(corev1.ResourceCPU),
+								Allocatable: resource.MustParse("10"),
+							},
+							{
+								Name:        string(corev1.ResourceMemory),
+								Allocatable: resource.MustParse("20Gi"),
+							},
+							{
+								Name:        "other-resource",
+								Allocatable: resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsZoneListResourceEqual(tt.args.a, tt.args.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/util/sloconfig/nodeslo_config.go
+++ b/pkg/util/sloconfig/nodeslo_config.go
@@ -54,6 +54,7 @@ func DefaultResourceThresholdStrategy() *slov1alpha1.ResourceThresholdStrategy {
 		CPUSuppressThresholdPercent: pointer.Int64(65),
 		CPUSuppressPolicy:           slov1alpha1.CPUSetPolicy,
 		MemoryEvictThresholdPercent: pointer.Int64(70),
+		CPUEvictPolicy:              slov1alpha1.EvictByRealLimitPolicy,
 	}
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

1. BECPUEvict: Support `evictByAllocatable` policy to calculate cpu satisfaction.
2. RdtResctrl: Support retrieve sandbox container's task IDs.
3. CPUSetAllocator: Fix the filters for qos=LS and qos=None pods.
4. SystemResourceCollector: Support a custom metric outdated interval.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
