### PR TITLE
 koordlet: skip the container which is not running in cpuBurst applyCFSQuotaBurst

### DIFF
--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
@@ -355,6 +355,11 @@ func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podM
 			continue
 		}
 
+		if containerStat.State.Running == nil {
+			klog.V(6).Infof("skip container %s/%s/%s, because it is not running", pod.Namespace, pod.Name, containerStat.Name)
+			continue
+		}
+
 		containerBaseCFS := koordletutil.GetContainerBaseCFSQuota(container)
 		if containerBaseCFS <= 0 {
 			continue

--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
@@ -149,6 +149,7 @@ func newTestPodWithQOS(name string, qos apiext.QoSClass, cpuMilli, memoryBytes i
 				{
 					Name:        containerName,
 					ContainerID: genTestContainerIDByName(containerName),
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 			Phase: corev1.PodRunning,
@@ -233,6 +234,7 @@ func createPodMetaByResource(podName string, containersRes map[string]corev1.Res
 		containerStat := corev1.ContainerStatus{
 			Name:        containerName,
 			ContainerID: genTestContainerIDByName(containerName),
+			State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 		}
 		pod.Spec.Containers = append(pod.Spec.Containers, container)
 		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, containerStat)


### PR DESCRIPTION
Some containers are not running, maybe they have failed, just skip them.
It can also reduce the confusing err msgs.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
