### PR TITLE
Makefile: exit for macOS

### DIFF
--- a/hack/libpfm.sh
+++ b/hack/libpfm.sh
@@ -26,6 +26,7 @@ elif [ -f /etc/debian_version ]; then
         sudo apt-get -y install bash build-essential cmake wget
 elif [ $(uname) == "Darwin" ]; then
     echo "skip macOS"
+    exit 0
 else
     echo "failed to install c++ build tools and wget, please install them manually."
     exit 1


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Skip `libpfm4` installation in macOS.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes #1654 
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
`libpfm4` is not installed in macOS.
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
