### PR TITLE
koordlet: fix recursively disabling bvt

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/groupidentity/rule.go
@@ -188,6 +188,7 @@ func (b *bvtPlugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
 		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, kubeQOSCgroupPath, strconv.FormatInt(bvtValue, 10), e)
 		if err != nil {
 			klog.Infof("bvt updater create failed, dir %v, error %v", kubeQOSCgroupPath, err)
+			continue
 		}
 		if _, err = b.executor.Update(true, bvtUpdater); err != nil {
 			klog.Infof("update kube qos %v cpu bvt failed, dir %v, error %v", kubeQOS, kubeQOSCgroupPath, err)
@@ -200,17 +201,19 @@ func (b *bvtPlugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
 	}
 
 	// FIXME(saintube): Currently the kernel feature core scheduling is strictly excluded with the group identity's
-	//  bvt=-1. So we have to check and disable all the BE cgroups' bvt for the GroupIdentity before creating the
-	//  core sched cookies. To keep the consistency of the cgroup tree's configuration, we list and update the cgroups
-	//  by the level order when the group identity is globally disabled.
-	//  This check should be removed after the kernel provides a more stable interface.
+	//   bvt=-1. So we have to check and disable all the BE cgroups' bvt for the GroupIdentity before creating the
+	//   core sched cookies. To keep the consistency of the cgroup tree's configuration, we list and update the cgroups
+	//   by the level order when the group identity is globally disabled.
+	//   This check should be removed after the kernel provides a more stable interface.
 	podCgroupMap := map[string]int64{}
 	// pod-level
 	for _, kubeQOS := range []corev1.PodQOSClass{corev1.PodQOSGuaranteed, corev1.PodQOSBurstable, corev1.PodQOSBestEffort} {
 		bvtValue := r.getKubeQOSDirBvtValue(kubeQOS)
-		podCgroupDirs, err := koordletutil.GetCgroupPathsByTargetDepth(kubeQOS, sysutil.CPUBVTWarpNsName, koordletutil.PodCgroupPathRelativeDepth)
+		kubeQOSParentDir := koordletutil.GetPodQoSRelativePath(kubeQOS)
+		podCgroupDirs, err := koordletutil.GetCgroupPathsByTargetDepth(sysutil.CPUBVTWarpNsName, kubeQOSParentDir, koordletutil.PodCgroupPathRelativeDepth)
 		if err != nil {
-			return fmt.Errorf("get pod cgroup paths failed, qos %s, err: %w", kubeQOS, err)
+			klog.Infof("get pod cgroup paths failed, qos %s, err: %w", kubeQOS, err)
+			continue
 		}
 		for _, cgroupDir := range podCgroupDirs {
 			if _, ok := qosCgroupMap[cgroupDir]; ok { // exclude qos cgroup
@@ -228,12 +231,32 @@ func (b *bvtPlugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
 		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, podCgroupPath, strconv.FormatInt(podBvt, 10), e)
 		if err != nil {
 			klog.Infof("bvt updater create failed, dir %v, error %v", podCgroupPath, err)
+			continue
 		}
 		if _, err = b.executor.Update(true, bvtUpdater); err != nil {
 			klog.Infof("update pod %s cpu bvt failed, dir %v, error %v",
 				util.GetPodKey(podMeta.Pod), podCgroupPath, err)
 		}
 		delete(podCgroupMap, podCgroupPath)
+
+		// container-level
+		// NOTE: Although we do not set the container's cpu.bvt_warp_ns directly, it is inheritable from the pod-level,
+		//       we have to handle the container-level only when we want to disable the group identity.
+		containerCgroupDirs, err := koordletutil.GetCgroupPathsByTargetDepth(sysutil.CPUBVTWarpNsName, podCgroupPath, 1)
+		if err != nil {
+			klog.Infof("get container cgroup paths failed, dir %s, error %v", podCgroupPath, err)
+			continue
+		}
+		for _, cgroupDir := range containerCgroupDirs {
+			bvtUpdater, err = resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupDir, strconv.FormatInt(podBvt, 10), e)
+			if err != nil {
+				klog.Infof("bvt updater create failed, dir %v, error %v", cgroupDir, err)
+				continue
+			}
+			if _, err = b.executor.Update(true, bvtUpdater); err != nil {
+				klog.Infof("update container cpu bvt failed, dir %v, error %v", cgroupDir, err)
+			}
+		}
 	}
 	for _, hostApp := range target.HostApplications {
 		hostCtx := protocol.HooksProtocolBuilder.HostApp(&hostApp)
@@ -250,35 +273,26 @@ func (b *bvtPlugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
 		bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, podCgroupDir, strconv.FormatInt(bvtValue, 10), e)
 		if err != nil {
 			klog.Infof("bvt updater create failed, dir %v, error %v", podCgroupDir, err)
+			continue
 		}
 		if _, err = b.executor.Update(true, bvtUpdater); err != nil {
 			klog.Infof("update remaining pod cpu bvt failed, dir %v, error %v", podCgroupDir, err)
 		}
-	}
 
-	// container-level
-	// NOTE: Although we do not set the container's cpu.bvt_warp_ns directly, it is inheritable from the pod-level,
-	//       we have to handle the container-level only when we want to disable the group identity.
-	if !r.getEnable() {
-		for _, kubeQOS := range []corev1.PodQOSClass{corev1.PodQOSGuaranteed, corev1.PodQOSBurstable, corev1.PodQOSBestEffort} {
-			bvtValue := r.getKubeQOSDirBvtValue(kubeQOS)
-			containerCgroupDirs, err := koordletutil.GetCgroupPathsByTargetDepth(kubeQOS, sysutil.CPUBVTWarpNsName, koordletutil.ContainerCgroupPathRelativeDepth)
+		// container-level
+		containerCgroupDirs, err := koordletutil.GetCgroupPathsByTargetDepth(sysutil.CPUBVTWarpNsName, podCgroupDir, 1)
+		if err != nil {
+			klog.Infof("get container cgroup paths failed, dir %s, error %v", podCgroupDir, err)
+			continue
+		}
+		for _, cgroupDir := range containerCgroupDirs {
+			bvtUpdater, err = resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupDir, strconv.FormatInt(bvtValue, 10), e)
 			if err != nil {
-				return fmt.Errorf("get container cgroup paths failed, qos %s, err: %w", kubeQOS, err)
+				klog.Infof("bvt updater create failed, dir %v, error %v", cgroupDir, err)
+				continue
 			}
-			for _, cgroupDir := range containerCgroupDirs {
-				if _, ok := podCgroupMap[cgroupDir]; ok {
-					continue
-				}
-
-				e := audit.V(3).Reason(name).Message("set bvt to %v", bvtValue)
-				bvtUpdater, err := resourceexecutor.DefaultCgroupUpdaterFactory.New(sysutil.CPUBVTWarpNsName, cgroupDir, strconv.FormatInt(bvtValue, 10), e)
-				if err != nil {
-					klog.Infof("bvt updater create failed, dir %v, error %v", cgroupDir, err)
-				}
-				if _, err = b.executor.Update(true, bvtUpdater); err != nil {
-					klog.Infof("update container cpu bvt failed, dir %v, error %v", cgroupDir, err)
-				}
+			if _, err = b.executor.Update(true, bvtUpdater); err != nil {
+				klog.Infof("update remaining container cpu bvt failed, dir %v, error %v", cgroupDir, err)
 			}
 		}
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: fix the group identity disabling for the special cases when some pod cgroups are not under the kube qos

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
