### PR TITLE
koord-scheduler: revise NodeNUMAResource

### DIFF
--- a/apis/extension/numa_aware.go
+++ b/apis/extension/numa_aware.go
@@ -189,9 +189,7 @@ type KubeletCPUManagerPolicy struct {
 
 // GetResourceSpec parses ResourceSpec from annotations
 func GetResourceSpec(annotations map[string]string) (*ResourceSpec, error) {
-	resourceSpec := &ResourceSpec{
-		PreferredCPUBindPolicy: CPUBindPolicyDefault,
-	}
+	resourceSpec := &ResourceSpec{}
 	data, ok := annotations[AnnotationResourceSpec]
 	if !ok {
 		return resourceSpec, nil

--- a/pkg/scheduler/plugins/nodenumaresource/scoring.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring.go
@@ -71,8 +71,8 @@ func (p *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, po
 		return 0, nil
 	}
 
-	policyType := getNUMATopologyPolicy(node.Labels, topologyOptions.NUMATopologyPolicy)
-	if policyType != extension.NUMATopologyPolicyNone {
+	numaTopologyPolicy := getNUMATopologyPolicy(node.Labels, topologyOptions.NUMATopologyPolicy)
+	if numaTopologyPolicy != extension.NUMATopologyPolicyNone {
 		store := topologymanager.GetStore(cycleState)
 		affinity := store.GetAffinity(nodeName)
 		podAllocation, status := p.allocateByHint(ctx, cycleState, pod, nodeName, affinity, topologyOptions, false)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. Remove unused field of preFilterState.
2. Enhance the verification of Required FullPCPUs to reject non-multiple CPU requests under the SMT architecture.
3. The logic of updating ResourceSpec during PreBind supports the Required field. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
