### PR TITLE
koordlet: add NRI reconnect

### DIFF
--- a/pkg/koordlet/runtimehooks/config_test.go
+++ b/pkg/koordlet/runtimehooks/config_test.go
@@ -18,6 +18,7 @@ package runtimehooks
 
 import (
 	"flag"
+	"math"
 	"testing"
 	"time"
 
@@ -36,6 +37,11 @@ func Test_NewDefaultConfig(t *testing.T) {
 		RuntimeHookHostEndpoint:         "/var/run/koordlet/koordlet.sock",
 		RuntimeHookDisableStages:        []string{},
 		RuntimeHooksNRI:                 true,
+		RuntimeHooksNRIConnectTimeout:   6 * time.Second,
+		RuntimeHooksNRIBackOffDuration:  1 * time.Second,
+		RuntimeHooksNRIBackOffCap:       1<<62 - 1,
+		RuntimeHooksNRIBackOffSteps:     math.MaxInt32,
+		RuntimeHooksNRIBackOffFactor:    2,
 		RuntimeHooksNRISocketPath:       "nri/nri.sock",
 		RuntimeHookReconcileInterval:    10 * time.Second,
 	}

--- a/pkg/koordlet/runtimehooks/nri/server_test.go
+++ b/pkg/koordlet/runtimehooks/nri/server_test.go
@@ -19,6 +19,7 @@ package nri
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/stub"
@@ -58,19 +59,19 @@ func TestNriServer_Start(t *testing.T) {
 				stub: nil,
 				mask: api.EventMask(1),
 				options: Options{
+					NriConnectTimeout:   time.Second,
 					PluginFailurePolicy: "Ignore",
 					DisableStages:       getDisableStagesMap([]string{"PreRunPodSandbox"}),
 					Executor:            nil,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			fields: fields{
 				stub: nil,
 			},
 		},
-		{},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Currently, if containerd restart or upgrade, koordlet will lost connection between koordlet and containerd. This PR will reconnect to containerd.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Restart containerd and see koordlet hooks still work.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
