### PR TITLE
koorldet: remove logging field from the kubelet configz

### DIFF
--- a/pkg/koordlet/statesinformer/impl/kubelet_stub.go
+++ b/pkg/koordlet/statesinformer/impl/kubelet_stub.go
@@ -28,6 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -99,6 +100,7 @@ type kubeletConfigz struct {
 	ComponentConfig kubeletconfigv1beta1.KubeletConfiguration `json:"kubeletconfig"`
 }
 
+// GetKubeletConfiguration removes the logging field from the configz during unmarshall to make sure the configz is compatible
 func (k *kubeletStub) GetKubeletConfiguration() (*kubeletconfiginternal.KubeletConfiguration, error) {
 	configzURL := url.URL{
 		Scheme: k.scheme,
@@ -119,10 +121,15 @@ func (k *kubeletStub) GetKubeletConfiguration() (*kubeletconfiginternal.KubeletC
 	if err != nil {
 		return nil, err
 	}
+	klog.V(6).Infof("get kubelet configz: %s", string(body))
 
 	var configz kubeletConfigz
 	if err = json.Unmarshal(body, &configz); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal kubeletConfigz: %v", err)
+		// TODO remove unmarshalFromNewVersionConfig after upgrade k8s dependency to 1.28
+		if newVersionErr := unmarshalFromNewVersionConfig(body, &configz); newVersionErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal new version kubeletConfigz, error %v, origin error :%v",
+				newVersionErr, err)
+		}
 	}
 
 	kubeletConfiguration, err := options.NewKubeletConfiguration()
@@ -138,4 +145,29 @@ func (k *kubeletStub) GetKubeletConfiguration() (*kubeletconfiginternal.KubeletC
 		return nil, err
 	}
 	return kubeletConfiguration, nil
+}
+
+// In the Kubernetes 1.28, the Kubelet configuration introduces an API change that is not forward-compatible:
+// v1.24: https://github.com/kubernetes/component-base/blob/release-1.24/config/types.go#L99
+// v1.26: https://github.com/kubernetes/component-base/blob/release-1.26/logs/api/v1/types.go#L45
+// v1.28: https://github.com/kubernetes/component-base/blob/release-1.28/logs/api/v1/types.go#L48
+// unmarshalFromNewVersionConfig removes the logging field from the configz
+func unmarshalFromNewVersionConfig(body []byte, configz *kubeletConfigz) error {
+	rawConfig := struct {
+		KubeletConfig map[string]interface{} `json:"kubeletconfig"`
+	}{}
+	if err := json.Unmarshal(body, &rawConfig); err != nil {
+		return fmt.Errorf("failed to unmarshal kubeletConfigz to raw map: %v", err)
+	}
+	delete(rawConfig.KubeletConfig, "logging")
+	scrubbedBody, err := json.Marshal(rawConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal scrubbed kubeletConfigz %v, error: %v", rawConfig, err)
+	}
+
+	if err = json.Unmarshal(scrubbedBody, &configz); err != nil {
+		return fmt.Errorf("failed to unmarshal scrubbed kubeletConfigz: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

remove logging field from the kubelet configz for forward compatibility to 1.28

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#1801

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
