### PR TITLE
scheduler: add monitor to detect scheduling deadlock

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -64,6 +64,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/defaultprofile"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/eventhandlers"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/util/asynclog"
 	utilroutes "github.com/koordinator-sh/koordinator/pkg/util/routes"
 	"github.com/koordinator-sh/koordinator/pkg/util/transformer"
@@ -356,6 +357,8 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 
 	frameworkext.SetupCustomInformers(cc.InformerFactory)
 	transformer.SetupTransformers(cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
+
+	metrics.Register()
 
 	// NOTE(joseph): K8s scheduling framework does not provide extension point for initialization.
 	// Currently, only by copying the initialization code and implementing custom initialization.

--- a/pkg/scheduler/frameworkext/scheduler_monitor.go
+++ b/pkg/scheduler/frameworkext/scheduler_monitor.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"sync"
+	"time"
+
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
+)
+
+var (
+	schedulerMonitorPeriod = 10 * time.Second
+	schedulingTimeout      = 30 * time.Second
+
+	logWarningF = klog.Warningf
+)
+
+func init() {
+	pflag.DurationVar(&schedulerMonitorPeriod, "scheduler-monitor-period", schedulerMonitorPeriod, "Execution period of scheduler monitor")
+	pflag.DurationVar(&schedulingTimeout, "scheduling-timeout", schedulingTimeout, "The maximum acceptable scheduling time interval. After timeout, the metric will be updated and the log will be printed.")
+}
+
+type SchedulerMonitor struct {
+	timeout        time.Duration
+	lock           sync.Mutex
+	schedulingPods map[types.UID]podScheduleState
+}
+
+type podScheduleState struct {
+	start         time.Time
+	namespace     string
+	name          string
+	schedulerName string
+}
+
+func NewSchedulerMonitor(period time.Duration, timeout time.Duration) *SchedulerMonitor {
+	m := &SchedulerMonitor{
+		timeout:        timeout,
+		schedulingPods: map[types.UID]podScheduleState{},
+	}
+	go wait.Forever(m.monitor, period)
+	return m
+}
+
+func (m *SchedulerMonitor) monitor() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	now := time.Now()
+	for uid, v := range m.schedulingPods {
+		recordIfSchedulingTimeout(uid, &v, now, m.timeout)
+	}
+}
+
+func (m *SchedulerMonitor) StartMonitoring(pod *corev1.Pod) {
+	klog.Infof("start monitoring pod %v(%s)", klog.KObj(pod), pod.UID)
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.schedulingPods[pod.UID] = podScheduleState{
+		start:         time.Now(),
+		namespace:     pod.Namespace,
+		name:          pod.Name,
+		schedulerName: pod.Spec.SchedulerName,
+	}
+}
+
+func (m *SchedulerMonitor) Complete(pod *corev1.Pod) {
+	klog.Infof("pod %v(%s) scheduled complete", klog.KObj(pod), pod.UID)
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	state, ok := m.schedulingPods[pod.UID]
+	if ok {
+		now := time.Now()
+		recordIfSchedulingTimeout(pod.UID, &state, now, m.timeout)
+		delete(m.schedulingPods, pod.UID)
+	}
+}
+
+func recordIfSchedulingTimeout(uid types.UID, state *podScheduleState, now time.Time, timeout time.Duration) {
+	if interval := now.Sub(state.start); interval > timeout {
+		logWarningF("!!!CRITICAL TIMEOUT!!! scheduling pod %s/%s(%s) took longer (%s) than the timeout %v", state.namespace, state.name, uid, interval, timeout)
+		metrics.SchedulingTimeout.WithLabelValues(state.schedulerName).Inc()
+	}
+}

--- a/pkg/scheduler/frameworkext/scheduler_monitor_test.go
+++ b/pkg/scheduler/frameworkext/scheduler_monitor_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+func TestSchedulerMonitor_Timeout(t *testing.T) {
+	timeout := 10 * time.Millisecond
+
+	var capturedLog string
+	mockLogFunction := func(format string, args ...interface{}) {
+		capturedLog = fmt.Sprintf(format, args...)
+	}
+	logWarningF = mockLogFunction
+	defer func() {
+		logWarningF = klog.Warningf
+	}()
+
+	monitor := NewSchedulerMonitor(schedulerMonitorPeriod, timeout)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+
+	monitor.StartMonitoring(pod)
+	time.Sleep(2 * timeout)
+	monitor.monitor()
+	if len(capturedLog) == 0 || !strings.Contains(capturedLog, "!!!CRITICAL TIMEOUT!!!") {
+		t.Errorf("Expected a timeout log to be recorded, but got: %s", capturedLog)
+	}
+	monitor.Complete(pod)
+}
+
+func TestSchedulerMonitor_NoTimeout(t *testing.T) {
+	timeout := 1 * time.Second
+
+	var capturedLog string
+	mockLogFunction := func(format string, args ...interface{}) {
+		capturedLog = fmt.Sprintf(format, args...)
+	}
+	logWarningF = mockLogFunction
+	defer func() {
+		logWarningF = klog.Warningf
+	}()
+
+	monitor := NewSchedulerMonitor(schedulerMonitorPeriod, timeout)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+
+	monitor.StartMonitoring(pod)
+	monitor.monitor()
+	if len(capturedLog) > 0 {
+		t.Errorf("Expected no timeout log to be recorded, but got: %s", capturedLog)
+	}
+	monitor.Complete(pod)
+}
+
+func TestSchedulerMonitor_StartAndCompleteMonitoring(t *testing.T) {
+	timeout := 10 * time.Millisecond
+
+	monitor := NewSchedulerMonitor(schedulerMonitorPeriod, timeout)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+
+	monitor.StartMonitoring(pod)
+	state, ok := monitor.schedulingPods[pod.UID]
+	if !ok {
+		t.Fatal("Pod not found in schedulingPods after StartMonitoring")
+	}
+	if state.start.IsZero() {
+		t.Errorf("Start time should not be zero after StartMonitoring")
+	}
+	time.Sleep(2 * timeout)
+	monitor.Complete(pod)
+	if _, exists := monitor.schedulingPods[pod.UID]; exists {
+		t.Errorf("Pod should be removed from schedulingPods after Complete")
+	}
+}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+)
+
+// All the histogram based metrics have 1ms as size for the smallest bucket.
+var (
+	SchedulingTimeout = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      schedulermetrics.SchedulerSubsystem,
+			Name:           "scheduling_timeout",
+			Help:           "The currently scheduled Pod exceeds the maximum acceptable time interval",
+			StabilityLevel: metrics.STABLE,
+		}, []string{"profile"})
+
+	metricsList = []metrics.Registerable{
+		SchedulingTimeout,
+	}
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	// Register the metrics.
+	registerMetrics.Do(func() {
+		RegisterMetrics(metricsList...)
+	})
+}
+
+// RegisterMetrics registers a list of metrics.
+// This function is exported because it is intended to be used by out-of-tree plugins to register their custom metrics.
+func RegisterMetrics(extraMetrics ...metrics.Registerable) {
+	for _, metric := range extraMetrics {
+		legacyregistry.MustRegister(metric)
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

feat: Add SchedulerMonitor for tracking pod scheduling timeouts

A new SchedulerMonitor component has been introduced to track the time taken to schedule pods and log warnings if the scheduling time exceeds a predefined threshold. This enhancement includes a mechanism to update metrics upon timeout, improving observability and aiding in debugging scheduling delays.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
