### PR TITLE
koordlet: fix metric name typo

### DIFF
--- a/pkg/koordlet/metrics/resource_summary.go
+++ b/pkg/koordlet/metrics/resource_summary.go
@@ -31,8 +31,8 @@ var (
 
 	NodeResourcePriorityReclaimable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KoordletSubsystem,
-		Name:      "node_priority_resource_allocatable",
-		Help:      "the node allocatable of different priority resources updated by koordinator",
+		Name:      "node_priority_resource_reclaimable",
+		Help:      "the node reclaimable of different priorities resources updated by koordinator",
 	}, []string{NodeKey, PriorityKey, ResourceKey, UnitKey})
 
 	ContainerResourceRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: fix the typo of the prom metric `koordlet_node_priority_resource_reclaimable`.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
