### PR TITLE
koordlet: fix lscpu for arm ut

### DIFF
--- a/pkg/koordlet/util/cpuinfo_test.go
+++ b/pkg/koordlet/util/cpuinfo_test.go
@@ -59,7 +59,7 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
 			args: args{
 				lsCPUStr: `
 CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
-0   0    0      0    -             yes
+0   0    0      0    no cacheinfo  yes
 1   0    0      0    no cacheinfo  yes
 `},
 			want:    nil,
@@ -387,7 +387,7 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getProcessorInfos(tt.args.lsCPUStr)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getProcessorInfos wantErr %v but got err %s", tt.wantErr, err)
+				t.Errorf("getProcessorInfos wantErr %v but got err %v", tt.wantErr, err)
 			}
 			if !reflect.DeepEqual(tt.want, got) {
 				t.Errorf("getProcessorInfos want %v but got %v", tt.want, got)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

fix the ut since it is legal for arm if lscpu returns:
```
CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
0   0    0      0    -             yes
```

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
