### PR TITLE
koord-scheduler: NodeNUMAResource supports amplification ratios

### DIFF
--- a/apis/extension/node_resource_amplification_test.go
+++ b/apis/extension/node_resource_amplification_test.go
@@ -28,19 +28,19 @@ import (
 func TestGetNodeResourceAmplificationRatios(t *testing.T) {
 	tests := []struct {
 		name    string
-		arg     *corev1.Node
+		node    *corev1.Node
 		want    map[corev1.ResourceName]Ratio
 		wantErr bool
 	}{
 		{
 			name:    "node has no annotation",
-			arg:     &corev1.Node{},
+			node:    &corev1.Node{},
 			want:    nil,
 			wantErr: false,
 		},
 		{
 			name: "node has no resource amplification ratio annotation",
-			arg: &corev1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"xxx": "yyy",
@@ -52,7 +52,7 @@ func TestGetNodeResourceAmplificationRatios(t *testing.T) {
 		},
 		{
 			name: "node has valid resource amplification ratio annotation",
-			arg: &corev1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"xxx":                                    "yyy",
@@ -65,7 +65,7 @@ func TestGetNodeResourceAmplificationRatios(t *testing.T) {
 		},
 		{
 			name: "node has invalid resource amplification ratio annotation",
-			arg: &corev1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"xxx":                                    "yyy",
@@ -79,7 +79,7 @@ func TestGetNodeResourceAmplificationRatios(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotErr := GetNodeResourceAmplificationRatios(tt.arg)
+			got, gotErr := GetNodeResourceAmplificationRatios(tt.node.Annotations)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantErr, gotErr != nil)
 		})

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_service.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_service.go
@@ -53,6 +53,10 @@ func (p *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 			return
 		}
 		topologyOptions.NUMATopologyPolicy = getNUMATopologyPolicy(node.Labels, topologyOptions.NUMATopologyPolicy)
+		if err := amplifyNUMANodeResources(node, &topologyOptions); err != nil {
+			services.ResponseErrorMessage(c, http.StatusInternalServerError, "failed to amplify NUMANode Resources, err: %v", err)
+			return
+		}
 
 		nodeAllocation := p.resourceManager.GetNodeAllocation(nodeName)
 		if nodeAllocation == nil {

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
@@ -33,12 +33,13 @@ import (
 
 func TestResourceManagerAllocate(t *testing.T) {
 	tests := []struct {
-		name      string
-		pod       *corev1.Pod
-		options   *ResourceOptions
-		allocated *PodAllocation
-		want      *PodAllocation
-		wantErr   bool
+		name                string
+		pod                 *corev1.Pod
+		options             *ResourceOptions
+		amplificationRatios map[corev1.ResourceName]apiext.Ratio
+		allocated           *PodAllocation
+		want                *PodAllocation
+		wantErr             bool
 	}{
 		{
 			name: "allocate with non-existing resources in NUMA",
@@ -334,6 +335,146 @@ func TestResourceManagerAllocate(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs and amplified requests",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("6"),
+				},
+				originalRequests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			amplificationRatios: map[corev1.ResourceName]apiext.Ratio{
+				corev1.ResourceCPU: 1.5,
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0,2,4,6"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "allocate with required CPUBindPolicySpreadByPCPUs and allocated and amplified requests",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        true,
+				requiredCPUBindPolicy: true,
+				cpuBindPolicy:         schedulingconfig.CPUBindPolicySpreadByPCPUs,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("6"),
+				},
+				originalRequests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			amplificationRatios: map[corev1.ResourceName]apiext.Ratio{
+				corev1.ResourceCPU: 1.5,
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("1,3,5,7-104"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("48"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("52"),
+						},
+					},
+				},
+			},
+			want: &PodAllocation{
+				CPUSet: cpuset.MustParse("0,2,4,6"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed to allocate with CPU Share and allocated and amplified ratios",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        false,
+				requiredCPUBindPolicy: false,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				originalRequests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hint: topologymanager.NUMATopologyHint{
+					NUMANodeAffinity: func() bitmask.BitMask {
+						mask, _ := bitmask.NewBitMask(0)
+						return mask
+					}(),
+				},
+			},
+			amplificationRatios: map[corev1.ResourceName]apiext.Ratio{
+				corev1.ResourceCPU: 1.5,
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("0-49,52-101"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -371,10 +512,16 @@ func TestResourceManagerAllocate(t *testing.T) {
 					},
 				},
 			}
+			apiext.SetNodeResourceAmplificationRatios(node, tt.amplificationRatios)
 			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
 			if tt.allocated != nil {
 				resourceManager.Update(node.Name, tt.allocated)
 			}
+			if tt.options.originalRequests == nil {
+				tt.options.originalRequests = tt.options.requests.DeepCopy()
+			}
+			assert.NoError(t, amplifyNUMANodeResources(node, &tt.options.topologyOptions))
+
 			got, err := resourceManager.Allocate(node, tt.pod, tt.options)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v but got %v", tt.wantErr, err != nil)
@@ -386,12 +533,13 @@ func TestResourceManagerAllocate(t *testing.T) {
 
 func TestResourceManagerGetTopologyHint(t *testing.T) {
 	tests := []struct {
-		name      string
-		pod       *corev1.Pod
-		options   *ResourceOptions
-		allocated *PodAllocation
-		want      map[string][]topologymanager.NUMATopologyHint
-		wantErr   bool
+		name                string
+		pod                 *corev1.Pod
+		options             *ResourceOptions
+		amplificationRatios map[corev1.ResourceName]apiext.Ratio
+		allocated           *PodAllocation
+		want                map[string][]topologymanager.NUMATopologyHint
+		wantErr             bool
 	}{
 		{
 			name: "allocate with required CPUBindPolicyFullPCPUs",
@@ -679,6 +827,55 @@ func TestResourceManagerGetTopologyHint(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "failed to allocate with CPU Share and allocated and amplified ratios",
+			pod:  &corev1.Pod{},
+			options: &ResourceOptions{
+				numCPUsNeeded:         4,
+				requestCPUBind:        false,
+				requiredCPUBindPolicy: false,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				originalRequests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			amplificationRatios: map[corev1.ResourceName]apiext.Ratio{
+				corev1.ResourceCPU: 1.5,
+			},
+			allocated: &PodAllocation{
+				UID:       "123456",
+				Name:      "test-xxx",
+				Namespace: "default",
+				CPUSet:    cpuset.MustParse("0-49,52-101"),
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					},
+					{
+						Node: 1,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					},
+				},
+			},
+			want: map[string][]topologymanager.NUMATopologyHint{
+				string(corev1.ResourceCPU): {
+					{
+						NUMANodeAffinity: func() bitmask.BitMask {
+							mask, _ := bitmask.NewBitMask(0, 1)
+							return mask
+						}(),
+						Preferred: true,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -714,10 +911,19 @@ func TestResourceManagerGetTopologyHint(t *testing.T) {
 					},
 				},
 			}
+			apiext.SetNodeResourceAmplificationRatios(node, tt.amplificationRatios)
+
 			resourceManager := NewResourceManager(suit.Handle, schedulingconfig.NUMALeastAllocated, tom)
 			if tt.allocated != nil {
 				resourceManager.Update(node.Name, tt.allocated)
 			}
+			tt.options.topologyOptions = tom.GetTopologyOptions(node.Name)
+
+			if tt.options.originalRequests == nil {
+				tt.options.originalRequests = tt.options.requests.DeepCopy()
+			}
+			assert.NoError(t, amplifyNUMANodeResources(node, &tt.options.topologyOptions))
+
 			got, err := resourceManager.GetTopologyHints(node, tt.pod, tt.options)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v but got %v", tt.wantErr, err != nil)

--- a/pkg/scheduler/plugins/nodenumaresource/topology_options.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_options.go
@@ -38,12 +38,13 @@ type TopologyOptionsManager interface {
 }
 
 type TopologyOptions struct {
-	CPUTopology        *CPUTopology                       `json:"cpuTopology"`
-	ReservedCPUs       cpuset.CPUSet                      `json:"reservedCPUs"`
-	MaxRefCount        int                                `json:"maxRefCount"`
-	Policy             *extension.KubeletCPUManagerPolicy `json:"policy,omitempty"`
-	NUMATopologyPolicy extension.NUMATopologyPolicy       `json:"numaTopologyPolicy"`
-	NUMANodeResources  []NUMANodeResource                 `json:"numaNodeResources"`
+	CPUTopology         *CPUTopology                            `json:"cpuTopology"`
+	ReservedCPUs        cpuset.CPUSet                           `json:"reservedCPUs"`
+	MaxRefCount         int                                     `json:"maxRefCount"`
+	Policy              *extension.KubeletCPUManagerPolicy      `json:"policy,omitempty"`
+	NUMATopologyPolicy  extension.NUMATopologyPolicy            `json:"numaTopologyPolicy"`
+	NUMANodeResources   []NUMANodeResource                      `json:"numaNodeResources"`
+	AmplificationRatios map[corev1.ResourceName]extension.Ratio `json:"amplificationRatios,omitempty"`
 }
 
 type NUMANodeResource struct {
@@ -135,13 +136,19 @@ func NewTopologyOptions(nrt *nrtv1alpha1.NodeResourceTopology) TopologyOptions {
 	policy := convertToNUMATopologyPolicy(nrt)
 	numaNodeResources := extractNUMANodeResources(nrt)
 
+	amplificationRatios, err := extension.GetNodeResourceAmplificationRatios(nrt.Annotations)
+	if err != nil {
+		klog.Errorf("Failed to GetNodeResourceAmplificationRatios, name: %s, err: %v", nrt.Name, err)
+	}
+
 	return TopologyOptions{
-		CPUTopology:        cpuTopology,
-		ReservedCPUs:       reservedCPUs,
-		Policy:             kubeletPolicy,
-		MaxRefCount:        1,
-		NUMATopologyPolicy: policy,
-		NUMANodeResources:  numaNodeResources,
+		CPUTopology:         cpuTopology,
+		ReservedCPUs:        reservedCPUs,
+		Policy:              kubeletPolicy,
+		MaxRefCount:         1,
+		NUMATopologyPolicy:  policy,
+		NUMANodeResources:   numaNodeResources,
+		AmplificationRatios: amplificationRatios,
 	}
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The NodeNUMAResource plugin amplifies the resource per NUMA Node of NRT(BTW: later NodeResource controller supports amplification rations, we should remove the operation.), and amplify requests and allocated of CPU Bind Pod such as LSE/LSR, but once the pod scheduled, the resource-status just records the original requests. For example, One LSR Pod requests 4000m CPU,  and Node-A has amplification ratios such as { "cpu": 1.5 }, so the plugin amplified the requests to 6000m, but in the NUMA Node still allocated 4000m.  This is done because the amplification ratios change dynamically.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
