### PR TITLE
scheduler: make ReservationInfo.AddAssignedPod idempotent

### DIFF
--- a/pkg/scheduler/frameworkext/helper/forcesync_eventhandler.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_eventhandler.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 type forceSyncEventHandler struct {
@@ -64,6 +65,7 @@ func (h *forceSyncEventHandler) OnAdd(obj interface{}) {
 				return
 			}
 			delete(h.objects, objectUID)
+			klog.Warningf("Object %q has been updated multiple times in a short period of time", klog.KObj(objectMeta).String())
 		}
 	}
 	if h.handler != nil {

--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -295,6 +295,10 @@ func (ri *ReservationInfo) UpdatePod(pod *corev1.Pod) {
 }
 
 func (ri *ReservationInfo) AddAssignedPod(pod *corev1.Pod) {
+	if _, ok := ri.AssignedPods[pod.UID]; ok {
+		klog.Warningf("Repeatedly add assigned Pod %v in reservation %v, skip it.", klog.KObj(pod), klog.KObj(ri))
+		return
+	}
 	requirement := NewPodRequirement(pod)
 	ri.Allocated = quotav1.Add(ri.Allocated, quotav1.Mask(requirement.Requests, ri.ResourceNames))
 	ri.AllocatedPorts = util.AppendHostPorts(ri.AllocatedPorts, requirement.Ports)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When the scheduler starts, some Pods may be updated multiple times in a short period of time, causing the ReservationInfo to add the same Pod multiple times, and ultimately cannot be reused because the reservation's allocated is greater than or equal to the reservation's allocable.  

The root cause is that the forceSyncEventHandler of the frameworkext helper module requires that all EventHandlers must be idempotent.

So the PR fix the issue. Make the ReservationInfo method `AddAssignedPod` idempotent.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
