### PR TITLE
scheduler: numa-aware scheduling supports selecting numa node by score

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -103,8 +103,14 @@ type ScoringStrategy struct {
 type NodeNUMAResourceArgs struct {
 	metav1.TypeMeta
 
+	// DefaultCPUBindPolicy represents the default CPU bind policy.
+	// If it is empty and the Pod does not declare a binding policy,
+	// the core will not be bound to the LSE/LSR type Pod.
 	DefaultCPUBindPolicy CPUBindPolicy
-	ScoringStrategy      *ScoringStrategy
+	// ScoringStrategy is used to configure the scoring strategy of the Node-level.
+	ScoringStrategy *ScoringStrategy
+	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
+	NUMAScoringStrategy *ScoringStrategy
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -132,7 +138,7 @@ const (
 	CPUExclusivePolicyNUMANodeLevel CPUExclusivePolicy = extension.CPUExclusivePolicyNUMANodeLevel
 )
 
-// NUMAAllocateStrategy indicates how to choose satisfied NUMA Nodes
+// NUMAAllocateStrategy indicates how to choose satisfied NUMA Nodes during binding CPUs
 type NUMAAllocateStrategy = extension.NUMAAllocateStrategy
 
 const (

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -118,6 +118,21 @@ func SetDefaults_NodeNUMAResourceArgs(obj *NodeNUMAResourceArgs) {
 			},
 		}
 	}
+	if obj.NUMAScoringStrategy == nil {
+		obj.NUMAScoringStrategy = &ScoringStrategy{
+			Type: LeastAllocated,
+			Resources: []schedconfigv1beta2.ResourceSpec{
+				{
+					Name:   string(corev1.ResourceCPU),
+					Weight: 1,
+				},
+				{
+					Name:   string(corev1.ResourceMemory),
+					Weight: 1,
+				},
+			},
+		}
+	}
 }
 
 func SetDefaults_ReservationArgs(obj *ReservationArgs) {

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -98,8 +98,14 @@ type ScoringStrategy struct {
 type NodeNUMAResourceArgs struct {
 	metav1.TypeMeta
 
-	DefaultCPUBindPolicy *CPUBindPolicy   `json:"defaultCPUBindPolicy,omitempty"`
-	ScoringStrategy      *ScoringStrategy `json:"scoringStrategy,omitempty"`
+	// DefaultCPUBindPolicy represents the default CPU bind policy.
+	// If it is empty and the Pod does not declare a binding policy,
+	// the core will not be bound to the LSE/LSR type Pod.
+	DefaultCPUBindPolicy *CPUBindPolicy `json:"defaultCPUBindPolicy,omitempty"`
+	// ScoringStrategy is used to configure the scoring strategy of the node-level.
+	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
+	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
+	NUMAScoringStrategy *ScoringStrategy `json:"numaScoringStrategy,omitempty"`
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -127,7 +133,7 @@ const (
 	CPUExclusivePolicyNUMANodeLevel CPUExclusivePolicy = extension.CPUExclusivePolicyNUMANodeLevel
 )
 
-// NUMAAllocateStrategy indicates how to choose satisfied NUMA Nodes
+// NUMAAllocateStrategy indicates how to choose satisfied NUMA Nodes during binding CPUs
 type NUMAAllocateStrategy = extension.NUMAAllocateStrategy
 
 const (

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -298,6 +298,7 @@ func autoConvert_v1beta2_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in 
 		return err
 	}
 	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
+	out.NUMAScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
 	return nil
 }
 
@@ -311,6 +312,7 @@ func autoConvert_config_NodeNUMAResourceArgs_To_v1beta2_NodeNUMAResourceArgs(in 
 		return err
 	}
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
+	out.NUMAScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -277,6 +277,11 @@ func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 		*out = new(ScoringStrategy)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NUMAScoringStrategy != nil {
+		in, out := &in.NUMAScoringStrategy, &out.NUMAScoringStrategy
+		*out = new(ScoringStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -254,6 +254,11 @@ func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 		*out = new(ScoringStrategy)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NUMAScoringStrategy != nil {
+		in, out := &in.NUMAScoringStrategy, &out.NUMAScoringStrategy
+		*out = new(ScoringStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
@@ -29,12 +29,12 @@ func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false},
+			hint:     NUMATopologyHint{nil, false, 0},
 			expected: true,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true},
+			hint:     NUMATopologyHint{nil, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_none_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_none_test.go
@@ -47,12 +47,12 @@ func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false},
+			hint:     NUMATopologyHint{nil, false, 0},
 			expected: true,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true},
+			hint:     NUMATopologyHint{nil, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
@@ -47,12 +47,12 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false},
+			hint:     NUMATopologyHint{nil, false, 0},
 			expected: false,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true},
+			hint:     NUMATopologyHint{nil, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node.go
@@ -64,13 +64,13 @@ func filterSingleNumaHints(allResourcesHints [][]NUMATopologyHint) [][]NUMATopol
 
 func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]NUMATopologyHint) (NUMATopologyHint, bool) {
 	filteredHints := filterProvidersHints(providersHints)
-	// Filter to only include don't cares and hints with a single NUMA node.
+	// Filter to only include don't care and hints with a single NUMA node.
 	singleNumaHints := filterSingleNumaHints(filteredHints)
 	bestHint := mergeFilteredHints(p.numaNodes, singleNumaHints)
 
 	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
 	if bestHint.NUMANodeAffinity.IsEqual(defaultAffinity) {
-		bestHint = NUMATopologyHint{nil, bestHint.Preferred}
+		bestHint = NUMATopologyHint{nil, bestHint.Preferred, 0}
 	}
 
 	admit := p.canAdmitPodResult(&bestHint)

--- a/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node_test.go
@@ -30,7 +30,7 @@ func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false},
+			hint:     NUMATopologyHint{nil, false, 0},
 			expected: false,
 		},
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager_test.go
@@ -928,7 +928,7 @@ func TestResourceManagerGetTopologyHint(t *testing.T) {
 							mask, _ := bitmask.NewBitMask(0, 1)
 							return mask
 						}(),
-						Preferred: true,
+						Preferred: false,
 					},
 				},
 			},

--- a/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
@@ -111,7 +111,7 @@ func TestNUMANodeScore(t *testing.T) {
 				"test-node-1": 2,
 				"test-node-2": 1,
 			},
-			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "54", "memory": "40Gi"}).Obj(),
+			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "50", "memory": "40Gi"}).Obj(),
 			strategy: &schedulerconfig.ScoringStrategy{
 				Type: schedulerconfig.MostAllocated,
 				Resources: []config.ResourceSpec{
@@ -128,52 +128,11 @@ func TestNUMANodeScore(t *testing.T) {
 			expectedScores: []framework.NodeScore{
 				{
 					Name:  "test-node-1",
-					Score: 33,
+					Score: 63,
 				},
 				{
 					Name:  "test-node-2",
-					Score: 57,
-				},
-			},
-		},
-		{
-			name: "restricted numa nodes score with same capacity",
-			nodes: []*corev1.Node{
-				st.MakeNode().Name("test-node-1").
-					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
-					Obj(),
-				st.MakeNode().Name("test-node-2").
-					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
-					Obj(),
-			},
-			numaNodeCounts: map[string]int{
-				"test-node-1": 2,
-				"test-node-2": 2,
-			},
-			requestedPod: st.MakePod().Req(map[corev1.ResourceName]string{"cpu": "54", "memory": "40Gi"}).Obj(),
-			strategy: &schedulerconfig.ScoringStrategy{
-				Type: schedulerconfig.MostAllocated,
-				Resources: []config.ResourceSpec{
-					{
-						Name:   string(corev1.ResourceCPU),
-						Weight: 1,
-					},
-					{
-						Name:   string(corev1.ResourceMemory),
-						Weight: 1,
-					},
-				},
-			},
-			expectedScores: []framework.NodeScore{
-				{
-					Name:  "test-node-1",
-					Score: 33,
-				},
-				{
-					Name:  "test-node-2",
-					Score: 33,
+					Score: 54,
 				},
 			},
 		},
@@ -182,15 +141,15 @@ func TestNUMANodeScore(t *testing.T) {
 			nodes: []*corev1.Node{
 				st.MakeNode().Name("test-node-1").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 				st.MakeNode().Name("test-node-2").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 				st.MakeNode().Name("test-node-3").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 			},
 			numaNodeCounts: map[string]int{
@@ -220,15 +179,15 @@ func TestNUMANodeScore(t *testing.T) {
 			expectedScores: []framework.NodeScore{
 				{
 					Name:  "test-node-1",
-					Score: 26,
+					Score: 19,
 				},
 				{
 					Name:  "test-node-2",
-					Score: 39,
+					Score: 19,
 				},
 				{
 					Name:  "test-node-3",
-					Score: 65,
+					Score: 19,
 				},
 			},
 		},
@@ -237,15 +196,15 @@ func TestNUMANodeScore(t *testing.T) {
 			nodes: []*corev1.Node{
 				st.MakeNode().Name("test-node-1").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 				st.MakeNode().Name("test-node-2").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 				st.MakeNode().Name("test-node-3").
 					Capacity(map[corev1.ResourceName]string{"cpu": "104", "memory": "256Gi"}).
-					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicyRestricted)).
+					Label(apiext.LabelNUMATopologyPolicy, string(apiext.NUMATopologyPolicySingleNUMANode)).
 					Obj(),
 			},
 			numaNodeCounts: map[string]int{
@@ -285,15 +244,15 @@ func TestNUMANodeScore(t *testing.T) {
 			expectedScores: []framework.NodeScore{
 				{
 					Name:  "test-node-1",
-					Score: 29,
+					Score: 23,
 				},
 				{
 					Name:  "test-node-2",
-					Score: 52,
+					Score: 27,
 				},
 				{
 					Name:  "test-node-3",
-					Score: 65,
+					Score: 34,
 				},
 			},
 		},

--- a/pkg/scheduler/plugins/nodenumaresource/topology_hint.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_hint.go
@@ -54,6 +54,7 @@ func (p *Plugin) GetPodTopologyHints(ctx context.Context, cycleState *framework.
 	if err != nil {
 		return nil, framework.AsStatus(err)
 	}
+	resourceOptions.numaScorer = p.numaScorer
 	hints, err := p.resourceManager.GetTopologyHints(node, pod, resourceOptions)
 	if err != nil {
 		return nil, framework.NewStatus(framework.Unschedulable, "node(s) Insufficient NUMA Node resources")

--- a/pkg/scheduler/plugins/nodenumaresource/util.go
+++ b/pkg/scheduler/plugins/nodenumaresource/util.go
@@ -24,9 +24,9 @@ import (
 )
 
 func GetDefaultNUMAAllocateStrategy(pluginArgs *schedulingconfig.NodeNUMAResourceArgs) schedulingconfig.NUMAAllocateStrategy {
-	numaAllocateStrategy := schedulingconfig.NUMAMostAllocated
-	if pluginArgs != nil && pluginArgs.ScoringStrategy != nil && pluginArgs.ScoringStrategy.Type == schedulingconfig.LeastAllocated {
-		numaAllocateStrategy = schedulingconfig.NUMALeastAllocated
+	numaAllocateStrategy := schedulingconfig.NUMALeastAllocated
+	if pluginArgs != nil && pluginArgs.NUMAScoringStrategy != nil && pluginArgs.NUMAScoringStrategy.Type == schedulingconfig.MostAllocated {
+		numaAllocateStrategy = schedulingconfig.NUMAMostAllocated
 	}
 	return numaAllocateStrategy
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Currently the NodeNUMAResource plugin uses TopologyManager to generate the best hint, but the hint is the narrowest, e.g. if the node's topology strategy is SingleNUMANode, the best hint is always the one with the smallest NUMA Node ID, it works like a bin-packing strategy. However, some scenarios require selecting the least allocated NUMA node to ensure runtime QoS.

Add a new scoring strategy to NodeNUMAResourceArgs to support NUMA-Node level scoring, so that we can select the numa node with the highest score, and then in score-phase, we can select the node with the highest score at the node level.

User can configure the NodeNUMAResourceArgs as the following:
```yaml
apiVersion: kubescheduler.config.k8s.io/v1beta2
kind: KubeSchedulerConfiguration
profiles:
  - pluginConfig:
      - name: NodeNUMAResource
        args:
          apiVersion: kubescheduler.config.k8s.io/v1beta2
          kind: NodeNUMAResourceArgs
          scoringStrategy:  # Here configure Node level scoring strategy
            type: LeastAllocated
            resources:
              - name: cpu
                weight: 1
              - name: memory
                weight: 1
              - name: "kubernetes.io/batch-cpu"
                weight: 1
              - name: "kubernetes.io/batch-memory"
                weight: 1
          numaScoringStrategy: # Here configure NUMA-Node level scoring strategy
            type: LeastAllocated
            resources:
              - name: cpu
                weight: 1
              - name: memory
                weight: 1
              - name: "kubernetes.io/batch-cpu"
                weight: 1
              - name: "kubernetes.io/batch-memory"
                weight: 1
```

We can  create a deployment affinities the special node with 10 replicas, 4C8G per replica, and use debug api `/apis/v1/plugins/NodeNUMAResource/nodes/:nodeName` to view effect. 
Use `LeastAllocated` strategy, we can get the result as following(just one node which has two numa-nodes):
```json
{
    ....
    "allocatedNUMANodeResources": [
       {"node":0,"resources":{"cpu":"25","memory":"53Gi"}},
       {"node":1,"resources":{"cpu":"28","memory":"58Gi"}}
    ]
}
```

Use `MostAllocated` strategy, we can get the result as following(just one node which has two numa-nodes):
```json
{
   ....
   "allocatedNUMANodeResources":[
        {"node":0,"resources":{"cpu":"53500m","memory":"113233253Ki"}}
   ]
}
```

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

fix #1680

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
