### PR TITLE
scheduler: fix preemption panic

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_resources.go
+++ b/pkg/scheduler/plugins/deviceshare/device_resources.go
@@ -63,19 +63,15 @@ func (r deviceResources) append(in deviceResources, hintMinors sets.Int) {
 }
 
 func (r deviceResources) subtract(in deviceResources, withNonNegativeResult bool) {
-	if len(r) == 0 {
+	if r == nil {
 		return
 	}
 	for minor, res := range in {
-		resourceList, ok := r[minor]
-		if !ok {
-			continue
-		}
-		resourceNames := quotav1.ResourceNames(resourceList)
+		resourceList := r[minor]
 		if withNonNegativeResult {
-			resourceList = quotav1.SubtractWithNonNegativeResult(resourceList, quotav1.Mask(res, resourceNames))
+			resourceList = quotav1.SubtractWithNonNegativeResult(resourceList, res)
 		} else {
-			resourceList = quotav1.Subtract(resourceList, quotav1.Mask(res, resourceNames))
+			resourceList = quotav1.Subtract(resourceList, res)
 		}
 		if quotav1.IsZero(resourceList) {
 			delete(r, minor)
@@ -105,8 +101,9 @@ func copyDeviceResources(m map[schedulingv1alpha1.DeviceType]deviceResources) ma
 func subtractAllocated(m, allocated map[schedulingv1alpha1.DeviceType]deviceResources, withNonNegativeResult bool) map[schedulingv1alpha1.DeviceType]deviceResources {
 	for deviceType, devicesResources := range allocated {
 		ra := m[deviceType]
-		if len(ra) == 0 {
-			continue
+		if ra == nil {
+			ra = deviceResources{}
+			m[deviceType] = ra
 		}
 		ra.subtract(devicesResources, withNonNegativeResult)
 		if len(ra) == 0 {

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -199,10 +199,22 @@ func (p *Plugin) AddPod(ctx context.Context, cycleState *framework.CycleState, p
 	}
 	if rInfo == nil {
 		preemptibleDevices := state.preemptibleDevices[node.Name]
+		if preemptibleDevices == nil {
+			preemptibleDevices = map[schedulingv1alpha1.DeviceType]deviceResources{}
+			state.preemptibleDevices[node.Name] = preemptibleDevices
+		}
 		state.preemptibleDevices[node.Name] = subtractAllocated(preemptibleDevices, podAllocated, false)
 	} else {
 		preemptibleInRRs := state.preemptibleInRRs[node.Name]
+		if preemptibleInRRs == nil {
+			preemptibleInRRs = map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources{}
+			state.preemptibleInRRs[node.Name] = preemptibleInRRs
+		}
 		preemptible := preemptibleInRRs[rInfo.UID()]
+		if preemptible == nil {
+			preemptible = map[schedulingv1alpha1.DeviceType]deviceResources{}
+			preemptibleInRRs[rInfo.UID()] = preemptible
+		}
 		preemptible = subtractAllocated(preemptible, podAllocated, false)
 		preemptibleInRRs[rInfo.UID()] = preemptible
 	}
@@ -246,6 +258,10 @@ func (p *Plugin) RemovePod(ctx context.Context, cycleState *framework.CycleState
 	}
 	if rInfo == nil {
 		preemptibleDevices := state.preemptibleDevices[node.Name]
+		if preemptibleDevices == nil {
+			preemptibleDevices = map[schedulingv1alpha1.DeviceType]deviceResources{}
+			state.preemptibleDevices[node.Name] = preemptibleDevices
+		}
 		state.preemptibleDevices[node.Name] = appendAllocated(preemptibleDevices, podAllocated)
 	} else {
 		preemptibleInRRs := state.preemptibleInRRs[node.Name]
@@ -254,6 +270,10 @@ func (p *Plugin) RemovePod(ctx context.Context, cycleState *framework.CycleState
 			state.preemptibleInRRs[node.Name] = preemptibleInRRs
 		}
 		preemptible := preemptibleInRRs[rInfo.UID()]
+		if preemptible == nil {
+			preemptible = map[schedulingv1alpha1.DeviceType]deviceResources{}
+			preemptibleInRRs[rInfo.UID()] = preemptible
+		}
 		preemptibleInRRs[rInfo.UID()] = appendAllocated(preemptible, podAllocated)
 	}
 

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -452,6 +452,24 @@ func Test_Plugin_PreFilterExtensionsWithReservation(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectPreemptible, state.preemptibleInRRs)
+
+	state.preemptibleInRRs = map[string]map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources{}
+	status = pl.PreFilterExtensions().AddPod(context.TODO(), cycleState, pod, framework.NewPodInfo(allocatedPod), nodeInfo)
+	assert.True(t, status.IsSuccess())
+	expectPreemptible = map[string]map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources{
+		"test-node-1": {
+			"123456": {
+				schedulingv1alpha1.GPU: {
+					1: {
+						apiext.ResourceGPUCore:        *resource.NewQuantity(-100, resource.DecimalSI),
+						apiext.ResourceGPUMemory:      *resource.NewQuantity(-8*1024*1024*1024, resource.BinarySI),
+						apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(-100, resource.DecimalSI),
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expectPreemptible, state.preemptibleInRRs)
 }
 
 func Test_Plugin_PreFilter(t *testing.T) {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -275,6 +275,10 @@ func (pl *Plugin) AddPod(ctx context.Context, cycleState *framework.CycleState, 
 		state.preemptible[node.Name] = quotav1.Subtract(preemptible, podRequests)
 	} else {
 		preemptibleInRRs := state.preemptibleInRRs[node.Name]
+		if preemptibleInRRs == nil {
+			preemptibleInRRs = map[types.UID]corev1.ResourceList{}
+			state.preemptibleInRRs[node.Name] = preemptibleInRRs
+		}
 		preemptible := preemptibleInRRs[rInfo.UID()]
 		preemptibleInRRs[rInfo.UID()] = quotav1.Subtract(preemptible, podRequests)
 	}

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -1330,6 +1330,40 @@ func TestPreFilterExtensionAddPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "add nominated pod allocated in reservation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "123456",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			withR: true,
+			state: &stateData{
+				preemptible:      map[string]corev1.ResourceList{},
+				preemptibleInRRs: map[string]map[types.UID]corev1.ResourceList{},
+			},
+			wantPreemptible: map[string]corev1.ResourceList{},
+			wantPreemptibleInRRs: map[string]map[types.UID]corev1.ResourceList{
+				"test-node": {
+					"123456": {
+						corev1.ResourceCPU: *resource.NewQuantity(-4, resource.DecimalSI),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. The scheduler will panic during preemption since some maps are nil.
2. DeviceShare's AddPod method gets unexpected result that must be negative but got empty.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
