### PR TITLE
chores: replace shimo doc to dingtalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Active communication channels:
 - Bi-weekly Community Meeting (APAC, *Chinese*):
   - Tuesday 19:30 GMT+8 (Asia/Shanghai)
   - [Meeting Link(DingTalk)](https://meeting.dingtalk.com/j/cgTTojEI8Zy)
-  - [Notes and agenda](https://shimo.im/docs/m4kMLdgO1LIma9qD)
+  - [Notes and agenda](https://alidocs.dingtalk.com/document/edit?docKey=oJGq769vBG4WnAKe&dentryKey=paP7wO3nXFnLzMAa&type=d)
 - Slack(English): [koordinator channel](https://kubernetes.slack.com/channels/koordinator) in Kubernetes workspace
 - DingTalk(Chinese): Search Group ID `33383887` or scan the following QR Code
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Currently, it seems koordinator use dingtalk doc for Notes and Agenda
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Can't access shimo doc now, but I can access dingtalk doc.
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
