### PR TITLE
feat: add priority in ClusterColocationProfile

### DIFF
--- a/apis/config/v1alpha1/cluster_colocation_profile_types.go
+++ b/apis/config/v1alpha1/cluster_colocation_profile_types.go
@@ -93,6 +93,11 @@ type ClusterColocationProfileSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
 	Patch runtime.RawExtension `json:"patch,omitempty"`
+
+	// Priority of profile if many profile matched
+	// The higher the value, the higher the priority.
+	// +optional
+	Priority int `json:"priority,omitempty"`
 }
 
 // ClusterColocationProfileStatus represents information about the status of a ClusterColocationProfile.

--- a/apis/extension/cluster_colocation_profile.go
+++ b/apis/extension/cluster_colocation_profile.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	AnnotationSkipUpdateResource = "config.koordinator.sh/skip-update-resources"
+	AnnotationSkipNextProfile    = "config.koordinator.sh/skip-next-profile"
 )
 
 func ShouldSkipUpdateResource(profile *configv1alpha1.ClusterColocationProfile) bool {
@@ -29,5 +30,13 @@ func ShouldSkipUpdateResource(profile *configv1alpha1.ClusterColocationProfile) 
 		return false
 	}
 	_, ok := profile.Annotations[AnnotationSkipUpdateResource]
+	return ok
+}
+
+func ShouldSkipNextProfile(profile *configv1alpha1.ClusterColocationProfile) bool {
+	if profile == nil || profile.Annotations == nil {
+		return false
+	}
+	_, ok := profile.Annotations[AnnotationSkipNextProfile]
 	return ok
 }

--- a/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
+++ b/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
@@ -122,6 +122,10 @@ spec:
                 description: Patch indicates patching podTemplate that will be injected
                   to the Pod.
                 x-kubernetes-preserve-unknown-fields: true
+              priority:
+                description: Priority of profile if many profile matched The higher
+                  the value, the higher the priority.
+                type: integer
               priorityClassName:
                 description: If specified, the priorityClassName and the priority
                   value defined in PriorityClass will be injected into the Pod. The


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- make ClusterColocationProfile support priorty
- add a annotation to skip next profiles.

Maybe you want to only match once, and have priority when you have many clusterColocationProfiles matched, this patch implement it.

### Ⅱ. Does this pull request fix one issue?
https://github.com/koordinator-sh/koordinator/issues/1871

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
