### PR TITLE
koordlet: fix struct type lost of node slo extension

### DIFF
--- a/apis/configuration/slo_controller_config.go
+++ b/apis/configuration/slo_controller_config.go
@@ -152,7 +152,7 @@ func (in *ExtensionCfg) DeepCopy() *ExtensionCfg {
 // +k8s:deepcopy-gen=false
 type NodeExtensionStrategy struct {
 	NodeCfgProfile `json:",inline"`
-	NodeStrategy   interface{} // for third-party extension
+	NodeStrategy   interface{} `json:",inline"` // for third-party extension
 }
 
 func (in *NodeExtensionStrategy) DeepCopyInto(out *NodeExtensionStrategy) {

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo.go
@@ -254,11 +254,18 @@ func mergeSLOSpecExtensions(defaultSpec,
 	if newSpec != nil {
 		spec = newSpec
 	}
-	// ignore err for serializing/deserializing the same struct type
-	data, _ := json.Marshal(spec)
-	// NOTE: use deepcopy to avoid a overwrite to the global default
+
 	out := defaultSpec.DeepCopy()
-	_ = json.Unmarshal(data, &out)
+	for key := range out.Object {
+		// merge extension one by one so that all extension types can be protected during unmarshal
+		if newObj, exist := spec.Object[key]; exist {
+			// ignore err for serializing/deserializing the same struct type
+			data, _ := json.Marshal(newObj)
+			// NOTE: use deepcopy to avoid a overwrite to the global default
+			_ = json.Unmarshal(data, out.Object[key])
+		}
+	}
+
 	return out
 }
 

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
@@ -58,7 +58,6 @@ func Test_mergeNodeSLOSpec(t *testing.T) {
 		SystemStrategy: &slov1alpha1.SystemStrategy{
 			WatermarkScaleFactor: pointer.Int64(200),
 		},
-		Extensions: &slov1alpha1.ExtensionsMap{},
 	}
 	testingMergedNodeSLOSpec := sloconfig.DefaultNodeSLOSpecConfig()
 	mergedInterface, err := util.MergeCfg(&testingMergedNodeSLOSpec, &testingCustomNodeSLOSpec)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
- fix lost json annotation in NodeStrategy struct
- fix the type lost in merging with default value in mergeSLOSpecExtensions

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
