### PR TITLE
apis & slo-controller: allow specifying node-wise total bandwidth via annotation

### DIFF
--- a/apis/extension/node_qos.go
+++ b/apis/extension/node_qos.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	// AnnotationNodeBandwidth specifies the total network bandwidth of the node, which can
+	// be set by cluster administrator or third party components. The value should be a valid
+	// resource.Quantity. Unit: bps.
+	AnnotationNodeBandwidth = NodeDomainPrefix + "/network-bandwidth"
+)
+
+func GetNodeTotalBandwidth(annotations map[string]string) (*resource.Quantity, error) {
+	var (
+		val string
+		ok  bool
+	)
+	if val, ok = annotations[AnnotationNodeBandwidth]; !ok {
+		return nil, nil
+	}
+	if quantity, err := resource.ParseQuantity(val); err != nil {
+		return nil, fmt.Errorf("failed to parse node bandwidth %v", err)
+	} else {
+		return &quantity, nil
+	}
+}

--- a/apis/extension/node_qos_test.go
+++ b/apis/extension/node_qos_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetNodeTotalBandwidth(t *testing.T) {
+	tests := []struct {
+		name    string
+		node    *corev1.Node
+		want    *resource.Quantity
+		wantErr bool
+	}{
+		{
+			name: "normal",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationNodeBandwidth: "10M",
+					},
+				},
+			},
+			want:    resource.NewScaledQuantity(10, 6),
+			wantErr: false,
+		},
+		{
+			name: "node has empty annotation",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "node has wrong-formatted annotation value",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationNodeBandwidth: "wrong-format",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := GetNodeTotalBandwidth(tt.node.Annotations)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, t, got)
+				assert.Equal(t, tt.want.Value(), got.Value())
+			}
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Introduce an extension API (through annotation) to specify the total bandwidth for a node. This parameter takes precedence over ones configured in cluster strategy or node strategy, and will take effect in NodeSLO.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

fixes #1883 (part 1).

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
