### PR TITLE
descheduler: change the order of check len(lowNodes) and len(sourceNodes)

### DIFF
--- a/pkg/descheduler/framework/plugins/loadaware/low_node_load.go
+++ b/pkg/descheduler/framework/plugins/loadaware/low_node_load.go
@@ -170,6 +170,17 @@ func (pl *LowNodeLoad) processOneNodePool(ctx context.Context, nodePool *desched
 
 	logUtilizationCriteria(nodePool.Name, "Criteria for nodes under low thresholds and above high thresholds", lowThresholds, highThresholds, len(lowNodes), len(sourceNodes), len(nodes))
 
+	if len(sourceNodes) == 0 {
+		klog.V(4).InfoS("All nodes are under target utilization, nothing to do here", "nodePool", nodePool.Name)
+		return nil
+	}
+
+	abnormalNodes := filterRealAbnormalNodes(sourceNodes, pl.nodeAnomalyDetectors, nodePool.AnomalyCondition)
+	if len(abnormalNodes) == 0 {
+		klog.V(4).InfoS("None of the nodes were detected as anomalous, nothing to do here", "nodePool", nodePool.Name)
+		return nil
+	}
+
 	if len(lowNodes) == 0 {
 		klog.V(4).InfoS("No nodes are underutilized, nothing to do here, you might tune your thresholds further", "nodePool", nodePool.Name)
 		return nil
@@ -185,17 +196,6 @@ func (pl *LowNodeLoad) processOneNodePool(ctx context.Context, nodePool *desched
 
 	if len(lowNodes) == len(nodes) {
 		klog.V(4).InfoS("All nodes are underutilized, nothing to do here", "nodePool", nodePool.Name)
-		return nil
-	}
-
-	if len(sourceNodes) == 0 {
-		klog.V(4).InfoS("All nodes are under target utilization, nothing to do here", "nodePool", nodePool.Name)
-		return nil
-	}
-
-	abnormalNodes := filterRealAbnormalNodes(sourceNodes, pl.nodeAnomalyDetectors, nodePool.AnomalyCondition)
-	if len(abnormalNodes) == 0 {
-		klog.V(4).InfoS("None of the nodes were detected as anomalous, nothing to do here", "nodePool", nodePool.Name)
 		return nil
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
We firstly check len(lowNodes) after classifyNodes, which cloud lead to the sourceNodes lose a chance to be mark as abnormal. If we change the order, the sourceNodes cloud be evict more quickly when we just add a new node to a overloaded cluster.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
