### PR TITLE
descheduler: check nodemetrics cr is expired or not when descheduling

### DIFF
--- a/pkg/descheduler/apis/config/types_loadaware.go
+++ b/pkg/descheduler/apis/config/types_loadaware.go
@@ -40,6 +40,11 @@ type LowNodeLoadArgs struct {
 	// By default, NumberOfNodes is set to zero.
 	NumberOfNodes int32
 
+	// NodeMetricExpirationSeconds indicates the NodeMetric expiration in seconds.
+	// When NodeMetrics expired, the node is considered abnormal, and should not be considered by deschedule plugin.
+	// Default is 180 seconds.
+	NodeMetricExpirationSeconds *int64
+
 	// Naming this one differently since namespaces are still
 	// considered while considering resoures used by pods
 	// but then filtered out before eviction

--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	defaultMigrationControllerMaxConcurrentReconciles = 1
+	defaultMigrationControllerMaxConcurrentReconciles       = 1
+	defaultNodeMetricExpirationSeconds                int64 = 180
 
 	defaultMaxMigratingPerNode         = 2
 	defaultMigrationJobMode            = sev1alpha1.PodMigrationJobModeReservationFirst
@@ -261,6 +262,10 @@ func SetDefaults_LowNodeLoadArgs(obj *LowNodeLoadArgs) {
 		obj.AnomalyCondition = defaultLoadAnomalyCondition
 	} else if obj.AnomalyCondition.ConsecutiveAbnormalities == 0 {
 		obj.AnomalyCondition.ConsecutiveAbnormalities = defaultLoadAnomalyCondition.ConsecutiveAbnormalities
+	}
+
+	if obj.NodeMetricExpirationSeconds == nil {
+		obj.NodeMetricExpirationSeconds = pointer.Int64(defaultNodeMetricExpirationSeconds)
 	}
 
 	defaultResourceWeights := map[corev1.ResourceName]int64{

--- a/pkg/descheduler/apis/config/v1alpha2/defaults_test.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults_test.go
@@ -38,8 +38,9 @@ func TestSetDefaults_LowNodeLoadArgs(t *testing.T) {
 				NodeFit: pointer.Bool(false),
 			},
 			expected: &LowNodeLoadArgs{
-				NodeFit:          pointer.Bool(false),
-				AnomalyCondition: defaultLoadAnomalyCondition,
+				NodeFit:                     pointer.Bool(false),
+				NodeMetricExpirationSeconds: pointer.Int64(defaultNodeMetricExpirationSeconds),
+				AnomalyCondition:            defaultLoadAnomalyCondition,
 				ResourceWeights: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    1,
 					corev1.ResourceMemory: 1,
@@ -56,7 +57,8 @@ func TestSetDefaults_LowNodeLoadArgs(t *testing.T) {
 				},
 			},
 			expected: &LowNodeLoadArgs{
-				NodeFit: pointer.Bool(true),
+				NodeFit:                     pointer.Bool(true),
+				NodeMetricExpirationSeconds: pointer.Int64(defaultNodeMetricExpirationSeconds),
 				AnomalyCondition: &LoadAnomalyCondition{
 					Timeout:                  &metav1.Duration{Duration: 10 * time.Second},
 					ConsecutiveAbnormalities: defaultLoadAnomalyCondition.ConsecutiveAbnormalities,
@@ -82,8 +84,9 @@ func TestSetDefaults_LowNodeLoadArgs(t *testing.T) {
 				},
 			},
 			expected: &LowNodeLoadArgs{
-				NodeFit:          pointer.Bool(true),
-				AnomalyCondition: defaultLoadAnomalyCondition,
+				NodeFit:                     pointer.Bool(true),
+				NodeMetricExpirationSeconds: pointer.Int64(defaultNodeMetricExpirationSeconds),
+				AnomalyCondition:            defaultLoadAnomalyCondition,
 				LowThresholds: ResourceThresholds{
 					corev1.ResourceCPU:    30,
 					corev1.ResourceMemory: 30,

--- a/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
@@ -39,6 +39,11 @@ type LowNodeLoadArgs struct {
 	// By default, NumberOfNodes is set to zero.
 	NumberOfNodes *int32 `json:"numberOfNodes,omitempty"`
 
+	// NodeMetricExpirationSeconds indicates the NodeMetric expiration in seconds.
+	// When NodeMetrics expired, the node is considered abnormal, and should not be considered by deschedule plugin.
+	// Default is 180 seconds.
+	NodeMetricExpirationSeconds *int64 `json:"nodeMetricExpirationSeconds,omitempty"`
+
 	// Naming this one differently since namespaces are still
 	// considered while considering resoures used by pods
 	// but then filtered out before eviction

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -367,6 +367,7 @@ func autoConvert_v1alpha2_LowNodeLoadArgs_To_config_LowNodeLoadArgs(in *LowNodeL
 	if err := v1.Convert_Pointer_int32_To_int32(&in.NumberOfNodes, &out.NumberOfNodes, s); err != nil {
 		return err
 	}
+	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EvictableNamespaces = (*config.Namespaces)(unsafe.Pointer(in.EvictableNamespaces))
 	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	out.PodSelectors = *(*[]config.LowNodeLoadPodSelector)(unsafe.Pointer(&in.PodSelectors))
@@ -412,6 +413,7 @@ func autoConvert_config_LowNodeLoadArgs_To_v1alpha2_LowNodeLoadArgs(in *config.L
 	if err := v1.Convert_int32_To_Pointer_int32(&in.NumberOfNodes, &out.NumberOfNodes, s); err != nil {
 		return err
 	}
+	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EvictableNamespaces = (*Namespaces)(unsafe.Pointer(in.EvictableNamespaces))
 	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	out.PodSelectors = *(*[]LowNodeLoadPodSelector)(unsafe.Pointer(&in.PodSelectors))

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *LowNodeLoadArgs) DeepCopyInto(out *LowNodeLoadArgs) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NodeMetricExpirationSeconds != nil {
+		in, out := &in.NodeMetricExpirationSeconds, &out.NodeMetricExpirationSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.EvictableNamespaces != nil {
 		in, out := &in.EvictableNamespaces, &out.EvictableNamespaces
 		*out = new(Namespaces)

--- a/pkg/descheduler/apis/config/validation/validation_loadaware.go
+++ b/pkg/descheduler/apis/config/validation/validation_loadaware.go
@@ -30,6 +30,10 @@ func ValidateLowLoadUtilizationArgs(path *field.Path, args *deschedulerconfig.Lo
 		allErrs = append(allErrs, field.Invalid(path.Child("numberOfNodes"), args.NumberOfNodes, "must be greater than or equal to 0"))
 	}
 
+	if args.NodeMetricExpirationSeconds != nil && *args.NodeMetricExpirationSeconds <= 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("nodeMetricExpiredSeconds"), *args.NodeMetricExpirationSeconds, "nodeMetricExpiredSeconds should be a positive value"))
+	}
+
 	if args.EvictableNamespaces != nil && len(args.EvictableNamespaces.Include) > 0 && len(args.EvictableNamespaces.Exclude) > 0 {
 		allErrs = append(allErrs, field.Invalid(path.Child("evictableNamespaces"), args.EvictableNamespaces, "only one of Include/Exclude namespaces can be set"))
 	}

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -165,6 +165,11 @@ func (in *LoadAnomalyCondition) DeepCopy() *LoadAnomalyCondition {
 func (in *LowNodeLoadArgs) DeepCopyInto(out *LowNodeLoadArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.NodeMetricExpirationSeconds != nil {
+		in, out := &in.NodeMetricExpirationSeconds, &out.NodeMetricExpirationSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.EvictableNamespaces != nil {
 		in, out := &in.EvictableNamespaces, &out.EvictableNamespaces
 		*out = new(Namespaces)

--- a/pkg/descheduler/framework/plugins/loadaware/low_node_load.go
+++ b/pkg/descheduler/framework/plugins/loadaware/low_node_load.go
@@ -164,7 +164,7 @@ func (pl *LowNodeLoad) processOneNodePool(ctx context.Context, nodePool *desched
 
 	lowThresholds, highThresholds := newThresholds(nodePool.UseDeviationThresholds, nodePool.LowThresholds, nodePool.HighThresholds)
 	resourceNames := getResourceNames(lowThresholds)
-	nodeUsages := getNodeUsage(nodes, resourceNames, pl.nodeMetricLister, pl.handle.GetPodsAssignedToNodeFunc())
+	nodeUsages := getNodeUsage(nodes, resourceNames, pl.nodeMetricLister, pl.handle.GetPodsAssignedToNodeFunc(), pl.args.NodeMetricExpirationSeconds)
 	nodeThresholds := getNodeThresholds(nodeUsages, lowThresholds, highThresholds, resourceNames, nodePool.UseDeviationThresholds)
 	lowNodes, sourceNodes := classifyNodes(nodeUsages, nodeThresholds, lowThresholdFilter, highThresholdFilter)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
case:
The nodemetric cr has not been updated for a long time, e.g. the koordlet was deleted, but the load information written last time is particularly high, causing pods on this node being evicted all the time, even though the actual load was low. 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
check nodemetrics cr is expired or not when descheduling
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
