### PR TITLE
colocationprofile: support mutating pod labels and annotations with mapping

### DIFF
--- a/apis/config/v1alpha1/cluster_colocation_profile_types.go
+++ b/apis/config/v1alpha1/cluster_colocation_profile_types.go
@@ -74,6 +74,16 @@ type ClusterColocationProfileSpec struct {
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// LabelKeysMapping describes the labels that needs to inject into Pod.Labels with the same values.
+	// It sets the Pod.Labels[LabelsToLabels[k]] = Pod.Labels[k] for each key k.
+	// +optional
+	LabelKeysMapping map[string]string `json:"labelKeysMapping,omitempty"`
+
+	// AnnotationKeysMapping describes the annotations that needs to inject into Pod.Annotations with the same values.
+	// It sets the Pod.Annotations[AnnotationsToAnnotations[k]] = Pod.Annotations[k] for each key k.
+	// +optional
+	AnnotationKeysMapping map[string]string `json:"annotationKeysMapping,omitempty"`
+
 	// If specified, the pod will be dispatched by specified scheduler.
 	// +optional
 	SchedulerName string `json:"schedulerName,omitempty"`

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -123,6 +123,20 @@ func (in *ClusterColocationProfileSpec) DeepCopyInto(out *ClusterColocationProfi
 			(*out)[key] = val
 		}
 	}
+	if in.LabelKeysMapping != nil {
+		in, out := &in.LabelKeysMapping, &out.LabelKeysMapping
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnnotationKeysMapping != nil {
+		in, out := &in.AnnotationKeysMapping, &out.AnnotationKeysMapping
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Patch.DeepCopyInto(&out.Patch)
 }
 

--- a/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
+++ b/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
@@ -36,6 +36,14 @@ spec:
           spec:
             description: ClusterColocationProfileSpec is a description of a ClusterColocationProfile.
             properties:
+              annotationKeysMapping:
+                additionalProperties:
+                  type: string
+                description: AnnotationKeysMapping describes the annotations that
+                  needs to inject into Pod.Annotations with the same values. It sets
+                  the Pod.Annotations[AnnotationsToAnnotations[k]] = Pod.Annotations[k]
+                  for each key k.
+                type: object
               annotations:
                 additionalProperties:
                   type: string
@@ -51,6 +59,13 @@ spec:
                   priority.
                 format: int32
                 type: integer
+              labelKeysMapping:
+                additionalProperties:
+                  type: string
+                description: LabelKeysMapping describes the labels that needs to inject
+                  into Pod.Labels with the same values. It sets the Pod.Labels[LabelsToLabels[k]]
+                  = Pod.Labels[k] for each key k.
+                type: object
               labels:
                 additionalProperties:
                   type: string

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile.go
@@ -173,6 +173,24 @@ func (h *PodMutatingHandler) doMutateByColocationProfile(ctx context.Context, po
 		}
 	}
 
+	if len(profile.Spec.LabelKeysMapping) > 0 {
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		for keyOld, keyNew := range profile.Spec.LabelKeysMapping {
+			pod.Labels[keyNew] = pod.Labels[keyOld]
+		}
+	}
+
+	if len(profile.Spec.AnnotationKeysMapping) > 0 {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		for keyOld, keyNew := range profile.Spec.AnnotationKeysMapping {
+			pod.Annotations[keyNew] = pod.Annotations[keyOld]
+		}
+	}
+
 	if profile.Spec.SchedulerName != "" {
 		pod.Spec.SchedulerName = profile.Spec.SchedulerName
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Colocation Profile: support mutating pod labels or annotations according to the mapping rules.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

It can be used to set the core scheduling group IDs (#1728) of the pods according to a given pod label.

e.g.

```
apiVersion: config.koordinator.sh/v1alpha1
kind: ClusterColocationProfile
metadata:
  name: colocation-profile-example
spec:
  namespaceSelector:
    matchLabels:
      koordinator.sh/enable-colocation: "true"
  selector:
    matchLabels:
      koordinator.sh/enable-colocation: "true"
  qosClass: BE
  priorityClassName: koord-batch
  koordinatorPriority: 1000
  schedulerName: koord-scheduler
  labels:
    koordinator.sh/mutated: "true"
  annotations: 
    koordinator.sh/intercepted: "true"
  labelsToLabels:
    # set the pod.labels["koordinator.sh/core-sched-group-id"] = pod.labels["app-user-id"],
    # make the SMT-isolation between pods with different `app-user-id`.
    app-user-id: koordinator.sh/core-sched-group-id
  patch:
    spec:
      terminationGracePeriodSeconds: 30
```

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
