### PR TITLE
koordlet: add nri remove

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/hooks.go
+++ b/pkg/koordlet/runtimehooks/hooks/hooks.go
@@ -106,6 +106,7 @@ func init() {
 		rmconfig.PostStopContainer:           make([]*Hook, 0),
 		rmconfig.PostStopPodSandbox:          make([]*Hook, 0),
 		rmconfig.PreUpdateContainerResources: make([]*Hook, 0),
+		rmconfig.PreRemoveRunPodSandbox:      make([]*Hook, 0),
 	}
 }
 

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -177,6 +177,14 @@ func (p *PodContext) NriDone(executor resourceexecutor.ResourceUpdateExecutor) {
 	p.Update()
 }
 
+func (p *PodContext) NriRemoveDone(executor resourceexecutor.ResourceUpdateExecutor) {
+	if p.executor == nil {
+		p.executor = executor
+	}
+	p.removeForExt()
+	p.Update()
+}
+
 func (p *PodContext) FromReconciler(podMeta *statesinformer.PodMeta) {
 	p.Request.FromReconciler(podMeta)
 }
@@ -277,4 +285,8 @@ func (p *PodContext) injectForExt() {
 				p.Request.PodMeta.Namespace, p.Request.PodMeta.Name, *p.Response.Resources.MemoryLimit, p.Request.CgroupParent)
 		}
 	}
+}
+
+func (p *PodContext) removeForExt() {
+	// TODO: cleanup
 }

--- a/pkg/koordlet/runtimehooks/protocol/pod_context_test.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context_test.go
@@ -140,3 +140,37 @@ func TestPodContext_NriDone(t *testing.T) {
 		})
 	}
 }
+
+func TestPodContext_NriRemoveDone(t *testing.T) {
+	type fields struct {
+		Request  PodRequest
+		Response PodResponse
+		executor resourceexecutor.ResourceUpdateExecutor
+	}
+	type args struct {
+		executor resourceexecutor.ResourceUpdateExecutor
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "nri remove done",
+			fields: fields{
+				executor: resourceexecutor.NewTestResourceExecutor(),
+			},
+			args: args{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PodContext{
+				Request:  tt.fields.Request,
+				Response: tt.fields.Response,
+				executor: tt.fields.executor,
+			}
+			p.NriRemoveDone(tt.args.executor)
+		})
+	}
+}

--- a/pkg/runtimeproxy/config/config.go
+++ b/pkg/runtimeproxy/config/config.go
@@ -57,6 +57,7 @@ const (
 	PostStartContainer          RuntimeHookType = "PostStartContainer"
 	PreUpdateContainerResources RuntimeHookType = "PreUpdateContainerResources"
 	PostStopContainer           RuntimeHookType = "PostStopContainer"
+	PreRemoveRunPodSandbox      RuntimeHookType = "PreRemoveRunPodSandbox"
 	NoneRuntimeHookType         RuntimeHookType = "NoneRuntimeHookType"
 )
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add NRI RemovePodSandbox event handler into koordlet hook. It's part of the #1974. Resctrl runtime hook will leverage this to cleanup the resctrl group.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
#1831 
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
