### PR TITLE
webhook: fix priority admission conflict

### DIFF
--- a/pkg/webhook/pod/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile.go
@@ -210,6 +210,7 @@ func (h *PodMutatingHandler) doMutateByColocationProfile(ctx context.Context, po
 		}
 		pod.Spec.PriorityClassName = profile.Spec.PriorityClassName
 		pod.Spec.Priority = pointer.Int32(priorityClass.Value)
+		pod.Spec.PreemptionPolicy = priorityClass.PreemptionPolicy
 	}
 
 	if profile.Spec.KoordinatorPriority != nil {

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
@@ -68,6 +68,7 @@ func newAdmissionRequest(op admissionv1.Operation, object, oldObject runtime.Raw
 }
 
 func TestClusterColocationProfileMutatingPod(t *testing.T) {
+	preemptionPolicy := corev1.PreemptionPolicy("fakePreemptionPolicy")
 	testCases := []struct {
 		name                      string
 		pod                       *corev1.Pod
@@ -210,6 +211,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -304,6 +306,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -394,6 +397,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -531,6 +535,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -930,6 +935,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1069,6 +1075,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1208,6 +1215,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1350,6 +1358,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1494,6 +1503,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1638,6 +1648,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 					SchedulerName:     "koordinator-scheduler",
 					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
 					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
 				},
 			},
 		},
@@ -1670,7 +1681,8 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "koordinator-batch",
 				},
-				Value: extension.PriorityBatchValueMax,
+				Value:            extension.PriorityBatchValueMax,
+				PreemptionPolicy: &preemptionPolicy,
 			}
 			err = client.Create(context.TODO(), batchPriorityClass)
 			assert.NoError(err)


### PR DESCRIPTION
when we set priorityclass koord-xxx with preemptionPolicy=Never, priority admission refuse to create pod with error like this:
```text
pods "test" is forbidden: the string value of PreemptionPolicy (Never)
must not be provided in pod spec; priority admission controller computed
PreemptLowerPriority from the given PriorityClass name
```

we overwrite PriorityClassName/Priority in cluster_colocation_profile, so as well PreemptionPolicy.

see
https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/priority/admission.go#L188

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
