### PR TITLE
apis: make PCIEID of DeviceTopology as string type

### DIFF
--- a/apis/scheduling/v1alpha1/device_types.go
+++ b/apis/scheduling/v1alpha1/device_types.go
@@ -56,19 +56,27 @@ type DeviceInfo struct {
 }
 
 type DeviceTopology struct {
-	SocketID int32  `json:"socketID"`
-	NodeID   int32  `json:"nodeID"`
-	PCIEID   int32  `json:"pcieID"`
-	BusID    string `json:"busID,omitempty"`
+	// SocketID is the ID of CPU Socket to which the device belongs
+	SocketID int32 `json:"socketID"`
+	// NodeID is the ID of NUMA Node to which the device belongs, it should be unique across different CPU Sockets
+	NodeID int32 `json:"nodeID"`
+	// PCIEID is the ID of PCIE Switch to which the device is connected, it should be unique across difference NUMANodes
+	PCIEID string `json:"pcieID"`
+	// BusID is the domain:bus:device.function formatted identifier of PCI/PCIE device
+	BusID string `json:"busID,omitempty"`
 }
 
 type VirtualFunctionGroup struct {
+	// Labels represents the Virtual Function properties that can be used to organize and categorize (scope and select) objects
 	Labels map[string]string `json:"labels,omitempty"`
-	VFs    []VirtualFunction `json:"vfs,omitempty"`
+	// VFs are the virtual function devices which belong to the group
+	VFs []VirtualFunction `json:"vfs,omitempty"`
 }
 
 type VirtualFunction struct {
-	Minor int32  `json:"minor"`
+	// Minor represents the Minor number of VirtualFunction, starting from 0, used to identify virtual function.
+	Minor int32 `json:"minor"`
+	// BusID is the domain:bus:device.function formatted identifier of PCI/PCIE virtual function device
 	BusID string `json:"busID,omitempty"`
 }
 

--- a/config/crd/bases/scheduling.koordinator.sh_devices.yaml
+++ b/config/crd/bases/scheduling.koordinator.sh_devices.yaml
@@ -73,14 +73,23 @@ spec:
                         the device
                       properties:
                         busID:
+                          description: BusID is the domain:bus:device.function formatted
+                            identifier of PCI/PCIE device
                           type: string
                         nodeID:
+                          description: NodeID is the ID of NUMA Node to which the
+                            device belongs, it should be unique across different CPU
+                            Sockets
                           format: int32
                           type: integer
                         pcieID:
-                          format: int32
-                          type: integer
+                          description: PCIEID is the ID of PCIE Switch to which the
+                            device is connected, it should be unique across difference
+                            NUMANodes
+                          type: string
                         socketID:
+                          description: SocketID is the ID of CPU Socket to which the
+                            device belongs
                           format: int32
                           type: integer
                       required:
@@ -98,13 +107,24 @@ spec:
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels represents the Virtual Function properties
+                              that can be used to organize and categorize (scope and
+                              select) objects
                             type: object
                           vfs:
+                            description: VFs are the virtual function devices which
+                              belong to the group
                             items:
                               properties:
                                 busID:
+                                  description: BusID is the domain:bus:device.function
+                                    formatted identifier of PCI/PCIE virtual function
+                                    device
                                   type: string
                                 minor:
+                                  description: Minor represents the Minor number of
+                                    VirtualFunction, starting from 0, used to identify
+                                    virtual function.
                                   format: int32
                                   type: integer
                               required:

--- a/config/crd/bases/slo.koordinator.sh_nodemetrics.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodemetrics.yaml
@@ -126,14 +126,23 @@ spec:
                                         information about the device
                                       properties:
                                         busID:
+                                          description: BusID is the domain:bus:device.function
+                                            formatted identifier of PCI/PCIE device
                                           type: string
                                         nodeID:
+                                          description: NodeID is the ID of NUMA Node
+                                            to which the device belongs, it should
+                                            be unique across different CPU Sockets
                                           format: int32
                                           type: integer
                                         pcieID:
-                                          format: int32
-                                          type: integer
+                                          description: PCIEID is the ID of PCIE Switch
+                                            to which the device is connected, it should
+                                            be unique across difference NUMANodes
+                                          type: string
                                         socketID:
+                                          description: SocketID is the ID of CPU Socket
+                                            to which the device belongs
                                           format: int32
                                           type: integer
                                       required:
@@ -152,13 +161,26 @@ spec:
                                           labels:
                                             additionalProperties:
                                               type: string
+                                            description: Labels represents the Virtual
+                                              Function properties that can be used
+                                              to organize and categorize (scope and
+                                              select) objects
                                             type: object
                                           vfs:
+                                            description: VFs are the virtual function
+                                              devices which belong to the group
                                             items:
                                               properties:
                                                 busID:
+                                                  description: BusID is the domain:bus:device.function
+                                                    formatted identifier of PCI/PCIE
+                                                    virtual function device
                                                   type: string
                                                 minor:
+                                                  description: Minor represents the
+                                                    Minor number of VirtualFunction,
+                                                    starting from 0, used to identify
+                                                    virtual function.
                                                   format: int32
                                                   type: integer
                                               required:
@@ -238,14 +260,23 @@ spec:
                                         information about the device
                                       properties:
                                         busID:
+                                          description: BusID is the domain:bus:device.function
+                                            formatted identifier of PCI/PCIE device
                                           type: string
                                         nodeID:
+                                          description: NodeID is the ID of NUMA Node
+                                            to which the device belongs, it should
+                                            be unique across different CPU Sockets
                                           format: int32
                                           type: integer
                                         pcieID:
-                                          format: int32
-                                          type: integer
+                                          description: PCIEID is the ID of PCIE Switch
+                                            to which the device is connected, it should
+                                            be unique across difference NUMANodes
+                                          type: string
                                         socketID:
+                                          description: SocketID is the ID of CPU Socket
+                                            to which the device belongs
                                           format: int32
                                           type: integer
                                       required:
@@ -264,13 +295,26 @@ spec:
                                           labels:
                                             additionalProperties:
                                               type: string
+                                            description: Labels represents the Virtual
+                                              Function properties that can be used
+                                              to organize and categorize (scope and
+                                              select) objects
                                             type: object
                                           vfs:
+                                            description: VFs are the virtual function
+                                              devices which belong to the group
                                             items:
                                               properties:
                                                 busID:
+                                                  description: BusID is the domain:bus:device.function
+                                                    formatted identifier of PCI/PCIE
+                                                    virtual function device
                                                   type: string
                                                 minor:
+                                                  description: Minor represents the
+                                                    Minor number of VirtualFunction,
+                                                    starting from 0, used to identify
+                                                    virtual function.
                                                   format: int32
                                                   type: integer
                                               required:
@@ -343,14 +387,23 @@ spec:
                                 about the device
                               properties:
                                 busID:
+                                  description: BusID is the domain:bus:device.function
+                                    formatted identifier of PCI/PCIE device
                                   type: string
                                 nodeID:
+                                  description: NodeID is the ID of NUMA Node to which
+                                    the device belongs, it should be unique across
+                                    different CPU Sockets
                                   format: int32
                                   type: integer
                                 pcieID:
-                                  format: int32
-                                  type: integer
+                                  description: PCIEID is the ID of PCIE Switch to
+                                    which the device is connected, it should be unique
+                                    across difference NUMANodes
+                                  type: string
                                 socketID:
+                                  description: SocketID is the ID of CPU Socket to
+                                    which the device belongs
                                   format: int32
                                   type: integer
                               required:
@@ -369,13 +422,24 @@ spec:
                                   labels:
                                     additionalProperties:
                                       type: string
+                                    description: Labels represents the Virtual Function
+                                      properties that can be used to organize and
+                                      categorize (scope and select) objects
                                     type: object
                                   vfs:
+                                    description: VFs are the virtual function devices
+                                      which belong to the group
                                     items:
                                       properties:
                                         busID:
+                                          description: BusID is the domain:bus:device.function
+                                            formatted identifier of PCI/PCIE virtual
+                                            function device
                                           type: string
                                         minor:
+                                          description: Minor represents the Minor
+                                            number of VirtualFunction, starting from
+                                            0, used to identify virtual function.
                                           format: int32
                                           type: integer
                                       required:
@@ -446,14 +510,23 @@ spec:
                                 about the device
                               properties:
                                 busID:
+                                  description: BusID is the domain:bus:device.function
+                                    formatted identifier of PCI/PCIE device
                                   type: string
                                 nodeID:
+                                  description: NodeID is the ID of NUMA Node to which
+                                    the device belongs, it should be unique across
+                                    different CPU Sockets
                                   format: int32
                                   type: integer
                                 pcieID:
-                                  format: int32
-                                  type: integer
+                                  description: PCIEID is the ID of PCIE Switch to
+                                    which the device is connected, it should be unique
+                                    across difference NUMANodes
+                                  type: string
                                 socketID:
+                                  description: SocketID is the ID of CPU Socket to
+                                    which the device belongs
                                   format: int32
                                   type: integer
                               required:
@@ -472,13 +545,24 @@ spec:
                                   labels:
                                     additionalProperties:
                                       type: string
+                                    description: Labels represents the Virtual Function
+                                      properties that can be used to organize and
+                                      categorize (scope and select) objects
                                     type: object
                                   vfs:
+                                    description: VFs are the virtual function devices
+                                      which belong to the group
                                     items:
                                       properties:
                                         busID:
+                                          description: BusID is the domain:bus:device.function
+                                            formatted identifier of PCI/PCIE virtual
+                                            function device
                                           type: string
                                         minor:
+                                          description: Minor represents the Minor
+                                            number of VirtualFunction, starting from
+                                            0, used to identify virtual function.
                                           format: int32
                                           type: integer
                                       required:
@@ -561,14 +645,23 @@ spec:
                                   about the device
                                 properties:
                                   busID:
+                                    description: BusID is the domain:bus:device.function
+                                      formatted identifier of PCI/PCIE device
                                     type: string
                                   nodeID:
+                                    description: NodeID is the ID of NUMA Node to
+                                      which the device belongs, it should be unique
+                                      across different CPU Sockets
                                     format: int32
                                     type: integer
                                   pcieID:
-                                    format: int32
-                                    type: integer
+                                    description: PCIEID is the ID of PCIE Switch to
+                                      which the device is connected, it should be
+                                      unique across difference NUMANodes
+                                    type: string
                                   socketID:
+                                    description: SocketID is the ID of CPU Socket
+                                      to which the device belongs
                                     format: int32
                                     type: integer
                                 required:
@@ -587,13 +680,24 @@ spec:
                                     labels:
                                       additionalProperties:
                                         type: string
+                                      description: Labels represents the Virtual Function
+                                        properties that can be used to organize and
+                                        categorize (scope and select) objects
                                       type: object
                                     vfs:
+                                      description: VFs are the virtual function devices
+                                        which belong to the group
                                       items:
                                         properties:
                                           busID:
+                                            description: BusID is the domain:bus:device.function
+                                              formatted identifier of PCI/PCIE virtual
+                                              function device
                                             type: string
                                           minor:
+                                            description: Minor represents the Minor
+                                              number of VirtualFunction, starting
+                                              from 0, used to identify virtual function.
                                             format: int32
                                             type: integer
                                         required:
@@ -669,14 +773,23 @@ spec:
                                 about the device
                               properties:
                                 busID:
+                                  description: BusID is the domain:bus:device.function
+                                    formatted identifier of PCI/PCIE device
                                   type: string
                                 nodeID:
+                                  description: NodeID is the ID of NUMA Node to which
+                                    the device belongs, it should be unique across
+                                    different CPU Sockets
                                   format: int32
                                   type: integer
                                 pcieID:
-                                  format: int32
-                                  type: integer
+                                  description: PCIEID is the ID of PCIE Switch to
+                                    which the device is connected, it should be unique
+                                    across difference NUMANodes
+                                  type: string
                                 socketID:
+                                  description: SocketID is the ID of CPU Socket to
+                                    which the device belongs
                                   format: int32
                                   type: integer
                               required:
@@ -695,13 +808,24 @@ spec:
                                   labels:
                                     additionalProperties:
                                       type: string
+                                    description: Labels represents the Virtual Function
+                                      properties that can be used to organize and
+                                      categorize (scope and select) objects
                                     type: object
                                   vfs:
+                                    description: VFs are the virtual function devices
+                                      which belong to the group
                                     items:
                                       properties:
                                         busID:
+                                          description: BusID is the domain:bus:device.function
+                                            formatted identifier of PCI/PCIE virtual
+                                            function device
                                           type: string
                                         minor:
+                                          description: Minor represents the Minor
+                                            number of VirtualFunction, starting from
+                                            0, used to identify virtual function.
                                           format: int32
                                           type: integer
                                       required:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Currently, DeviceInfo in Device CRD is insufficient for AI/Data Computing Scenarios. Some device such as NICs support SR-IOV virtualization. The DeviceInfo lack of such information. In addition, every pcie device has its own topology such as cpu socket, NUNANode, bdf and the pcie switch to which the device is connected.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
