### PR TITLE
koordlet: support hugepage reporting

### DIFF
--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -133,6 +133,14 @@ const (
 	//
 	// ColdPageCollector enables coldPageCollector feature of koordlet.
 	ColdPageCollector featuregate.Feature = "ColdPageCollector"
+
+	// HugePageReport enables hugepage collector feature of koordlet.
+	// This feature supports reporting of hugepages.
+	// The koord-scheduler will allocate hugepage information based on the user's hugepage request and add it to the Pod's annotations.
+	// Format: scheduling.koordinator.sh/resource-status: '{"numaNodeResources":[{"node":1,"resources":{"hugepages-1Gi":"50Gi"}}]}'.
+	// Backend applications can enable the hugepages based on the allocation results.
+	// For example, the CSI mounts the pre-allocated hugepages into the pod.
+	HugePageReport featuregate.Feature = "HugePageReport"
 )
 
 func init() {
@@ -161,6 +169,7 @@ var (
 		PSICollector:           {Default: false, PreRelease: featuregate.Alpha},
 		BlkIOReconcile:         {Default: false, PreRelease: featuregate.Alpha},
 		ColdPageCollector:      {Default: false, PreRelease: featuregate.Alpha},
+		HugePageReport:         {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/koordlet/metricsadvisor/collectors/nodeinfo/node_info_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/nodeinfo/node_info_collector.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
@@ -110,6 +111,9 @@ func (n *nodeInfoCollector) collectNodeNUMAInfo() error {
 	if err != nil {
 		metrics.RecordCollectNodeNUMAInfoStatus(err)
 		return err
+	}
+	if features.DefaultKoordletFeatureGate.Enabled(features.HugePageReport) {
+		koordletutil.GetAndMergeHugepageToNumaInfo(nodeNUMAInfo)
 	}
 	klog.V(6).Infof("collect NUMA info successfully, info %+v", nodeNUMAInfo)
 

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
@@ -492,6 +492,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Available:   *resource.NewQuantity(4, resource.DecimalSI),
 				},
 				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
 					Name:        "memory",
 					Capacity:    *resource.NewQuantity(269755191296, resource.BinarySI),
 					Allocatable: *resource.NewQuantity(269755191296, resource.BinarySI),
@@ -508,6 +520,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Capacity:    *resource.NewQuantity(4, resource.DecimalSI),
 					Allocatable: *resource.NewQuantity(4, resource.DecimalSI),
 					Available:   *resource.NewQuantity(4, resource.DecimalSI),
+				},
+				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
 				},
 				{
 					Name:        "memory",
@@ -586,6 +610,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Available:   *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
 					Name:        "memory",
 					Capacity:    *resource.NewQuantity(269755191296, resource.BinarySI),
 					Allocatable: *resource.NewQuantity(269755191296, resource.BinarySI),
@@ -608,6 +644,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Capacity:    *resource.NewQuantity(1, resource.DecimalSI),
 					Allocatable: *resource.NewQuantity(1, resource.DecimalSI),
 					Available:   *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
 				},
 				{
 					Name:        "memory",
@@ -640,6 +688,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Available:   *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
 					Name:        "memory",
 					Capacity:    *resource.NewQuantity(269755191296, resource.BinarySI),
 					Allocatable: *resource.NewQuantity(269755191296, resource.BinarySI),
@@ -662,6 +722,18 @@ func Test_reportNodeTopology(t *testing.T) {
 					Capacity:    *resource.NewQuantity(1, resource.DecimalSI),
 					Allocatable: *resource.NewQuantity(1, resource.DecimalSI),
 					Available:   *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				{
+					Name:        "hugepages-1Gi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
+				},
+				{
+					Name:        "hugepages-2Mi",
+					Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+					Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+					Available:   *resource.NewQuantity(0, resource.BinarySI),
 				},
 				{
 					Name:        "memory",
@@ -1212,11 +1284,12 @@ func Test_calTopologyZoneList(t *testing.T) {
 		nodeCPUInfo *metriccache.NodeCPUInfo
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    topologyv1alpha1.ZoneList
-		wantErr bool
+		name           string
+		fields         fields
+		args           args
+		hugepageEnable bool
+		want           topologyv1alpha1.ZoneList
+		wantErr        bool
 	}{
 		{
 			name: "err when numa info not exist",
@@ -1284,13 +1357,13 @@ func Test_calTopologyZoneList(t *testing.T) {
 							{
 								NUMANodeID: 0,
 								MemInfo: &koordletutil.MemInfo{
-									MemTotal: 1024000,
+									MemTotal: 157286400, // 150G
 								},
 							},
 						},
 						MemInfoMap: map[int32]*koordletutil.MemInfo{
 							0: {
-								MemTotal: 1024000,
+								MemTotal: 157286400, // 150G
 							},
 						},
 					}, true).Times(1)
@@ -1331,10 +1404,225 @@ func Test_calTopologyZoneList(t *testing.T) {
 							Available:   *resource.NewQuantity(2, resource.DecimalSI),
 						},
 						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
 							Name:        "memory",
-							Capacity:    *resource.NewQuantity(1048576000, resource.BinarySI),
-							Allocatable: *resource.NewQuantity(1048576000, resource.BinarySI),
-							Available:   *resource.NewQuantity(1048576000, resource.BinarySI),
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate single numa node with hugepage, but featuregate hugepage not enable",
+			fields: fields{
+				metricCache: func(ctrl *gomock.Controller) metriccache.MetricCache {
+					mc := mock_metriccache.NewMockMetricCache(ctrl)
+					mc.EXPECT().Get(metriccache.NodeNUMAInfoKey).Return(&koordletutil.NodeNUMAInfo{
+						NUMAInfos: []koordletutil.NUMAInfo{
+							{
+								NUMANodeID: 0,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+						},
+						MemInfoMap: map[int32]*koordletutil.MemInfo{
+							0: {
+								MemTotal: 157286400, // 150G
+							},
+						},
+						HugePagesMap: map[int32]map[uint64]*koordletutil.HugePagesInfo{
+							0: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								}, // 60M
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								}, // 30G
+							},
+						},
+					}, true).Times(1)
+					return mc
+				},
+			},
+			args: args{
+				nodeCPUInfo: &metriccache.NodeCPUInfo{
+					TotalInfo: koordletutil.CPUTotalInfo{
+						NodeToCPU: map[int32][]koordletutil.ProcessorInfo{
+							0: {
+								{
+									CPUID:    0,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    1,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(2, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(2, resource.DecimalSI),
+							Available:   *resource.NewQuantity(2, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "calculate single numa node with hugepage, featuregate hugepage enable",
+			hugepageEnable: true,
+			fields: fields{
+				metricCache: func(ctrl *gomock.Controller) metriccache.MetricCache {
+					mc := mock_metriccache.NewMockMetricCache(ctrl)
+					mc.EXPECT().Get(metriccache.NodeNUMAInfoKey).Return(&koordletutil.NodeNUMAInfo{
+						NUMAInfos: []koordletutil.NUMAInfo{
+							{
+								NUMANodeID: 0,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+						},
+						MemInfoMap: map[int32]*koordletutil.MemInfo{
+							0: {
+								MemTotal: 157286400, // 150G
+							},
+						},
+						HugePagesMap: map[int32]map[uint64]*koordletutil.HugePagesInfo{
+							0: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								}, // 60M
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								}, // 30G
+							},
+						},
+					}, true).Times(1)
+					return mc
+				},
+			},
+			args: args{
+				nodeCPUInfo: &metriccache.NodeCPUInfo{
+					TotalInfo: koordletutil.CPUTotalInfo{
+						NodeToCPU: map[int32][]koordletutil.ProcessorInfo{
+							0: {
+								{
+									CPUID:    0,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    1,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(2, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(2, resource.DecimalSI),
+							Available:   *resource.NewQuantity(2, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(32212254720, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(32212254720, resource.BinarySI),
+							Available:   *resource.NewQuantity(32212254720, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(62914560, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(62914560, resource.BinarySI),
+							Available:   *resource.NewQuantity(62914560, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(128786104320, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(128786104320, resource.BinarySI),
+							Available:   *resource.NewQuantity(128786104320, resource.BinarySI),
 						},
 					},
 				},
@@ -1351,22 +1639,22 @@ func Test_calTopologyZoneList(t *testing.T) {
 							{
 								NUMANodeID: 0,
 								MemInfo: &koordletutil.MemInfo{
-									MemTotal: 1024000,
+									MemTotal: 157286400, // 150G
 								},
 							},
 							{
 								NUMANodeID: 1,
 								MemInfo: &koordletutil.MemInfo{
-									MemTotal: 1000000,
+									MemTotal: 157286400, // 150G
 								},
 							},
 						},
 						MemInfoMap: map[int32]*koordletutil.MemInfo{
 							0: {
-								MemTotal: 1024000,
+								MemTotal: 157286400,
 							},
 							1: {
-								MemTotal: 1000000,
+								MemTotal: 157286400,
 							},
 						},
 					}, true).Times(1)
@@ -1445,10 +1733,22 @@ func Test_calTopologyZoneList(t *testing.T) {
 							Available:   *resource.NewQuantity(4, resource.DecimalSI),
 						},
 						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
 							Name:        "memory",
-							Capacity:    *resource.NewQuantity(1048576000, resource.BinarySI),
-							Allocatable: *resource.NewQuantity(1048576000, resource.BinarySI),
-							Available:   *resource.NewQuantity(1048576000, resource.BinarySI),
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
 						},
 					},
 				},
@@ -1463,10 +1763,419 @@ func Test_calTopologyZoneList(t *testing.T) {
 							Available:   *resource.NewQuantity(4, resource.DecimalSI),
 						},
 						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
 							Name:        "memory",
-							Capacity:    *resource.NewQuantity(1024000000, resource.BinarySI),
-							Allocatable: *resource.NewQuantity(1024000000, resource.BinarySI),
-							Available:   *resource.NewQuantity(1024000000, resource.BinarySI),
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate multiple numa nodes with hugepage, but featuregate hugepage not enable",
+			fields: fields{
+				metricCache: func(ctrl *gomock.Controller) metriccache.MetricCache {
+					mc := mock_metriccache.NewMockMetricCache(ctrl)
+					mc.EXPECT().Get(metriccache.NodeNUMAInfoKey).Return(&koordletutil.NodeNUMAInfo{
+						NUMAInfos: []koordletutil.NUMAInfo{
+							{
+								NUMANodeID: 0,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+							{
+								NUMANodeID: 1,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+						},
+						MemInfoMap: map[int32]*koordletutil.MemInfo{
+							0: {
+								MemTotal: 157286400,
+							},
+							1: {
+								MemTotal: 157286400,
+							},
+						},
+						HugePagesMap: map[int32]map[uint64]*koordletutil.HugePagesInfo{
+							0: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								},
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								},
+							},
+							1: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								},
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								},
+							},
+						},
+					}, true).Times(1)
+					return mc
+				},
+			},
+			args: args{
+				nodeCPUInfo: &metriccache.NodeCPUInfo{
+					TotalInfo: koordletutil.CPUTotalInfo{
+						NodeToCPU: map[int32][]koordletutil.ProcessorInfo{
+							0: {
+								{
+									CPUID:    0,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    1,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    4,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    5,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+							},
+							1: {
+								{
+									CPUID:    2,
+									CoreID:   2,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    3,
+									CoreID:   3,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    6,
+									CoreID:   2,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    7,
+									CoreID:   3,
+									SocketID: 1,
+									NodeID:   1,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(4, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(4, resource.DecimalSI),
+							Available:   *resource.NewQuantity(4, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
+						},
+					},
+				},
+				{
+					Name: "node-1",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(4, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(4, resource.DecimalSI),
+							Available:   *resource.NewQuantity(4, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(0, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(0, resource.BinarySI),
+							Available:   *resource.NewQuantity(0, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(161061273600, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(161061273600, resource.BinarySI),
+							Available:   *resource.NewQuantity(161061273600, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "calculate multiple numa nodes with hugepage, featuregate hugepage enable",
+			hugepageEnable: true,
+			fields: fields{
+				metricCache: func(ctrl *gomock.Controller) metriccache.MetricCache {
+					mc := mock_metriccache.NewMockMetricCache(ctrl)
+					mc.EXPECT().Get(metriccache.NodeNUMAInfoKey).Return(&koordletutil.NodeNUMAInfo{
+						NUMAInfos: []koordletutil.NUMAInfo{
+							{
+								NUMANodeID: 0,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+							{
+								NUMANodeID: 1,
+								MemInfo: &koordletutil.MemInfo{
+									MemTotal: 157286400, // 150G
+								},
+								HugePages: map[uint64]*koordletutil.HugePagesInfo{
+									koordletutil.Hugepage2Mkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage2Mkbyte,
+									}, // 60M
+									koordletutil.Hugepage1Gkbyte: {
+										NumPages: 30,
+										PageSize: koordletutil.Hugepage1Gkbyte,
+									}, // 30G
+								},
+							},
+						},
+						MemInfoMap: map[int32]*koordletutil.MemInfo{
+							0: {
+								MemTotal: 157286400,
+							},
+							1: {
+								MemTotal: 157286400,
+							},
+						},
+						HugePagesMap: map[int32]map[uint64]*koordletutil.HugePagesInfo{
+							0: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								},
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								},
+							},
+							1: {
+								koordletutil.Hugepage2Mkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage2Mkbyte,
+								},
+								koordletutil.Hugepage1Gkbyte: {
+									NumPages: 30,
+									PageSize: koordletutil.Hugepage1Gkbyte,
+								},
+							},
+						},
+					}, true).Times(1)
+					return mc
+				},
+			},
+			args: args{
+				nodeCPUInfo: &metriccache.NodeCPUInfo{
+					TotalInfo: koordletutil.CPUTotalInfo{
+						NodeToCPU: map[int32][]koordletutil.ProcessorInfo{
+							0: {
+								{
+									CPUID:    0,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    1,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    4,
+									CoreID:   0,
+									SocketID: 0,
+									NodeID:   0,
+								},
+								{
+									CPUID:    5,
+									CoreID:   1,
+									SocketID: 0,
+									NodeID:   0,
+								},
+							},
+							1: {
+								{
+									CPUID:    2,
+									CoreID:   2,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    3,
+									CoreID:   3,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    6,
+									CoreID:   2,
+									SocketID: 1,
+									NodeID:   1,
+								},
+								{
+									CPUID:    7,
+									CoreID:   3,
+									SocketID: 1,
+									NodeID:   1,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(4, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(4, resource.DecimalSI),
+							Available:   *resource.NewQuantity(4, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(32212254720, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(32212254720, resource.BinarySI),
+							Available:   *resource.NewQuantity(32212254720, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(62914560, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(62914560, resource.BinarySI),
+							Available:   *resource.NewQuantity(62914560, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(128786104320, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(128786104320, resource.BinarySI),
+							Available:   *resource.NewQuantity(128786104320, resource.BinarySI),
+						},
+					},
+				},
+				{
+					Name: "node-1",
+					Type: util.NodeZoneType,
+					Resources: topologyv1alpha1.ResourceInfoList{
+						{
+							Name:        "cpu",
+							Capacity:    *resource.NewQuantity(4, resource.DecimalSI),
+							Allocatable: *resource.NewQuantity(4, resource.DecimalSI),
+							Available:   *resource.NewQuantity(4, resource.DecimalSI),
+						},
+						{
+							Name:        "hugepages-1Gi",
+							Capacity:    *resource.NewQuantity(32212254720, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(32212254720, resource.BinarySI),
+							Available:   *resource.NewQuantity(32212254720, resource.BinarySI),
+						},
+						{
+							Name:        "hugepages-2Mi",
+							Capacity:    *resource.NewQuantity(62914560, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(62914560, resource.BinarySI),
+							Available:   *resource.NewQuantity(62914560, resource.BinarySI),
+						},
+						{
+							Name:        "memory",
+							Capacity:    *resource.NewQuantity(128786104320, resource.BinarySI),
+							Allocatable: *resource.NewQuantity(128786104320, resource.BinarySI),
+							Available:   *resource.NewQuantity(128786104320, resource.BinarySI),
 						},
 					},
 				},
@@ -1478,6 +2187,16 @@ func Test_calTopologyZoneList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+
+			enabled := features.DefaultKoordletFeatureGate.Enabled(features.HugePageReport)
+			testFeatureGates := map[string]bool{string(features.HugePageReport): tt.hugepageEnable}
+			err := features.DefaultMutableKoordletFeatureGate.SetFromMap(testFeatureGates)
+			assert.NoError(t, err)
+			defer func() {
+				testFeatureGates[string(features.HugePageReport)] = enabled
+				err = features.DefaultMutableKoordletFeatureGate.SetFromMap(testFeatureGates)
+				assert.NoError(t, err)
+			}()
 
 			s := &nodeTopoInformer{
 				metricCache: tt.fields.metricCache(ctrl),

--- a/pkg/koordlet/util/meminfo_test.go
+++ b/pkg/koordlet/util/meminfo_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -485,4 +486,339 @@ Node 1 HugePages_Surp:        0`
 	got, err = GetNodeNUMAInfo()
 	assert.Error(t, err)
 	assert.Nil(t, got)
+}
+
+func TestGetNodeHugePagesInfo(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+
+	numaHugePage1GPath0 := system.GetNUMAHugepagesNrPath("node0", "hugepages-1048576kB")
+	helper.WriteFileContents(numaHugePage1GPath0, "10")
+	numaHugePage2MPath0 := system.GetNUMAHugepagesNrPath("node0", "hugepages-2048kB")
+	helper.WriteFileContents(numaHugePage2MPath0, "20")
+
+	numaHugePage1GPath1 := system.GetNUMAHugepagesNrPath("node1", "hugepages-1048576kB")
+	helper.WriteFileContents(numaHugePage1GPath1, "10")
+	numaHugePage2MPath1 := system.GetNUMAHugepagesNrPath("node1", "hugepages-2048kB")
+	helper.WriteFileContents(numaHugePage2MPath1, "20")
+
+	expected := map[int32]map[uint64]*HugePagesInfo{
+		0: {
+			Hugepage1Gkbyte: {
+				NumPages: 10,
+				PageSize: Hugepage1Gkbyte,
+			},
+			Hugepage2Mkbyte: {
+				NumPages: 20,
+				PageSize: Hugepage2Mkbyte,
+			},
+		},
+		1: {
+			Hugepage1Gkbyte: {
+				NumPages: 10,
+				PageSize: Hugepage1Gkbyte,
+			},
+			Hugepage2Mkbyte: {
+				NumPages: 20,
+				PageSize: Hugepage2Mkbyte,
+			},
+		},
+	}
+
+	got, err := GetNodeHugePagesInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+
+	// test partial failure
+	numaMemInfoPath2 := system.GetNUMAMemInfoPath("node2")
+	helper.MkDirAll(filepath.Dir(numaMemInfoPath2))
+	got, err = GetNodeHugePagesInfo()
+	assert.Error(t, err)
+	assert.Nil(t, got)
+
+	// test path not exist
+	helper.Cleanup()
+	got, err = GetNodeHugePagesInfo()
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetAndMergeHugepageToNumaInfo(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+	numaMemInfoContentStr0 := `Node 0 MemTotal:       263432804 kB
+Node 0 MemFree:        254391744 kB
+Node 0 MemAvailable:   256703236 kB
+Node 0 Buffers:          958096 kB
+Node 0 Cached:                0 kB
+Node 0 SwapCached:            0 kB
+Node 0 Active:          2786012 kB
+Node 0 Inactive:        2223752 kB
+Node 0 Active(anon):     289488 kB
+Node 0 Inactive(anon):     1300 kB
+Node 0 Active(file):    2496524 kB
+Node 0 Inactive(file):  2222452 kB
+Node 0 Unevictable:           0 kB
+Node 0 Mlocked:               0 kB
+Node 0 SwapTotal:             0 kB
+Node 0 SwapFree:              0 kB
+Node 0 Dirty:               624 kB
+Node 0 Writeback:             0 kB
+Node 0 AnonPages:        281748 kB
+Node 0 Mapped:           495936 kB
+Node 0 Shmem:              2340 kB
+Node 0 Slab:            1097040 kB
+Node 0 SReclaimable:     445164 kB
+Node 0 SUnreclaim:       651876 kB
+Node 0 KernelStack:       20944 kB
+Node 0 PageTables:         7896 kB
+Node 0 NFS_Unstable:          0 kB
+Node 0 Bounce:                0 kB
+Node 0 WritebackTmp:          0 kB
+Node 0 AnonHugePages:     38912 kB
+Node 0 ShmemHugePages:        0 kB
+Node 0 ShmemPmdMapped:        0 kB
+Node 0 HugePages_Total:       0
+Node 0 HugePages_Free:        0
+Node 0 HugePages_Rsvd:        0
+Node 0 HugePages_Surp:        0`
+	numaMemInfoContentStr1 := `Node 1 MemTotal:       263432000 kB
+Node 1 MemFree:        254391744 kB
+Node 1 MemAvailable:   256703236 kB
+Node 1 Buffers:          958096 kB
+Node 1 Cached:                0 kB
+Node 1 SwapCached:            0 kB
+Node 1 Active:          2786012 kB
+Node 1 Inactive:        2223752 kB
+Node 1 Active(anon):     289488 kB
+Node 1 Inactive(anon):     1300 kB
+Node 1 Active(file):    2496524 kB
+Node 1 Inactive(file):  2222452 kB
+Node 1 Unevictable:           0 kB
+Node 1 Mlocked:               0 kB
+Node 1 SwapTotal:             0 kB
+Node 1 SwapFree:              0 kB
+Node 1 Dirty:               624 kB
+Node 1 Writeback:             0 kB
+Node 1 AnonPages:        281748 kB
+Node 1 Mapped:           495936 kB
+Node 1 Shmem:              2340 kB
+Node 1 Slab:            1097040 kB
+Node 1 SReclaimable:     445164 kB
+Node 1 SUnreclaim:       651876 kB
+Node 1 KernelStack:       20944 kB
+Node 1 PageTables:         7896 kB
+Node 1 NFS_Unstable:          0 kB
+Node 1 Bounce:                0 kB
+Node 1 WritebackTmp:          0 kB
+Node 1 AnonHugePages:     38912 kB
+Node 1 ShmemHugePages:        0 kB
+Node 1 ShmemPmdMapped:        0 kB
+Node 1 HugePages_Total:       0
+Node 1 HugePages_Free:        0
+Node 1 HugePages_Rsvd:        0
+Node 1 HugePages_Surp:        0`
+	numaMemInfoPath0 := system.GetNUMAMemInfoPath("node0")
+	helper.WriteFileContents(numaMemInfoPath0, numaMemInfoContentStr0)
+	numaMemInfoPath1 := system.GetNUMAMemInfoPath("node1")
+	helper.WriteFileContents(numaMemInfoPath1, numaMemInfoContentStr1)
+
+	numaHugePage1GPath0 := system.GetNUMAHugepagesNrPath("node0", "hugepages-1048576kB")
+	helper.WriteFileContents(numaHugePage1GPath0, "10")
+	numaHugePage2MPath0 := system.GetNUMAHugepagesNrPath("node0", "hugepages-2048kB")
+	helper.WriteFileContents(numaHugePage2MPath0, "20")
+
+	numaHugePage1GPath1 := system.GetNUMAHugepagesNrPath("node1", "hugepages-1048576kB")
+	helper.WriteFileContents(numaHugePage1GPath1, "10")
+	numaHugePage2MPath1 := system.GetNUMAHugepagesNrPath("node1", "hugepages-2048kB")
+	helper.WriteFileContents(numaHugePage2MPath1, "20")
+
+	testMemInfo0 := &MemInfo{
+		MemTotal: 263432804, MemFree: 254391744, MemAvailable: 256703236,
+		Buffers: 958096, Cached: 0, SwapCached: 0,
+		Active: 2786012, Inactive: 2223752, ActiveAnon: 289488,
+		InactiveAnon: 1300, ActiveFile: 2496524, InactiveFile: 2222452,
+		Unevictable: 0, Mlocked: 0, SwapTotal: 0,
+		SwapFree: 0, Dirty: 624, Writeback: 0,
+		AnonPages: 281748, Mapped: 495936, Shmem: 2340,
+		Slab: 1097040, SReclaimable: 445164, SUnreclaim: 651876,
+		KernelStack: 20944, PageTables: 7896, NFS_Unstable: 0,
+		Bounce: 0, WritebackTmp: 0, AnonHugePages: 38912,
+		HugePages_Total: 0, HugePages_Free: 0, HugePages_Rsvd: 0,
+		HugePages_Surp: 0,
+	}
+	testMemInfo1 := &MemInfo{
+		MemTotal: 263432000, MemFree: 254391744, MemAvailable: 256703236,
+		Buffers: 958096, Cached: 0, SwapCached: 0,
+		Active: 2786012, Inactive: 2223752, ActiveAnon: 289488,
+		InactiveAnon: 1300, ActiveFile: 2496524, InactiveFile: 2222452,
+		Unevictable: 0, Mlocked: 0, SwapTotal: 0,
+		SwapFree: 0, Dirty: 624, Writeback: 0,
+		AnonPages: 281748, Mapped: 495936, Shmem: 2340,
+		Slab: 1097040, SReclaimable: 445164, SUnreclaim: 651876,
+		KernelStack: 20944, PageTables: 7896, NFS_Unstable: 0,
+		Bounce: 0, WritebackTmp: 0, AnonHugePages: 38912,
+		HugePages_Total: 0, HugePages_Free: 0, HugePages_Rsvd: 0,
+		HugePages_Surp: 0,
+	}
+
+	testEmptyHugePagesMap0 := map[uint64]*HugePagesInfo{
+		Hugepage1Gkbyte: {
+			NumPages: 0,
+			PageSize: Hugepage1Gkbyte,
+		},
+		Hugepage2Mkbyte: {
+			NumPages: 0,
+			PageSize: Hugepage2Mkbyte,
+		},
+	}
+
+	testHugePagesMap0 := map[uint64]*HugePagesInfo{
+		Hugepage1Gkbyte: {
+			NumPages: 10,
+			PageSize: Hugepage1Gkbyte,
+		},
+		Hugepage2Mkbyte: {
+			NumPages: 20,
+			PageSize: Hugepage2Mkbyte,
+		},
+	}
+
+	testHugePagesMap1 := map[uint64]*HugePagesInfo{
+		Hugepage1Gkbyte: {
+			NumPages: 10,
+			PageSize: Hugepage1Gkbyte,
+		},
+		Hugepage2Mkbyte: {
+			NumPages: 20,
+			PageSize: Hugepage2Mkbyte,
+		},
+	}
+
+	expectedWithoutHugepage := &NodeNUMAInfo{
+		NUMAInfos: []NUMAInfo{
+			{
+				NUMANodeID: 0,
+				MemInfo:    testMemInfo0,
+			},
+			{
+				NUMANodeID: 1,
+				MemInfo:    testMemInfo1,
+			},
+		},
+		MemInfoMap: map[int32]*MemInfo{
+			0: testMemInfo0,
+			1: testMemInfo1,
+		},
+	}
+
+	expectedEmptyHugepage := &NodeNUMAInfo{
+		NUMAInfos: []NUMAInfo{
+			{
+				NUMANodeID: 0,
+				MemInfo:    testMemInfo0,
+				HugePages:  testEmptyHugePagesMap0,
+			},
+			{
+				NUMANodeID: 1,
+				MemInfo:    testMemInfo1,
+				HugePages:  testEmptyHugePagesMap0,
+			},
+		},
+		MemInfoMap: map[int32]*MemInfo{
+			0: testMemInfo0,
+			1: testMemInfo1,
+		},
+		HugePagesMap: map[int32]map[uint64]*HugePagesInfo{
+			0: {
+				Hugepage1Gkbyte: {
+					NumPages: 0,
+					PageSize: Hugepage1Gkbyte,
+				},
+				Hugepage2Mkbyte: {
+					NumPages: 0,
+					PageSize: Hugepage2Mkbyte,
+				},
+			},
+			1: {
+				Hugepage1Gkbyte: {
+					NumPages: 0,
+					PageSize: Hugepage1Gkbyte,
+				},
+				Hugepage2Mkbyte: {
+					NumPages: 0,
+					PageSize: Hugepage2Mkbyte,
+				},
+			},
+		},
+	}
+
+	expected := &NodeNUMAInfo{
+		NUMAInfos: []NUMAInfo{
+			{
+				NUMANodeID: 0,
+				MemInfo:    testMemInfo0,
+				HugePages:  testHugePagesMap0,
+			},
+			{
+				NUMANodeID: 1,
+				MemInfo:    testMemInfo1,
+				HugePages:  testHugePagesMap1,
+			},
+		},
+		MemInfoMap: map[int32]*MemInfo{
+			0: testMemInfo0,
+			1: testMemInfo1,
+		},
+		HugePagesMap: map[int32]map[uint64]*HugePagesInfo{
+			0: {
+				Hugepage1Gkbyte: {
+					NumPages: 10,
+					PageSize: Hugepage1Gkbyte,
+				},
+				Hugepage2Mkbyte: {
+					NumPages: 20,
+					PageSize: Hugepage2Mkbyte,
+				},
+			},
+			1: {
+				Hugepage1Gkbyte: {
+					NumPages: 10,
+					PageSize: Hugepage1Gkbyte,
+				},
+				Hugepage2Mkbyte: {
+					NumPages: 20,
+					PageSize: Hugepage2Mkbyte,
+				},
+			},
+		},
+	}
+
+	numaInfo, err := GetNodeNUMAInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedWithoutHugepage, numaInfo)
+
+	numaInfo1, err := GetNodeNUMAInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedWithoutHugepage, numaInfo1)
+
+	numaInfo2, err := GetNodeNUMAInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedWithoutHugepage, numaInfo2)
+
+	numaInfoWithHugePage := GetAndMergeHugepageToNumaInfo(numaInfo)
+	assert.Equal(t, expected, numaInfoWithHugePage)
+
+	// test partial failure
+
+	numaMemInfoPath2 := system.GetNUMAMemInfoPath("node2")
+	helper.MkDirAll(filepath.Dir(numaMemInfoPath2))
+	fmt.Printf("%v", numaInfo1)
+	numaInfoWithHugePageErr := GetAndMergeHugepageToNumaInfo(numaInfo1)
+	assert.Equal(t, expectedEmptyHugepage, numaInfoWithHugePageErr)
+
+	// test path not exist
+	helper.Cleanup()
+	numaInfoWithHugePageErr2 := GetAndMergeHugepageToNumaInfo(numaInfo2)
+	assert.Equal(t, expectedEmptyHugepage, numaInfoWithHugePageErr2)
 }

--- a/pkg/koordlet/util/system/system_file.go
+++ b/pkg/koordlet/util/system/system_file.go
@@ -36,6 +36,8 @@ const (
 	SysctlSubDir          = "sys"
 	ProcCPUInfoName       = "cpuinfo"
 	KernelCmdlineFileName = "cmdline"
+	HugepageDir           = "hugepages"
+	nrPath                = "nr_hugepages"
 
 	KernelSchedGroupIdentityEnable = "kernel/sched_group_identity_enabled"
 
@@ -100,6 +102,14 @@ func GetSysNUMADir() string {
 
 func GetNUMAMemInfoPath(numaNodeSubDir string) string {
 	return filepath.Join(Conf.SysRootDir, SysNUMASubDir, numaNodeSubDir, ProcMemInfoName)
+}
+
+func GetNUMAHugepagesDir(numaNodeSubDir string) string {
+	return filepath.Join(Conf.SysRootDir, SysNUMASubDir, numaNodeSubDir, HugepageDir)
+}
+
+func GetNUMAHugepagesNrPath(numaNodeSubDir string, page string) string {
+	return filepath.Join(Conf.SysRootDir, SysNUMASubDir, numaNodeSubDir, HugepageDir, page, nrPath)
 }
 
 func GetCPUInfoPath() string {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

支持了大页上报的功能，包括2M和1G大页

### Ⅱ. Does this pull request fix one issue?

无

### Ⅲ. Describe how to verify it

可通过k8s `kubectl get noderesourcetopologies` 查看

### Ⅳ. Special notes for reviews

支持了大页内存的上报，其中原本的内存memory上送的数目也进行了修改，将上报内存 设置为 总内存大小 减去 大页内存的数量。

func (s *nodeTopoInformer) calTopologyZoneList(nodeCPUInfo *metriccache.NodeCPUInfo) 需重点看下。

### V. Checklist

-  I have written necessary docs and comments
-  I have added necessary unit tests and integration tests
-  All checks passed in `make test`
