### PR TITLE
metrics: seperater metrics as internal and external for slo-controller and koordlet

### DIFF
--- a/pkg/koordlet/metrics/external_metrics.go
+++ b/pkg/koordlet/metrics/external_metrics.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	ExternalHTTPPath = "/external-metrics"
+)
+
+var (
+	// ExternalRegistry	register metrics for users such as PMU or extended resources settings
+	ExternalRegistry = prometheus.NewRegistry()
+)
+
+func ExternalMustRegister(metrics ...prometheus.Collector) {
+	ExternalRegistry.MustRegister(metrics...)
+}
+
+func init() {
+	ExternalMustRegister(ResourceSummaryCollectors...)
+	ExternalMustRegister(CPICollectors...)
+	ExternalMustRegister(PSICollectors...)
+}

--- a/pkg/koordlet/metrics/internal_metrics.go
+++ b/pkg/koordlet/metrics/internal_metrics.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	InternalHTTPPath = "/internal-metrics"
+)
+
+var (
+	// InternalRegistry only register metrics of koordlet itself for performance and functional monitor
+	// TODO consider using k8s.io/component-base/metrics to replace github.com/prometheus/client_golang/prometheus
+	InternalRegistry = legacyregistry.DefaultGatherer
+)
+
+func internalMustRegister(metrics ...prometheus.Collector) {
+	legacyregistry.RawMustRegister(metrics...)
+}
+
+func init() {
+	internalMustRegister(CommonCollectors...)
+	internalMustRegister(CPUSuppressCollector...)
+	internalMustRegister(CPUBurstCollector...)
+	internalMustRegister(PredictionCollectors...)
+	internalMustRegister(CoreSchedCollector...)
+}

--- a/pkg/koordlet/metrics/metrics.go
+++ b/pkg/koordlet/metrics/metrics.go
@@ -24,17 +24,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func init() {
-	prometheus.MustRegister(CommonCollectors...)
-	prometheus.MustRegister(ResourceSummaryCollectors...)
-	prometheus.MustRegister(CPICollectors...)
-	prometheus.MustRegister(PSICollectors...)
-	prometheus.MustRegister(CPUSuppressCollector...)
-	prometheus.MustRegister(CPUBurstCollector...)
-	prometheus.MustRegister(PredictionCollectors...)
-	prometheus.MustRegister(CoreSchedCollector...)
-}
-
 const (
 	KoordletSubsystem = "koordlet"
 
@@ -70,6 +59,10 @@ var (
 	Node     *corev1.Node
 
 	nodeLock sync.RWMutex
+)
+
+const (
+	DefaultHTTPPath = "/metrics"
 )
 
 // Register registers the metrics with the node object

--- a/pkg/slo-controller/metrics/common.go
+++ b/pkg/slo-controller/metrics/common.go
@@ -19,7 +19,7 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func init() {
-	MustRegister(CommonCollectors...)
+	InternalMustRegister(CommonCollectors...)
 }
 
 var (

--- a/pkg/slo-controller/metrics/metrics.go
+++ b/pkg/slo-controller/metrics/metrics.go
@@ -19,7 +19,8 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load restclient and workqueue metrics
 )
 
 const (
@@ -41,11 +42,27 @@ const (
 	UnitInteger = "integer"
 )
 
-// DefaultRegistry uses the controller runtime registry by default.
-var DefaultRegistry = metrics.Registry
+const (
+	// DefaultHTTPPath use /all-metrics since /metrics is occupied by controller manager default registry
+	DefaultHTTPPath  = "/all-metrics"
+	ExternalHTTPPath = "/external-metrics"
+	InternalHTTPPath = "/internal-metrics"
+)
 
-func MustRegister(cs ...prometheus.Collector) {
-	DefaultRegistry.MustRegister(cs...)
+var (
+	// ExternalRegistry	register metrics for users
+	ExternalRegistry = prometheus.NewRegistry()
+
+	// InternalRegistry only register metrics of koord-manager itself for performance and functional monitor
+	InternalRegistry = legacyregistry.DefaultGatherer
+)
+
+func ExternalMustRegister(cs ...prometheus.Collector) {
+	ExternalRegistry.MustRegister(cs...)
+}
+
+func InternalMustRegister(cs ...prometheus.Collector) {
+	legacyregistry.RawMustRegister(cs...)
 }
 
 func genNodeLabels(node *corev1.Node) prometheus.Labels {

--- a/pkg/slo-controller/metrics/metrics_test.go
+++ b/pkg/slo-controller/metrics/metrics_test.go
@@ -35,7 +35,16 @@ func TestMustRegister(t *testing.T) {
 		Help:      "test counter",
 	}, []string{StatusKey, ReasonKey})
 	assert.NotPanics(t, func() {
-		MustRegister(testMetricVec)
+		InternalMustRegister(testMetricVec)
+	})
+
+	testExternalMetricVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: "test",
+		Name:      "test_external_counter",
+		Help:      "test counter",
+	}, []string{StatusKey, ReasonKey})
+	assert.NotPanics(t, func() {
+		ExternalMustRegister(testExternalMetricVec)
 	})
 }
 

--- a/pkg/slo-controller/metrics/node_resource.go
+++ b/pkg/slo-controller/metrics/node_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	MustRegister(NodeResourceCollectors...)
+	InternalMustRegister(NodeResourceCollectors...)
 }
 
 var (

--- a/pkg/util/metrics/merged_gather.go
+++ b/pkg/util/metrics/merged_gather.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+var _ prometheus.Gatherer = &mergedGather{}
+
+type mergedGather struct {
+	gathers []prometheus.Gatherer
+}
+
+// MergedGatherFunc returns a Gatherer that merges the results of multiple Gatherers
+func MergedGatherFunc(g ...prometheus.Gatherer) prometheus.Gatherer {
+	return &mergedGather{gathers: g}
+}
+
+func (m *mergedGather) Gather() ([]*dto.MetricFamily, error) {
+	result := make([]*dto.MetricFamily, 0)
+	for _, g := range m.gathers {
+		if metrics, err := g.Gather(); err != nil {
+			return result, err
+		} else {
+			result = append(result, metrics...)
+		}
+	}
+	return result, nil
+}

--- a/pkg/util/metrics/merged_gather_test.go
+++ b/pkg/util/metrics/merged_gather_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergedGather(t *testing.T) {
+	// Create two Gatherer objects
+	gatherer1 := prometheus.NewRegistry()
+	gatherer2 := prometheus.NewRegistry()
+
+	// Add some metrics to the Gatherer objects
+	c1 := prometheus.NewCounter(prometheus.CounterOpts{Name: "c1"})
+	c2 := prometheus.NewCounter(prometheus.CounterOpts{Name: "c2"})
+	gatherer1.MustRegister(c1)
+	gatherer2.MustRegister(c2)
+
+	// Create a Merged Gatherer
+	mergedGatherer := MergedGatherFunc(gatherer1, gatherer2)
+
+	// Call Gather and check the result
+	metrics, err := mergedGatherer.Gather()
+	require.NoError(t, err)
+
+	// Verify that the result contains the expected metrics
+	assert.Equal(t, 2, len(metrics))
+	assert.Equal(t, "c1", *metrics[0].Name)
+	assert.Equal(t, "c2", *metrics[1].Name)
+}
+
+func TestMergedGatherEmpty(t *testing.T) {
+	// Create empty merged gatherer
+	mergedGatherer := MergedGatherFunc()
+
+	// Gather metrics
+	metricsFamilies, err := mergedGatherer.Gather()
+	assert.NoError(t, err)
+
+	// Check if no metric families are returned
+	assert.Equal(t, 0, len(metricsFamilies))
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
seperate koordlet/slo-controller metrics as internal and external
ExternalHTTPPath: for end users, such as batch resource util (also compatible with old URL /metircs for koordlet）
InternalHTTPPath: for cluster admin, such as performance of components.
DefaultHTTPPath: merge all internal, external and controller runtime metrics.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
