### PR TITLE
scheduler: add Reservation restricted options to control allocatable resources

### DIFF
--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -528,3 +528,22 @@ func UpdateReservationResizeAllocatable(obj metav1.Object, resources corev1.Reso
 	}
 	return SetReservationResizeAllocatable(obj, resizeAllocatable)
 }
+
+func GetReservationRestrictedResources(allocatableResources []corev1.ResourceName, options *extension.ReservationRestrictedOptions) []corev1.ResourceName {
+	if options == nil {
+		return allocatableResources
+	}
+	result := make([]corev1.ResourceName, 0, len(allocatableResources))
+	for _, resourceName := range allocatableResources {
+		for _, v := range options.Resources {
+			if resourceName == v {
+				result = append(result, resourceName)
+				break
+			}
+		}
+	}
+	if len(result) == 0 {
+		result = allocatableResources
+	}
+	return result
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When a Pod uses a Reservation with an allocation policy of Restricted, the maximum amount of resources that can be used by intersecting resource requests cannot exceed the amount of resources in the Reservation. But in fact, some scenarios require that even intersecting resource requests should be allowed to break this limit. This PR introduces annotation `scheduling.koordinator.sh/reservation-restricted-options` to solve this problem.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Create Reservation with the annotation `scheduling.koordinator.sh/reservation-restricted-options`.

```yaml
apiVersion: scheduling.koordinator.sh/v1alpha1
kind: Reservation
metadata:
  annotations:
    scheduling.koordinator.sh/reservation-restricted-options: |- 
      {"resources": ["cpu", "memory"]}
  name: test-reservation
spec:
  allocateOnce: false
  allocatePolicy: Restricted
  owners:
  - labelSelector:
      matchLabels:
        app: test
  template:
    metadata:
      creationTimestamp: null
    spec:
      schedulerName: koord-scheduler
      containers:
      - image: mock
        imagePullPolicy: IfNotPresent
        name: mock
        resources:
          limits:
            cpu: "4"
            memory: 8Gi
            fakeResources: "4"
          requests:
            cpu: "4"
            memory: 8Gi
            fakeResources: "4"
  ttl: 0s
```

2. Create Pods that used the Reservation.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: test
    spec:
      containers:
      - command:
        - bash
        - -c
        - sleep 360000
        image: busybox:latest
        imagePullPolicy: Always
        name: main
        resources:
          limits:
            cpu: "1"
            fakeResources: "8"
            memory: 1Gi
      schedulerName: koord-scheduler
```

3. Pod successfully scheduled.

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
