### PR TITLE
koordlet: eliminate cache GC is not started

### DIFF
--- a/pkg/koordlet/resourceexecutor/executor.go
+++ b/pkg/koordlet/resourceexecutor/executor.go
@@ -187,7 +187,6 @@ func (e *ResourceUpdateExecutorImpl) LeveledUpdateBatch(updaters [][]ResourceUpd
 }
 
 // Run runs the ResourceUpdateExecutor.
-// TODO: run single executor when the qos manager starts.
 func (e *ResourceUpdateExecutorImpl) Run(stopCh <-chan struct{}) {
 	e.onceRun.Do(func() {
 		e.run(stopCh)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: eliminate the error "cache GC is not started" when the koordlet starts.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

It fixes the cgroups updating failure of the runtime hooks' rule callbacks since they can be invoked just after the states informer's running and before the runtime hook runs.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
