### PR TITLE
scheduler: remove reservation nominator useless code

### DIFF
--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -67,7 +67,6 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 	if reservationutil.IsReservationActive(newR) || reservationutil.IsReservationFailed(newR) || reservationutil.IsReservationSucceeded(newR) {
 		h.cache.updateReservation(newR)
-		h.rrNominator.DeleteReservePod(framework.NewPodInfo(reservationutil.NewReservePod(newR)))
 		klog.V(4).InfoS("update reservation into reservationCache", "reservation", klog.KObj(newR))
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
If Reservation is Active, Failed or Succeed, it must be scheduled after it triggers preemption, so its nominated information will be deleted in this round schedule process. As in the framework, it will exec DeleteNominatedReservePod in RunReservePluginsReserve.
In a conclusion, it is no need to DeleteReservePod in ReservationHandler OnUpdate handler.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
