### PR TITLE
scheduler: optimize reservation BeforePreFilter performance

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -108,3 +108,17 @@ func GetReservationAffinity(annotations map[string]string) (*ReservationAffinity
 	}
 	return &affinity, nil
 }
+
+func SetReservationAffinity(obj metav1.Object, affinity *ReservationAffinity) error {
+	data, err := json.Marshal(affinity)
+	if err != nil {
+		return err
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[AnnotationReservationAffinity] = string(data)
+	obj.SetAnnotations(annotations)
+	return nil
+}

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -120,7 +120,7 @@ type pluginTestSuit struct {
 	extenderFactory *frameworkext.FrameworkExtenderFactory
 }
 
-func newPluginTestSuitWith(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *pluginTestSuit {
+func newPluginTestSuitWith(t testing.TB, pods []*corev1.Pod, nodes []*corev1.Node) *pluginTestSuit {
 	var v1beta2args v1beta2.ReservationArgs
 	v1beta2.SetDefaults_ReservationArgs(&v1beta2args)
 	var reservationArgs config.ReservationArgs

--- a/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/utils/pointer"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+func BenchmarkBeforePrefilterWithMatchedPod(b *testing.B) {
+	var nodes []*corev1.Node
+	for i := 0; i < 1024; i++ {
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("64Gi"),
+				},
+			},
+		})
+	}
+	suit := newPluginTestSuitWith(b, nil, nodes)
+	p, err := suit.pluginFactory()
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	reservePods := map[string]*corev1.Pod{}
+	for i, node := range nodes {
+		reservation := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  uuid.NewUUID(),
+				Name: fmt.Sprintf("reservation-%d", i),
+				Labels: map[string]string{
+					"test-reservation": "true",
+				},
+			},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				AllocateOnce: pointer.Bool(false),
+				Owners: []schedulingv1alpha1.ReservationOwner{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"test-reservation": "true",
+							},
+						},
+					},
+				},
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("32"),
+										corev1.ResourceMemory: resource.MustParse("64Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{
+				Phase:    schedulingv1alpha1.ReservationAvailable,
+				NodeName: node.Name,
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("64Gi"),
+				},
+			},
+		}
+		pl.reservationCache.updateReservation(reservation)
+		nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(node.Name)
+		assert.NoError(b, err)
+		reservePod := reservationutil.NewReservePod(reservation)
+		reservePods[string(reservePod.UID)] = reservePod
+		nodeInfo.AddPod(reservePod)
+		assert.NoError(b, pl.handle.Scheduler().GetCache().AddPod(reservePod))
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test-reservation": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("32"),
+							corev1.ResourceMemory: resource.MustParse("64Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err = apiext.SetReservationAffinity(pod, &apiext.ReservationAffinity{
+		ReservationSelector: map[string]string{
+			"test-reservation": "true",
+		},
+	})
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, pod)
+		assert.True(b, restored)
+		assert.True(b, status.IsSuccess())
+
+		sd := getStateData(cycleState)
+		for _, v := range sd.nodeReservationStates {
+			nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(v.nodeName)
+			assert.NoError(b, err)
+			for _, ri := range v.matched {
+				p := reservePods[string(ri.UID())]
+				if p != nil {
+					nodeInfo.AddPod(p)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkBeforePrefilterWithUnmatchedPod(b *testing.B) {
+	var nodes []*corev1.Node
+	for i := 0; i < 1024; i++ {
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("64Gi"),
+				},
+			},
+		})
+	}
+	suit := newPluginTestSuitWith(b, nil, nodes)
+	p, err := suit.pluginFactory()
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i, node := range nodes {
+		reservation := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  uuid.NewUUID(),
+				Name: fmt.Sprintf("reservation-%d", i),
+				Labels: map[string]string{
+					"test-reservation": "true",
+				},
+			},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				AllocateOnce: pointer.Bool(false),
+				Owners: []schedulingv1alpha1.ReservationOwner{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"test-reservation": "true",
+							},
+						},
+					},
+				},
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("32"),
+										corev1.ResourceMemory: resource.MustParse("64Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{
+				Phase:    schedulingv1alpha1.ReservationAvailable,
+				NodeName: node.Name,
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("64Gi"),
+				},
+			},
+		}
+		pl.reservationCache.updateReservation(reservation)
+		assignedPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      fmt.Sprintf("pod-%s", reservation.Name),
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				NodeName: node.Name,
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("8Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		pl.reservationCache.updatePod(reservation.UID, nil, assignedPod)
+		nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(node.Name)
+		assert.NoError(b, err)
+		reservePod := reservationutil.NewReservePod(reservation)
+		nodeInfo.AddPod(reservePod)
+		nodeInfo.AddPod(assignedPod)
+		assert.NoError(b, pl.handle.Scheduler().GetCache().AddPod(reservePod))
+		assert.NoError(b, pl.handle.Scheduler().GetCache().AddPod(assignedPod))
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("32"),
+							corev1.ResourceMemory: resource.MustParse("64Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, pod)
+		assert.True(b, restored)
+		assert.True(b, status.IsSuccess())
+	}
+}

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -253,7 +253,7 @@ func TestGetReservationSchedulerName(t *testing.T) {
 	}
 }
 
-func Test_matchReservationOwners(t *testing.T) {
+func TestMatchReservationOwners(t *testing.T) {
 	type args struct {
 		pod *corev1.Pod
 		r   *schedulingv1alpha1.Reservation
@@ -434,7 +434,9 @@ func Test_matchReservationOwners(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MatchReservationOwners(tt.args.pod, tt.args.r.Spec.Owners)
+			matchers, err := ParseReservationOwnerMatchers(tt.args.r.Spec.Owners)
+			assert.NoError(t, err)
+			got := MatchReservationOwners(tt.args.pod, matchers)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Optimize plugin Reservation's BeforePreFilter performance.

```
goos: darwin
goarch: amd64
pkg: github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz

benchmark                                       old ns/op     new ns/op     delta
BenchmarkBeforePrefilterWithMatchedPod-12       7191996       3728866       -48.15%
BenchmarkBeforePrefilterWithMatchedPod-12       6965735       4111975       -40.97%
BenchmarkBeforePrefilterWithMatchedPod-12       7242072       3918338       -45.89%
BenchmarkBeforePrefilterWithMatchedPod-12       7099550       3754856       -47.11%
BenchmarkBeforePrefilterWithMatchedPod-12       7360839       3836024       -47.89%
BenchmarkBeforePrefilterWithMatchedPod-12       7233161       4295326       -40.62%
BenchmarkBeforePrefilterWithMatchedPod-12       7480983       4074013       -45.54%
BenchmarkBeforePrefilterWithMatchedPod-12       7236430       4320509       -40.30%
BenchmarkBeforePrefilterWithMatchedPod-12       6774842       4410080       -34.91%
BenchmarkBeforePrefilterWithMatchedPod-12       6926647       4682762       -32.39%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7741868       2451607       -68.33%
BenchmarkBeforePrefilterWithUnmatchedPod-12     8023967       2744553       -65.80%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7538820       2640237       -64.98%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7633984       2493778       -67.33%
BenchmarkBeforePrefilterWithUnmatchedPod-12     8053347       2841502       -64.72%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7839942       2779620       -64.55%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7826316       2923067       -62.65%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7310364       2461115       -66.33%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7578863       2605870       -65.62%
BenchmarkBeforePrefilterWithUnmatchedPod-12     7700427       2374196       -69.17%


                                   │   old.txt   │               new.txt               │
                                   │   sec/op    │   sec/op     vs base                │
BeforePrefilterWithMatchedPod-12     7.213m ± 4%   4.093m ± 8%  -43.25% (p=0.000 n=10)
BeforePrefilterWithUnmatchedPod-12   7.721m ± 4%   2.623m ± 8%  -66.03% (p=0.000 n=10)
geomean                              7.463m        3.277m       -56.09%

```

### Ⅱ. Does this pull request fix one issue?

fix #1696 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
