### PR TITLE
scheduler: ElasticQuota runtime is no longer calculated when not needed

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -258,10 +258,10 @@ func (gqm *GroupQuotaManager) RefreshRuntime(quotaName string) v1.ResourceList {
 	gqm.hierarchyUpdateLock.RLock()
 	defer gqm.hierarchyUpdateLock.RUnlock()
 
-	return gqm.RefreshRuntimeNoLock(quotaName)
+	return gqm.refreshRuntimeNoLock(quotaName)
 }
 
-func (gqm *GroupQuotaManager) RefreshRuntimeNoLock(quotaName string) v1.ResourceList {
+func (gqm *GroupQuotaManager) refreshRuntimeNoLock(quotaName string) v1.ResourceList {
 	quotaInfo := gqm.getQuotaInfoByNameNoLock(quotaName)
 	if quotaInfo == nil {
 		return nil
@@ -705,10 +705,7 @@ func (gqm *GroupQuotaManager) GetQuotaSummary(quotaName string, includePods bool
 		return nil, false
 	}
 
-	quotaSummary := quotaInfo.GetQuotaSummary(includePods)
-	runtime := gqm.RefreshRuntimeNoLock(quotaName)
-	quotaSummary.Runtime = runtime.DeepCopy()
-	quotaSummary.Tree = gqm.treeID
+	quotaSummary := quotaInfo.GetQuotaSummary(gqm.treeID, includePods)
 	return quotaSummary, true
 }
 
@@ -722,10 +719,7 @@ func (gqm *GroupQuotaManager) GetQuotaSummaries(includePods bool) map[string]*Qu
 		if quotaName == extension.RootQuotaName {
 			continue
 		}
-		quotaSummary := quotaInfo.GetQuotaSummary(includePods)
-		runtime := gqm.RefreshRuntimeNoLock(quotaName)
-		quotaSummary.Runtime = runtime.DeepCopy()
-		quotaSummary.Tree = gqm.treeID
+		quotaSummary := quotaInfo.GetQuotaSummary(gqm.treeID, includePods)
 		result[quotaName] = quotaSummary
 	}
 

--- a/pkg/scheduler/plugins/elasticquota/core/quota_info.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info.go
@@ -139,7 +139,7 @@ func (qi *QuotaInfo) DeepCopy() *QuotaInfo {
 	return quotaInfo
 }
 
-func (qi *QuotaInfo) GetQuotaSummary(includePods bool) *QuotaInfoSummary {
+func (qi *QuotaInfo) GetQuotaSummary(treeID string, includePods bool) *QuotaInfoSummary {
 	qi.lock.Lock()
 	defer qi.lock.Unlock()
 
@@ -149,6 +149,7 @@ func (qi *QuotaInfo) GetQuotaSummary(includePods bool) *QuotaInfoSummary {
 	quotaInfoSummary.IsParent = qi.IsParent
 	quotaInfoSummary.RuntimeVersion = qi.RuntimeVersion
 	quotaInfoSummary.AllowLentResource = qi.AllowLentResource
+	quotaInfoSummary.Tree = treeID
 	quotaInfoSummary.Max = qi.CalculateInfo.Max.DeepCopy()
 	quotaInfoSummary.Min = qi.CalculateInfo.Min.DeepCopy()
 	quotaInfoSummary.AutoScaleMin = qi.CalculateInfo.AutoScaleMin.DeepCopy()

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -219,7 +219,9 @@ func (g *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 	if mgr == nil {
 		return nil, framework.NewStatus(framework.Error, fmt.Sprintf("Could not find the specified ElasticQuotaManager for quota: %v, tree: %v", quotaName, treeID))
 	}
-	mgr.RefreshRuntime(quotaName)
+	if g.pluginArgs.EnableRuntimeQuota {
+		mgr.RefreshRuntime(quotaName)
+	}
 	quotaInfo := mgr.GetQuotaInfoByName(quotaName)
 	if quotaInfo == nil {
 		return nil, framework.NewStatus(framework.Error, fmt.Sprintf("Could not find the specified ElasticQuota"))

--- a/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
@@ -41,9 +41,9 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 	assert.NotNil(t, p)
 	assert.Nil(t, err)
 
-	eq := p.(*Plugin)
+	plugin := p.(*Plugin)
 	quota := CreateQuota2("test1", "", 100, 100, 10, 10, 20, 20, false, "")
-	eq.OnQuotaAdd(quota)
+	plugin.OnQuotaAdd(quota)
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -53,7 +53,7 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 			Allocatable: createResourceList(1000, 1000),
 		},
 	}
-	eq.OnNodeAdd(node)
+	plugin.OnNodeAdd(node)
 
 	podToCreate := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -74,7 +74,10 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 		},
 	}
 	podToCreate.Spec.NodeName = "n1"
-	eq.OnPodAdd(podToCreate)
+	plugin.OnPodAdd(podToCreate)
+
+	mgr := plugin.GetGroupQuotaManagerForQuota(quota.Name)
+	mgr.RefreshRuntime(quota.Name)
 
 	quotaExpected := core.QuotaInfoSummary{
 		Name:              "test1",
@@ -98,7 +101,7 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 	}
 	{
 		engine := gin.Default()
-		eq.RegisterEndpoints(engine.Group("/"))
+		plugin.RegisterEndpoints(engine.Group("/"))
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/quotas/test1?includePods=true", nil)
 		engine.ServeHTTP(w, req)
@@ -125,7 +128,7 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 	}
 	{
 		engine := gin.Default()
-		eq.RegisterEndpoints(engine.Group("/"))
+		plugin.RegisterEndpoints(engine.Group("/"))
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/quotas?includePods=true", nil)
 		engine.ServeHTTP(w, req)
@@ -155,10 +158,10 @@ func TestEndpointsQueryQuotaInfo(t *testing.T) {
 		defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 
 		// add root quota
-		eq.addRootQuota("tree1-root", "", 20, 20, 10, 10, 30, 30, false, "", "tree1")
+		plugin.addRootQuota("tree1-root", "", 20, 20, 10, 10, 30, 30, false, "", "tree1")
 
 		engine := gin.Default()
-		eq.RegisterEndpoints(engine.Group("/"))
+		plugin.RegisterEndpoints(engine.Group("/"))
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/quotas?tree=tree1&includePods=true", nil)
 		engine.ServeHTTP(w, req)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Changes have been made in PR #1839. When `runtime` is not needed, `max` will be used as the upper limit of ElasticQuota. But it hasn't been done thoroughly yet. Since there is no need to use `runtime`, there is no need to calculate runtime in the PreFilter stage. In addition, `GetQuotaSummary` is an externally exposed interface. It only needs to read the most recent `runtime`, and there is no need to recalculate `runtime`. If we need to compute `runtime` more aggressively in the future, we should consider implementing a more efficient, cohesive method to support it.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
