### PR TITLE
scheduler: extend reservation nominator to support reservation preemption

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -60,12 +60,18 @@ func MakeReservationErrorHandler(
 		}
 
 		// if the pod is not a reserve pod, use the default error handler
-		if !reservationutil.IsReservePod(pod) {
-			// If the Pod failed to schedule or no post-filter plugins, should remove exist NominatedReservation of the Pod.
-			if _, ok := schedulingErr.(*framework.FitError); !ok || !fwk.HasPostFilterPlugins() {
-				extendedHandle := fwk.(frameworkext.ExtendedHandle)
-				extendedHandle.GetReservationNominator().RemoveNominatedReservations(pod)
+		// If the Pod failed to schedule or no post-filter plugins, should remove exist NominatedReservation of the Pod.
+		if _, ok := schedulingErr.(*framework.FitError); !ok || !fwk.HasPostFilterPlugins() {
+			if extendedHandle, ok := fwk.(frameworkext.ExtendedHandle); ok {
+				if !reservationutil.IsReservePod(pod) {
+					extendedHandle.GetReservationNominator().RemoveNominatedReservations(pod)
+				} else {
+					extendedHandle.GetReservationNominator().DeleteNominatedReservePod(pod)
+				}
 			}
+		}
+
+		if !reservationutil.IsReservePod(pod) {
 			return false
 		}
 

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -229,6 +229,7 @@ func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, stat
 	result, status := ext.Framework.RunPostFilterPlugins(ctx, state, pod, filteredNodeStatusMap)
 	if result == nil || result.NominatingInfo.NominatedNodeName == "" {
 		ext.GetReservationNominator().RemoveNominatedReservations(pod)
+		ext.GetReservationNominator().DeleteNominatedReservePod(pod)
 	}
 	return result, status
 }
@@ -461,6 +462,7 @@ func (ext *frameworkExtenderImpl) RunReservePluginsReserve(ctx context.Context, 
 	}
 	status := ext.Framework.RunReservePluginsReserve(ctx, cycleState, pod, nodeName)
 	ext.GetReservationNominator().RemoveNominatedReservations(pod)
+	ext.GetReservationNominator().DeleteNominatedReservePod(pod)
 	return status
 }
 

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -132,6 +132,8 @@ type ReservationNominator interface {
 	AddNominatedReservation(pod *corev1.Pod, nodeName string, rInfo *ReservationInfo)
 	RemoveNominatedReservations(pod *corev1.Pod)
 	GetNominatedReservation(pod *corev1.Pod, nodeName string) *ReservationInfo
+	AddNominatedReservePod(reservePod *corev1.Pod, nodeName string)
+	DeleteNominatedReservePod(reservePod *corev1.Pod)
 }
 
 const (

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
@@ -95,6 +96,7 @@ func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 	}
 
 	h.nominator.RemoveNominatedReservation(newPod)
+	h.nominator.DeleteReservePod(framework.NewPodInfo(newPod))
 
 	var reservationUID types.UID
 	if oldPod != nil {
@@ -128,6 +130,7 @@ func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 
 func (h *podEventHandler) deletePod(pod *corev1.Pod) {
 	h.nominator.RemoveNominatedReservation(pod)
+	h.nominator.DeleteReservePod(framework.NewPodInfo(pod))
 
 	reservationAllocated, err := apiext.GetReservationAllocated(pod)
 	if err == nil && reservationAllocated != nil && reservationAllocated.UID != "" {

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -75,20 +76,38 @@ func TestPodEventHandler(t *testing.T) {
 		},
 	}
 
+	handler.nominator.AddNominatedReservePod(framework.NewPodInfo(pod), "test-node-1")
+	assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[pod.UID])
+	assert.Equal(t, []*framework.PodInfo{
+		framework.NewPodInfo(pod),
+	}, handler.nominator.nominatedReservePod["test-node-1"])
 	handler.OnAdd(pod)
 	rInfo := handler.cache.getReservationInfoByUID(reservationUID)
 	assert.Empty(t, rInfo.AssignedPods)
+	// pod not assigned, no need to delete reservation nominated node
+	assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[pod.UID])
+	assert.Equal(t, []*framework.PodInfo{
+		framework.NewPodInfo(pod),
+	}, handler.nominator.nominatedReservePod["test-node-1"])
 
 	newPod := pod.DeepCopy()
 	apiext.SetReservationAllocated(newPod, reservation)
 	handler.OnUpdate(pod, newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
 	assert.Len(t, rInfo.AssignedPods, 0)
+	// pod not assigned, no need to delete reservation nominated node
+	assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[pod.UID])
+	assert.Equal(t, []*framework.PodInfo{
+		framework.NewPodInfo(pod),
+	}, handler.nominator.nominatedReservePod["test-node-1"])
 
 	newPod.Spec.NodeName = reservation.Status.NodeName
 	handler.OnUpdate(pod, newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
 	assert.Len(t, rInfo.AssignedPods, 1)
+	// pod assigned, delete reservation nominated node
+	assert.Equal(t, "", handler.nominator.nominatedReservePodToNode[pod.UID])
+	assert.Equal(t, []*framework.PodInfo(nil), handler.nominator.nominatedReservePod["test-node-1"])
 
 	expectPodRequirement := &frameworkext.PodRequirement{
 		Name:      pod.Name,
@@ -100,9 +119,38 @@ func TestPodEventHandler(t *testing.T) {
 	}
 	assert.Equal(t, expectPodRequirement, rInfo.AssignedPods[pod.UID])
 
+	handler.nominator.nominatedReservePod["test-node-1"] = []*framework.PodInfo{
+		framework.NewPodInfo(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-1",
+				UID:  "test-1",
+			},
+		}),
+	}
+	handler.nominator.AddNominatedReservePod(framework.NewPodInfo(newPod), "test-node-1")
+	assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[newPod.UID])
+	assert.Equal(t, []*framework.PodInfo{
+		framework.NewPodInfo(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-1",
+				UID:  "test-1",
+			},
+		}),
+		framework.NewPodInfo(newPod),
+	}, handler.nominator.nominatedReservePod["test-node-1"])
+
 	handler.OnDelete(newPod)
 	rInfo = handler.cache.getReservationInfoByUID(reservationUID)
 	assert.Empty(t, rInfo.AssignedPods)
+	assert.Equal(t, "", handler.nominator.nominatedReservePodToNode[newPod.UID])
+	assert.Equal(t, []*framework.PodInfo{
+		framework.NewPodInfo(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-1",
+				UID:  "test-1",
+			},
+		}),
+	}, handler.nominator.nominatedReservePod["test-node-1"])
 }
 
 func TestPodEventHandlerWithOperatingPod(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Extend the reservation nominator. Reservation plugin implements the BeforeFilter function. In this function, we do add the nominated reservation infos.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fix #1935 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
