### PR TITLE
ci: fix scheduler e2e workflow after 1.28 upgradation

### DIFF
--- a/.github/workflows/e2e-k8s-1.22.yaml
+++ b/.github/workflows/e2e-k8s-1.22.yaml
@@ -43,8 +43,14 @@ jobs:
           docker build --pull . -t ${MANAGER_IMAGE} -f docker/koord-manager.dockerfile
           export KOORDLET_IMAGE="koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
+          export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
+          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -58,7 +64,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          KUBERNETES_VERSION="1.22" MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          KUBERNETES_VERSION="1.22" MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-1.22.yaml
+++ b/.github/workflows/e2e-k8s-1.22.yaml
@@ -45,12 +45,9 @@ jobs:
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
           export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
-          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
-          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -64,7 +61,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          KUBERNETES_VERSION="1.22" MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          KUBERNETES_VERSION="1.22" MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-1.24.yaml
+++ b/.github/workflows/e2e-k8s-1.24.yaml
@@ -45,12 +45,9 @@ jobs:
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
           export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
-          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
-          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -64,7 +61,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-1.24.yaml
+++ b/.github/workflows/e2e-k8s-1.24.yaml
@@ -43,8 +43,14 @@ jobs:
           docker build --pull . -t ${MANAGER_IMAGE} -f docker/koord-manager.dockerfile
           export KOORDLET_IMAGE="koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
+          export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
+          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -58,7 +64,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-1.28.yaml
+++ b/.github/workflows/e2e-k8s-1.28.yaml
@@ -45,12 +45,9 @@ jobs:
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
           export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
-          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
-          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -64,7 +61,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-1.28.yaml
+++ b/.github/workflows/e2e-k8s-1.28.yaml
@@ -43,8 +43,14 @@ jobs:
           docker build --pull . -t ${MANAGER_IMAGE} -f docker/koord-manager.dockerfile
           export KOORDLET_IMAGE="koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
+          export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
+          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -58,7 +64,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-latest.yaml
+++ b/.github/workflows/e2e-k8s-latest.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release-*
-  pull_request: {}
+  # For the latest version of the K8S, check it in the main branch and no need to run in each PR.
   workflow_dispatch: {}
 
 env:
@@ -43,12 +43,9 @@ jobs:
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
           export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
-          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
-          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -62,7 +59,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/.github/workflows/e2e-k8s-latest.yaml
+++ b/.github/workflows/e2e-k8s-latest.yaml
@@ -12,7 +12,7 @@ env:
   # Common versions
   GO_VERSION: '1.20'
   KIND_ACTION_VERSION: 'v1.5.0'
-  KIND_VERSION: 'v0.20.0'
+  KIND_VERSION: 'v0.22.0'
   KIND_CLUSTER_NAME: 'ci-testing'
   COMPONENT_NS: "koordinator-system"
 
@@ -41,8 +41,14 @@ jobs:
           docker build --pull . -t ${MANAGER_IMAGE} -f docker/koord-manager.dockerfile
           export KOORDLET_IMAGE="koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID}"
           docker build --pull . -t ${KOORDLET_IMAGE} -f docker/koordlet.dockerfile
+          export SCHEDULER_IMAGE="koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${SCHEDULER_IMAGE} -f docker/koord-scheduler.dockerfile
+          export DESCHEDULER_IMAGE="koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID}"
+          docker build --pull . -t ${DESCHEDULER_IMAGE} -f docker/koord-descheduler.dockerfile
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMAGE}"; exit 1; }
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${KOORDLET_IMAGE} || { echo >&2 "kind not installed or error loading image: ${KOORDLET_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${SCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${SCHEDULER_IMAGE}"; exit 1; }
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${DESCHEDULER_IMAGE} || { echo >&2 "kind not installed or error loading image: ${DESCHEDULER_IMAGE}"; exit 1; }
       - name: Check host environment
         run: |
           set -ex
@@ -56,7 +62,7 @@ jobs:
         run: |
           set -ex
           kubectl cluster-info
-          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
+          MANAGER_IMG=koordinator-sh/koord-manager:e2e-${GITHUB_RUN_ID} KOORDLET_IMG=koordinator-sh/koordlet:e2e-${GITHUB_RUN_ID} SCHEDULER_IMG=koordinator-sh/koord-scheduler:e2e-${GITHUB_RUN_ID} DESCHEDULER_IMG=koordinator-sh/koord-descheduler:e2e-${GITHUB_RUN_ID} ./hack/deploy_kind.sh
           NODES=$(kubectl get node | wc -l)
           for ((i=1;i<10;i++));
           do

--- a/config/manager/scheduler-config.yaml
+++ b/config/manager/scheduler-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system
 data:
   koord-scheduler-config: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
@@ -16,7 +16,7 @@ data:
       - pluginConfig:
         - name: NodeResourcesFit
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1beta3
             kind: NodeResourcesFitArgs
             scoringStrategy:
               type: LeastAllocated
@@ -31,7 +31,7 @@ data:
                   weight: 1
         - name: LoadAwareScheduling
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1beta3
             kind: LoadAwareSchedulingArgs
             filterExpiredNodeMetrics: false
             nodeMetricExpirationSeconds: 300
@@ -46,7 +46,7 @@ data:
               memory: 70
         - name: ElasticQuota
           args:
-            apiVersion: kubescheduler.config.k8s.io/v1beta2
+            apiVersion: kubescheduler.config.k8s.io/v1beta3
             kind: ElasticQuotaArgs
             quotaGroupNamespace: koordinator-system
         plugins:

--- a/config/manager/scheduler.yaml
+++ b/config/manager/scheduler.yaml
@@ -35,7 +35,6 @@ spec:
       containers:
         - args:
             - --port=10251
-            - --logtostderr=true
             - --authentication-skip-lookup=true
             - --v=4
             - --feature-gates=


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Fix the deployment arguments of the koord-scheduler since some klog flags are not supported anymore.
  - https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components#removed-klog-flags
- Refine the E2E workflow so that the scheduler and descheduler images of the current branch are loaded.
- TODO: koord-descheduler image is still not loaded in E2E due to the "no space left on device" problem in the GitHub Actions.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
