### PR TITLE
scheduler: Coscheduling skips check schedule cycle if pod has nominated node

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -254,6 +254,9 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, pod *corev1.Pod) er
 
 	gangMode := gang.getGangMode()
 	if gangMode == extension.GangModeStrict {
+		if pod.Status.NominatedNodeName != "" {
+			return nil
+		}
 		podScheduleCycle := gang.getChildScheduleCycle(pod)
 		if !gang.isScheduleCycleValid() {
 			return fmt.Errorf("gang scheduleCycle not valid, gangName: %v, podName: %v",

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -176,6 +176,28 @@ func TestPlugin_PreFilter(t *testing.T) {
 			expectedScheduleCycleValid: true,
 		},
 		{
+			name: "due to reschedule pod6's podScheduleCycle is equal with the gangScheduleCycle, but pod6's nominatedNodeName is not empty",
+			pod: st.MakePod().Name("pod6").UID("pod6").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "gangc").
+				NominatedNodeName("N1").Obj(),
+			pods: []*corev1.Pod{
+				st.MakePod().Name("pod6-1").UID("pod6-1").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "gangc").Obj(),
+				st.MakePod().Name("pod6-2").UID("pod6-2").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "gangc").Obj(),
+				st.MakePod().Name("pod6-3").UID("pod6-3").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "gangc").Obj(),
+			},
+			pgs:                           makePg("gangc", "ganga_ns", 4, &gangACreatedTime, nil),
+			shouldSetCycleEqualWithGlobal: true,
+			totalNum:                      5,
+			expectedScheduleCycle:         1,
+			expectedChildCycleMap: map[string]int{
+				"ganga_ns/pod6":   1,
+				"ganga_ns/pod6-1": 1,
+				"ganga_ns/pod6-2": 1,
+				"ganga_ns/pod6-3": 1,
+			},
+			expectedErrorMessage:       "",
+			expectedScheduleCycleValid: true,
+		},
+		{
 			name: "pods count equal with minMember,is StrictMode,but the gang's scheduleCycle is not valid due to pre pod Filter Failed",
 			pod:  st.MakePod().Name("pod7").UID("pod7").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "gangd").Obj(),
 			pods: []*corev1.Pod{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
For a gang job, for example, there are four pods, three pods have been assumed, but the fourth cannot be scheduled. The fourth obtains resources through preemption. But in the next round of allocation, the gang's preFilter will be calibrated checking scheduleCycle, which makes makes pod fail to schedule, so we hope to modify the verification logic of gang's preFilter.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
