### PR TITLE
scheduler : supports disable runtime quota

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -186,6 +186,9 @@ type ElasticQuotaArgs struct {
 
 	// EnableCheckParentQuota check parentQuotaGroups' used and runtime Quota in PreFilter
 	EnableCheckParentQuota *bool
+
+	// EnableRuntimeQuota if true, use max instead of runtime for all checks.
+	EnableRuntimeQuota bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -67,6 +67,7 @@ var (
 
 	defaultMonitorAllQuotas       = pointer.Bool(false)
 	defaultEnableCheckParentQuota = pointer.Bool(false)
+	defaultEnableRuntimeQuota     = pointer.Bool(true)
 
 	defaultTimeout           = 600 * time.Second
 	defaultControllerWorkers = 1
@@ -166,6 +167,9 @@ func SetDefaults_ElasticQuotaArgs(obj *ElasticQuotaArgs) {
 	}
 	if obj.EnableCheckParentQuota == nil {
 		obj.EnableCheckParentQuota = defaultEnableCheckParentQuota
+	}
+	if obj.EnableRuntimeQuota == nil {
+		obj.EnableRuntimeQuota = defaultEnableRuntimeQuota
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/types.go
+++ b/pkg/scheduler/apis/config/v1beta2/types.go
@@ -181,6 +181,9 @@ type ElasticQuotaArgs struct {
 
 	// EnableCheckParentQuota check parentQuotaGroups' used and runtime Quota in PreFilter
 	EnableCheckParentQuota *bool `json:"enableCheckParentQuota,omitempty"`
+
+	// EnableRuntimeQuota if false, use max instead of runtime for all checks.
+	EnableRuntimeQuota *bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -182,6 +182,9 @@ func autoConvert_v1beta2_ElasticQuotaArgs_To_config_ElasticQuotaArgs(in *Elastic
 	out.QuotaGroupNamespace = in.QuotaGroupNamespace
 	out.MonitorAllQuotas = (*bool)(unsafe.Pointer(in.MonitorAllQuotas))
 	out.EnableCheckParentQuota = (*bool)(unsafe.Pointer(in.EnableCheckParentQuota))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -198,6 +201,9 @@ func autoConvert_config_ElasticQuotaArgs_To_v1beta2_ElasticQuotaArgs(in *config.
 	out.QuotaGroupNamespace = in.QuotaGroupNamespace
 	out.MonitorAllQuotas = (*bool)(unsafe.Pointer(in.MonitorAllQuotas))
 	out.EnableCheckParentQuota = (*bool)(unsafe.Pointer(in.EnableCheckParentQuota))
+	if err := v1.Convert_bool_To_Pointer_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -136,6 +136,11 @@ func (in *ElasticQuotaArgs) DeepCopyInto(out *ElasticQuotaArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableRuntimeQuota != nil {
+		in, out := &in.EnableRuntimeQuota, &out.EnableRuntimeQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -602,11 +602,12 @@ func setLoglevel(logLevel string) {
 
 func TestPlugin_PreFilter(t *testing.T) {
 	test := []struct {
-		name           string
-		pod            *corev1.Pod
-		quotaInfo      *core.QuotaInfo
-		expectedStatus *framework.Status
-		checkParent    bool
+		name                string
+		pod                 *corev1.Pod
+		quotaInfo           *core.QuotaInfo
+		expectedStatus      *framework.Status
+		checkParent         bool
+		disableRuntimeQuota bool
 	}{
 		{
 			name: "default",
@@ -663,6 +664,20 @@ func TestPlugin_PreFilter(t *testing.T) {
 			},
 			expectedStatus: framework.NewStatus(framework.Success, ""),
 		},
+		{
+			name: "runtime not enough, but disable runtime",
+			pod: MakePod("t1-ns1", "pod1").Container(
+				MakeResourceList().CPU(1).Mem(3).GPU(1).Obj()).Obj(),
+			quotaInfo: &core.QuotaInfo{
+				Name: extension.DefaultQuotaName,
+				CalculateInfo: core.QuotaCalculateInfo{
+					Max:     MakeResourceList().CPU(1).Mem(3).Obj(),
+					Runtime: MakeResourceList().CPU(1).Mem(2).Obj(),
+				},
+			},
+			disableRuntimeQuota: true,
+			expectedStatus:      framework.NewStatus(framework.Success, ""),
+		},
 	}
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
@@ -670,6 +685,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 			p, err := suit.proxyNew(suit.elasticQuotaArgs, suit.Handle)
 			assert.Nil(t, err)
 			gp := p.(*Plugin)
+			gp.pluginArgs.EnableRuntimeQuota = !tt.disableRuntimeQuota
 			qi := gp.groupQuotaManager.GetQuotaInfoByName(tt.quotaInfo.Name)
 			qi.Lock()
 			qi.CalculateInfo.Runtime = tt.quotaInfo.CalculateInfo.Runtime.DeepCopy()

--- a/pkg/scheduler/plugins/elasticquota/preempt.go
+++ b/pkg/scheduler/plugins/elasticquota/preempt.go
@@ -188,7 +188,7 @@ func (g *Plugin) SelectVictimsOnNode(
 		}
 
 		newUsed := quotav1.Mask(quotav1.Add(postFilterState.used, podReq), quotav1.ResourceNames(podReq))
-		if isLessEqual, _ := quotav1.LessThanOrEqual(newUsed, postFilterState.runtime); !isLessEqual {
+		if isLessEqual, _ := quotav1.LessThanOrEqual(newUsed, postFilterState.usedLimit); !isLessEqual {
 			if err := removePod(pi); err != nil {
 				return false, err
 			}

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke.go
@@ -152,6 +152,7 @@ type QuotaOverUsedRevokeController struct {
 	overUsedTriggerEvictDuration time.Duration
 	revokePodCycle               time.Duration
 	monitorAllQuotas             bool
+	enableRuntimeQuota           bool
 	plugin                       *Plugin
 }
 
@@ -165,6 +166,8 @@ func NewQuotaOverUsedRevokeController(plugin *Plugin) *QuotaOverUsedRevokeContro
 	if plugin.pluginArgs.MonitorAllQuotas != nil {
 		controller.monitorAllQuotas = *plugin.pluginArgs.MonitorAllQuotas
 	}
+	controller.enableRuntimeQuota = plugin.pluginArgs.EnableRuntimeQuota
+
 	return controller
 }
 
@@ -175,6 +178,10 @@ func (controller *QuotaOverUsedRevokeController) Name() string {
 func (controller *QuotaOverUsedRevokeController) Start() {
 	if !controller.monitorAllQuotas {
 		klog.Infof("monitorAllQuotas not true. will not start elasticQuota QuotaOverUsedRevokeController")
+		return
+	}
+	if !controller.enableRuntimeQuota {
+		klog.Infof("enableRuntimeQuota is false. will not start elasticQuota QuotaOverUsedRevokeController")
 		return
 	}
 	go wait.Until(controller.revokePodDueToQuotaOverUsed, controller.revokePodCycle, nil)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Runtime quota can solve the fairness problem at the Quota layer, but in some scenarios, such as AI model training scenarios, the job may not be able to run due to runtime quota. It is necessary to provide a switch to turn off this ability to deal with this scenario.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
to https://github.com/koordinator-sh/koordinator/issues/1780
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
