### PR TITLE
koordlet: add external prom metrics collector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.38.0 // indirect
+	github.com/prometheus/common v0.38.0
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/quobyte/api v0.1.8 // indirect

--- a/pkg/koordlet/metriccache/metric_resources.go
+++ b/pkg/koordlet/metriccache/metric_resources.go
@@ -73,3 +73,7 @@ var (
 	HostAppMemoryUsageMetric              = defaultMetricFactory.New(HostAppMemoryUsage).withPropertySchema(MetricPropertyHostAppName)
 	HostAppMemoryUsageWithPageCacheMetric = defaultMetricFactory.New(HostAppMemoryWithPageCacheUsage).withPropertySchema(MetricPropertyHostAppName)
 )
+
+func GenMetricResource(metricKind MetricKind, propertySchema ...MetricProperty) MetricResource {
+	return defaultMetricFactory.New(metricKind).withPropertySchema(propertySchema...)
+}

--- a/pkg/koordlet/metriccache/metric_types.go
+++ b/pkg/koordlet/metriccache/metric_types.go
@@ -110,6 +110,8 @@ const (
 	MetricPropertyBEAllocation MetricProperty = "be_allocation"
 
 	MetricPropertyHostAppName MetricProperty = "host_app_name"
+
+	MetricPropertyQoS MetricProperty = "qos"
 )
 
 // MetricPropertyValue is the property value
@@ -147,6 +149,7 @@ var MetricPropertiesFunc = struct {
 	ContainerGPU        func(string, string, string) map[MetricProperty]string
 	NodeBE              func(string, string) map[MetricProperty]string
 	HostApplication     func(string) map[MetricProperty]string
+	QoS                 func(string) map[MetricProperty]string // koordinator QoS
 }{
 	Pod: func(podUID string) map[MetricProperty]string {
 		return map[MetricProperty]string{MetricPropertyPodUID: podUID}
@@ -180,6 +183,9 @@ var MetricPropertiesFunc = struct {
 	},
 	HostApplication: func(appName string) map[MetricProperty]string {
 		return map[MetricProperty]string{MetricPropertyHostAppName: appName}
+	},
+	QoS: func(qos string) map[MetricProperty]string {
+		return map[MetricProperty]string{MetricPropertyQoS: qos}
 	},
 }
 

--- a/pkg/koordlet/metrics/metrics.go
+++ b/pkg/koordlet/metrics/metrics.go
@@ -58,6 +58,17 @@ const (
 
 	ResourceKey = "resource"
 
+	ModuleKey            = "module"
+	ModulePluginKey      = "module_plugin"
+	ModuleMetricsAdvisor = "metrics_advisor"
+	ModuleStatesInformer = "states_informer"
+	ModuleQoSManager     = "qos_manager"
+
+	PromScraperKey = "prom_scraper"
+
+	HttpURLKey          = "url"
+	HttpResponseCodeKey = "response_code"
+
 	UnitKey     = "unit"
 	UnitCore    = "core"
 	UnitByte    = "byte"

--- a/pkg/koordlet/metrics/metrics_test.go
+++ b/pkg/koordlet/metrics/metrics_test.go
@@ -123,6 +123,9 @@ func TestCommonCollectors(t *testing.T) {
 			FullSupported: true,
 		},
 	}
+	testModule := "test_module"
+	testPlugin := "test_plugin"
+	testScraper := "test_job"
 
 	t.Run("test not panic", func(t *testing.T) {
 		Register(testingNode)
@@ -147,6 +150,14 @@ func TestCommonCollectors(t *testing.T) {
 		RecordContainerPSI(testingContainer, testingPod, testingPSI)
 		ResetPodPSI()
 		RecordPodPSI(testingPod, testingPSI)
+		RecordReportNodeMetricStatus(testingErr)
+		RecordReportNodeMetricStatus(nil)
+		RecordModuleHealthyStatus(testModule, testPlugin, false)
+		RecordModuleHealthyStatus(testModule, testPlugin, true)
+		RecordCollectPromMetricsStatus(testScraper, false)
+		RecordCollectPromMetricsStatus(testScraper, true)
+		RecordHttpClientQueryStatus("127.0.0.1:9316/metrics", 200)
+		RecordHttpClientQueryLatency("127.0.0.1:9316/metrics", 10)
 	})
 }
 

--- a/pkg/koordlet/metricsadvisor/collectors/nodeinfo/node_info_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/nodeinfo/node_info_collector.go
@@ -68,17 +68,20 @@ func (n *nodeInfoCollector) collectNodeInfo() {
 
 	err := n.collectNodeCPUInfo()
 	if err != nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
 		klog.Warningf("failed to collect node CPU info, err: %s", err)
 		return
 	}
 
 	err = n.collectNodeNUMAInfo()
 	if err != nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
 		klog.Warningf("failed to collect node NUMA info, err: %s", err)
 		return
 	}
 
 	n.started.Store(true)
+	metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, true)
 	klog.V(4).Infof("collect node info finished, elapsed %s", time.Since(started).String())
 }
 

--- a/pkg/koordlet/metricsadvisor/collectors/nodestorageinfo/node_info_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/nodestorageinfo/node_info_collector.go
@@ -69,6 +69,7 @@ func (n *nodeInfoCollector) collectNodeLocalStorageInfo() {
 	if err != nil {
 		klog.Warningf("failed to collect node local storage info, err: %s", err)
 		metrics.RecordCollectNodeLocalStorageInfoStatus(err)
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
 		return
 	}
 
@@ -83,5 +84,6 @@ func (n *nodeInfoCollector) collectNodeLocalStorageInfo() {
 	klog.V(6).Infof("collect node local storage info finished, nodeCPUInfo %v", localStorageInfo)
 	n.storage.Set(metriccache.NodeLocalStorageInfoKey, nodeLocalStorageInfo)
 	n.started.Store(true)
+	metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, true)
 	metrics.RecordCollectNodeLocalStorageInfoStatus(nil)
 }

--- a/pkg/koordlet/metricsadvisor/collectors/prom/collect_rule.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/collect_rule.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
+	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultScrapeInterval   = 30 * time.Second
+	DefaultScrapeTimeout    = 10 * time.Second
+	MinValidMetricTimeRange = 2 * time.Second
+)
+
+// CollectRule is the collecting rule of the scrapers.
+// It defines whether the global scraper is enabled and the jobs to scrape.
+/**
+# Example
+config:
+  enable: true
+  jobs:
+  - name: job1
+    enable: true
+    address: "127.0.0.1"
+    port: 9317
+    path: /metrics
+    scrapeInterval: 10s
+    scrapeTimeout: 5s
+    metrics:
+    - sourceName: metric1
+      sourceLabels:
+        label1: value1
+      targetName: metric1
+      targetType: node
+    - sourceName: metric2
+      targetName: metricA
+      targetType: pod
+      targetLabels:
+        pod: pod_name
+        namespace: pod_namespace
+  - name: job2
+    enable: true
+    address: "127.0.0.1"
+    port: 9316
+    path: /metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric3
+      targetName: metric3
+      targetType: node
+  - name: job3
+    enable: false
+    address: "127.0.0.1"
+    port: 9090
+    path: /metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric3
+      targetName: metric3
+      targetType: node
+**/
+type CollectRule struct {
+	Enable bool      `json:"enable,omitempty"`
+	Jobs   []JobRule `json:"jobs,omitempty"`
+}
+
+// JobRule is the rule of the job.
+// It defines the job name, whether the job is enabled, the job address, port, path, scrape interval, scrape timeout,
+// and the metrics to be scraped.
+type JobRule struct {
+	Name           string        `yaml:"name,omitempty" json:"name,omitempty"`
+	Enable         bool          `yaml:"enable,omitempty" json:"enable,omitempty"`
+	Address        string        `yaml:"address,omitempty" json:"address,omitempty"`
+	Port           int           `yaml:"port,omitempty" json:"port,omitempty"`
+	Path           string        `yaml:"path,omitempty" json:"path,omitempty"`
+	ScrapeInterval time.Duration `yaml:"scrapeInterval,omitempty" json:"scrapeInterval,omitempty"`
+	ScrapeTimeout  time.Duration `yaml:"scrapeTimeout,omitempty" json:"scrapeTimeout,omitempty"`
+	Metrics        []MetricRule  `yaml:"metrics,omitempty" json:"metrics,omitempty"`
+}
+
+// MetricRule is the rule of the metric.
+// It defines the name of the source metric to be scraped, the matched labels of the source metric, the name of the
+// target metric to be stored into the metric cache and the target labels to identify the metric.
+type MetricRule struct {
+	SourceName   string         `yaml:"sourceName,omitempty" json:"sourceName,omitempty"`
+	SourceLabels model.LabelSet `yaml:"sourceLabels,omitempty" json:"sourceLabels,omitempty"`
+	TargetName   string         `yaml:"targetName,omitempty" json:"targetName,omitempty"`
+	TargetType   MetricType     `yaml:"targetType,omitempty" json:"targetType,omitempty"`
+	TargetLabels model.LabelSet `yaml:"targetLabels,omitempty" json:"targetLabels,omitempty"`
+}
+
+func LoadCollectRuleFromFile(path string) (*CollectRule, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("file does not exist")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file, err: %w", err)
+	}
+	ruleBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file, err: %w", err)
+	}
+
+	rule := &CollectRule{}
+	err = yaml.Unmarshal(ruleBytes, rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal file, content %s, err: %w", string(ruleBytes), err)
+	}
+
+	return rule, nil
+}
+
+func (c *CollectRule) IsEnabled() bool {
+	return c.Enable
+}
+
+func (c *CollectRule) Validate() error {
+	if len(c.Jobs) <= 0 {
+		return fmt.Errorf("no job config")
+	}
+
+	jobMap := map[string]*JobRule{} // job name should be unique
+	m := map[string]*MetricRule{}   // target metric name should be unique
+
+	for i := range c.Jobs {
+		job := &c.Jobs[i]
+		if len(job.Name) <= 0 {
+			return fmt.Errorf("job name is empty, job index %d", i)
+		}
+		_, ok := jobMap[job.Name]
+		if ok {
+			return fmt.Errorf("duplicate job name %s, job index %d", job.Name, i)
+		}
+		if len(job.Address) <= 0 || job.Port <= 0 {
+			return fmt.Errorf("job address or port is empty, job %s", job.Name)
+		}
+
+		for j := range job.Metrics {
+			metric := &job.Metrics[j]
+			if len(metric.TargetName) <= 0 {
+				return fmt.Errorf("metric target name is empty, job %s, metric index %d", job.Name, j)
+			}
+			_, ok = m[metric.TargetName]
+			if ok {
+				return fmt.Errorf("duplicate metric target name %s, job %s, metric index %d", metric.TargetName, job.Name, j)
+			}
+			if err := IsValidMetricRule(metric); err != nil {
+				return fmt.Errorf("invalid metric reason %s, job %s, target metric %s", err, job.Name, metric.TargetName)
+			}
+
+			m[metric.TargetName] = metric
+		}
+
+		jobMap[job.Name] = job
+	}
+
+	return nil
+}
+
+func (c *CollectRule) ToConfigs() ([]*ScraperConfig, error) {
+	if err := c.Validate(); err != nil {
+		return nil, fmt.Errorf("validate failed, err: %w", err)
+	}
+
+	if !c.IsEnabled() {
+		klog.V(4).Infof("ScrapeConfig is disabled, skip init scrapers")
+		return nil, nil
+	}
+
+	var scrapeConfigs []*ScraperConfig
+	for _, job := range c.Jobs {
+		scrapeConfig := &ScraperConfig{
+			Enable:         job.Enable,
+			JobName:        job.Name,
+			ScrapeInterval: job.ScrapeInterval,
+			Client: &ClientConfig{
+				Timeout:     job.ScrapeTimeout,
+				InsecureTLS: true,
+				Address:     job.Address,
+				Port:        job.Port,
+				Path:        job.Path,
+			},
+		}
+		if scrapeConfig.ScrapeInterval <= 0 {
+			scrapeConfig.ScrapeInterval = DefaultScrapeInterval
+		}
+		if scrapeConfig.Client.Timeout <= 0 {
+			scrapeConfig.Client.Timeout = DefaultScrapeTimeout
+		}
+		validTimeRange := scrapeConfig.ScrapeInterval / 2
+		if validTimeRange < MinValidMetricTimeRange {
+			validTimeRange = MinValidMetricTimeRange
+		}
+
+		var subDecoderConfigs []*DecodeConfig
+		for _, metric := range job.Metrics {
+			decoderConfig := &DecodeConfig{
+				TargetMetric:   metric.TargetName,
+				TargetType:     metric.TargetType,
+				TargetLabels:   metric.TargetLabels,
+				SourceMetric:   metric.SourceName,
+				SourceLabels:   metric.SourceLabels,
+				ValidTimeRange: validTimeRange,
+			}
+			subDecoderConfigs = append(subDecoderConfigs, decoderConfig)
+		}
+		scrapeConfig.Decoders = subDecoderConfigs
+
+		scrapeConfigs = append(scrapeConfigs, scrapeConfig)
+	}
+
+	return scrapeConfigs, nil
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/collect_rule_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/collect_rule_test.go
@@ -1,0 +1,746 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func TestLoadCollectRuleFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tests := []struct {
+		name      string
+		prepareFn func(helper *system.FileTestUtil)
+		arg       string
+		want      *CollectRule
+		wantErr   bool
+	}{
+		{
+			name:    "file not exist",
+			arg:     "/unknown-path-xxx",
+			wantErr: true,
+		},
+		{
+			name: "file parse correctly",
+			prepareFn: func(helper *system.FileTestUtil) {
+				_ = os.WriteFile(tmpDir+"/test-path", []byte(`
+---
+enable: true
+jobs:
+  - name: job-0
+    enable: true
+    address: "127.0.0.1"
+    port: 8000
+    path: /metrics
+    scrapeInterval: 20s
+    scrapeTimeout: 5s
+    metrics:
+    - sourceName: metric_a
+      targetName: metric_a
+      targetType: "node"
+    - sourceName: metric_b
+      sourceLabels:
+        bbb: aaa
+      targetName: metric_b
+      targetType: "node"
+  - name: job-1
+    enable: true
+    address: "127.0.0.1"
+    port: 9316
+    path: /metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric_c
+      targetName: metric_c
+      targetType: "pod"
+  - name: job-2
+    enable: false
+    address: "127.0.0.1"
+    port: 9090
+    path: /default-metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric_d
+      targetName: metric_d
+      targetType: "pod"
+`), 0644)
+			},
+			arg:     tmpDir + "/test-path",
+			wantErr: false,
+			want: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:           "job-0",
+						Enable:         true,
+						Address:        "127.0.0.1",
+						Port:           8000,
+						Path:           "/metrics",
+						ScrapeInterval: 20 * time.Second,
+						ScrapeTimeout:  5 * time.Second,
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_a",
+								TargetName: "metric_a",
+								TargetType: MetricTypeNode,
+							},
+							{
+								SourceName: "metric_b",
+								SourceLabels: model.LabelSet{
+									"bbb": "aaa",
+								},
+								TargetName: "metric_b",
+								TargetType: MetricTypeNode,
+							},
+						},
+					},
+					{
+						Name:           "job-1",
+						Enable:         true,
+						Address:        "127.0.0.1",
+						Port:           9316,
+						Path:           "/metrics",
+						ScrapeInterval: 30 * time.Second,
+						ScrapeTimeout:  10 * time.Second,
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_c",
+								TargetName: "metric_c",
+								TargetType: MetricTypePod,
+							},
+						},
+					},
+					{
+						Name:           "job-2",
+						Enable:         false,
+						Address:        "127.0.0.1",
+						Port:           9090,
+						Path:           "/default-metrics",
+						ScrapeInterval: 30 * time.Second,
+						ScrapeTimeout:  10 * time.Second,
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_d",
+								TargetName: "metric_d",
+								TargetType: MetricTypePod,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := system.NewFileTestUtil(t)
+			defer helper.Cleanup()
+			if tt.prepareFn != nil {
+				tt.prepareFn(helper)
+			}
+			got, gotErr := LoadCollectRuleFromFile(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCollectRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     *CollectRule
+		wantErr bool
+		want    []*ScraperConfig
+	}{
+		{
+			name:    "missing job rule",
+			arg:     &CollectRule{},
+			wantErr: true,
+		},
+		{
+			name: "missing job rule name",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Enable: true,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing job address",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:   "job-0",
+						Enable: true,
+						Port:   9316,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing metric rule target name",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_a",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing metric rule source name",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								TargetName: "metric_a",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing metric target type",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported metric target type",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "unknown",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid pod uid metric rule",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+							{
+								SourceName: "metric_s_1",
+								TargetName: "metric_t_1",
+								TargetType: "container",
+							},
+							{
+								SourceName: "metric_s_2",
+								TargetName: "metric_t_2",
+								TargetType: "pod_uid",
+								TargetLabels: model.LabelSet{
+									"unknown_label": "unknown",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid container metric rule",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+							{
+								SourceName: "metric_s_2",
+								TargetName: "metric_t_2",
+								TargetType: "pod_uid",
+							},
+							{
+								SourceName: "metric_s_1",
+								TargetName: "metric_t_1",
+								TargetType: "container",
+								TargetLabels: model.LabelSet{
+									"unknown_label": "unknown",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid container id metric rule",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+							{
+								SourceName: "metric_s_2",
+								TargetName: "metric_t_2",
+								TargetType: "pod_uid",
+							},
+							{
+								SourceName: "metric_s_1",
+								TargetName: "metric_t_1",
+								TargetType: "container_id",
+								TargetLabels: model.LabelSet{
+									"unknown_label": "unknown",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate metric target name",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+						},
+					},
+					{
+						Name:    "job-1",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9317,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_1",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid rule",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s",
+								TargetName: "metric_t",
+								TargetType: "node",
+							},
+							{
+								SourceName: "metric_s_1",
+								SourceLabels: model.LabelSet{
+									"label_0": "value_0",
+								},
+								TargetName: "metric_t_1",
+								TargetType: "pod",
+								TargetLabels: model.LabelSet{
+									"pod":       "pod_name",
+									"namespace": "pod_namespace",
+								},
+							},
+						},
+					},
+					{
+						Name:           "job-1",
+						Enable:         true,
+						Address:        "127.0.0.1",
+						Port:           9317,
+						Path:           "/metrics",
+						ScrapeInterval: 60 * time.Second,
+						ScrapeTimeout:  10 * time.Second,
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_2",
+								TargetName: "metric_t_2",
+								TargetType: "node",
+							},
+						},
+					},
+					{
+						Name:    "job-2",
+						Enable:  false,
+						Address: "127.0.0.1",
+						Port:    9000,
+						Path:    "",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_3",
+								TargetName: "metric_t_3",
+								TargetType: "node",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: []*ScraperConfig{
+				{
+					Enable:         true,
+					JobName:        "job-0",
+					ScrapeInterval: DefaultScrapeInterval,
+					Client: &ClientConfig{
+						Timeout:     DefaultScrapeTimeout,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9316,
+						Path:        "/metrics",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t",
+							TargetType:     "node",
+							SourceMetric:   "metric_s",
+							ValidTimeRange: DefaultScrapeInterval / 2,
+						},
+						{
+							TargetMetric:   "metric_t_1",
+							TargetType:     "pod",
+							TargetLabels:   model.LabelSet{"pod": "pod_name", "namespace": "pod_namespace"},
+							SourceMetric:   "metric_s_1",
+							SourceLabels:   model.LabelSet{"label_0": "value_0"},
+							ValidTimeRange: DefaultScrapeInterval / 2,
+						},
+					},
+				},
+				{
+					Enable:         true,
+					JobName:        "job-1",
+					ScrapeInterval: 60 * time.Second,
+					Client: &ClientConfig{
+						Timeout:     10 * time.Second,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9317,
+						Path:        "/metrics",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t_2",
+							TargetType:     "node",
+							SourceMetric:   "metric_s_2",
+							ValidTimeRange: 30 * time.Second,
+						},
+					},
+				},
+				{
+					Enable:         false,
+					JobName:        "job-2",
+					ScrapeInterval: DefaultScrapeInterval,
+					Client: &ClientConfig{
+						Timeout:     DefaultScrapeTimeout,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9000,
+						Path:        "",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t_3",
+							TargetType:     "node",
+							SourceMetric:   "metric_s_3",
+							ValidTimeRange: DefaultScrapeInterval / 2,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid rule 1",
+			arg: &CollectRule{
+				Enable: true,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_1",
+								SourceLabels: model.LabelSet{
+									"label_0": "value_0",
+								},
+								TargetName: "metric_t_1",
+								TargetType: "pod",
+								TargetLabels: model.LabelSet{
+									"pod":       "pod_name",
+									"namespace": "pod_namespace",
+								},
+							},
+						},
+					},
+					{
+						Name:           "job-1",
+						Enable:         true,
+						Address:        "127.0.0.1",
+						Port:           9317,
+						Path:           "/metrics",
+						ScrapeInterval: 3 * time.Second,
+						ScrapeTimeout:  1 * time.Second,
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_2",
+								TargetName: "metric_t_2",
+								TargetType: "node",
+								TargetLabels: model.LabelSet{
+									"type": "node",
+								},
+							},
+						},
+					},
+					{
+						Name:    "job-2",
+						Enable:  false,
+						Address: "127.0.0.1",
+						Port:    9000,
+						Path:    "",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_3",
+								TargetName: "metric_t_3",
+								TargetType: "qos",
+								TargetLabels: model.LabelSet{
+									"qos": "qos_class",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: []*ScraperConfig{
+				{
+					Enable:         true,
+					JobName:        "job-0",
+					ScrapeInterval: DefaultScrapeInterval,
+					Client: &ClientConfig{
+						Timeout:     DefaultScrapeTimeout,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9316,
+						Path:        "/metrics",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t_1",
+							TargetType:     "pod",
+							TargetLabels:   model.LabelSet{"pod": "pod_name", "namespace": "pod_namespace"},
+							SourceMetric:   "metric_s_1",
+							SourceLabels:   model.LabelSet{"label_0": "value_0"},
+							ValidTimeRange: DefaultScrapeInterval / 2,
+						},
+					},
+				},
+				{
+					Enable:         true,
+					JobName:        "job-1",
+					ScrapeInterval: 3 * time.Second,
+					Client: &ClientConfig{
+						Timeout:     1 * time.Second,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9317,
+						Path:        "/metrics",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t_2",
+							TargetType:     "node",
+							TargetLabels:   model.LabelSet{"type": "node"},
+							SourceMetric:   "metric_s_2",
+							ValidTimeRange: MinValidMetricTimeRange,
+						},
+					},
+				},
+				{
+					Enable:         false,
+					JobName:        "job-2",
+					ScrapeInterval: DefaultScrapeInterval,
+					Client: &ClientConfig{
+						Timeout:     DefaultScrapeTimeout,
+						InsecureTLS: true,
+						Address:     "127.0.0.1",
+						Port:        9000,
+						Path:        "",
+					},
+					Decoders: []*DecodeConfig{
+						{
+							TargetMetric:   "metric_t_3",
+							TargetType:     "qos",
+							TargetLabels:   model.LabelSet{"qos": "qos_class"},
+							SourceMetric:   "metric_s_3",
+							ValidTimeRange: DefaultScrapeInterval / 2,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rule disabled",
+			arg: &CollectRule{
+				Enable: false,
+				Jobs: []JobRule{
+					{
+						Name:    "job-0",
+						Enable:  true,
+						Address: "127.0.0.1",
+						Port:    9316,
+						Path:    "/metrics",
+						Metrics: []MetricRule{
+							{
+								SourceName: "metric_s_1",
+								SourceLabels: model.LabelSet{
+									"label_0": "value_0",
+								},
+								TargetName: "metric_t_1",
+								TargetType: "pod",
+								TargetLabels: model.LabelSet{
+									"pod":       "pod_name",
+									"namespace": "pod_namespace",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := tt.arg.ToConfigs()
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/prom_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/prom_collector.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+const CollectorName = "PromCollector"
+
+// The collector is for collecting the metrics (prometheus format encoded) from external prometheus exporters.
+// To simplify the implementation of the prometheus metrics collection, the collector allows multiple scrapers to
+// register, and a scraper is responsible for scrape and decode the metrics from a prometheus exporter.
+// A scraper collects from only one exporter and decode the raw metrics into the metrics classified by the metric
+// level (node, pod, container, qos...).
+type collector struct {
+	appendableDB   metriccache.Appendable
+	statesInformer statesinformer.StatesInformer
+	rulePath       string
+	started        *atomic.Bool
+}
+
+func New(opt *framework.Options) framework.Collector {
+	return &collector{
+		appendableDB:   opt.MetricCache,
+		statesInformer: opt.StatesInformer,
+		rulePath:       opt.Config.CollectPromMetricRulePath,
+		started:        atomic.NewBool(false),
+	}
+}
+
+func (c *collector) Enabled() bool {
+	return len(c.rulePath) > 0
+}
+
+func (c *collector) Setup(s *framework.Context) {}
+
+func (c *collector) Run(stopCh <-chan struct{}) {
+	if !cache.WaitForCacheSync(stopCh, c.statesInformer.HasSynced) {
+		// exit when statesInformer sync failed
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
+		klog.Fatalf("timed out waiting for states informer caches to sync")
+	}
+	c.run(stopCh)
+}
+
+func (c *collector) Started() bool {
+	return c.started.Load()
+}
+
+func (c *collector) run(stopCh <-chan struct{}) {
+	// load rules from the rule and generate scraper configs
+	rule, err := LoadCollectRuleFromFile(c.rulePath)
+	if err != nil {
+		klog.Warningf("load collect rule failed, file %s, err: %w", c.rulePath, err)
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
+		return
+	}
+	configs, err := rule.ToConfigs()
+	if err != nil {
+		klog.Warningf("convert collect rule to config failed, rule %+v, err: %w", rule, err)
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
+		return
+	}
+
+	// init scrapers
+	scrapersWithInterval := map[time.Duration][]Scraper{}
+	for _, cfg := range configs {
+		s, err := NewGenericScraper(cfg)
+		if err != nil {
+			klog.Warningf("failed to init prom scraper %+v, err: %s", s, err)
+			continue
+		}
+
+		klog.V(4).Infof("init prom scraper %s successfully", s.Name())
+		_, ok := scrapersWithInterval[cfg.ScrapeInterval]
+		if !ok {
+			scrapersWithInterval[cfg.ScrapeInterval] = []Scraper{s}
+		} else {
+			scrapersWithInterval[cfg.ScrapeInterval] = append(scrapersWithInterval[cfg.ScrapeInterval], s)
+		}
+	}
+
+	for interval := range scrapersWithInterval {
+		scrapers := scrapersWithInterval[interval]
+		go wait.Until(func() {
+			c.runScrapers(scrapers...)
+		}, interval, stopCh)
+		klog.V(5).Infof("run scrapers at interval %v, num %d", interval, len(scrapers))
+	}
+
+	klog.V(4).Infof("start prom collector, scrapers num %d", len(scrapersWithInterval))
+}
+
+func (c *collector) runScrapers(scrapers ...Scraper) {
+	node := c.statesInformer.GetNode()
+	if node == nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, false)
+		klog.V(4).Infof("failed to run prom collector, err: no node found")
+		return
+	}
+	podMetas := c.statesInformer.GetAllPods()
+
+	count := 0
+	for _, s := range scrapers {
+		scraperName := s.Name()
+		metricSamples, err := s.GetMetricSamples(node, podMetas)
+		if err != nil {
+			metrics.RecordCollectPromMetricsStatus(scraperName, false)
+			klog.V(4).Infof("failed to scrape prom samples by scraper %s, err: %s", scraperName, err)
+			continue
+		}
+		metrics.RecordCollectPromMetricsStatus(scraperName, true)
+		klog.V(6).Infof("scrape prom metrics finished by scraper %s, metrics num %d", scraperName, len(metricSamples))
+
+		appender := c.appendableDB.Appender()
+		if err = appender.Append(metricSamples); err != nil {
+			klog.V(4).Infof("failed to append metrics for scraper %s, samples %+v, err: %s", scraperName, metricSamples, err)
+			continue
+		}
+		klog.V(6).Infof("append metric samples finished for scraper %s, metrics num %d", scraperName, len(metricSamples))
+
+		if err = appender.Commit(); err != nil {
+			klog.V(4).Infof("failed to commit metrics for scraper %s, err: %s", scraperName, err)
+			continue
+		}
+
+		count += len(metricSamples)
+	}
+
+	klog.V(4).Infof("prom collector scrapes metrics finished, scraper num %d, metrics num %d", len(scrapers), count)
+	c.started.Store(true)
+	metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, CollectorName, true)
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/prom_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/prom_collector_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	mockmetriccache "github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache/mockmetriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	mockstatesinformer "github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer/mockstatesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func TestCollector(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		statesInformer := mockstatesinformer.NewMockStatesInformer(ctrl)
+		metricCache := mockmetriccache.NewMockMetricCache(ctrl)
+		appender := mockmetriccache.NewMockAppender(ctrl)
+		helper := system.NewFileTestUtil(t)
+		defer helper.Cleanup()
+		testRuleContent := `
+---
+enable: true
+jobs:
+  - name: job-0
+    enable: true
+    address: "127.0.0.1"
+    port: 8000
+    path: /metrics
+    scrapeInterval: 20s
+    scrapeTimeout: 5s
+    metrics:
+    - sourceName: metric_a
+      targetName: metric_a
+      targetType: "node"
+    - sourceName: metric_b
+      sourceLabels:
+        bbb: aaa
+      targetName: metric_b
+      targetType: "node"
+  - name: job-1
+    enable: true
+    address: "127.0.0.1"
+    port: 9316
+    path: /metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric_c
+      targetName: metric_c
+      targetType: "pod"
+  - name: job-2
+    enable: false
+    address: "127.0.0.1"
+    port: 9090
+    path: /default-metrics
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    metrics:
+    - sourceName: metric_d
+      targetName: metric_d
+      targetType: "pod"
+`
+		helper.WriteFileContents("prom-collect-rule.yaml", testRuleContent)
+		testNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100"),
+					corev1.ResourceMemory: resource.MustParse("400Gi"),
+				},
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100"),
+					corev1.ResourceMemory: resource.MustParse("400Gi"),
+				},
+			},
+		}
+		testPodMetas := []*statesinformer.PodMeta{
+			{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-be-pod",
+						Namespace: "test-ns",
+						UID:       "uid-xxxxxx",
+						Labels: map[string]string{
+							extension.LabelPodQoS: string(extension.QoSBE),
+						},
+					},
+				},
+			},
+			{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ls-pod",
+						Namespace: "test-ns",
+						UID:       "uid-yyyyyy",
+						Labels: map[string]string{
+							extension.LabelPodQoS: string(extension.QoSLS),
+						},
+					},
+				},
+			},
+		}
+
+		c := New(&framework.Options{
+			MetricCache:    metricCache,
+			StatesInformer: statesInformer,
+			Config: &framework.Config{
+				CollectPromMetricRulePath: helper.TempDir + "/prom-collect-rule.yaml",
+			},
+		})
+		assert.NotNil(t, c)
+		assert.True(t, c.Enabled())
+		c.Setup(&framework.Context{})
+
+		statesInformer.EXPECT().HasSynced().Return(true)
+		statesInformer.EXPECT().GetNode().Return(testNode).AnyTimes()
+		statesInformer.EXPECT().GetAllPods().Return(testPodMetas).AnyTimes()
+		metricCache.EXPECT().Appender().Return(appender).AnyTimes()
+		appender.EXPECT().Append(gomock.Any()).Return(nil).AnyTimes()
+		appender.EXPECT().Commit().Return(nil).AnyTimes()
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		c.Run(stopCh)
+	})
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/scrape_client.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/scrape_client.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
+)
+
+type ScrapeClient interface {
+	URL() string
+	GetMetrics() ([]*model.Sample, error)
+}
+
+type ClientConfig struct {
+	Timeout     time.Duration
+	InsecureTLS bool
+	Address     string
+	Port        int
+	Path        string
+}
+
+type ScrapeClientImpl struct {
+	httpClient *http.Client
+	url        *url.URL
+	buffers    *sync.Pool
+}
+
+func NewScrapeClientFromConfig(cfg *ClientConfig) (ScrapeClient, error) {
+	var (
+		scheme     string
+		restConfig *rest.Config
+		err        error
+	)
+
+	if cfg.InsecureTLS {
+		scheme = "http"
+	} else {
+		restConfig, err = config.GetConfig()
+		if err != nil {
+			return nil, err
+		}
+		restConfig.TLSClientConfig.Insecure = true
+		restConfig.TLSClientConfig.CAData = nil
+		restConfig.TLSClientConfig.CAFile = ""
+		scheme = "https"
+	}
+
+	return NewScrapeClient(cfg.Address, cfg.Port, cfg.Path, scheme, cfg.Timeout, restConfig)
+}
+
+func NewScrapeClient(addr string, port int, path string, scheme string, timeout time.Duration, cfg *rest.Config) (ScrapeClient, error) {
+	c := &http.Client{
+		Timeout: timeout,
+	}
+	if cfg != nil && rest.IsConfigTransportTLS(*cfg) {
+		transport, err := rest.TransportFor(cfg)
+		if err != nil {
+			return nil, err
+		}
+		c.Transport = transport
+	}
+
+	u := &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(addr, strconv.Itoa(port)),
+		Path:   path,
+	}
+
+	return &ScrapeClientImpl{
+		httpClient: c,
+		url:        u,
+		buffers: &sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
+		},
+	}, nil
+}
+
+func (s *ScrapeClientImpl) URL() string {
+	return s.url.String()
+}
+
+func (s *ScrapeClientImpl) GetMetrics() ([]*model.Sample, error) {
+	metricsURL := s.url.String()
+	timeNow := time.Now()
+	resp, err := s.httpClient.Get(metricsURL)
+	metrics.RecordHttpClientQueryLatency(metricsURL, float64(time.Since(timeNow).Milliseconds()))
+	if err != nil {
+		metrics.RecordHttpClientQueryStatus(metricsURL, -1)
+		return nil, err
+	}
+	defer func() {
+		err1 := resp.Body.Close()
+		if err1 != nil {
+			klog.Warningf("close response body failed, err: %s", err1)
+		}
+	}()
+	metrics.RecordHttpClientQueryStatus(metricsURL, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request %s failed, code %d", metricsURL, resp.StatusCode)
+	}
+
+	b := s.getBuffer()
+	defer s.returnBuffer(b)
+	_, err = io.Copy(b, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := expfmt.NewDecoder(b, expfmt.ResponseFormat(resp.Header))
+	decoder := expfmt.SampleDecoder{
+		Dec:  dec,
+		Opts: &expfmt.DecodeOptions{},
+	}
+
+	var samples []*model.Sample
+	for {
+		var v model.Vector
+		if err = decoder.Decode(&v); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		samples = append(samples, v...)
+	}
+
+	return samples, nil
+}
+
+func (s *ScrapeClientImpl) getBuffer() *bytes.Buffer {
+	return s.buffers.Get().(*bytes.Buffer)
+}
+
+func (s *ScrapeClientImpl) returnBuffer(b *bytes.Buffer) {
+	b.Reset()
+	s.buffers.Put(b)
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/scrape_client_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/scrape_client_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewScrapeClientFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     *ClientConfig
+		wantErr bool
+		want    ScrapeClient
+	}{
+		{
+			name: "new http client",
+			arg: &ClientConfig{
+				Timeout:     3 * time.Second,
+				Address:     "127.0.0.1",
+				Port:        9316,
+				Path:        "/metrics",
+				InsecureTLS: true,
+			},
+			wantErr: false,
+			want: &ScrapeClientImpl{
+				httpClient: &http.Client{
+					Timeout: 3 * time.Second,
+				},
+				url: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1:9316",
+					Path:   "/metrics",
+				},
+				buffers: &sync.Pool{
+					New: func() interface{} {
+						return new(bytes.Buffer)
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := NewScrapeClientFromConfig(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assertSameScrapeClientImpl(t, tt.want, got)
+		})
+	}
+}
+
+func TestScrapeClient(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		testRespBytes := `# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 50
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 30
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 10000.00
+`
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(testRespBytes))
+		}))
+		sURL, err := url.Parse(s.URL)
+		assert.NoError(t, err)
+		c := &ScrapeClientImpl{
+			httpClient: &http.Client{
+				Timeout: 3 * time.Second,
+			},
+			url: sURL,
+			buffers: &sync.Pool{
+				New: func() interface{} {
+					return new(bytes.Buffer)
+				},
+			},
+		}
+
+		want := []*model.Sample{
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "go_goroutines",
+				},
+				Value: model.SampleValue(50),
+			},
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "go_threads",
+				},
+				Value: model.SampleValue(30),
+			},
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "process_cpu_seconds_total",
+				},
+				Value: model.SampleValue(10000),
+			},
+		}
+		got, err := c.GetMetrics()
+		assert.NoError(t, err)
+		assertEqualSamplesOutOfOrder(t, want, got)
+
+		s.Close()
+
+		got, err = c.GetMetrics()
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func assertSameScrapeClientImpl(t *testing.T, want, got ScrapeClient) {
+	if want == nil || got == nil {
+		assert.Equal(t, want, got)
+		return
+	}
+	ai, aOK := want.(*ScrapeClientImpl)
+	bi, bOK := got.(*ScrapeClientImpl)
+	assert.True(t, aOK)
+	assert.True(t, bOK)
+	aBufFn := ai.buffers
+	bBufFn := bi.buffers
+	assert.NotNil(t, aBufFn)
+	assert.NotNil(t, bBufFn)
+	ai.buffers = nil
+	bi.buffers = nil
+	assert.Equal(t, ai, bi)
+	ai.buffers = aBufFn
+	bi.buffers = bBufFn
+}
+
+func assertEqualSamplesOutOfOrder(t *testing.T, want, got []*model.Sample) {
+	mW := map[model.LabelValue]*model.Sample{}
+	for _, s := range want {
+		mW[s.Metric[model.MetricNameLabel]] = s
+	}
+	mG := map[model.LabelValue]*model.Sample{}
+	for _, s := range got {
+		mG[s.Metric[model.MetricNameLabel]] = s
+	}
+	assert.Equal(t, len(mW), len(mG), "equal metric number")
+	for k, s := range mW {
+		sG, ok := mG[k]
+		assert.True(t, ok, k)
+		assert.Equal(t, s, sG)
+	}
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/scraper.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/scraper.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	corev1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+type MetricType string
+
+const (
+	MetricTypeNode        MetricType = "node"         // target labels: none
+	MetricTypeQoS         MetricType = "qos"          // target labels: <"qos">
+	MetricTypePod         MetricType = "pod"          // target labels: <"namespace", "pod">
+	MetricTypePodUID      MetricType = "pod_uid"      // target labels: <"pod_uid">
+	MetricTypeContainer   MetricType = "container"    // target labels: <"namespace", "pod", "container">
+	MetricTypeContainerID MetricType = "container_id" // target labels: <"container_id">
+	// TODO: support hostApp type
+
+	TargetLabelKeyQoS         model.LabelName = "qos"
+	TargetLabelKeyPod         model.LabelName = "pod"
+	TargetLabelKeyNamespace   model.LabelName = "namespace"
+	TargetLabelKeyPodUID      model.LabelName = "uid"
+	TargetLabelKeyContainer   model.LabelName = "container"
+	TargetLabelKeyContainerID model.LabelName = "container_id"
+
+	SampleKeyNode              = "__node__"
+	SampleKeyQoSPrefix         = "__qos_"
+	SampleKeyPodUIDPrefix      = "__pod_uid_"
+	SampleKeyContainerIDPrefix = "__container_id_"
+)
+
+func IsValidMetricRule(metricRule *MetricRule) error {
+	if len(metricRule.TargetName) <= 0 {
+		return fmt.Errorf("empty metric target name")
+	}
+	if len(metricRule.SourceName) <= 0 {
+		return fmt.Errorf("empty metric source name")
+	}
+
+	switch metricRule.TargetType {
+	case MetricTypeNode:
+		break
+	case MetricTypeQoS:
+		if len(metricRule.TargetLabels) <= 0 {
+			break
+		}
+		if _, ok := metricRule.TargetLabels[TargetLabelKeyQoS]; !ok {
+			return fmt.Errorf("metric type %s required target label key %s not found",
+				metricRule.TargetType, TargetLabelKeyQoS)
+		}
+	case MetricTypePod:
+		if len(metricRule.TargetLabels) <= 0 {
+			break
+		}
+		_, NamespaceIsOK := metricRule.TargetLabels[TargetLabelKeyNamespace]
+		_, podNameIsOK := metricRule.TargetLabels[TargetLabelKeyPod]
+		if !NamespaceIsOK || !podNameIsOK {
+			return fmt.Errorf("metric type %s required target label keys <%s, %s> not found",
+				metricRule.TargetType, TargetLabelKeyNamespace, TargetLabelKeyPod)
+		}
+	case MetricTypePodUID:
+		if len(metricRule.TargetLabels) <= 0 {
+			break
+		}
+		_, podUIDIsOK := metricRule.TargetLabels[TargetLabelKeyPodUID]
+		if !podUIDIsOK {
+			return fmt.Errorf("metric type %s required target label keys  %s not found",
+				metricRule.TargetType, TargetLabelKeyPodUID)
+		}
+	case MetricTypeContainer:
+		if len(metricRule.TargetLabels) <= 0 {
+			break
+		}
+		_, NamespaceIsOK := metricRule.TargetLabels[TargetLabelKeyNamespace]
+		_, podNameIsOK := metricRule.TargetLabels[TargetLabelKeyPod]
+		_, containerNameIsOK := metricRule.TargetLabels[TargetLabelKeyContainer]
+		if !NamespaceIsOK || !podNameIsOK || !containerNameIsOK {
+			return fmt.Errorf("metric type %s required target label keys <%s, %s, %s> not found",
+				metricRule.TargetType, TargetLabelKeyNamespace, TargetLabelKeyPod, TargetLabelKeyContainer)
+		}
+	case MetricTypeContainerID:
+		if len(metricRule.TargetLabels) <= 0 {
+			break
+		}
+		_, containerIDIsOK := metricRule.TargetLabels[TargetLabelKeyContainerID]
+		if !containerIDIsOK {
+			return fmt.Errorf("metric type %s required target label keys %s not found",
+				metricRule.TargetType, TargetLabelKeyContainerID)
+		}
+	default:
+		return fmt.Errorf("unsupported metric target type %s", metricRule.TargetType)
+	}
+
+	return nil
+}
+
+func GenSampleKey(sample *model.Sample, metricType MetricType, targetLabels model.LabelSet) string {
+	switch metricType {
+	case MetricTypeNode:
+		// e.g. "__node__"
+		return SampleKeyNode
+	case MetricTypeQoS:
+		// e.g. "__qos_BE"
+		qosKey := TargetLabelKeyQoS
+		if len(targetLabels) > 0 {
+			qosKey = model.LabelName(targetLabels[TargetLabelKeyQoS])
+		}
+		return SampleKeyQoSPrefix + string(sample.Metric[qosKey])
+	case MetricTypePod:
+		// e.g. "example-ns/example-pod"
+		podNamespaceKey := TargetLabelKeyNamespace
+		podNameKey := TargetLabelKeyPod
+		if len(targetLabels) > 0 {
+			if key, ok := targetLabels[TargetLabelKeyNamespace]; ok {
+				podNamespaceKey = model.LabelName(key)
+			}
+			if key, ok := targetLabels[TargetLabelKeyPod]; ok {
+				podNameKey = model.LabelName(key)
+			}
+		}
+		return string(sample.Metric[podNamespaceKey]) + "/" + string(sample.Metric[podNameKey])
+	case MetricTypePodUID:
+		// e.g. "__pod_uid_xxxxxx"
+		podUIDKey := TargetLabelKeyPodUID
+		if len(targetLabels) > 0 {
+			if key, ok := targetLabels[TargetLabelKeyPodUID]; ok {
+				podUIDKey = model.LabelName(key)
+			}
+		}
+		return SampleKeyPodUIDPrefix + string(sample.Metric[podUIDKey])
+	case MetricTypeContainer:
+		// e.g. "example-ns/example-pod/example-container"
+		podNamespaceKey := TargetLabelKeyNamespace
+		podNameKey := TargetLabelKeyPod
+		containerNameKey := TargetLabelKeyContainer
+		if len(targetLabels) > 0 {
+			if key, ok := targetLabels[TargetLabelKeyNamespace]; ok {
+				podNamespaceKey = model.LabelName(key)
+			}
+			if key, ok := targetLabels[TargetLabelKeyPod]; ok {
+				podNameKey = model.LabelName(key)
+			}
+			if key, ok := targetLabels[TargetLabelKeyContainer]; ok {
+				containerNameKey = model.LabelName(key)
+			}
+		}
+		return string(sample.Metric[podNamespaceKey]) + "/" + string(sample.Metric[podNameKey]) + "/" + string(sample.Metric[containerNameKey])
+	case MetricTypeContainerID:
+		// e.g. "__container_id_containerd://yyyyyy"
+		containerIDKey := TargetLabelKeyContainerID
+		if len(targetLabels) > 0 {
+			if key, ok := targetLabels[TargetLabelKeyContainerID]; ok {
+				containerIDKey = model.LabelName(key)
+			}
+		}
+		return SampleKeyContainerIDPrefix + string(sample.Metric[containerIDKey])
+	}
+	return ""
+}
+
+func MakeMetricSamples(samplesMap map[string][]*model.Sample, targetName string, targetType MetricType, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	switch targetType {
+	case MetricTypeNode:
+		return GenerateNodeMetrics(samplesMap, targetName, node)
+	case MetricTypeQoS:
+		return GenerateQoSMetrics(samplesMap, targetName)
+	case MetricTypePod:
+		return GeneratePodMetrics(samplesMap, targetName, podMetas)
+	case MetricTypePodUID:
+		return GeneratePodUIDMetrics(samplesMap, targetName)
+	case MetricTypeContainer:
+		return GenerateContainerMetrics(samplesMap, targetName, podMetas)
+	case MetricTypeContainerID:
+		return GenerateContainerIDMetrics(samplesMap, targetName)
+	}
+	return nil, fmt.Errorf("unsupported metric type %s", targetType)
+}
+
+type ScraperConfig struct {
+	Enable         bool
+	Client         *ClientConfig
+	Decoders       []*DecodeConfig
+	ScrapeInterval time.Duration
+	JobName        string
+}
+
+type ScraperFactory interface {
+	New(clientConfig *ScraperConfig) (Scraper, error)
+}
+
+// Scraper is the interface for scraping the prometheus metrics and decoding into the metric cache's metric samples.
+type Scraper interface {
+	Name() string
+	GetMetricSamples(node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error)
+}
+
+type GenericScraper struct {
+	Client  ScrapeClient
+	Decoder Decoder
+	JobName string
+	Enable  bool
+}
+
+func NewGenericScraper(cfg *ScraperConfig) (Scraper, error) {
+	client, err := NewScrapeClientFromConfig(cfg.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scrape client, cfg %+v, err: %w", cfg, err)
+	}
+
+	s := &GenericScraper{
+		Client:  client,
+		JobName: cfg.JobName,
+		Enable:  cfg.Enable,
+	}
+
+	if len(cfg.Decoders) <= 0 {
+		return nil, fmt.Errorf("no decoder config found")
+	}
+
+	s.Decoder = NewMultiDecoder(cfg.Decoders...)
+
+	return s, nil
+}
+
+func (c *GenericScraper) Name() string {
+	return c.JobName
+}
+
+func (c *GenericScraper) GetMetricSamples(node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	if !c.Enable {
+		klog.V(6).Infof("scraper %s is disabled, skip scrape metrics", c.Name())
+		return nil, nil
+	}
+
+	samples, err := c.Client.GetMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("get metrics failed, url %s, err: %w", c.Client.URL(), err)
+	}
+	klog.V(6).Infof("scrape prom metrics finished by scraper %s, url %s, metrics num %d", c.Name(), c.Client.URL(), len(samples))
+
+	metricSamples, err := c.Decoder.Decode(samples, node, podMetas)
+	if err != nil {
+		return nil, fmt.Errorf("decode metrics failed, err: %w", err)
+	}
+
+	klog.V(6).Infof("decode prom samples finished by scraper %s, metrics num %d", c.Name(), len(metricSamples))
+	return metricSamples, nil
+}
+
+type DecodeConfig struct {
+	TargetMetric   string
+	TargetType     MetricType
+	TargetLabels   model.LabelSet
+	SourceMetric   string
+	SourceLabels   model.LabelSet
+	ValidTimeRange time.Duration
+}
+
+type Decoder interface {
+	Decode(samples []*model.Sample, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error)
+}
+
+type DecodeFn func(samples []*model.Sample, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error)
+
+type MultiDecoder struct {
+	decoders []Decoder
+}
+
+func NewMultiDecoder(configs ...*DecodeConfig) Decoder {
+	var decoders []Decoder
+	for _, cfg := range configs {
+		decoders = append(decoders, NewGenericDecoder(cfg))
+	}
+	return &MultiDecoder{
+		decoders: decoders,
+	}
+}
+
+func (m *MultiDecoder) Decode(samples []*model.Sample, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	// TODO: look up multiple target metrics faster
+	var allMetricSamples []metriccache.MetricSample
+	var errs []error
+	for _, decoder := range m.decoders {
+		metricSamples, err := decoder.Decode(samples, node, podMetas)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		allMetricSamples = append(allMetricSamples, metricSamples...)
+	}
+	if len(errs) > 0 {
+		return allMetricSamples, utilerrors.NewAggregate(errs)
+	}
+	return allMetricSamples, nil
+}
+
+type GenericDecoder struct {
+	decodeFn DecodeFn
+}
+
+func NewGenericDecoder(cfg *DecodeConfig) Decoder {
+	return &GenericDecoder{
+		decodeFn: GenericDecodeFn(cfg),
+	}
+}
+
+func (d *GenericDecoder) Decode(samples []*model.Sample, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	return d.decodeFn(samples, node, podMetas)
+}
+
+func GenericDecodeFn(cfg *DecodeConfig) DecodeFn {
+	return func(samples []*model.Sample, node *corev1.Node, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+		timeNow := model.Now()
+		samplesMap := map[string][]*model.Sample{}
+		for _, sample := range samples {
+			if string(sample.Metric[model.MetricNameLabel]) != cfg.SourceMetric {
+				continue
+			}
+			// in case some metrics have no timestamp
+			if sample.Timestamp.UnixNano() <= 0 {
+				sample.Timestamp = timeNow
+			} else if sample.Timestamp.Sub(timeNow) > cfg.ValidTimeRange || timeNow.Sub(sample.Timestamp) > cfg.ValidTimeRange {
+				continue
+			}
+
+			labelsMatched := true
+			for key, value := range cfg.SourceLabels {
+				if sample.Metric[key] != value {
+					labelsMatched = false
+					break
+				}
+			}
+			if !labelsMatched {
+				continue
+			}
+
+			sampleKey := GenSampleKey(sample, cfg.TargetType, cfg.TargetLabels)
+			vec, ok := samplesMap[sampleKey]
+			if ok {
+				samplesMap[sampleKey] = append(vec, sample)
+			} else {
+				samplesMap[sampleKey] = []*model.Sample{sample}
+			}
+		}
+
+		klog.V(6).Infof("decode prom samples num %v for metric name %s, target %s, detail %+v",
+			len(samplesMap), cfg.SourceMetric, cfg.TargetMetric, samplesMap)
+		return MakeMetricSamples(samplesMap, cfg.TargetMetric, cfg.TargetType, node, podMetas)
+	}
+}
+
+func GenerateNodeMetrics(samplesMap map[string][]*model.Sample, targetName string, _ *corev1.Node) ([]metriccache.MetricSample, error) {
+	samples, ok := samplesMap[SampleKeyNode]
+	if !ok || len(samples) <= 0 {
+		klog.V(5).Infof("find no sample for node, sample num %s", len(samplesMap))
+		return nil, nil
+	}
+
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName))
+	var metricSamples []metriccache.MetricSample
+	for _, sample := range samples {
+		metricSample, err := metricResource.GenerateSample(nil, sample.Timestamp.Time(), float64(sample.Value))
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate metric sample for node, metric %s, err: %w", targetName, err)
+		}
+		metricSamples = append(metricSamples, metricSample)
+	}
+
+	return metricSamples, nil
+}
+
+func GenerateQoSMetrics(samplesMap map[string][]*model.Sample, targetName string) ([]metriccache.MetricSample, error) {
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName), metriccache.MetricPropertyQoS)
+	var metricSamples []metriccache.MetricSample
+	for sampleKey, samples := range samplesMap {
+		if !strings.HasPrefix(sampleKey, SampleKeyQoSPrefix) {
+			continue
+		}
+
+		qos := strings.TrimPrefix(sampleKey, SampleKeyQoSPrefix)
+		if len(samples) <= 0 {
+			klog.V(5).Infof("find no sample for qos %s, sample num %s", qos, len(samplesMap))
+			continue
+		}
+		for _, sample := range samples {
+			metricSample, err := metricResource.GenerateSample(metriccache.MetricPropertiesFunc.QoS(qos), sample.Timestamp.Time(), float64(sample.Value))
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate metric sample for qos %s, metric %s, err: %w", qos, targetName, err)
+			}
+			metricSamples = append(metricSamples, metricSample)
+		}
+	}
+
+	return metricSamples, nil
+}
+
+func GeneratePodMetrics(samplesMap map[string][]*model.Sample, targetName string, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName), metriccache.MetricPropertyPodUID)
+	var metricSamples []metriccache.MetricSample
+	for _, podMeta := range podMetas {
+		samples, ok := samplesMap[podMeta.Key()]
+		if !ok {
+			klog.V(5).Infof("failed to find sample for pod %s, metric %s", podMeta.Key(), targetName)
+			continue
+		}
+
+		for _, sample := range samples {
+			metricSample, err := metricResource.GenerateSample(metriccache.MetricPropertiesFunc.Pod(string(podMeta.Pod.UID)), sample.Timestamp.Time(), float64(sample.Value))
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate metric sample for pod %s, metric %s, err: %w", podMeta.Key(), targetName, err)
+			}
+			metricSamples = append(metricSamples, metricSample)
+		}
+	}
+
+	return metricSamples, nil
+}
+
+func GeneratePodUIDMetrics(samplesMap map[string][]*model.Sample, targetName string) ([]metriccache.MetricSample, error) {
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName), metriccache.MetricPropertyPodUID)
+	var metricSamples []metriccache.MetricSample
+	for sampleKey, samples := range samplesMap {
+		if !strings.HasPrefix(sampleKey, SampleKeyPodUIDPrefix) {
+			continue
+		}
+
+		uid := strings.TrimPrefix(sampleKey, SampleKeyPodUIDPrefix)
+		if len(samples) <= 0 {
+			klog.V(5).Infof("find no sample for pod uid %s, sample num %s", uid, len(samplesMap))
+			continue
+		}
+		for _, sample := range samples {
+			metricSample, err := metricResource.GenerateSample(metriccache.MetricPropertiesFunc.Pod(uid), sample.Timestamp.Time(), float64(sample.Value))
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate metric sample for pod uid %s, metric %s, err: %w", uid, targetName, err)
+			}
+			metricSamples = append(metricSamples, metricSample)
+		}
+	}
+
+	return metricSamples, nil
+}
+
+func GenerateContainerMetrics(samplesMap map[string][]*model.Sample, targetName string, podMetas []*statesinformer.PodMeta) ([]metriccache.MetricSample, error) {
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName), metriccache.MetricPropertyContainerID)
+	var metricSamples []metriccache.MetricSample
+	for _, podMeta := range podMetas {
+		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+			if len(containerStat.ContainerID) <= 0 {
+				klog.V(6).Infof("skip find sample for container %s/%s, metric %s, no container id", podMeta.Key(), containerStat.Name, targetName)
+				continue
+			}
+
+			samples, ok := samplesMap[podMeta.Key()+"/"+containerStat.Name]
+			if !ok {
+				klog.V(5).Infof("failed to find sample for container %s/%s, metric %s", podMeta.Key(), containerStat.Name, targetName)
+				continue
+			}
+
+			for _, sample := range samples {
+				metricSample, err := metricResource.GenerateSample(metriccache.MetricPropertiesFunc.Container(containerStat.ContainerID), sample.Timestamp.Time(), float64(sample.Value))
+				if err != nil {
+					return nil, fmt.Errorf("failed to generate metric sample for container %s/%s, metric %s, err: %w", podMeta.Key(), containerStat.Name, targetName, err)
+				}
+				metricSamples = append(metricSamples, metricSample)
+			}
+		}
+	}
+
+	return metricSamples, nil
+}
+
+func GenerateContainerIDMetrics(samplesMap map[string][]*model.Sample, targetName string) ([]metriccache.MetricSample, error) {
+	metricResource := metriccache.GenMetricResource(metriccache.MetricKind(targetName), metriccache.MetricPropertyContainerID)
+	var metricSamples []metriccache.MetricSample
+	for sampleKey, samples := range samplesMap {
+		if !strings.HasPrefix(sampleKey, SampleKeyContainerIDPrefix) {
+			continue
+		}
+
+		containerID := strings.TrimPrefix(sampleKey, SampleKeyContainerIDPrefix)
+		if len(samples) <= 0 {
+			klog.V(5).Infof("find no sample for container id %s, sample num %s", containerID, len(samplesMap))
+			continue
+		}
+		for _, sample := range samples {
+			metricSample, err := metricResource.GenerateSample(metriccache.MetricPropertiesFunc.Container(containerID), sample.Timestamp.Time(), float64(sample.Value))
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate metric sample for container id %s, metric %s, err: %w", containerID, targetName, err)
+			}
+			metricSamples = append(metricSamples, metricSample)
+		}
+	}
+
+	return metricSamples, nil
+}

--- a/pkg/koordlet/metricsadvisor/collectors/prom/scraper_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/prom/scraper_test.go
@@ -1,0 +1,1084 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+func TestDecoder(t *testing.T) {
+	testNow := model.Now()
+	testOneHourAgo := testNow.Add(-time.Hour)
+	testNodeMetricResource := metriccache.GenMetricResource("node_load_1m")
+	testMetricSample, err := testNodeMetricResource.GenerateSample(nil, testNow.Time(), 20)
+	assert.NoError(t, err)
+	testQoSMetricResource := metriccache.GenMetricResource("node_qos_load_1m", metriccache.MetricPropertyQoS)
+	testMetricSample1, err := testQoSMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.QoS("BE"), testNow.Time(), 20)
+	assert.NoError(t, err)
+	testMetricSample2, err := testQoSMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.QoS("LS"), testNow.Time(), 10)
+	assert.NoError(t, err)
+	testPodMetricResource := metriccache.GenMetricResource("pod_load_1m", metriccache.MetricPropertyPodUID)
+	testMetricSample3, err := testPodMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.Pod("uid-xxxxxx"), testNow.Time(), 20)
+	assert.NoError(t, err)
+	testMetricSample4, err := testPodMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.Pod("uid-yyyyyy"), testNow.Time(), 10)
+	assert.NoError(t, err)
+	testContainerMetricResource := metriccache.GenMetricResource("container_load_1m", metriccache.MetricPropertyContainerID)
+	testMetricSample5, err := testContainerMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.Container("containerd://aaa"), testNow.Time(), 20)
+	assert.NoError(t, err)
+	testMetricSample6, err := testContainerMetricResource.GenerateSample(metriccache.MetricPropertiesFunc.Container("containerd://bbb"), testNow.Time(), 10)
+	assert.NoError(t, err)
+	type args struct {
+		samples  []*model.Sample
+		node     *corev1.Node
+		podMetas []*statesinformer.PodMeta
+	}
+	tests := []struct {
+		name    string
+		field   []*DecodeConfig
+		args    args
+		want    []metriccache.MetricSample
+		wantErr bool
+	}{
+		{
+			name:    "nothing to decode",
+			wantErr: false,
+		},
+		{
+			name: "decode node metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric:   "node_load_1m",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "node_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_5m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter expired node metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric:   "node_load_1m",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "node_load_1m",
+					ValidTimeRange: 15 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testOneHourAgo,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_5m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "decode and filter qos metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric:   "node_qos_load_1m",
+					TargetType:     MetricTypeQoS,
+					SourceMetric:   "node_qos_load_1m",
+					ValidTimeRange: 15 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_qos_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_qos_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_qos_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample1,
+				testMetricSample2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter pod metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric: "pod_load_1m",
+					TargetType:   MetricTypePod,
+					TargetLabels: model.LabelSet{
+						"pod":       "pod_name",
+						"namespace": "pod_namespace",
+					},
+					SourceMetric:   "pod_cpu_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-be-pod",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-ls-pod",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-lsr-pod",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample3,
+				testMetricSample4,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter pod uid metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric:   "pod_load_1m",
+					TargetType:     MetricTypePodUID,
+					SourceMetric:   "pod_cpu_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-be-pod",
+							"uid":                 "uid-xxxxxx",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-ls-pod",
+							"uid":                 "uid-yyyyyy",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-lsr-pod",
+							"uid":                 "uid-zzzzzz",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample3,
+				testMetricSample4,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter pod uid metrics 1",
+			field: []*DecodeConfig{
+				{
+					TargetMetric: "pod_load_1m",
+					TargetType:   MetricTypePodUID,
+					TargetLabels: model.LabelSet{
+						"uid": "pod_uid",
+					},
+					SourceMetric:   "pod_cpu_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-be-pod",
+							"pod_uid":             "uid-xxxxxx",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-ls-pod",
+							"pod_uid":             "uid-yyyyyy",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_cpu_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"pod_namespace":       "test-ns",
+							"pod_name":            "test-lsr-pod",
+							"pod_uid":             "uid-zzzzzz",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample3,
+				testMetricSample4,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter container metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric: "container_load_1m",
+					TargetType:   MetricTypeContainer,
+					TargetLabels: model.LabelSet{
+						"container": "container_name",
+					},
+					SourceMetric:   "container_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"namespace":           "test-ns",
+							"pod":                 "test-be-pod",
+							"uid":                 "uid-xxxxxx",
+							"container_name":      "test-be-container",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"namespace":           "test-ns",
+							"pod":                 "test-ls-pod",
+							"uid":                 "uid-yyyyyy",
+							"container_name":      "test-ls-container",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"namespace":           "test-ns",
+							"pod":                 "test-lsr-pod",
+							"uid":                 "uid-zzzzzz",
+							"container_name":      "test-lsr-container",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "test-be-container",
+										ContainerID: "containerd://aaa",
+									},
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "test-ls-container",
+										ContainerID: "containerd://bbb",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample5,
+				testMetricSample6,
+			},
+			wantErr: false,
+		},
+		{
+			name: "decode and filter container id metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric: "container_load_1m",
+					TargetType:   MetricTypeContainerID,
+					TargetLabels: model.LabelSet{
+						"container_id": "id",
+					},
+					SourceMetric:   "container_load_1m",
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"namespace":           "test-ns",
+							"pod":                 "test-be-pod",
+							"uid":                 "uid-xxxxxx",
+							"id":                  "containerd://aaa",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"namespace":           "test-ns",
+							"pod":                 "test-ls-pod",
+							"uid":                 "uid-yyyyyy",
+							"id":                  "containerd://bbb",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "container_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"namespace":           "test-ns",
+							"pod":                 "test-lsr-pod",
+							"uid":                 "uid-zzzzzz",
+							"id":                  "containerd://ccc",
+						},
+						Value:     model.SampleValue(30),
+						Timestamp: testOneHourAgo,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "test-be-container",
+										ContainerID: "containerd://aaa",
+									},
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										Name:        "test-ls-container",
+										ContainerID: "containerd://bbb",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample5,
+				testMetricSample6,
+			},
+			wantErr: false,
+		},
+		{
+			name: "multi decoder for node and pod metrics",
+			field: []*DecodeConfig{
+				{
+					TargetMetric:   "node_load_1m",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "node_load_1m",
+					ValidTimeRange: 15 * time.Second,
+				},
+				{
+					TargetMetric: "pod_load_1m",
+					TargetType:   MetricTypePod,
+					SourceMetric: "pod_load_1m",
+					SourceLabels: model.LabelSet{
+						"namespace": "test-ns",
+					},
+					ValidTimeRange: 10 * time.Second,
+				},
+			},
+			args: args{
+				samples: []*model.Sample{
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "node_load_1m",
+							"node":                "test-node",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_load_1m",
+							"node":                "test-node",
+							"qos":                 "BE",
+							"namespace":           "test-ns",
+							"pod":                 "test-be-pod",
+							"uid":                 "uid-xxxxxx",
+						},
+						Value:     model.SampleValue(20),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_load_1m",
+							"node":                "test-node",
+							"qos":                 "LS",
+							"namespace":           "test-ns",
+							"pod":                 "test-ls-pod",
+							"uid":                 "uid-yyyyyy",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testNow,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_load_1m",
+							"node":                "test-node",
+							"qos":                 "LSR",
+							"namespace":           "test-ns",
+							"pod":                 "test-lsr-pod",
+							"uid":                 "uid-zzzzzz",
+						},
+						Value:     model.SampleValue(10),
+						Timestamp: testOneHourAgo,
+					},
+					{
+						Metric: model.Metric{
+							model.MetricNameLabel: "pod_load_1m",
+							"node":                "test-node",
+							"namespace":           "test-ns-1",
+							"pod":                 "test-ls-pod-1",
+							"uid":                 "uid-mmmmmm",
+						},
+						Value:     model.SampleValue(0),
+						Timestamp: testNow,
+					},
+				},
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+						Capacity: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("400Gi"),
+						},
+					},
+				},
+				podMetas: []*statesinformer.PodMeta{
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-be-pod",
+								Namespace: "test-ns",
+								UID:       "uid-xxxxxx",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSBE),
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod",
+								Namespace: "test-ns",
+								UID:       "uid-yyyyyy",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+						},
+					},
+					{
+						Pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-ls-pod-1",
+								Namespace: "test-ns-1",
+								UID:       "uid-mmmmmm",
+								Labels: map[string]string{
+									extension.LabelPodQoS: string(extension.QoSLS),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []metriccache.MetricSample{
+				testMetricSample,
+				testMetricSample3,
+				testMetricSample4,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewMultiDecoder(tt.field...)
+			got, gotErr := d.Decode(tt.args.samples, tt.args.node, tt.args.podMetas)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			assertEqualMetricSamplesOutOfOrder(t, tt.want, got)
+		})
+	}
+}
+
+func TestScraper(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		testRespBytes := `# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 50
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 30
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 10000.00
+`
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(testRespBytes))
+		}))
+		sURL, err := url.Parse(s.URL)
+		assert.NoError(t, err)
+		port, err := strconv.Atoi(sURL.Port())
+		assert.NoError(t, err)
+		testNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100"),
+					corev1.ResourceMemory: resource.MustParse("400Gi"),
+				},
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100"),
+					corev1.ResourceMemory: resource.MustParse("400Gi"),
+				},
+			},
+		}
+		testPodMetas := []*statesinformer.PodMeta{
+			{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-be-pod",
+						Namespace: "test-ns",
+						UID:       "uid-xxxxxx",
+						Labels: map[string]string{
+							extension.LabelPodQoS: string(extension.QoSBE),
+						},
+					},
+				},
+			},
+			{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ls-pod",
+						Namespace: "test-ns",
+						UID:       "uid-yyyyyy",
+						Labels: map[string]string{
+							extension.LabelPodQoS: string(extension.QoSLS),
+						},
+					},
+				},
+			},
+		}
+
+		cfg := &ScraperConfig{
+			JobName:        "test-job",
+			Enable:         true,
+			ScrapeInterval: 10 * time.Second,
+			Client: &ClientConfig{
+				Timeout:     3 * time.Second,
+				InsecureTLS: true,
+				Address:     sURL.Hostname(),
+				Port:        port,
+				Path:        sURL.Path,
+			},
+			Decoders: []*DecodeConfig{
+				{
+					TargetMetric:   "go_goroutines",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "go_goroutines",
+					ValidTimeRange: 5 * time.Second,
+				},
+				{
+					TargetMetric:   "go_threads",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "go_threads",
+					ValidTimeRange: 5 * time.Second,
+				},
+				{
+					TargetMetric:   "process_cpu_seconds_total",
+					TargetType:     MetricTypeNode,
+					SourceMetric:   "process_cpu_seconds_total",
+					ValidTimeRange: 5 * time.Second,
+				},
+			},
+		}
+		scraper, err := NewGenericScraper(cfg)
+		assert.NoError(t, err)
+		samples, err := scraper.GetMetricSamples(testNode, testPodMetas)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(samples))
+
+		cfg.Decoders = nil
+		scraper, err = NewGenericScraper(cfg)
+		assert.Error(t, err)
+		assert.Nil(t, scraper)
+	})
+}
+
+func assertEqualMetricSamplesOutOfOrder(t *testing.T, want, got []metriccache.MetricSample) {
+	assert.Equal(t, len(want), len(got))
+	for i := range want {
+		found := false
+		for j := range got {
+			if reflect.DeepEqual(want[i], got[j]) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "metric sample %+v not found", want[i])
+	}
+}

--- a/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux.go
+++ b/pkg/koordlet/metricsadvisor/devices/gpu/collector_gpu_linux.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 )
 
@@ -347,6 +348,7 @@ func (g *gpuDeviceManager) collectGPUUsage() {
 	g.collectTime = time.Now()
 	g.start.Store(true)
 	g.Unlock()
+	metrics.RecordModuleHealthyStatus(metrics.ModuleMetricsAdvisor, DeviceCollectorName, true)
 }
 
 func (g *gpuDeviceManager) started() bool {

--- a/pkg/koordlet/metricsadvisor/framework/config.go
+++ b/pkg/koordlet/metricsadvisor/framework/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	CPICollectorTimeWindow           time.Duration
 	ColdPageCollectorInterval        time.Duration
 	EnablePageCacheCollector         bool
+	CollectPromMetricRulePath        string
 }
 
 func NewDefaultConfig() *Config {
@@ -49,6 +50,7 @@ func NewDefaultConfig() *Config {
 		CPICollectorTimeWindow:           10 * time.Second,
 		ColdPageCollectorInterval:        5 * time.Second,
 		EnablePageCacheCollector:         false,
+		CollectPromMetricRulePath:        "",
 	}
 }
 
@@ -62,4 +64,17 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.CPICollectorTimeWindow, "collect-cpi-timewindow", c.CPICollectorTimeWindow, "Collect cpi time window. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.DurationVar(&c.ColdPageCollectorInterval, "coldpage-collector-interval", c.ColdPageCollectorInterval, "Collect cold page interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.BoolVar(&c.EnablePageCacheCollector, "enable-pagecache-collector", c.EnablePageCacheCollector, "Enable cache collector of node, pods and containers")
+	// TODO: support refreshing metric rule without restarting
+	fs.StringVar(&c.CollectPromMetricRulePath, "collect-prom-metric-rule-path", c.CollectPromMetricRulePath, "Collect prometheus metrics rule path. The prometheus collector is disabled when the path is empty.")
+
+	// init extended flags
+	for _, fn := range ExtendedInitFlagsFn {
+		fn(fs)
+	}
+}
+
+var ExtendedInitFlagsFn []func(fs *flag.FlagSet)
+
+func RegisterExtendedInitFlags(fn func(fs *flag.FlagSet)) {
+	ExtendedInitFlagsFn = append(ExtendedInitFlagsFn, fn)
 }

--- a/pkg/koordlet/metricsadvisor/plugins_profile.go
+++ b/pkg/koordlet/metricsadvisor/plugins_profile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/performance"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/podresource"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/podthrottled"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/prom"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/collectors/sysresource"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/devices/gpu"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metricsadvisor/framework"
@@ -51,6 +52,7 @@ var (
 		coldmemoryresource.CollectorName: coldmemoryresource.New,
 		pagecache.CollectorName:          pagecache.New,
 		hostapplication.CollectorName:    hostapplication.New,
+		prom.CollectorName:               prom.New,
 	}
 
 	podFilters = map[string]framework.PodFilter{

--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
@@ -19,7 +19,6 @@ package cpuburst
 import (
 	"encoding/json"
 	"fmt"
-
 	"math/rand"
 	"strconv"
 	"time"
@@ -211,6 +210,7 @@ func (b *cpuBurst) start() {
 	// sync config from node slo
 	nodeSLO := b.statesInformer.GetNodeSLO()
 	if nodeSLO == nil || nodeSLO.Spec.CPUBurstStrategy == nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleQoSManager, CPUBurstName, false)
 		klog.Warningf("cpu burst strategy config is nil, %+v", nodeSLO)
 		return
 	}
@@ -252,6 +252,7 @@ func (b *cpuBurst) start() {
 		b.applyCFSQuotaBurst(cpuBurstCfg, podMeta, nodeState)
 	}
 	b.Recycle()
+	metrics.RecordModuleHealthyStatus(metrics.ModuleQoSManager, CPUBurstName, true)
 }
 
 // getNodeStateForBurst checks whether node share pool cpu usage beyonds the threshold

--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
@@ -86,7 +86,7 @@ func (r *hostReconciler) Run(stopCh <-chan struct{}) error {
 }
 
 func (r *hostReconciler) reconcile(stopCh <-chan struct{}) {
-	timer := time.NewTicker(r.reconcileInterval)
+	timer := time.NewTimer(r.reconcileInterval)
 	defer timer.Stop()
 	for {
 		select {

--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	koordletuti "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
@@ -39,11 +40,13 @@ import (
 func (s *statesInformer) reportDevice() {
 	node := s.GetNode()
 	if node == nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", false)
 		klog.Errorf("node is nil")
 		return
 	}
 	gpuDevices := s.buildGPUDevice()
 	if len(gpuDevices) == 0 {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", true)
 		return
 	}
 
@@ -54,18 +57,22 @@ func (s *statesInformer) reportDevice() {
 
 	err := s.updateDevice(device)
 	if err == nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", true)
 		klog.V(4).Infof("successfully update Device %s", node.Name)
 		return
 	}
 	if !errors.IsNotFound(err) {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", false)
 		klog.Errorf("Failed to updateDevice %s, err: %v", node.Name, err)
 		return
 	}
 
 	err = s.createDevice(device)
 	if err == nil {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", true)
 		klog.V(4).Infof("successfully create Device %s", node.Name)
 	} else {
+		metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, "deviceInformer", false)
 		klog.Errorf("Failed to create Device %s, err: %v", node.Name, err)
 	}
 }

--- a/pkg/koordlet/statesinformer/impl/states_node.go
+++ b/pkg/koordlet/statesinformer/impl/states_node.go
@@ -22,9 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -167,6 +166,7 @@ func (s *nodeInformer) syncNode(newNode *corev1.Node) {
 
 	// also register node for metrics
 	recordNodeResourceMetrics(newNode)
+	metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, string(nodeInformerName), true)
 }
 
 func isNodeMetadataUpdated(oldNode, newNode *corev1.Node) bool {

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo.go
@@ -31,6 +31,7 @@ import (
 
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	koordclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	"github.com/koordinator-sh/koordinator/pkg/util/sloconfig"
@@ -105,6 +106,7 @@ func (s *nodeSLOInformer) HasSynced() bool {
 
 func (s *nodeSLOInformer) updateNodeSLOSpec(nodeSLO *slov1alpha1.NodeSLO) {
 	s.setNodeSLOSpec(nodeSLO)
+	metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, string(nodeSLOInformerName), true)
 	s.callbackRunner.SendCallback(statesinformer.RegisterTypeNodeSLOSpec)
 }
 

--- a/pkg/koordlet/statesinformer/impl/states_pvc.go
+++ b/pkg/koordlet/statesinformer/impl/states_pvc.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/koordinator-sh/koordinator/pkg/features"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -64,6 +65,7 @@ func (s *pvcInformer) Setup(ctx *PluginOption, state *PluginState) {
 			pvc, ok := obj.(*corev1.PersistentVolumeClaim)
 			if ok {
 				s.updateVolumeNameMap(pvc)
+				metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, string(pvcInformerName), true)
 				klog.Infof("add PVC %s", util.GetNamespacedName(pvc.Namespace, pvc.Name))
 			} else {
 				klog.Errorf("pvc informer add func parse PVC failed")
@@ -73,6 +75,7 @@ func (s *pvcInformer) Setup(ctx *PluginOption, state *PluginState) {
 			pvc, ok := newObj.(*corev1.PersistentVolumeClaim)
 			if ok {
 				s.updateVolumeNameMap(pvc)
+				metrics.RecordModuleHealthyStatus(metrics.ModuleStatesInformer, string(pvcInformerName), true)
 				klog.Infof("update PVC %s", util.GetNamespacedName(pvc.Namespace, pvc.Name))
 			} else {
 				klog.Errorf("pvc informer update func parse PVC failed")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koordlet: support the prom collector. With a YAML configuration, it scrapes the prom metrics of external Prometheus exporters and stores them into the koordlet metric cache.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1735.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
