### PR TITLE
scheduler: leaky resources in ReservationInfo when pod failed to bind

### DIFF
--- a/pkg/scheduler/plugins/reservation/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler.go
@@ -42,6 +42,11 @@ func registerPodEventHandler(cache *reservationCache, factory informers.SharedIn
 	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), factory, informer, eventHandler)
 }
 
+// assignedPod selects pods that are assigned (scheduled and running).
+func assignedPod(pod *corev1.Pod) bool {
+	return len(pod.Spec.NodeName) != 0
+}
+
 func (h *podEventHandler) OnAdd(obj interface{}) {
 	pod, _ := obj.(*corev1.Pod)
 	if pod == nil {
@@ -80,6 +85,10 @@ func (h *podEventHandler) OnDelete(obj interface{}) {
 func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 	if util.IsPodTerminated(newPod) {
 		h.deletePod(newPod)
+		return
+	}
+
+	if !assignedPod(newPod) {
 		return
 	}
 

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -82,7 +82,13 @@ func TestPodEventHandler(t *testing.T) {
 	apiext.SetReservationAllocated(newPod, reservation)
 	handler.OnUpdate(pod, newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
+	assert.Len(t, rInfo.AssignedPods, 0)
+
+	newPod.Spec.NodeName = reservation.Status.NodeName
+	handler.OnUpdate(pod, newPod)
+	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
 	assert.Len(t, rInfo.AssignedPods, 1)
+
 	expectPodRequirement := &frameworkext.PodRequirement{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

scheduler: leaky resources in ReservationInfo when pod failed to bind

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1741 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
