### PR TITLE
scheduler: refine restricted topology policy

### DIFF
--- a/pkg/scheduler/frameworkext/topologymanager/policy.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy.go
@@ -73,12 +73,14 @@ func mergePermutation(numaNodes []int, permutation []NUMATopologyHint) NUMATopol
 	var numaAffinities []bitmask.BitMask
 	for _, hint := range permutation {
 		// Only consider hints that have an actual NUMANodeAffinity set.
-		if hint.NUMANodeAffinity == nil {
-			numaAffinities = append(numaAffinities, defaultAffinity)
-		} else {
+		if hint.NUMANodeAffinity != nil {
 			numaAffinities = append(numaAffinities, hint.NUMANodeAffinity)
+			// Only mark preferred if all affinities are equal.
+			if !hint.NUMANodeAffinity.IsEqual(numaAffinities[0]) {
+				preferred = false
+			}
 		}
-
+		// Only mark preferred if all affinities are preferred.
 		if !hint.Preferred {
 			preferred = false
 		}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
@@ -51,7 +51,7 @@ func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 }
 
 func TestPolicyBestEffortMerge(t *testing.T) {
-	numaNodes := []int{0, 1}
+	numaNodes := []int{0, 1, 2, 3}
 	policy := NewBestEffortPolicy(numaNodes)
 
 	tcases := commonPolicyMergeTestCases(numaNodes)

--- a/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
@@ -69,7 +69,7 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 }
 
 func TestPolicyRestrictedMerge(t *testing.T) {
-	numaNodes := []int{0, 1}
+	numaNodes := []int{0, 1, 2, 3}
 	policy := NewRestrictedPolicy(numaNodes)
 
 	tcases := commonPolicyMergeTestCases(numaNodes)

--- a/pkg/scheduler/frameworkext/topologymanager/policy_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_test.go
@@ -344,6 +344,43 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase {
 	return []policyMergeTestCase{
 		{
+			name: "Two providers, 2 hints each, same mask (some with different bits), same preferred",
+			hp: []NUMATopologyHintProvider{
+				&mockNUMATopologyHintProvider{
+					map[string][]NUMATopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 2),
+								Preferred:        true,
+							},
+						},
+					},
+				},
+				&mockNUMATopologyHintProvider{
+					map[string][]NUMATopologyHint{
+						"resource2": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 2),
+								Preferred:        true,
+							},
+						},
+					},
+				},
+			},
+			expected: NUMATopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0, 1),
+				Preferred:        true,
+			},
+		},
+		{
 			name: "NUMATopologyHint not set",
 			hp:   []NUMATopologyHintProvider{},
 			expected: NUMATopologyHint{
@@ -541,7 +578,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 			},
 			expected: NUMATopologyHint{
 				NUMANodeAffinity: NewTestBitMask(0),
-				Preferred:        true,
+				Preferred:        false,
 			},
 		},
 		{
@@ -578,7 +615,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 			},
 		},
 		{
-			name: "Two providers, 1 hint each, 1 wider mask, both preferred 1/2",
+			name: "Two providers, 1 hint each, 1 wider mask, both preferred 2/2",
 			hp: []NUMATopologyHintProvider{
 				&mockNUMATopologyHintProvider{
 					map[string][]NUMATopologyHint{
@@ -603,7 +640,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 			},
 			expected: NUMATopologyHint{
 				NUMANodeAffinity: NewTestBitMask(1),
-				Preferred:        true,
+				Preferred:        false,
 			},
 		},
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

将 NUMA 对齐策略 Restricted 与上游 Kubelet 逻辑对齐，即不同资源的 Hint 的 NUMAAffinity 一样时，才讲该 merged 后的 Hint 置为 preferred 

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
