### PR TITLE
koordlet: add metrics for kubelet and resource executor

### DIFF
--- a/pkg/koordlet/metrics/internal_metrics.go
+++ b/pkg/koordlet/metrics/internal_metrics.go
@@ -41,4 +41,6 @@ func init() {
 	internalMustRegister(CPUBurstCollector...)
 	internalMustRegister(PredictionCollectors...)
 	internalMustRegister(CoreSchedCollector...)
+	internalMustRegister(ResourceExecutorCollector...)
+	internalMustRegister(KubeletStubCollector...)
 }

--- a/pkg/koordlet/metrics/kubelet.go
+++ b/pkg/koordlet/metrics/kubelet.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	HTTPVerbKey = "verb"
+	HTTPPathKey = "path"
+	HTTPCodeKey = "code"
+)
+
+const (
+	HTTPVerbGet = "get"
+)
+
+var (
+	kubeletRequestDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: KoordletSubsystem,
+			Name:      "kubelet_request_duration_seconds",
+			Help:      "kubelet http request duration in seconds",
+			// 10s ~ 4s, /config <= 4ms, /pods <= 16ms
+			Buckets: prometheus.ExponentialBuckets(0.001, 4, 7),
+		},
+		[]string{HTTPVerbKey, HTTPPathKey, HTTPCodeKey},
+	)
+
+	KubeletStubCollector = []prometheus.Collector{
+		kubeletRequestDurationSeconds,
+	}
+)
+
+// RecordKubeletRequestDuration records the duration of kubelet http request
+func RecordKubeletRequestDuration(verb, path, code string, seconds float64) {
+	kubeletRequestDurationSeconds.WithLabelValues(verb, path, code).Observe(seconds)
+}
+
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
+}

--- a/pkg/koordlet/metrics/metrics_test.go
+++ b/pkg/koordlet/metrics/metrics_test.go
@@ -28,7 +28,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -77,30 +77,15 @@ func TestCommonCollectors(t *testing.T) {
 			UID:       "test01",
 		},
 	}
-	testingPSI := &resourceexecutor.PSIByResource{
-		CPU: resourceexecutor.PSIStats{
-			Some: &resourceexecutor.PSILine{
+	testingPSI := &system.PSIByResource{
+		CPU: system.PSIStats{
+			Some: &system.PSILine{
 				Avg10:  1,
 				Avg60:  1,
 				Avg300: 1,
 				Total:  1,
 			},
-			Full: &resourceexecutor.PSILine{
-				Avg10:  1,
-				Avg60:  1,
-				Avg300: 1,
-				Total:  1,
-			},
-			FullSupported: true,
-		},
-		Mem: resourceexecutor.PSIStats{
-			Some: &resourceexecutor.PSILine{
-				Avg10:  1,
-				Avg60:  1,
-				Avg300: 1,
-				Total:  1,
-			},
-			Full: &resourceexecutor.PSILine{
+			Full: &system.PSILine{
 				Avg10:  1,
 				Avg60:  1,
 				Avg300: 1,
@@ -108,14 +93,29 @@ func TestCommonCollectors(t *testing.T) {
 			},
 			FullSupported: true,
 		},
-		IO: resourceexecutor.PSIStats{
-			Some: &resourceexecutor.PSILine{
+		Mem: system.PSIStats{
+			Some: &system.PSILine{
 				Avg10:  1,
 				Avg60:  1,
 				Avg300: 1,
 				Total:  1,
 			},
-			Full: &resourceexecutor.PSILine{
+			Full: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			FullSupported: true,
+		},
+		IO: system.PSIStats{
+			Some: &system.PSILine{
+				Avg10:  1,
+				Avg60:  1,
+				Avg300: 1,
+				Total:  1,
+			},
+			Full: &system.PSILine{
 				Avg10:  1,
 				Avg60:  1,
 				Avg300: 1,

--- a/pkg/koordlet/metrics/psi.go
+++ b/pkg/koordlet/metrics/psi.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
 const (
@@ -73,7 +73,7 @@ type PSIRecord struct {
 	CPUFullSupported bool
 }
 
-func getPSIRecords(psi *resourceexecutor.PSIByResource) []PSIRecord {
+func getPSIRecords(psi *system.PSIByResource) []PSIRecord {
 	var psiRecordAll []PSIRecord
 	psiRecordAll = append(psiRecordAll, makePSIRecordSlice(ResourceTypeCPU, psi.CPU)...)
 	psiRecordAll = append(psiRecordAll, makePSIRecordSlice(ResourceTypeMem, psi.Mem)...)
@@ -81,7 +81,7 @@ func getPSIRecords(psi *resourceexecutor.PSIByResource) []PSIRecord {
 	return psiRecordAll
 }
 
-func makePSIRecordSlice(resourceType string, psiStats resourceexecutor.PSIStats) []PSIRecord {
+func makePSIRecordSlice(resourceType string, psiStats system.PSIStats) []PSIRecord {
 	records := []PSIRecord{
 		{
 			ResourceType:     resourceType,
@@ -134,7 +134,7 @@ func makePSIRecordSlice(resourceType string, psiStats resourceexecutor.PSIStats)
 	return records
 }
 
-func RecordContainerPSI(status *corev1.ContainerStatus, pod *corev1.Pod, psi *resourceexecutor.PSIByResource) {
+func RecordContainerPSI(status *corev1.ContainerStatus, pod *corev1.Pod, psi *system.PSIByResource) {
 	psiRecords := getPSIRecords(psi)
 	for _, record := range psiRecords {
 		labels := genNodeLabels()
@@ -155,7 +155,7 @@ func RecordContainerPSI(status *corev1.ContainerStatus, pod *corev1.Pod, psi *re
 	}
 }
 
-func RecordPodPSI(pod *corev1.Pod, psi *resourceexecutor.PSIByResource) {
+func RecordPodPSI(pod *corev1.Pod, psi *system.PSIByResource) {
 	psiRecords := getPSIRecords(psi)
 	for _, record := range psiRecords {
 		labels := genNodeLabels()

--- a/pkg/koordlet/metrics/psi_test.go
+++ b/pkg/koordlet/metrics/psi_test.go
@@ -21,24 +21,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
 func TestGetPSIRecords(t *testing.T) {
-	testingRecords := &resourceexecutor.PSIByResource{
-		CPU: resourceexecutor.PSIStats{
-			Some:          &resourceexecutor.PSILine{},
-			Full:          &resourceexecutor.PSILine{},
+	testingRecords := &system.PSIByResource{
+		CPU: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
 			FullSupported: true,
 		},
-		Mem: resourceexecutor.PSIStats{
-			Some:          &resourceexecutor.PSILine{},
-			Full:          &resourceexecutor.PSILine{},
+		Mem: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
 			FullSupported: true,
 		},
-		IO: resourceexecutor.PSIStats{
-			Some:          &resourceexecutor.PSILine{},
-			Full:          &resourceexecutor.PSILine{},
+		IO: system.PSIStats{
+			Some:          &system.PSILine{},
+			Full:          &system.PSILine{},
 			FullSupported: true,
 		},
 	}

--- a/pkg/koordlet/metrics/resource_executor.go
+++ b/pkg/koordlet/metrics/resource_executor.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// ResourceUpdaterType represents the type of resource udpater, including cgroup files, resctrl files, etc
+	ResourceUpdaterType = "type"
+	// ResourceUpdateStatusKey represents the status of resource update
+	ResourceUpdateStatusKey = "status"
+)
+
+const (
+	ResourceUpdateStatusSuccess = "success"
+	ResourceUpdateStatusFailed  = "failed"
+)
+
+var (
+	resourceUpdateDurationMilliSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "resource_update_duration_milliseconds",
+		Help:      "time duration of resource update such as cgroup files",
+		// 10us ~ 10.24ms, cgroup <= 40us
+		Buckets: prometheus.ExponentialBuckets(0.01, 4, 8),
+	}, []string{ResourceUpdaterType, ResourceUpdateStatusKey})
+
+	ResourceExecutorCollector = []prometheus.Collector{
+		resourceUpdateDurationMilliSeconds,
+	}
+)
+
+func RecordResourceUpdateDuration(updaterType, status string, seconds float64) {
+	resourceUpdateDurationMilliSeconds.WithLabelValues(updaterType, status).Observe(seconds * 1000)
+}

--- a/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/performance/performance_collector_linux_test.go
@@ -404,8 +404,8 @@ func mockLSPod() *corev1.Pod {
 //	   Mem: /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/memory.pressure
 //	   IO:  /sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-pod7712555c_ce62_454a_9e18_9ff0217b8941.slice/io.pressure
 //	 }
-func getPodCgroupCPUAcctPSIPath(podParentDir string) resourceexecutor.PSIPath {
-	return resourceexecutor.PSIPath{
+func getPodCgroupCPUAcctPSIPath(podParentDir string) system.PSIPath {
+	return system.PSIPath{
 		CPU: system.GetCgroupFilePath(podParentDir, system.CPUAcctCPUPressure),
 		Mem: system.GetCgroupFilePath(podParentDir, system.CPUAcctMemoryPressure),
 		IO:  system.GetCgroupFilePath(podParentDir, system.CPUAcctIOPressure),

--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -38,7 +38,7 @@ type CgroupReader interface {
 	ReadMemoryNumaStat(parentDir string) ([]sysutil.NumaMemoryPages, error)
 	ReadCPUTasks(parentDir string) ([]int32, error)
 	ReadCPUProcs(parentDir string) ([]uint32, error)
-	ReadPSI(parentDir string) (*PSIByResource, error)
+	ReadPSI(parentDir string) (*sysutil.PSIByResource, error)
 	ReadMemoryColdPageUsage(parentDir string) (uint64, error)
 }
 
@@ -204,7 +204,7 @@ func (r *CgroupV1Reader) ReadCPUProcs(parentDir string) ([]uint32, error) {
 	return sysutil.ParseCgroupProcs(s)
 }
 
-func (r *CgroupV1Reader) ReadPSI(parentDir string) (*PSIByResource, error) {
+func (r *CgroupV1Reader) ReadPSI(parentDir string) (*sysutil.PSIByResource, error) {
 	cpuPressureResource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV1, sysutil.CPUAcctCPUPressureName)
 	if !ok {
 		return nil, ErrResourceNotRegistered
@@ -218,12 +218,12 @@ func (r *CgroupV1Reader) ReadPSI(parentDir string) (*PSIByResource, error) {
 		return nil, ErrResourceNotRegistered
 	}
 
-	paths := PSIPath{
+	paths := sysutil.PSIPath{
 		CPU: cpuPressureResource.Path(parentDir),
 		Mem: memPressureResource.Path(parentDir),
 		IO:  ioPressureResource.Path(parentDir),
 	}
-	psi, err := getPSIByResource(paths)
+	psi, err := sysutil.GetPSIByResource(paths)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (r *CgroupV2Reader) ReadCPUProcs(parentDir string) ([]uint32, error) {
 	return sysutil.ParseCgroupProcs(s)
 }
 
-func (r *CgroupV2Reader) ReadPSI(parentDir string) (*PSIByResource, error) {
+func (r *CgroupV2Reader) ReadPSI(parentDir string) (*sysutil.PSIByResource, error) {
 	cpuPressureResource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV2, sysutil.CPUAcctCPUPressureName)
 	if !ok {
 		return nil, ErrResourceNotRegistered
@@ -424,12 +424,12 @@ func (r *CgroupV2Reader) ReadPSI(parentDir string) (*PSIByResource, error) {
 		return nil, ErrResourceNotRegistered
 	}
 
-	paths := PSIPath{
+	paths := sysutil.PSIPath{
 		CPU: cpuPressureResource.Path(parentDir),
 		Mem: memPressureResource.Path(parentDir),
 		IO:  ioPressureResource.Path(parentDir),
 	}
-	psi, err := getPSIByResource(paths)
+	psi, err := sysutil.GetPSIByResource(paths)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/koordlet/resourceexecutor/resctrl_updater.go
+++ b/pkg/koordlet/resourceexecutor/resctrl_updater.go
@@ -36,6 +36,10 @@ type ResctrlSchemataResourceUpdater struct {
 	schemataRaw *sysutil.ResctrlSchemataRaw
 }
 
+func (r *ResctrlSchemataResourceUpdater) Name() string {
+	return "resctrl-schema"
+}
+
 func (r *ResctrlSchemataResourceUpdater) Key() string {
 	return r.schemataRaw.Prefix() + r.file
 }

--- a/pkg/koordlet/resourceexecutor/updater.go
+++ b/pkg/koordlet/resourceexecutor/updater.go
@@ -84,6 +84,8 @@ type UpdateFunc func(resource ResourceUpdater) error
 type MergeUpdateFunc func(resource ResourceUpdater) (ResourceUpdater, error)
 
 type ResourceUpdater interface {
+	// Name returns the name of the resource updater
+	Name() string
 	ResourceType() sysutil.ResourceType
 	Key() string
 	Path() string
@@ -110,6 +112,10 @@ type CgroupResourceUpdater struct {
 	//    the new value with old value; then update resources from lower to upper with the new value.
 	mergeUpdateFunc MergeUpdateFunc
 	eventHelper     *audit.EventHelper
+}
+
+func (u *CgroupResourceUpdater) Name() string {
+	return "cgroup"
 }
 
 func (u *CgroupResourceUpdater) ResourceType() sysutil.ResourceType {
@@ -186,6 +192,10 @@ type DefaultResourceUpdater struct {
 	eventHelper         *audit.EventHelper
 }
 
+func (u *DefaultResourceUpdater) Name() string {
+	return "default"
+}
+
 func (u *DefaultResourceUpdater) ResourceType() sysutil.ResourceType {
 	return sysutil.ResourceType(u.file)
 }
@@ -243,11 +253,6 @@ func NewCommonDefaultUpdaterWithUpdateFunc(key string, file string, value string
 		updateFunc:  updateFunc,
 		eventHelper: e,
 	}, nil
-}
-
-type GuestCgroupResourceUpdater struct {
-	*CgroupResourceUpdater
-	sandboxID string // for execute the file operation inside the sandbox
 }
 
 type NewResourceUpdaterFunc func(resourceType sysutil.ResourceType, parentDir string, value string, e *audit.EventHelper) (ResourceUpdater, error)

--- a/pkg/koordlet/util/system/psi.go
+++ b/pkg/koordlet/util/system/psi.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resourceexecutor
+package system
 
 import (
 	"bufio"
@@ -93,7 +93,7 @@ func ParsePSIStats(r io.Reader) (PSIStats, error) {
 	return psiStats, nil
 }
 
-func getPSIByResource(paths PSIPath) (*PSIByResource, error) {
+func GetPSIByResource(paths PSIPath) (*PSIByResource, error) {
 	cpuStats, err := readPSI(paths.CPU)
 	if err != nil {
 		return nil, err

--- a/pkg/koordlet/util/system/psi_test.go
+++ b/pkg/koordlet/util/system/psi_test.go
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resourceexecutor
+package system
 
 import (
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
 const (
@@ -37,7 +35,7 @@ func TestGetPSIByResource_CPUErr(t *testing.T) {
 		IO:  path.Join(dir, "io.pressure"),
 	}
 	assert.NotPanics(t, func() {
-		_, err := getPSIByResource(psiPath)
+		_, err := GetPSIByResource(psiPath)
 		if err != nil {
 			return
 		}
@@ -45,7 +43,7 @@ func TestGetPSIByResource_CPUErr(t *testing.T) {
 }
 
 func TestGetPSIByResource_MemErr(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
 	psiPath := PSIPath{
@@ -54,7 +52,7 @@ func TestGetPSIByResource_MemErr(t *testing.T) {
 		IO:  path.Join(helper.TempDir, "io.pressure"),
 	}
 	assert.NotPanics(t, func() {
-		_, err := getPSIByResource(psiPath)
+		_, err := GetPSIByResource(psiPath)
 		if err != nil {
 			return
 		}
@@ -62,7 +60,7 @@ func TestGetPSIByResource_MemErr(t *testing.T) {
 }
 
 func TestGetPSIByResource_IOErr(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
 	helper.CreateFile("memory.pressure")
@@ -73,7 +71,7 @@ func TestGetPSIByResource_IOErr(t *testing.T) {
 		IO:  path.Join(helper.TempDir, "io.pressure"),
 	}
 	assert.NotPanics(t, func() {
-		_, err := getPSIByResource(psiPath)
+		_, err := GetPSIByResource(psiPath)
 		if err != nil {
 			return
 		}
@@ -81,7 +79,7 @@ func TestGetPSIByResource_IOErr(t *testing.T) {
 }
 
 func TestGetPSIByResource(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", FullCorrectPSIContents)
 	helper.CreateFile("memory.pressure")
@@ -94,7 +92,7 @@ func TestGetPSIByResource(t *testing.T) {
 		IO:  path.Join(helper.TempDir, "io.pressure"),
 	}
 	assert.NotPanics(t, func() {
-		_, err := getPSIByResource(psiPath)
+		_, err := GetPSIByResource(psiPath)
 		if err != nil {
 			return
 		}
@@ -102,7 +100,7 @@ func TestGetPSIByResource(t *testing.T) {
 }
 
 func TestGetPSIRecords(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0")
 
@@ -115,7 +113,7 @@ func TestGetPSIRecords(t *testing.T) {
 }
 
 func TestGetPSIRecords_wrongSomeFormat(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0")
 
@@ -124,7 +122,7 @@ func TestGetPSIRecords_wrongSomeFormat(t *testing.T) {
 }
 
 func TestGetPSIRecords_wrongFullFormat(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 total=0\nfull 0.00 avg300=0.00 total=0")
 
@@ -133,7 +131,7 @@ func TestGetPSIRecords_wrongFullFormat(t *testing.T) {
 }
 
 func TestGetPSIRecords_wrongPrefix(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", "wrong avg10=0.00 total=0\nfull 0.00 avg300=0.00 total=0")
 
@@ -142,7 +140,7 @@ func TestGetPSIRecords_wrongPrefix(t *testing.T) {
 }
 
 func TestGetPSIRecords_FullNotSupported(t *testing.T) {
-	helper := sysutil.NewFileTestUtil(t)
+	helper := NewFileTestUtil(t)
 	helper.CreateFile("cpu.pressure")
 	helper.WriteFileContents("cpu.pressure", "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n")
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
#1867

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
curl http://localhost:9316/metrics
```
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="0.001"} 64
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="0.004"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="0.016"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="0.064"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="0.256"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="1.024"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="4.096"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/configz",verb="get",le="+Inf"} 65
koordlet_kubelet_request_duration_seconds_sum{code="200",path="/configz",verb="get"} 0.03827992899999999
koordlet_kubelet_request_duration_seconds_count{code="200",path="/configz",verb="get"} 65
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="0.001"} 0
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="0.004"} 17
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="0.016"} 20
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="0.064"} 20
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="0.256"} 20
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="1.024"} 20
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="4.096"} 20
koordlet_kubelet_request_duration_seconds_bucket{code="200",path="/pods/",verb="get",le="+Inf"} 20
koordlet_kubelet_request_duration_seconds_sum{code="200",path="/pods/",verb="get"} 0.05541508399999999
koordlet_kubelet_request_duration_seconds_count{code="200",path="/pods/",verb="get"} 20

# HELP koordlet_resource_update_duration_milliseconds time duration of resource update such as cgroup files
# TYPE koordlet_resource_update_duration_milliseconds histogram
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="0.01"} 0
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="0.04"} 74
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="0.16"} 145
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="0.64"} 146
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="2.56"} 146
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="10.24"} 146
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="40.96"} 146
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="163.84"} 146
koordlet_resource_update_duration_milliseconds_bucket{status="success",type="cgroup",le="+Inf"} 146
koordlet_resource_update_duration_milliseconds_sum{status="success",type="cgroup"} 7.001778000000003
koordlet_resource_update_duration_milliseconds_count{status="success",type="cgroup"} 146
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
