### PR TITLE
apis: add Resctrl API

### DIFF
--- a/apis/extension/resctrl.go
+++ b/apis/extension/resctrl.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"encoding/json"
+)
+
+const (
+	// AnnotationResctrl describes the resctrl config of pod
+	AnnotationResctrl = NodeDomainPrefix + "/resctrl"
+)
+
+type Resctrl struct {
+	L3 map[int]string
+	MB map[int]string
+}
+
+type ResctrlConfig struct {
+	LLC LLC `json:"llc,omitempty"`
+	MB  MB  `json:"mb,omitempty"`
+}
+
+type LLC struct {
+	Schemata         SchemataConfig           `json:"schemata,omitempty"`
+	SchemataPerCache []SchemataPerCacheConfig `json:"schemataPerCache,omitempty"`
+}
+
+type MB struct {
+	Schemata         SchemataConfig           `json:"schemata,omitempty"`
+	SchemataPerCache []SchemataPerCacheConfig `json:"schemataPerCache,omitempty"`
+}
+
+type SchemataConfig struct {
+	Percent int   `json:"percent,omitempty"`
+	Range   []int `json:"range,omitempty"`
+}
+
+type SchemataPerCacheConfig struct {
+	CacheID        int `json:"cacheID,omitempty"`
+	SchemataConfig `json:",inline"`
+}
+
+func GetResctrlInfo(annotations map[string]string) (*ResctrlConfig, error) {
+	res := &ResctrlConfig{}
+	data, ok := annotations[AnnotationResctrl]
+	if !ok {
+		return res, nil
+	}
+	err := json.Unmarshal([]byte(data), &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/apis/extension/resctrl_test.go
+++ b/apis/extension/resctrl_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetResctrlInfo(t *testing.T) {
+	type args struct {
+		annotation map[string]string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *ResctrlConfig
+		wantErr bool
+	}{
+		{
+			name: "only MB parse",
+			args: args{
+				annotation: map[string]string{
+					AnnotationResctrl: `{
+                    "mb": {
+                      "schemata": {
+                        "percent": 35
+                      },
+                      "schemataPerCache": [
+                        {
+                          "cacheid": 0,
+                          "percent": 80
+                        }
+                      ]
+                    }
+                  }`,
+				},
+			},
+			want: &ResctrlConfig{
+				MB: MB{
+					Schemata: SchemataConfig{
+						Percent: 35,
+						Range:   nil,
+					},
+					SchemataPerCache: []SchemataPerCacheConfig{{
+						CacheID: 0,
+						SchemataConfig: SchemataConfig{
+							Percent: 80,
+							Range:   nil,
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "only LLC parse",
+			args: args{
+				annotation: map[string]string{
+					AnnotationResctrl: `
+                    {
+                       "llc": {
+                         "schemata": {
+                           "range": [20,80]
+                         },
+                         "schemataPerCache": [
+                           {
+                             "cacheid": 0,
+                             "range": [20,30]
+                           }
+                         ]
+                       }
+                     }`,
+				},
+			},
+			want: &ResctrlConfig{
+				LLC: LLC{
+					Schemata: SchemataConfig{
+						Percent: 0,
+						Range:   []int{20, 80},
+					},
+					SchemataPerCache: []SchemataPerCacheConfig{{
+						CacheID: 0,
+						SchemataConfig: SchemataConfig{
+							Percent: 0,
+							Range:   []int{20, 30},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "MB and LLC parse",
+			args: args{
+				annotation: map[string]string{
+					AnnotationResctrl: `
+                    {
+                        "mb": {
+                          "schemata": {
+                            "percent": 35
+                          },
+                          "schemataPerCache": [
+                            {
+                              "cacheid": 0,
+                              "percent": 80
+                            }
+                          ]
+                        },
+                        "llc": {
+                         "schemata": {
+                           "range": [20,80]
+                         },
+                         "schemataPerCache": [
+                           {
+                             "cacheid": 0,
+                             "range": [20,30]
+                           }
+                         ]
+                       }
+                    }`,
+				},
+			},
+			want: &ResctrlConfig{
+				LLC: LLC{
+					Schemata: SchemataConfig{
+						Percent: 0,
+						Range:   []int{20, 80},
+					},
+					SchemataPerCache: []SchemataPerCacheConfig{{
+						CacheID: 0,
+						SchemataConfig: SchemataConfig{
+							Percent: 0,
+							Range:   []int{20, 30},
+						},
+					}},
+				},
+				MB: MB{
+					Schemata: SchemataConfig{
+						Percent: 35,
+						Range:   nil,
+					},
+					SchemataPerCache: []SchemataPerCacheConfig{{
+						CacheID: 0,
+						SchemataConfig: SchemataConfig{
+							Percent: 80,
+							Range:   nil,
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "parse error",
+			args: args{
+				annotation: map[string]string{
+					AnnotationResctrl: `test`,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetResctrlInfo(tt.args.annotation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetResctrlInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetResctrlInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add resctrl API. The API should be like below which you can refer to [proposal of resctrl enhance](https://github.com/koordinator-sh/koordinator/blob/main/docs/proposals/koordlet/20231227-koordlet-resctrl-qos-enhance.md)
```yaml
{
  "llc": {
    "schemata": {
      "range": [20,80],
    },
    "schemataPerCache": [
      {
        "cacheid" : 0,
        "range": [20,50]
      },
      {
        "cacheid" : 1,
        "range": [20,60]
      },
    ],
  },
  "mb": {
    "schemata": {
      "percent": 20,
    },
    "schemataPerCache": [
      {
        "cacheid": 0,
        "percent": 20
      },
      {
        "cacheid": 1,
        "percent": 40
      },
    ],
  }
}
```
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
