### PR TITLE
koordlet: revise node topology reporting for the kubelet cpu manager

### DIFF
--- a/pkg/koordlet/qosmanager/plugins/blkio/blkio_reconcile.go
+++ b/pkg/koordlet/qosmanager/plugins/blkio/blkio_reconcile.go
@@ -296,7 +296,7 @@ func (b *blkIOReconcile) getDiskNumberFromVolumeGroup(vgName string) (string, er
 // diskNumber: 253:16
 func (b *blkIOReconcile) getDiskNumberFromPodVolume(podMeta *statesinformer.PodMeta, volumeName string) (string, error) {
 	podUUID := podMeta.Pod.UID
-	mountpoint := filepath.Join(system.Conf.CgroupKubePath, "pods", string(podUUID), "volumes/kubernetes.io~csi", volumeName, "mount")
+	mountpoint := filepath.Join(system.Conf.VarLibKubeletRootDir, "pods", string(podUUID), "volumes/kubernetes.io~csi", volumeName, "mount")
 	disk := getDiskByMountPoint(b.storageInfo, mountpoint)
 	diskNumber := getDiskNumber(b.storageInfo, disk)
 	if diskNumber == "" {

--- a/pkg/koordlet/qosmanager/plugins/blkio/blkio_reconcile_test.go
+++ b/pkg/koordlet/qosmanager/plugins/blkio/blkio_reconcile_test.go
@@ -50,6 +50,7 @@ const (
 )
 
 func TestBlkIOReconcile_reconcile(t *testing.T) {
+	helper := system.NewFileTestUtil(t)
 	sysFSRootDirName := BlkIOReconcileName
 
 	testingNodeSLO := newNodeSLO()
@@ -92,7 +93,14 @@ func TestBlkIOReconcile_reconcile(t *testing.T) {
 		"/dev/mapper/yoda--pool0-yoda--test1":                                    "yoda-pool0",
 		"/dev/mapper/yoda--pool0-yoda--test2":                                    "yoda-pool0",
 	}
-	system.Conf.CgroupKubePath = KubePath
+
+	var oldVarLibKubeletRoot string
+	helper.SetConf(func(conf *system.Config) {
+		oldVarLibKubeletRoot = conf.VarLibKubeletRootDir
+		conf.VarLibKubeletRootDir = KubePath
+	}, func(conf *system.Config) {
+		conf.VarLibKubeletRootDir = oldVarLibKubeletRoot
+	})
 	mpDiskMap := map[string]string{
 		fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~csi/%s/mount", KubePath, pod0.UID, "yoda-87d8625a-dcc9-47bf-a14a-994cf2971193"): "/dev/mapper/yoda--pool0-yoda--87d8625a--dcc9--47bf--a14a--994cf2971193",
 		fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~csi/html/mount", KubePath, pod1.UID):                                            "/dev/mapper/yoda--pool0-yoda--test1",

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -40,6 +40,7 @@ type cpusetRule struct {
 	sharePools      []extension.CPUSharedPool
 	beSharePools    []extension.CPUSharedPool
 	systemQOSCPUSet string
+	// TODO: support per-node disable
 }
 
 func (r *cpusetRule) getContainerCPUSet(containerReq *protocol.ContainerRequest) (*string, error) {

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -36,11 +36,11 @@ var UseCgroupsV2 = atomic.NewBool(false)
 
 type Config struct {
 	CgroupRootDir         string
-	CgroupKubePath        string
 	SysRootDir            string
 	SysFSRootDir          string
 	ProcRootDir           string
 	VarRunRootDir         string
+	VarLibKubeletRootDir  string
 	RunRootDir            string
 	RuntimeHooksConfigDir string
 
@@ -76,12 +76,12 @@ func InitSupportConfigs() {
 
 func NewHostModeConfig() *Config {
 	return &Config{
-		CgroupKubePath:        "kubepods/",
 		CgroupRootDir:         "/sys/fs/cgroup/",
 		ProcRootDir:           "/proc/",
 		SysRootDir:            "/sys/",
 		SysFSRootDir:          "/sys/fs/",
 		VarRunRootDir:         "/var/run/",
+		VarLibKubeletRootDir:  "/var/lib/kubelet/",
 		RunRootDir:            "/run/",
 		RuntimeHooksConfigDir: "/etc/runtime/hookserver.d",
 		DefaultRuntimeType:    "containerd",
@@ -90,13 +90,13 @@ func NewHostModeConfig() *Config {
 
 func NewDsModeConfig() *Config {
 	return &Config{
-		CgroupKubePath: "kubepods/",
-		CgroupRootDir:  "/host-cgroup/",
+		CgroupRootDir: "/host-cgroup/",
 		// some dirs are not covered by ns, or unused with `hostPID` is on
 		ProcRootDir:           "/proc/",
 		SysRootDir:            "/host-sys/",
 		SysFSRootDir:          "/host-sys-fs/",
 		VarRunRootDir:         "/host-var-run/",
+		VarLibKubeletRootDir:  "/var/lib/kubelet/",
 		RunRootDir:            "/host-run/",
 		RuntimeHooksConfigDir: "/host-etc-hookserver/",
 		DefaultRuntimeType:    "containerd",
@@ -113,9 +113,9 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.SysFSRootDir, "sys-fs-root-dir", c.SysFSRootDir, "host /sys/fs dir in container, used by resctrl fs")
 	fs.StringVar(&c.ProcRootDir, "proc-root-dir", c.ProcRootDir, "host /proc dir in container")
 	fs.StringVar(&c.VarRunRootDir, "var-run-root-dir", c.VarRunRootDir, "host /var/run dir in container")
+	fs.StringVar(&c.VarLibKubeletRootDir, "var-lib-kubelet-dir", c.VarLibKubeletRootDir, "host /var/lib/kubelet dir in container")
 	fs.StringVar(&c.RunRootDir, "run-root-dir", c.RunRootDir, "host /run dir in container")
 
-	fs.StringVar(&c.CgroupKubePath, "cgroup-kube-dir", c.CgroupKubePath, "Cgroup kube dir")
 	fs.StringVar(&c.ContainerdEndPoint, "containerd-endpoint", c.ContainerdEndPoint, "containerd endPoint")
 	fs.StringVar(&c.DockerEndPoint, "docker-endpoint", c.DockerEndPoint, "docker endPoint")
 	fs.StringVar(&c.PouchEndpoint, "pouch-endpoint", c.PouchEndpoint, "pouch endPoint")

--- a/pkg/koordlet/util/system/config_test.go
+++ b/pkg/koordlet/util/system/config_test.go
@@ -24,12 +24,12 @@ import (
 
 func Test_NewDsModeConfig(t *testing.T) {
 	expectConfig := &Config{
-		CgroupKubePath:        "kubepods/",
 		CgroupRootDir:         "/host-cgroup/",
 		ProcRootDir:           "/proc/",
 		SysRootDir:            "/host-sys/",
 		SysFSRootDir:          "/host-sys-fs/",
 		VarRunRootDir:         "/host-var-run/",
+		VarLibKubeletRootDir:  "/var/lib/kubelet/",
 		RunRootDir:            "/host-run/",
 		RuntimeHooksConfigDir: "/host-etc-hookserver/",
 		DefaultRuntimeType:    "containerd",
@@ -40,12 +40,12 @@ func Test_NewDsModeConfig(t *testing.T) {
 
 func Test_NewHostModeConfig(t *testing.T) {
 	expectConfig := &Config{
-		CgroupKubePath:        "kubepods/",
 		CgroupRootDir:         "/sys/fs/cgroup/",
 		ProcRootDir:           "/proc/",
 		SysRootDir:            "/sys/",
 		SysFSRootDir:          "/sys/fs/",
 		VarRunRootDir:         "/var/run/",
+		VarLibKubeletRootDir:  "/var/lib/kubelet/",
 		RunRootDir:            "/run/",
 		RuntimeHooksConfigDir: "/etc/runtime/hookserver.d",
 		DefaultRuntimeType:    "containerd",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- CPU topology reporting: always update the NodeResourceTopology's annotation `node.koordinator.sh/node-cpu-allocs` even if the Kubelet cpu manager policy is none or it failed to read the checkpoint file, instead of only updating when it succeeded in parsing the checkpoint file and at least one pod is managed by the static policy. It also helps when we want the koordlet to ignore the cpu manager cpuset in some special cases.
- Command args: Remove the misused argument `cgroup-kube-dir`. Add an argument to parameterize the host directory `/var/lib/kubelet`.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
