### PR TITLE
scheduler: improve NodeNUMAResource handling node cpu bind policy

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/cpu_topology.go
+++ b/pkg/scheduler/plugins/nodenumaresource/cpu_topology.go
@@ -75,7 +75,7 @@ func (b *CPUTopologyBuilder) Result() *CPUTopology {
 
 // IsValid checks if the topology is valid
 func (topo *CPUTopology) IsValid() bool {
-	return topo.NumSockets != 0 && topo.NumNodes != 0 && topo.NumCores != 0 && topo.NumCPUs != 0
+	return topo != nil && topo.NumSockets != 0 && topo.NumNodes != 0 && topo.NumCores != 0 && topo.NumCPUs != 0
 }
 
 // CPUsPerCore returns the number of logical CPUs are associated with each core.

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
@@ -361,7 +361,7 @@ func (c *resourceManager) allocateCPUSet(node *corev1.Node, pod *corev1.Pod, all
 
 func (c *resourceManager) Update(nodeName string, allocation *PodAllocation) {
 	topologyOptions := c.topologyOptionsManager.GetTopologyOptions(nodeName)
-	if topologyOptions.CPUTopology == nil || !topologyOptions.CPUTopology.IsValid() {
+	if !topologyOptions.CPUTopology.IsValid() {
 		return
 	}
 
@@ -390,7 +390,7 @@ func (c *resourceManager) GetAllocatedCPUSet(nodeName string, podUID types.UID) 
 func (c *resourceManager) GetAvailableCPUs(nodeName string, preferredCPUs cpuset.CPUSet) (availableCPUs cpuset.CPUSet, allocated CPUDetails, err error) {
 	topologyOptions := c.topologyOptionsManager.GetTopologyOptions(nodeName)
 	if topologyOptions.CPUTopology == nil {
-		return cpuset.NewCPUSet(), nil, errors.New(ErrNotFoundCPUTopology)
+		return cpuset.NewCPUSet(), nil, nil
 	}
 	if !topologyOptions.CPUTopology.IsValid() {
 		return cpuset.NewCPUSet(), nil, errors.New(ErrInvalidCPUTopology)

--- a/pkg/scheduler/plugins/nodenumaresource/service.go
+++ b/pkg/scheduler/plugins/nodenumaresource/service.go
@@ -48,7 +48,7 @@ func (p *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 		}
 
 		topologyOptions := p.topologyOptionsManager.GetTopologyOptions(nodeName)
-		if topologyOptions.CPUTopology == nil || !topologyOptions.CPUTopology.IsValid() {
+		if !topologyOptions.CPUTopology.IsValid() {
 			services.ResponseErrorMessage(c, http.StatusInternalServerError, "invalid topology, please check the NodeResourceTopology object")
 			return
 		}

--- a/pkg/scheduler/plugins/nodenumaresource/util_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/util_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+)
+
+func Test_getCPUBindPolicy(t *testing.T) {
+	tests := []struct {
+		name            string
+		kubeletPolicy   *extension.KubeletCPUManagerPolicy
+		nodePolicy      extension.NodeCPUBindPolicy
+		requiredPolicy  schedulingconfig.CPUBindPolicy
+		preferredPolicy schedulingconfig.CPUBindPolicy
+		wantPolicy      schedulingconfig.CPUBindPolicy
+		wantRequired    bool
+		wantError       bool
+	}{
+		{
+			name: "kubelet enables FullPCPUsOnly",
+			kubeletPolicy: &extension.KubeletCPUManagerPolicy{
+				Policy: extension.KubeletCPUManagerPolicyStatic,
+				Options: map[string]string{
+					extension.KubeletCPUManagerPolicyFullPCPUsOnlyOption: "true",
+				},
+			},
+			nodePolicy:      "",
+			requiredPolicy:  "",
+			preferredPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantPolicy:      schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantRequired:    true,
+			wantError:       false,
+		},
+		{
+			name:            "node enables FullPCPUsOnly",
+			nodePolicy:      extension.NodeCPUBindPolicyFullPCPUsOnly,
+			requiredPolicy:  "",
+			preferredPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantPolicy:      schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantRequired:    true,
+			wantError:       false,
+		},
+		{
+			name:           "pod enables required FullPCPUsOnly",
+			requiredPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantPolicy:     schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantRequired:   true,
+			wantError:      false,
+		},
+		{
+			name:            "pod enables preferred FullPCPUsOnly",
+			preferredPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantPolicy:      schedulingconfig.CPUBindPolicyFullPCPUs,
+			wantRequired:    false,
+			wantError:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			topologyOpts := &TopologyOptions{
+				Policy: tt.kubeletPolicy,
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			}
+			if tt.nodePolicy != "" {
+				node.Labels[extension.LabelNodeCPUBindPolicy] = string(tt.nodePolicy)
+			}
+			policy, required, err := getCPUBindPolicy(topologyOpts, node, tt.requiredPolicy, tt.preferredPolicy)
+			assert.Equal(t, tt.wantPolicy, policy)
+			assert.Equal(t, tt.wantRequired, required)
+			if tt.wantError != (err != nil) {
+				t.Errorf("wantErr=%v, but got err=%v", tt.wantError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

If the node enables label `node.koordinator.sh/cpu-bind-policy` and configures the corresponding value to `FullPCPUsOnly` or `SpreadByPCPUs`, then the scheduler should ensure that the allocation result corresponding to `ResourceSpec.RequiredCPUBindPolicy` is consistent.

And the node policy may conflict with the `ResourceSpec.RequiredCPUBindPolicy` defined in the Pod.  For example: the node defined the policy with `FullPCPUsOnly`, and the Pod required `SpreadByPCPUs`,  this creates a conflict that should be filtered.

If the Pod does not declare the ResourceSpec with CPUBindPolicy(either required or preferred), and the node declares the CPUBindPolicy, the scheduler should allocate CPUs by node's CPUBindPolicy, even though the Pod's QoSClass is LS. Although the previous implementation could work, but the implementation was not complete enough.
As for whether koordlet or kubelet will set the cgroup according to the scheduler allocation result on the LS Pod, I think this is a strategic issue. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
