### PR TITLE
scheduler: ReservationNominator senses ReservationAffinity

### DIFF
--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -128,6 +128,10 @@ type ReservationFilterPlugin interface {
 // and locate the previously returned reusable resources for Pod allocation.
 type ReservationNominator interface {
 	framework.Plugin
+	// NominateReservation nominates reservation that fits the Pod.
+	// If the pod has one or more reservation matched, return the best-fit reservation.
+	// If the pod needs to be allocated from reservations, and no reservations matched, return nil reservation with error.
+	// Otherwise, return nil reservation with framework.Success.
 	NominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) (*ReservationInfo, *framework.Status)
 	AddNominatedReservation(pod *corev1.Pod, nodeName string, rInfo *ReservationInfo)
 	RemoveNominatedReservations(pod *corev1.Pod)

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -536,7 +536,7 @@ func (pl *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState,
 		// The scheduleOne skip scores and reservation nomination if there is only one node available.
 		var status *framework.Status
 		nominatedReservation, status = pl.handle.GetReservationNominator().NominateReservation(ctx, cycleState, pod, nodeName)
-		if status != nil {
+		if !status.IsSuccess() {
 			return status
 		}
 		if nominatedReservation == nil {

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -54,7 +54,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 	}
 
 	specificNodes, status := parseSpecificNodesFromAffinity(pod)
-	if status != nil {
+	if !status.IsSuccess() {
 		return nil, false, status
 	}
 	requiredNodeAffinity := nodeaffinity.GetRequiredNodeAffinity(pod)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

scheduler: ReservationNominator senses ReservationAffinity.

If no reservations matched, and the Pod needs to be allocated from reservation, nominator return error.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
