### PR TITLE
scheduler: use asynclog to reduce klog performance overhead

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -64,6 +64,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/defaultprofile"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/eventhandlers"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
+	"github.com/koordinator-sh/koordinator/pkg/util/asynclog"
 	utilroutes "github.com/koordinator-sh/koordinator/pkg/util/routes"
 	"github.com/koordinator-sh/koordinator/pkg/util/transformer"
 )
@@ -126,6 +127,9 @@ for cost reduction and efficiency enhancement.
 // runCommand runs the scheduler.
 func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Option) error {
 	verflag.PrintAndExitIfRequested()
+	if asynclog.EnableAsyncIfNeed() {
+		defer asynclog.FlushAndExit()
+	}
 
 	// Activate logging as soon as possible, after that
 	// show flags with the final logging configuration.
@@ -236,6 +240,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 					// We lost the lock.
 					klog.ErrorS(nil, "Leaderelection lost")
 					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+					asynclog.FlushAndExit()
 				}
 			},
 		}

--- a/pkg/util/asynclog/async_log.go
+++ b/pkg/util/asynclog/async_log.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asynclog
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+var (
+	enableAsync = pflag.Bool("async-log", false, "Enable asynchronous logging to improve performance. When enabling async-log, should enable logtostderr and disable alsologtostderr at the same time. By default, klog outputs logs synchronously to stderr, which will affect performance when there are too many logs.")
+	queueLength = pflag.Int("async-log-queue-length", 10000, "Control the log queue length to tune performance.")
+
+	globalOutput *output
+	once         sync.Once
+
+	dataPool = &sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(nil)
+		},
+	}
+)
+
+func EnableAsyncIfNeed() bool {
+	once.Do(func() {
+		if *enableAsync {
+			globalOutput = newOutput(*queueLength)
+			klog.SetOutput(globalOutput)
+			klog.LogToStderr(false)
+		}
+	})
+	return *enableAsync
+}
+
+func FlushAndExit() {
+	globalOutput.FlushAndExit()
+}
+
+type output struct {
+	w            io.Writer
+	logCh        chan *bytes.Buffer
+	quit         chan bool
+	shuttingDown int32
+}
+
+func newOutput(queueLength int) *output {
+	o := &output{
+		w:     os.Stderr,
+		logCh: make(chan *bytes.Buffer, queueLength),
+		quit:  make(chan bool),
+	}
+	go o.logger()
+	return o
+}
+
+func (o *output) logger() {
+	for {
+		select {
+		case <-o.quit:
+		drain:
+			for {
+				select {
+				case buff := <-o.logCh:
+					buff.WriteTo(o.w)
+				default:
+					break drain
+				}
+			}
+			close(o.quit)
+			return
+		case buff := <-o.logCh:
+			buff.WriteTo(o.w)
+			buff.Reset()
+			dataPool.Put(buff)
+		}
+	}
+}
+
+func (o *output) FlushAndExit() {
+	if atomic.CompareAndSwapInt32(&o.shuttingDown, 0, 1) {
+		o.quit <- true
+		<-o.quit
+	}
+}
+
+func (o *output) Write(data []byte) (int, error) {
+	if atomic.LoadInt32(&o.shuttingDown) == 1 {
+		<-o.quit
+		return o.w.Write(data)
+	}
+	// The data must be copied to a temporary buffer because the data may be reused
+	buff := dataPool.Get().(*bytes.Buffer)
+	buff.Write(data)
+	o.logCh <- buff
+	return len(data), nil
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

By default, klog outputs logs synchronously to stderr, which will affect performance when there are too many logs.
Therefore, we can reduce the delay caused by syscall and IO by outputting logs asynchronously, thus improving performance.

When enable `--async-log`,  also need to enable `-logtostderr` and disable `-alsologtostderr`. And also can set `--async-log-queue-length` to fine-tune performance.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
