### PR TITLE
scheduler: resolve the wrong use of gangmod in gang init phase

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -139,8 +139,8 @@ func (gang *Gang) tryInitByPodConfig(pod *v1.Pod, args *config.CoschedulingArgs)
 	gang.Mode = mode
 
 	matchPolicy := util.GetGangMatchPolicyByPod(pod)
-	if matchPolicy != extension.GangMatchPolicyOnlyWaiting && mode != extension.GangMatchPolicyWaitingAndRunning &&
-		mode != extension.GangMatchPolicyOnceSatisfied {
+	if matchPolicy != extension.GangMatchPolicyOnlyWaiting && matchPolicy != extension.GangMatchPolicyWaitingAndRunning &&
+		matchPolicy != extension.GangMatchPolicyOnceSatisfied {
 		klog.Errorf("pod's annotation AnnotationGangMatchPolicy illegal, gangName: %v, value: %v",
 			gang.Name, matchPolicy)
 		matchPolicy = extension.GangMatchPolicyOnceSatisfied
@@ -205,9 +205,9 @@ func (gang *Gang) tryInitByPodGroup(pg *v1alpha1.PodGroup, args *config.Coschedu
 	gang.Mode = mode
 
 	matchPolicy := pg.Annotations[extension.AnnotationGangMatchPolicy]
-	if matchPolicy != extension.GangMatchPolicyOnlyWaiting && mode != extension.GangMatchPolicyWaitingAndRunning &&
-		mode != extension.GangMatchPolicyOnceSatisfied {
-		klog.Errorf("pod's annotation AnnotationGangMatchPolicy illegal, gangName: %v, value: %v",
+	if matchPolicy != extension.GangMatchPolicyOnlyWaiting && matchPolicy != extension.GangMatchPolicyWaitingAndRunning &&
+		matchPolicy != extension.GangMatchPolicyOnceSatisfied {
+		klog.Errorf("podGroup's annotation AnnotationGangMatchPolicy illegal, gangName: %v, value: %v",
 			gang.Name, matchPolicy)
 		matchPolicy = extension.GangMatchPolicyOnceSatisfied
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The use of pod and podgroup was confused during the gang init phase, result failed to update the  GangMatchPolicy configuration
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
