### PR TITLE
scheduler: reservation transformer ends early with reservation affinity

### DIFF
--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -129,6 +129,13 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			return
 		}
 
+		// The Pod declares a ReservationAffinity, which means that the Pod must reuse the Reservation resources,
+		// but there are no matching Reservations, which means that the node itself does not need to be processed.
+		// We can end early to avoid meaningless operations.
+		if reservationAffinity != nil && len(matched) == 0 {
+			return
+		}
+
 		if err := extender.Scheduler().GetCache().InvalidNodeInfo(node.Name); err != nil {
 			klog.ErrorS(err, "Failed to InvalidNodeInfo", "pod", klog.KObj(pod), "node", node.Name)
 			errCh.SendErrorWithCancel(err, cancel)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The Pod declares a ReservationAffinity, which means that the Pod must reuse the Reservation resources, but there are no matching Reservations, which means that the node itself does not need to be processed. We can end early to avoid meaningless operations.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
