### PR TITLE
scheduler: fix DeviceShare concurrent map read and map write

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/devicehandler_gpu.go
+++ b/pkg/scheduler/plugins/deviceshare/devicehandler_gpu.go
@@ -37,6 +37,7 @@ type GPUHandler struct {
 }
 
 func (h *GPUHandler) CalcDesiredRequestsAndCount(podRequests corev1.ResourceList, totalDevices deviceResources, hint *apiext.DeviceHint) (corev1.ResourceList, int, error) {
+	podRequests = podRequests.DeepCopy()
 	if err := fillGPUTotalMem(totalDevices, podRequests); err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The function `fillGPUTotalMem` modifies shared `state.podRequests`, causing map concurrent read and write conflicts to be triggered.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
