### PR TITLE
koord-scheduler: NodeNUMAResource only consider allocatable when generating hints

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/plugin_service.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_service.go
@@ -80,7 +80,7 @@ func dumpNodeAllocation(nodeAllocation *NodeAllocation, topologyOptions Topology
 		resp.AllocatedPods = podAllocations
 	}
 	resp.AvailableCPUs, resp.AllocatedCPUs = nodeAllocation.getAvailableCPUs(topologyOptions.CPUTopology, topologyOptions.MaxRefCount, topologyOptions.ReservedCPUs, cpuset.CPUSet{})
-	availableResources, allocatedResource := nodeAllocation.getAvailableNUMANodeResources(topologyOptions)
+	availableResources, allocatedResource := nodeAllocation.getAvailableNUMANodeResources(topologyOptions, nil)
 	for nodeID, v := range availableResources {
 		resp.RemainingNUMANodeResources = append(resp.RemainingNUMANodeResources, NUMANodeResource{
 			Node:      nodeID,

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -678,7 +678,7 @@ func TestPlugin_Filter(t *testing.T) {
 				})
 
 				cpuManager := plg.resourceManager.(*resourceManager)
-				cpuManager.allocationStates[tt.allocationState.nodeName] = tt.allocationState
+				cpuManager.nodeAllocations[tt.allocationState.nodeName] = tt.allocationState
 			}
 
 			suit.start()
@@ -908,7 +908,7 @@ func TestPlugin_Score(t *testing.T) {
 			}
 
 			cpuManager := plg.resourceManager.(*resourceManager)
-			cpuManager.allocationStates[allocateState.nodeName] = allocateState
+			cpuManager.nodeAllocations[allocateState.nodeName] = allocateState
 
 			suit.start()
 
@@ -1129,7 +1129,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			}
 
 			cpuManager := plg.resourceManager.(*resourceManager)
-			cpuManager.allocationStates[nodeAllocation.nodeName] = nodeAllocation
+			cpuManager.nodeAllocations[nodeAllocation.nodeName] = nodeAllocation
 
 			suit.start()
 
@@ -1202,8 +1202,8 @@ func TestPlugin_Unreserve(t *testing.T) {
 	})
 	plg := &Plugin{
 		resourceManager: &resourceManager{
-			topologyManager:  topologyOptionsManager,
-			allocationStates: map[string]*NodeAllocation{},
+			topologyOptionsManager: topologyOptionsManager,
+			nodeAllocations:        map[string]*NodeAllocation{},
 		},
 	}
 	plg.resourceManager.Update("test-node-1", &PodAllocation{

--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
@@ -108,8 +108,8 @@ func TestPodEventHandler(t *testing.T) {
 				options.CPUTopology = cpuTopology
 			})
 			resourceManager := &resourceManager{
-				topologyManager:  topologyOptionsManager,
-				allocationStates: map[string]*NodeAllocation{},
+				topologyOptionsManager: topologyOptionsManager,
+				nodeAllocations:        map[string]*NodeAllocation{},
 			}
 			handler := &podEventHandler{
 				resourceManager: resourceManager,

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
@@ -358,6 +358,8 @@ func TestResourceManagerAllocate(t *testing.T) {
 					},
 				}
 			})
+			tt.options.topologyOptions = tom.GetTopologyOptions("test-node")
+
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The original implementation of GetPodTopologyHints of NodeNUMAResource provides special processing for CPU-binding scenarios, but this is actually problematic. For example, if a node has two NUMA Nodes, the most CPUs on each NUMA Node are allocated by CPUShare Pods. If we create a LSR Pod at this time, TopologyHint will still be generated, although the allocation will fail in the end. So we need to correct this implementation from the beginning.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
