### PR TITLE
koordlet: revise system qos and numa aware cpuset

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
 	ext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -287,6 +289,9 @@ func Test_cpusetPlugin_SetContainerCPUSet(t *testing.T) {
 					NUMANodeResources: []ext.NUMANodeResource{
 						{
 							Node: 0,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+							},
 						},
 					},
 				},

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
@@ -24,6 +24,7 @@ import (
 	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -40,9 +41,10 @@ import (
 
 func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 	type fields struct {
-		kubeletPoicy string
-		sharePools   []ext.CPUSharedPool
-		beSharePools []ext.CPUSharedPool
+		kubeletPolicy   string
+		sharePools      []ext.CPUSharedPool
+		beSharePools    []ext.CPUSharedPool
+		systemQOSCPUSet string
 	}
 	type args struct {
 		podAlloc            *ext.ResourceStatus
@@ -57,7 +59,7 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "get cpuset fqrom bad annotation",
+			name: "get cpuset from bad annotation",
 			fields: fields{
 				sharePools: []ext.CPUSharedPool{
 					{
@@ -123,6 +125,9 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 					NUMANodeResources: []ext.NUMANodeResource{
 						{
 							Node: 0,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+							},
 						},
 					},
 				},
@@ -159,6 +164,9 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 					NUMANodeResources: []ext.NUMANodeResource{
 						{
 							Node: 0,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+							},
 						},
 					},
 				},
@@ -197,9 +205,49 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "get all share pools for ls pod with no cpu numa allocation",
+			fields: fields{
+				sharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "0-7",
+					},
+					{
+						Socket: 1,
+						Node:   1,
+						CPUSet: "8-15",
+					},
+				},
+			},
+			args: args{
+				containerReq: &protocol.ContainerRequest{
+					PodMeta:       protocol.PodMeta{},
+					ContainerMeta: protocol.ContainerMeta{},
+					PodLabels: map[string]string{
+						ext.LabelPodQoS: string(ext.QoSLS),
+					},
+					PodAnnotations: map[string]string{},
+					CgroupParent:   "burstable/test-pod/test-container",
+				},
+				podAlloc: &ext.ResourceStatus{
+					NUMANodeResources: []ext.NUMANodeResource{
+						{
+							Node: 0,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			want:    pointer.String("0-7,8-15"),
+			wantErr: false,
+		},
+		{
 			name: "get all share pools for origin burstable pod under none policy",
 			fields: fields{
-				kubeletPoicy: ext.KubeletCPUManagerPolicyNone,
+				kubeletPolicy: ext.KubeletCPUManagerPolicyNone,
 				sharePools: []ext.CPUSharedPool{
 					{
 						Socket: 0,
@@ -228,7 +276,7 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 		{
 			name: "do nothing for origin burstable pod under static policy",
 			fields: fields{
-				kubeletPoicy: ext.KubeletCPUManagerPolicyStatic,
+				kubeletPolicy: ext.KubeletCPUManagerPolicyStatic,
 				sharePools: []ext.CPUSharedPool{
 					{
 						Socket: 0,
@@ -282,15 +330,121 @@ func Test_cpusetRule_getContainerCPUSet(t *testing.T) {
 			want:    pointer.String(""),
 			wantErr: false,
 		},
+		{
+			name: "get cpuset from annotation ls share pool",
+			fields: fields{
+				sharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "1-7",
+					},
+					{
+						Socket: 1,
+						Node:   1,
+						CPUSet: "9-15",
+					},
+				},
+				beSharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "0-7",
+					},
+					{
+						Socket: 1,
+						Node:   1,
+						CPUSet: "8-15",
+					},
+				},
+			},
+			args: args{
+				containerReq: &protocol.ContainerRequest{
+					PodMeta:       protocol.PodMeta{},
+					ContainerMeta: protocol.ContainerMeta{},
+					PodLabels: map[string]string{
+						ext.LabelPodQoS: string(ext.QoSLS),
+					},
+					PodAnnotations: map[string]string{},
+					CgroupParent:   "burstable/test-pod/test-container",
+				},
+				podAlloc: &ext.ResourceStatus{
+					NUMANodeResources: []ext.NUMANodeResource{
+						{
+							Node: 1,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			want:    pointer.String("9-15"),
+			wantErr: false,
+		},
+		{
+			name: "get cpuset from annotation system qos resource",
+			fields: fields{
+				sharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "4-7",
+					},
+					{
+						Socket: 1,
+						Node:   1,
+						CPUSet: "9-15",
+					},
+				},
+				beSharePools: []ext.CPUSharedPool{
+					{
+						Socket: 0,
+						Node:   0,
+						CPUSet: "4-7",
+					},
+					{
+						Socket: 1,
+						Node:   1,
+						CPUSet: "8-15",
+					},
+				},
+				systemQOSCPUSet: "0-3",
+			},
+			args: args{
+				containerReq: &protocol.ContainerRequest{
+					PodMeta:       protocol.PodMeta{},
+					ContainerMeta: protocol.ContainerMeta{},
+					PodLabels: map[string]string{
+						ext.LabelPodQoS: string(ext.QoSSystem),
+					},
+					PodAnnotations: map[string]string{},
+					CgroupParent:   "burstable/test-pod/test-container",
+				},
+				podAlloc: &ext.ResourceStatus{
+					NUMANodeResources: []ext.NUMANodeResource{
+						{
+							Node: 1,
+							Resources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			want:    pointer.String("0-3"),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &cpusetRule{
 				kubeletPolicy: ext.KubeletCPUManagerPolicy{
-					Policy: tt.fields.kubeletPoicy,
+					Policy: tt.fields.kubeletPolicy,
 				},
-				sharePools:   tt.fields.sharePools,
-				beSharePools: tt.fields.beSharePools,
+				sharePools:      tt.fields.sharePools,
+				beSharePools:    tt.fields.beSharePools,
+				systemQOSCPUSet: tt.fields.systemQOSCPUSet,
 			}
 			if tt.args.podAlloc != nil {
 				podAllocJson := util.DumpJSON(tt.args.podAlloc)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koordlet: revise the cpuset runtime hook for two cases below:
    1. If a pod allocates NUMA-aware resources excluding CPU, it should follow the non-NUMA cpuset.
    2. If a SYSTEM pod allocates NUMA-aware resources including CPU, it just follows the cpuset rule of NUMA resource since the NUMA-aware system-qos-resource is undefined.

Generally, a pod use NUMA-level cpuset should be:

1. QoS is not SYSTEM.
2. Pod annotations["scheduling.koordinator.sh/resource-status"].numaNodeResources[*]["cpu"] should be non-zero.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
