### PR TITLE
slo-controller: Introduce node resource amplification plugin

### DIFF
--- a/pkg/slo-controller/noderesource/plugins/resourceamplification/plugin.go
+++ b/pkg/slo-controller/noderesource/plugins/resourceamplification/plugin.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceamplification
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
+)
+
+const PluginName = "ResourceAmplification"
+
+// Plugin calculates and updates final node resource amplification ratios automatically
+// based on user config (not implemented) and node cpu normalization ratio.
+type Plugin struct{}
+
+func (p *Plugin) Name() string {
+	return PluginName
+}
+
+func (p *Plugin) NeedSyncMeta(_ *configuration.ColocationStrategy, oldNode, newNode *corev1.Node) (bool, string) {
+	oldRatioStr := oldNode.Annotations[extension.AnnotationNodeResourceAmplificationRatio]
+	newRatioStr := newNode.Annotations[extension.AnnotationNodeResourceAmplificationRatio]
+
+	if oldRatioStr == "" && newRatioStr == "" {
+		return false, "ratio remains empty"
+	}
+	if oldRatioStr == "" {
+		return true, "old ratio is empty"
+	}
+	if newRatioStr == "" {
+		return true, "new ratio is empty"
+	}
+	if oldRatioStr == newRatioStr {
+		return false, "ratio remains unchanged"
+	}
+	return true, "ratio changed"
+}
+
+func (p *Plugin) Prepare(_ *configuration.ColocationStrategy, node *corev1.Node, nr *framework.NodeResource) error {
+	ratioStr, ok := nr.Annotations[extension.AnnotationNodeResourceAmplificationRatio]
+	if !ok {
+		klog.V(6).Infof("prepare node resource amplification ratio to unset, node %s", node.Name)
+		delete(node.Annotations, extension.AnnotationNodeResourceAmplificationRatio)
+		return nil
+	}
+
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[extension.AnnotationNodeResourceAmplificationRatio] = ratioStr
+	klog.V(6).Infof("prepare node resource amplification ratio to set, node %s, ratio %s", node.Name, ratioStr)
+
+	return nil
+}
+
+func (p *Plugin) Reset(node *corev1.Node, message string) []framework.ResourceItem {
+	// Currently we have no user configurations so there's no need to reset.
+	return nil
+}
+
+func (p *Plugin) Calculate(_ *configuration.ColocationStrategy, node *corev1.Node, _ *corev1.PodList, _ *framework.ResourceMetrics) ([]framework.ResourceItem, error) {
+	normRatio, err := extension.GetCPUNormalizationRatio(node)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cpu normalization ratio: %w", err)
+	}
+
+	if normRatio <= 1 {
+		return []framework.ResourceItem{
+			{
+				Name: PluginName,
+			},
+		}, nil
+	}
+
+	// Set cpu amplification ratio according to cpu normalization ratio.
+	// TODO: In the future, we should read user's amplification config, multiply its cpu amplification ratio
+	// with cpu normalization ratio, and apply the final result.
+	ampRatios := map[corev1.ResourceName]extension.Ratio{
+		corev1.ResourceCPU: extension.Ratio(normRatio),
+	}
+	ratioBytes, _ := json.Marshal(ampRatios)
+	ratioStr := string(ratioBytes)
+	klog.V(6).Infof("calculate resource amplification ratio %s for node %s", ratioStr, node.Name)
+	return []framework.ResourceItem{
+		{
+			Name: PluginName,
+			Annotations: map[string]string{
+				extension.AnnotationNodeResourceAmplificationRatio: ratioStr,
+			},
+		},
+	}, nil
+}

--- a/pkg/slo-controller/noderesource/plugins/resourceamplification/plugin_test.go
+++ b/pkg/slo-controller/noderesource/plugins/resourceamplification/plugin_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceamplification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
+)
+
+func TestPluginNeedSyncMeta(t *testing.T) {
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Annotations: map[string]string{
+				extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.12}`,
+			},
+		},
+	}
+	testNodeHasNoRatio := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	type args struct {
+		oldNode *corev1.Node
+		newNode *corev1.Node
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       bool
+		wantReason string
+	}{
+		{
+			name: "no need sync when both have no ratio",
+			args: args{
+				oldNode: testNodeHasNoRatio,
+				newNode: testNodeHasNoRatio,
+			},
+			want:       false,
+			wantReason: "ratio remains empty",
+		},
+		{
+			name: "need sync when old has no ratio",
+			args: args{
+				oldNode: testNodeHasNoRatio,
+				newNode: testNode,
+			},
+			want:       true,
+			wantReason: "old ratio is empty",
+		},
+		{
+			name: "need sync when new has no ratio",
+			args: args{
+				oldNode: testNode,
+				newNode: testNodeHasNoRatio,
+			},
+			want:       true,
+			wantReason: "new ratio is empty",
+		},
+		{
+			name: "skip sync when ratio is unchanged",
+			args: args{
+				oldNode: testNode,
+				newNode: testNode,
+			},
+			want:       false,
+			wantReason: "ratio remains unchanged",
+		},
+		{
+			name: "need sync when ratio is different",
+			args: args{
+				oldNode: testNode,
+				newNode: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Annotations: map[string]string{
+							extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.23}`,
+						},
+					},
+				},
+			},
+			want:       true,
+			wantReason: "ratio changed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			got, gotReason := p.NeedSyncMeta(nil, tt.args.oldNode, tt.args.newNode)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantReason, gotReason)
+		})
+	}
+}
+
+func TestPluginPrepare(t *testing.T) {
+	type args struct {
+		node *corev1.Node
+		nr   *framework.NodeResource
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		wantField *corev1.Node
+	}{
+		{
+			name: "no annotation to prepare",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+				},
+				nr: framework.NewNodeResource(),
+			},
+			wantErr: false,
+			wantField: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+			},
+		},
+		{
+			name: "remove old annotation when no annotation prepare",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Annotations: map[string]string{
+							extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+						},
+					},
+				},
+				nr: framework.NewNodeResource(),
+			},
+			wantErr: false,
+			wantField: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "prepare ratio successfully",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+				},
+				nr: &framework.NodeResource{
+					Annotations: map[string]string{
+						extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+					},
+				},
+			},
+		},
+		{
+			name: "prepare ratio successfully with other existing annotations",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Annotations: map[string]string{
+							"xxx": "yyy",
+						},
+					},
+				},
+				nr: &framework.NodeResource{
+					Annotations: map[string]string{
+						extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+					},
+				},
+			},
+			wantErr: false,
+			wantField: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						"xxx": "yyy",
+						extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			gotErr := p.Prepare(nil, tt.args.node, tt.args.nr)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+			assert.Equal(t, tt.wantField, tt.args.node)
+		})
+	}
+}
+
+func TestPluginCalculate(t *testing.T) {
+	type args struct {
+		node *corev1.Node
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []framework.ResourceItem
+		wantErr bool
+	}{
+		{
+			name: "get cpu normalization ratio failed",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Annotations: map[string]string{
+							extension.AnnotationCPUNormalizationRatio: "invalid",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "calculate ratio correctly with cpu normalization",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Annotations: map[string]string{
+							extension.AnnotationCPUNormalizationRatio: "1.22",
+						},
+					},
+				},
+			},
+			want: []framework.ResourceItem{
+				{
+					Name: PluginName,
+					Annotations: map[string]string{
+						extension.AnnotationNodeResourceAmplificationRatio: `{"cpu":1.22}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate ratio correctly without cpu normalization",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+				},
+			},
+			want: []framework.ResourceItem{
+				{
+					Name: PluginName,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Plugin{}
+			got, gotErr := p.Calculate(nil, tt.args.node, nil, nil)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+		})
+	}
+}

--- a/pkg/slo-controller/noderesource/plugins_profile.go
+++ b/pkg/slo-controller/noderesource/plugins_profile.go
@@ -21,6 +21,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/batchresource"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/cpunormalization"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/midresource"
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/resourceamplification"
 )
 
 // NOTE: functions in this file can be overwritten for extension
@@ -30,6 +31,7 @@ func init() {
 	addPluginOption(&midresource.Plugin{}, true)
 	addPluginOption(&batchresource.Plugin{}, true)
 	addPluginOption(&cpunormalization.Plugin{}, true)
+	addPluginOption(&resourceamplification.Plugin{}, true)
 }
 
 func addPlugins(filter framework.FilterFn) {
@@ -55,6 +57,7 @@ var (
 	// NodePreparePlugin implements node resource preparing for the calculated results.
 	nodePreparePlugins = []framework.NodePreparePlugin{
 		&cpunormalization.Plugin{}, // should be first
+		&resourceamplification.Plugin{},
 		&midresource.Plugin{},
 		&batchresource.Plugin{},
 	}
@@ -66,10 +69,12 @@ var (
 	// nodeMetaCheckPlugins implements the check of node meta updating.
 	nodeMetaCheckPlugins = []framework.NodeMetaCheckPlugin{
 		&cpunormalization.Plugin{},
+		&resourceamplification.Plugin{},
 	}
 	// ResourceCalculatePlugin implements resource counting and overcommitment algorithms.
 	resourceCalculatePlugins = []framework.ResourceCalculatePlugin{
 		&cpunormalization.Plugin{},
+		&resourceamplification.Plugin{},
 		&midresource.Plugin{},
 		&batchresource.Plugin{},
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR introduces node resource amplification plugin to koord-manager.

Currently, it is meant to implement below logic with bold text described in the [CPU normalization proposal](https://github.com/koordinator-sh/koordinator/blob/main/docs/proposals/scheduling/20230831-cpu-normalization.md):

> On koord-manager side, the Node resource controller runs a reconcile loop to do following things for Nodes with CPU normalization enabled:
>
> 1. Get CPU normalization ratio of the Node from CPU normalization model according to the Node's CPU basic info from its NodeResourceTopology.
> 2. **Calculate the final CPU amplification ratio (this is covered in the Node Resource Amplification proposal) by following formula: CPU_Amplification_Ratio = CPU_Amplification_Ratio_Original * CPU_Normalization_Ratio. The CPU_Amplification_Ratio_Original defaults to 1 if not specified beforehand.**
> 3. **Annotate the** CPU normalization ratio and **new CPU amplification ratio to the Node**.

This makes CPU normalization works with the node resource amplification webhook and scheduler.

Note that currently we have not exposed resource amplification configurations to users, so there's no `CPU_Amplification_Ratio_Original` thus `CPU_Amplification_Ratio` would always be the same as `CPU_Normalization_Ratio`.

### Ⅱ. Does this pull request fix one issue?

part of #1539 and #1570

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
