### PR TITLE
utils: change metrics server util pkg name

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -32,4 +32,4 @@ test/e2e/e2e_test.go
 test/e2e/suites.go
 test/utils/image
 pkg/util/histogram
-pkg/util/metricserver
+pkg/util/metricsserver

--- a/pkg/util/metricsserver/metrics_client.go
+++ b/pkg/util/metricsserver/metrics_client.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metricsserver
 
 import (
 	"context"

--- a/pkg/util/metricsserver/metrics_client_test.go
+++ b/pkg/util/metricsserver/metrics_client_test.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metricsserver
 
 import (
 	"testing"

--- a/pkg/util/metricsserver/metrics_client_test_util.go
+++ b/pkg/util/metricsserver/metrics_client_test_util.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metricsserver
 
 import (
 	"time"


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

pkg name `metrics` is conflict in `pkg/util/metricsserver` and `pkg/util/metrics`

change to `metricsserver`

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
