### PR TITLE
scheduler: change reservation default allocate policy to aligned

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_allocator.go
+++ b/pkg/scheduler/plugins/deviceshare/device_allocator.go
@@ -406,8 +406,8 @@ func defaultAllocateDevices(
 
 	var allocations []*apiext.DeviceAllocation
 	resourceMinorPairs := scoreDevices(podRequestPerInstance, nodeDeviceTotal, freeDevices, requestCtx.allocationScorer)
-	resourceMinorPairs = sortDeviceResourcesByMinor(resourceMinorPairs, requestCtx.preferred[deviceType])
 	resourceMinorPairs = sortDeviceResourcesByPreferredPCIe(resourceMinorPairs, preferredPCIEs, deviceInfos)
+	resourceMinorPairs = sortDeviceResourcesByMinor(resourceMinorPairs, requestCtx.preferred[deviceType])
 	for _, resourceMinorPair := range resourceMinorPairs {
 		if required.Len() > 0 && !required.Has(resourceMinorPair.minor) {
 			continue

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -2014,7 +2014,26 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 			NodeName: "test-node-1",
 		},
 	}
-	nd.updateCacheUsed(allocations, allocatedPod, true)
+	nd.updateCacheUsed(apiext.DeviceAllocations{
+		schedulingv1alpha1.GPU: {
+			{
+				Minor: 1,
+				Resources: corev1.ResourceList{
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+				},
+			},
+			{
+				Minor: 2,
+				Resources: corev1.ResourceList{
+					apiext.ResourceGPUCore:        resource.MustParse("100"),
+					apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+				},
+			},
+		},
+	}, allocatedPod, true)
 	reservationInfo.AddAssignedPod(allocatedPod)
 	nodeToState, status = pl.RestoreReservation(context.TODO(), cycleState, pod, []*frameworkext.ReservationInfo{reservationInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
@@ -2024,7 +2043,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 	assert.True(t, status.IsSuccess())
 
 	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
-	assert.Equal(t, framework.NewStatus(framework.Unschedulable, ErrInsufficientDevices), status)
+	assert.Equal(t, framework.NewStatus(framework.Unschedulable, "node(s) no reservation(s) to meet the device requirements"), status)
 }
 
 func Test_Plugin_Reserve(t *testing.T) {

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -424,8 +424,19 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 				},
 			},
 			requiredFromReservation: true,
-			wantResult:              nil,
-			wantStatus:              nil,
+			wantResult: apiext.DeviceAllocations{
+				schedulingv1alpha1.GPU: {
+					{
+						Minor: 1,
+						Resources: corev1.ResourceList{
+							apiext.ResourceGPUCore:        resource.MustParse("50"),
+							apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
+							apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			wantStatus: nil,
 		},
 		{
 			name: "allocate from Aligned policy reservation",
@@ -510,8 +521,9 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 				},
 			},
-			wantResult: nil,
-			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) reservations insufficient devices"),
+			requiredFromReservation: true,
+			wantResult:              nil,
+			wantStatus:              framework.NewStatus(framework.Unschedulable, "node(s) no reservation(s) to meet the device requirements"),
 		},
 		{
 			name: "failed to allocate from Aligned policy reservation that remaining little not fits request",
@@ -552,8 +564,9 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 				},
 			},
-			wantResult: nil,
-			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) reservations insufficient devices"),
+			requiredFromReservation: true,
+			wantResult:              nil,
+			wantStatus:              framework.NewStatus(framework.Unschedulable, "node(s) no reservation(s) to meet the device requirements"),
 		},
 		{
 			name: "allocate from Restricted policy reservation",
@@ -635,8 +648,9 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 				},
 			},
-			wantResult: nil,
-			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) reservations insufficient devices"),
+			requiredFromReservation: true,
+			wantResult:              nil,
+			wantStatus:              framework.NewStatus(framework.Unschedulable, "node(s) no reservation(s) to meet the device requirements"),
 		},
 	}
 

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -31,6 +31,7 @@ import (
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/util"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 const (
@@ -218,6 +219,11 @@ func preparePod(pod *corev1.Pod) (state *preFilterState, status *framework.Statu
 		if err != nil {
 			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
 		}
+		reservationAffinity, err := reservationutil.GetRequiredReservationAffinity(pod)
+		if err != nil {
+			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
+		}
+		state.hasReservationAffinity = reservationAffinity != nil
 	}
 
 	return

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -18,6 +18,7 @@ package reservation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apiresource "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/utils/pointer"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -284,8 +287,11 @@ func TestNominateReservation(t *testing.T) {
 			assert.NoError(t, err)
 			pl := plugin.(*Plugin)
 			cycleState := framework.NewCycleState()
+			requests, _ := apiresource.PodRequestsAndLimits(tt.pod)
 			state := &stateData{
 				nodeReservationStates: map[string]nodeReservationState{},
+				podRequests:           requests,
+				podRequestsResources:  framework.NewResource(requests),
 			}
 			for _, reservation := range tt.reservations {
 				rInfo := frameworkext.NewReservationInfo(reservation)
@@ -307,5 +313,124 @@ func TestNominateReservation(t *testing.T) {
 			}
 			assert.Equal(t, tt.wantStatus, status.IsSuccess())
 		})
+	}
+}
+
+func newTestReservation(t *testing.T, name string, labels, ownerLabels map[string]string, nodeName string, allocatable corev1.ResourceList) *schedulingv1alpha1.Reservation {
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:    uuid.NewUUID(),
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: allocatable.DeepCopy(),
+							},
+						},
+					},
+				},
+			},
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: ownerLabels,
+					},
+				},
+			},
+			AllocateOnce:   pointer.Bool(false),
+			AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+		},
+	}
+	assert.NoError(t, reservationutil.SetReservationAvailable(reservation, nodeName))
+	return reservation
+}
+
+func TestMultiReservationsOnSameNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("96"),
+				corev1.ResourceMemory: resource.MustParse("1886495404Ki"),
+			},
+		},
+	}
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("16"),
+		corev1.ResourceMemory: resource.MustParse("32Gi"),
+	}
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	suit := newPluginTestSuitWith(t, nil, []*corev1.Node{node})
+	var reservations []*schedulingv1alpha1.Reservation
+	for i := 0; i < 3; i++ {
+		r := newTestReservation(t, fmt.Sprintf("test-r-%d", i), labels, labels, node.Name, resourceList)
+		reservations = append(reservations, r)
+		_, err := suit.extenderFactory.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), r, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+	nodeInfo, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+	assert.NoError(t, err)
+	recoverNodeInfoFn := func() {
+		for _, v := range reservations {
+			nodeInfo.AddPod(reservationutil.NewReservePod(v))
+		}
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+			Labels:    labels,
+			UID:       uuid.NewUUID(),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: resourceList,
+					},
+				},
+			},
+		},
+	}
+	affinity := &apiext.ReservationAffinity{
+		ReservationSelector: labels,
+	}
+	assert.NoError(t, apiext.SetReservationAffinity(pod, affinity))
+
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+
+	nominatedReservationCount := map[types.UID]int{}
+	for range reservations {
+		recoverNodeInfoFn()
+		cycleState := framework.NewCycleState()
+		pl.BeforePreFilter(context.TODO(), cycleState, pod)
+		pl.PreFilter(context.TODO(), cycleState, pod)
+		nominator := pl.handle.(frameworkext.FrameworkExtender).GetReservationNominator()
+		rInfo, status := nominator.NominateReservation(context.TODO(), cycleState, pod, node.Name)
+		assert.True(t, status.IsSuccess())
+		nominator.AddNominatedReservation(pod, node.Name, rInfo)
+		rInfo = pl.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
+		assert.NotNil(t, rInfo)
+		pl.Reserve(context.TODO(), cycleState, pod, node.Name)
+		nominatedReservationCount[rInfo.UID()]++
+		nominator.RemoveNominatedReservations(pod)
+	}
+
+	assert.Len(t, nominatedReservationCount, len(reservations))
+	for _, v := range nominatedReservationCount {
+		assert.Equal(t, 1, v)
 	}
 }

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -54,8 +54,8 @@ const (
 	ErrReasonReservationAllocatePolicyConflict = "node(s) reservation allocate policy conflict"
 	// ErrReasonReservationInactive is the reason for the reservation is failed/succeeded and should not be used.
 	ErrReasonReservationInactive = "reservation is not active"
-	// ErrReasonReservationInsufficientResources is the reason for the reservation's resources are insufficient.
-	ErrReasonReservationInsufficientResources = "node(s) reservations insufficient resources"
+	// ErrReasonNoReservationsMeetRequirements is the reason for no reservation(s) to meet the requirements.
+	ErrReasonNoReservationsMeetRequirements = "node(s) no reservation(s) to meet the requirements"
 	// ErrReasonPreemptionFailed is the reason for preemption failed
 	ErrReasonPreemptionFailed = "node(s) preemption failed due to insufficient resources"
 )
@@ -378,44 +378,38 @@ func (pl *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, 
 			return nil
 		}
 
-		return pl.filterWithReservations(ctx, cycleState, pod, nodeInfo, matchedReservations)
+		return pl.filterWithReservations(ctx, cycleState, pod, nodeInfo, matchedReservations, state.hasAffinity)
 	}
 
 	// TODO: handle pre-allocation cases
 	return nil
 }
 
-func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo, matchedReservations []*frameworkext.ReservationInfo) *framework.Status {
+func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo, matchedReservations []*frameworkext.ReservationInfo, requiredFromReservation bool) *framework.Status {
 	node := nodeInfo.Node()
 	state := getStateData(cycleState)
 	nodeRState := state.nodeReservationStates[node.Name]
+	podRequests, _ := resourceapi.PodRequestsAndLimits(pod)
+	podRequestsResourceNames := quotav1.ResourceNames(podRequests)
 
-	var (
-		totalDefault           int
-		insufficientDefault    int
-		insufficientAligned    int
-		insufficientRestricted int
-	)
+	var hasSatisfiedReservation bool
 	for _, rInfo := range matchedReservations {
+		resourceNames := quotav1.Intersection(rInfo.ResourceNames, podRequestsResourceNames)
+		if len(resourceNames) == 0 {
+			continue
+		}
+
 		preemptibleInRR := state.preemptibleInRRs[node.Name][rInfo.UID()]
 		preemptible := framework.NewResource(preemptibleInRR)
 		preemptible.Add(state.preemptible[node.Name])
-		allocatePolicy := rInfo.GetAllocatePolicy()
-		if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyDefault {
-			totalDefault++
-			if len(preemptibleInRR) > 0 || len(state.preemptible[node.Name]) > 0 {
-				if !fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo, preemptible) {
-					insufficientDefault++
-				}
-			}
-			continue
-		}
 		nodeFits := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo, preemptible)
-		if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyAligned {
+		allocatePolicy := rInfo.GetAllocatePolicy()
+		if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyDefault ||
+			allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyAligned {
 			if nodeFits {
-				return nil
+				hasSatisfiedReservation = true
+				break
 			}
-			insufficientAligned++
 		} else if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyRestricted {
 			allocated := rInfo.Allocated
 			if len(preemptibleInRR) > 0 {
@@ -425,15 +419,14 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 			rRemained := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, allocated)
 			fits, _ := quotav1.LessThanOrEqual(state.podRequests, rRemained)
 			if fits && nodeFits {
-				return nil
+				hasSatisfiedReservation = true
+				break
 			}
-			insufficientRestricted++
 		}
 	}
-	if (totalDefault > 0 && totalDefault == insufficientDefault) ||
-		(nodeRState.totalAligned > 0 && nodeRState.totalAligned == insufficientAligned) ||
-		(nodeRState.totalRestricted > 0 && nodeRState.totalRestricted == insufficientRestricted) {
-		return framework.NewStatus(framework.Unschedulable, ErrReasonReservationInsufficientResources)
+	// The Pod requirement must be allocated from Reservation, but currently no Reservation meets the requirement
+	if !hasSatisfiedReservation && requiredFromReservation {
+		return framework.NewStatus(framework.Unschedulable, ErrReasonNoReservationsMeetRequirements)
 	}
 	return nil
 }
@@ -501,6 +494,7 @@ func (pl *Plugin) PostFilter(ctx context.Context, cycleState *framework.CycleSta
 }
 
 func (pl *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
+	// TODO(joseph): We can consider optimizing these codes. It seems that there is no need to exist at present.
 	state := getStateData(cycleState)
 	nodeRState := state.nodeReservationStates[nodeName]
 
@@ -520,18 +514,12 @@ func (pl *Plugin) FilterReservation(ctx context.Context, cycleState *framework.C
 		return framework.NewStatus(framework.Unschedulable, "reservation has allocateOnce enabled and has already been allocated")
 	}
 
-	podRequests, _ := resourceapi.PodRequestsAndLimits(pod)
-	resourceNames := quotav1.Intersection(rInfo.ResourceNames, quotav1.ResourceNames(podRequests))
-	if len(resourceNames) == 0 {
-		return framework.NewStatus(framework.Unschedulable, "no intersection resources")
-	}
-
 	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
 	if err != nil {
 		return framework.NewStatus(framework.UnschedulableAndUnresolvable, "missing node")
 	}
 
-	return pl.filterWithReservations(ctx, cycleState, pod, nodeInfo, []*frameworkext.ReservationInfo{rInfo})
+	return pl.filterWithReservations(ctx, cycleState, pod, nodeInfo, []*frameworkext.ReservationInfo{rInfo}, true)
 }
 
 func (pl *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status {

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apiresource "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -220,6 +221,8 @@ func TestScore(t *testing.T) {
 			state := &stateData{
 				nodeReservationStates: map[string]nodeReservationState{},
 			}
+			state.podRequests, _ = apiresource.PodRequestsAndLimits(tt.pod)
+			state.podRequestsResources = framework.NewResource(state.podRequests)
 			for _, reservation := range tt.reservations {
 				rInfo := frameworkext.NewReservationInfo(reservation)
 				if allocated := tt.allocated[reservation.UID]; len(allocated) > 0 {
@@ -320,6 +323,8 @@ func TestScoreWithOrder(t *testing.T) {
 	state := &stateData{
 		nodeReservationStates: map[string]nodeReservationState{},
 	}
+	state.podRequests, _ = apiresource.PodRequestsAndLimits(normalPod)
+	state.podRequestsResources = framework.NewResource(state.podRequests)
 
 	// add three Reservations to three node
 	for i := 0; i < 3; i++ {
@@ -689,6 +694,8 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 			state := &stateData{
 				nodeReservationStates: map[string]nodeReservationState{},
 			}
+			state.podRequests, _ = apiresource.PodRequestsAndLimits(tt.pod)
+			state.podRequestsResources = framework.NewResource(state.podRequests)
 			for _, reservation := range tt.reservations {
 				rInfo := frameworkext.NewReservationInfo(reservation)
 				if allocated := tt.allocated[reservation.UID]; len(allocated) > 0 {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In the past, for the Default policy, the remaining resources of the Reservation were returned to NodeInfo to ensure that the filter could pass the resource verification. However, in the FilterReservation, it only checked whether the remaining resources of the Reservation were sufficient. This actually led to the logical inconsistency between the Filter and the FilterReservation. For example, if a Reservation A has no remaining resources, it can pass the verification in the Filter, but fails in the FilterReservation. This is very strange. If we try to unify the logic of Filter and FilterReservation, we will find that the Default and Aligned strategies are consistent.

In addition, if a Pod declares a ReservationAffinity but the matching Reservation cannot meet the requirements, the node will be filtered out even if there are remaining resources on the node that can meet the Pod's requirements.

There is actually a potential challenge here: whether the Restricted strategy still makes sense. For example, if a Pod declares a Reservation Affinity, it means that it must be allocated from the Reservation. Does this mean that the Pod actually takes the initiative in allocation, not the Reservation? If it is determined that the Pod has the upper hand, the original Reservation AllocatePolicy can be discarded. This can be considered as part of future work.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
