### PR TITLE
koordlet: add taskids in statesinformer

### DIFF
--- a/pkg/koordlet/statesinformer/api.go
+++ b/pkg/koordlet/statesinformer/api.go
@@ -27,14 +27,37 @@ import (
 )
 
 type PodMeta struct {
-	Pod       *corev1.Pod
-	CgroupDir string
+	Pod              *corev1.Pod
+	CgroupDir        string
+	ContainerTaskIds map[string][]int32
+}
+
+// DeepCopyContainerTaskIds creates a deep copy of ContainerTaskIds
+func DeepCopyContainerTaskIds(in map[string][]int32) map[string][]int32 {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string][]int32, len(in))
+
+	for key, value := range in {
+		if value == nil {
+			out[key] = nil
+		} else {
+			copyValue := make([]int32, len(value))
+			copy(copyValue, value)
+			out[key] = copyValue
+		}
+	}
+
+	return out
 }
 
 func (in *PodMeta) DeepCopy() *PodMeta {
 	out := new(PodMeta)
 	out.Pod = in.Pod.DeepCopy()
 	out.CgroupDir = in.CgroupDir
+	out.ContainerTaskIds = DeepCopyContainerTaskIds(in.ContainerTaskIds)
 	return out
 }
 

--- a/pkg/koordlet/statesinformer/impl/config.go
+++ b/pkg/koordlet/statesinformer/impl/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	DisableQueryKubeletConfig   bool
 	EnableNodeMetricReport      bool
 	MetricReportInterval        time.Duration // Deprecated
+	EnablePodTaskIds            bool
 }
 
 func NewDefaultConfig() *Config {
@@ -45,6 +46,7 @@ func NewDefaultConfig() *Config {
 		NodeTopologySyncInterval:    3 * time.Second,
 		DisableQueryKubeletConfig:   false,
 		EnableNodeMetricReport:      true,
+		EnablePodTaskIds:            false,
 	}
 }
 
@@ -58,4 +60,5 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.DisableQueryKubeletConfig, "disable-query-kubelet-config", c.DisableQueryKubeletConfig, "Disables querying the kubelet configuration from kubelet. Flag must be set to true if kubelet-insecure-tls=true is configured")
 	fs.DurationVar(&c.MetricReportInterval, "report-interval", c.MetricReportInterval, "Deprecated since v1.1, use ColocationStrategy.MetricReportIntervalSeconds in config map of slo-controller")
 	fs.BoolVar(&c.EnableNodeMetricReport, "enable-node-metric-report", c.EnableNodeMetricReport, "Enable status update of node metric crd.")
+	fs.BoolVar(&c.EnablePodTaskIds, "enable-pod-taskids", c.EnablePodTaskIds, "Enable pod taskids in statesinformer.")
 }

--- a/pkg/koordlet/statesinformer/impl/config_test.go
+++ b/pkg/koordlet/statesinformer/impl/config_test.go
@@ -42,6 +42,7 @@ func TestNewDefaultConfig(t *testing.T) {
 				DisableQueryKubeletConfig:   false,
 				EnableNodeMetricReport:      true,
 				MetricReportInterval:        0,
+				EnablePodTaskIds:            false,
 			},
 		},
 	}
@@ -64,6 +65,7 @@ func TestConfig_InitFlags(t *testing.T) {
 		"--node-topology-sync-interval=10s",
 		"--disable-query-kubelet-config=true",
 		"--enable-node-metric-report=false",
+		"--enable-pod-taskids=true",
 	}
 	fs := flag.NewFlagSet(cmdArgs[0], flag.ExitOnError)
 
@@ -76,6 +78,7 @@ func TestConfig_InitFlags(t *testing.T) {
 		NodeTopologySyncInterval    time.Duration
 		DisableQueryKubeletConfig   bool
 		EnableNodeMetricReport      bool
+		EnablePodTaskIds            bool
 	}
 	type args struct {
 		fs *flag.FlagSet
@@ -96,6 +99,7 @@ func TestConfig_InitFlags(t *testing.T) {
 				NodeTopologySyncInterval:    10 * time.Second,
 				DisableQueryKubeletConfig:   true,
 				EnableNodeMetricReport:      false,
+				EnablePodTaskIds:            true,
 			},
 			args: args{fs: fs},
 		},
@@ -111,6 +115,7 @@ func TestConfig_InitFlags(t *testing.T) {
 				NodeTopologySyncInterval:    tt.fields.NodeTopologySyncInterval,
 				DisableQueryKubeletConfig:   tt.fields.DisableQueryKubeletConfig,
 				EnableNodeMetricReport:      tt.fields.EnableNodeMetricReport,
+				EnablePodTaskIds:            tt.fields.EnablePodTaskIds,
 			}
 			c := NewDefaultConfig()
 			c.InitFlags(tt.args.fs)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add taskids for each pod as an attributes. It's part of the https://github.com/koordinator-sh/koordinator/pull/1974. Resctrl runtime hook will leverage this to write new taskids to resctrl group.
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
https://github.com/koordinator-sh/koordinator/issues/1831
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
