### PR TITLE
koordlet: revise cgroupRoot param in podsInformer

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_pods.go
+++ b/pkg/koordlet/statesinformer/impl/states_pods.go
@@ -60,21 +60,21 @@ type podsInformer struct {
 }
 
 func NewPodsInformer() *podsInformer {
-	p, err := pleg.NewPLEG(system.Conf.CgroupRootDir)
-	if err != nil {
-		klog.Fatalf("failed to create PLEG, %v", err)
-	}
-
 	podsInformer := &podsInformer{
 		podMap:       map[string]*statesinformer.PodMeta{},
 		podHasSynced: atomic.NewBool(false),
-		pleg:         p,
 		podCreated:   make(chan string, 1),
 	}
 	return podsInformer
 }
 
 func (s *podsInformer) Setup(ctx *PluginOption, states *PluginState) {
+	p, err := pleg.NewPLEG(system.Conf.CgroupRootDir)
+	if err != nil {
+		klog.Fatalf("failed to create PLEG, %v", err)
+	}
+	s.pleg = p
+
 	s.config = ctx.config
 
 	nodeInformerIf := states.informerPlugins[nodeInformerName]


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: revise podsInformer, pass cgroupRoot during the runtime instead of the global initialization.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
