### PR TITLE
scheduler: enhance ReservationNominator to support preemption

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -37,6 +37,7 @@ type extendedHandleOptions struct {
 	servicesEngine                   *services.Engine
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
+	reservationNominator             ReservationNominator
 }
 
 type Option func(*extendedHandleOptions)
@@ -59,11 +60,18 @@ func WithKoordinatorSharedInformerFactory(informerFactory koordinatorinformers.S
 	}
 }
 
+func WithReservationNominator(nominator ReservationNominator) Option {
+	return func(options *extendedHandleOptions) {
+		options.reservationNominator = nominator
+	}
+}
+
 type FrameworkExtenderFactory struct {
 	controllerMaps                   *ControllersMap
 	servicesEngine                   *services.Engine
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
+	reservationNominator             ReservationNominator
 	profiles                         map[string]FrameworkExtender
 	scheduler                        Scheduler
 	schedulePod                      func(ctx context.Context, fwk framework.Framework, state *framework.CycleState, pod *corev1.Pod) (scheduler.ScheduleResult, error)
@@ -85,6 +93,7 @@ func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, 
 		servicesEngine:                   handleOptions.servicesEngine,
 		koordinatorClientSet:             handleOptions.koordinatorClientSet,
 		koordinatorSharedInformerFactory: handleOptions.koordinatorSharedInformerFactory,
+		reservationNominator:             handleOptions.reservationNominator,
 		profiles:                         map[string]FrameworkExtender{},
 		errorHandlerDispatcher:           newErrorHandlerDispatcher(),
 	}, nil

--- a/pkg/scheduler/frameworkext/testing/fake_reservation_nominator.go
+++ b/pkg/scheduler/frameworkext/testing/fake_reservation_nominator.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+var _ frameworkext.ReservationNominator = &FakeNominator{}
+
+type FakeNominator struct {
+	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is nominated.
+	nominatedPodToNode map[types.UID]map[string]types.UID
+	reservations       map[types.UID]*frameworkext.ReservationInfo
+	lock               sync.RWMutex
+}
+
+func NewFakeReservationNominator() *FakeNominator {
+	return &FakeNominator{
+		nominatedPodToNode: map[types.UID]map[string]types.UID{},
+		reservations:       map[types.UID]*frameworkext.ReservationInfo{},
+	}
+}
+
+func (nm *FakeNominator) Name() string { return "FakeNominator" }
+
+func (nm *FakeNominator) AddNominatedReservation(pod *corev1.Pod, nodeName string, rInfo *frameworkext.ReservationInfo) {
+	if rInfo == nil {
+		return
+	}
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	nodeToReservation := nm.nominatedPodToNode[pod.UID]
+	if nodeToReservation == nil {
+		nodeToReservation = map[string]types.UID{}
+		nm.nominatedPodToNode[pod.UID] = nodeToReservation
+	}
+	nodeToReservation[nodeName] = rInfo.UID()
+	nm.reservations[rInfo.UID()] = rInfo
+}
+
+func (nm *FakeNominator) RemoveNominatedReservations(pod *corev1.Pod) {
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	nodeToReservation := nm.nominatedPodToNode[pod.UID]
+	delete(nm.nominatedPodToNode, pod.UID)
+	for _, reservationUID := range nodeToReservation {
+		delete(nm.reservations, reservationUID)
+	}
+}
+
+func (nm *FakeNominator) GetNominatedReservation(pod *corev1.Pod, nodeName string) *frameworkext.ReservationInfo {
+	nm.lock.RLock()
+	defer nm.lock.RUnlock()
+	return nm.reservations[nm.nominatedPodToNode[pod.UID][nodeName]]
+}
+
+func (nm *FakeNominator) NominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) (*frameworkext.ReservationInfo, *framework.Status) {
+	if reservationutil.IsReservePod(pod) {
+		return nil, nil
+	}
+
+	rInfo := nm.GetNominatedReservation(pod, nodeName)
+	return rInfo, nil
+}

--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -371,7 +371,7 @@ func (p *Plugin) allocateWithNominatedReservation(
 		return nil, nil
 	}
 
-	reservation := frameworkext.GetNominatedReservation(cycleState, node.Name)
+	reservation := p.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
 	if reservation == nil {
 		return nil, nil
 	}

--- a/pkg/scheduler/plugins/deviceshare/scoring.go
+++ b/pkg/scheduler/plugins/deviceshare/scoring.go
@@ -69,7 +69,7 @@ func (p *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, po
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
 
-	reservationInfo := frameworkext.GetNominatedReservation(cycleState, nodeName)
+	reservationInfo := p.handle.GetReservationNominator().GetNominatedReservation(pod, nodeName)
 	if reservationInfo != nil {
 		score, status := p.scoreWithNominatedReservation(allocator, state, restoreState, nodeName, pod, preemptible, reservationInfo)
 		if status.IsSuccess() {

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -70,7 +70,7 @@ var (
 )
 
 type Plugin struct {
-	handle          framework.Handle
+	handle          frameworkext.ExtendedHandle
 	pluginArgs      *schedulingconfig.NodeNUMAResourceArgs
 	nrtLister       topologylister.NodeResourceTopologyLister
 	scorer          *resourceAllocationScorer
@@ -150,7 +150,7 @@ func NewWithOptions(args runtime.Object, handle framework.Handle, opts ...Option
 	nrtLister := nrtInformerFactory.Topology().V1alpha1().NodeResourceTopologies().Lister()
 
 	return &Plugin{
-		handle:                 handle,
+		handle:                 handle.(frameworkext.ExtendedHandle),
 		pluginArgs:             pluginArgs,
 		nrtLister:              nrtLister,
 		scorer:                 scorer,
@@ -515,7 +515,7 @@ func (p *Plugin) getReservationReservedCPUs(cycleState *framework.CycleState, po
 	if reservationutil.IsReservePod(pod) {
 		return result, nil
 	}
-	nominatedReservation := frameworkext.GetNominatedReservation(cycleState, nodeName)
+	nominatedReservation := p.handle.GetReservationNominator().GetNominatedReservation(pod, nodeName)
 	if nominatedReservation == nil {
 		return result, nil
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/scheme"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1beta2"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexttesting "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/testing"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
@@ -163,6 +164,7 @@ func newPluginTestSuit(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *
 	extenderFactory, err := frameworkext.NewFrameworkExtenderFactory(
 		frameworkext.WithKoordinatorClientSet(koordClientSet),
 		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+		frameworkext.WithReservationNominator(frameworkexttesting.NewFakeReservationNominator()),
 	)
 	assert.NoError(t, err)
 
@@ -1117,7 +1119,7 @@ func TestPlugin_Reserve(t *testing.T) {
 							},
 						}
 						rInfo := frameworkext.NewReservationInfo(reservation)
-						frameworkext.SetNominatedReservation(cycleState, map[string]*frameworkext.ReservationInfo{"test-node-1": rInfo})
+						plg.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node-1", rInfo)
 					}
 					cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
 						skip: false,

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -1828,7 +1828,7 @@ func TestReserve(t *testing.T) {
 			if tt.reservation != nil {
 				rInfo = frameworkext.NewReservationInfo(tt.reservation)
 			}
-			frameworkext.SetNominatedReservation(cycleState, map[string]*frameworkext.ReservationInfo{"test-node": rInfo})
+			pl.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node", rInfo)
 			status := pl.Reserve(context.TODO(), cycleState, tt.pod, "test-node")
 			assert.Equal(t, tt.wantStatus, status)
 			if tt.wantReservation == nil {
@@ -1948,7 +1948,7 @@ func TestUnreserve(t *testing.T) {
 			if tt.reservation != nil {
 				rInfo = frameworkext.NewReservationInfo(tt.reservation)
 			}
-			frameworkext.SetNominatedReservation(cycleState, map[string]*frameworkext.ReservationInfo{"test-node": rInfo})
+			pl.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node", rInfo)
 			status := pl.Reserve(context.TODO(), cycleState, tt.pod, "test-node")
 			pl.Unreserve(context.TODO(), cycleState, tt.pod, "test-node")
 			assert.Equal(t, tt.wantStatus, status)

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -32,7 +32,8 @@ import (
 
 func TestPodEventHandler(t *testing.T) {
 	handler := &podEventHandler{
-		cache: newReservationCache(nil),
+		cache:     newReservationCache(nil),
+		nominator: newNominator(),
 	}
 	reservationUID := uuid.NewUUID()
 	reservationName := "test-reservation"
@@ -106,7 +107,8 @@ func TestPodEventHandler(t *testing.T) {
 
 func TestPodEventHandlerWithOperatingPod(t *testing.T) {
 	handler := &podEventHandler{
-		cache: newReservationCache(nil),
+		cache:     newReservationCache(nil),
+		nominator: newNominator(),
 	}
 	reservationUID := uuid.NewUUID()
 	reservationName := "test-reservation"

--- a/pkg/scheduler/plugins/reservation/scoring.go
+++ b/pkg/scheduler/plugins/reservation/scoring.go
@@ -66,7 +66,7 @@ func (pl *Plugin) PreScore(ctx context.Context, cycleState *framework.CycleState
 		_, order := findMostPreferredReservationByOrder(reservationInfos)
 		nodeOrders[piece] = order
 
-		nominatedReservationInfo, status := pl.NominateReservation(ctx, cycleState, pod, node.Name)
+		nominatedReservationInfo, status := pl.handle.GetReservationNominator().NominateReservation(ctx, cycleState, pod, node.Name)
 		if !status.IsSuccess() {
 			errCh.SendErrorWithCancel(status.AsError(), cancel)
 			return
@@ -82,11 +82,9 @@ func (pl *Plugin) PreScore(ctx context.Context, cycleState *framework.CycleState
 	}
 
 	nominatedReservations = nominatedReservations[:nominatedNodeIndex]
-	reservations := make(map[string]*frameworkext.ReservationInfo, len(nominatedReservations))
 	for _, v := range nominatedReservations {
-		reservations[v.GetNodeName()] = v
+		pl.handle.GetReservationNominator().AddNominatedReservation(pod, v.GetNodeName(), v)
 	}
-	frameworkext.SetNominatedReservation(cycleState, reservations)
 
 	var selectOrder int64 = math.MaxInt64
 	var nodeIndex int
@@ -113,7 +111,7 @@ func (pl *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, p
 		return mostPreferredScore, nil
 	}
 
-	reservationInfo := frameworkext.GetNominatedReservation(cycleState, nodeName)
+	reservationInfo := pl.handle.GetReservationNominator().GetNominatedReservation(pod, nodeName)
 	if reservationInfo == nil {
 		return framework.MinNodeScore, nil
 	}

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -501,6 +501,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 						Labels: map[string]string{
 							apiext.LabelReservationOrder: "100",
 						},
+						UID: "123456",
 					},
 					Spec: schedulingv1alpha1.ReservationSpec{
 						Template: &corev1.PodTemplateSpec{
@@ -525,6 +526,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "normal-reservation",
+						UID:  "654321",
 					},
 					Spec: schedulingv1alpha1.ReservationSpec{
 						Template: &corev1.PodTemplateSpec{
@@ -554,6 +556,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 						Labels: map[string]string{
 							apiext.LabelReservationOrder: "100",
 						},
+						UID: "123456",
 					},
 					Spec: schedulingv1alpha1.ReservationSpec{
 						Template: &corev1.PodTemplateSpec{
@@ -706,7 +709,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 				sort.Slice(wantReservationInfo.ResourceNames, func(i, j int) bool {
 					return wantReservationInfo.ResourceNames[i] < wantReservationInfo.ResourceNames[j]
 				})
-				rInfo := frameworkext.GetNominatedReservation(cycleState, nodeName)
+				rInfo := pl.handle.GetReservationNominator().GetNominatedReservation(tt.pod, nodeName)
 				if rInfo != nil {
 					sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 						return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The `ReservationNominator` interface and its implementation have been enhanced to support preemption scenarios. 

When performing preemption at the job granularity level, many Pods will initiate preemption in the PostFilter stage. As each Pod secures resources, the `ReservationNominator.NominateReservation` method is called to elect a Reservation. The `ReservationNominator.AddNominatedReservation` and PreFilterExtension.AddPod methods are then used to record the Request quantity. This ensures that the preemption results of one Pod can be perceived by the next Pod during its preemption process. 

When a new scheduling cycle begins, there is a possibility that a Pod awaiting scheduling may trigger the PreFilterExtension.AddPod again. Since the `AddNominatedReservation` method has already recorded that the Pod has reserved resources on a certain node, it ensures that this reserved resource will not be taken by lower-priority Pods.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
