### PR TITLE
koord-descheduler: balance prod pods between nodes in LowNodeLoad

### DIFF
--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/descheduler/apis/config/types_loadaware.go
+++ b/pkg/descheduler/apis/config/types_loadaware.go
@@ -37,6 +37,7 @@ type LowNodeLoadArgs struct {
 
 	// NumberOfNodes can be configured to activate the strategy only when the number of under utilized nodes are above the configured value.
 	// This could be helpful in large clusters where a few nodes could go under utilized frequently or for a short period of time.
+	// This parameter includes the sum of nodes with low node utilization, low prod utilization, and both.
 	// By default, NumberOfNodes is set to zero.
 	NumberOfNodes int32
 
@@ -65,11 +66,17 @@ type LowNodeLoadArgs struct {
 	// A resource consumption above (resp. below) this window is considered as overutilization (resp. underutilization).
 	UseDeviationThresholds bool
 
-	// HighThresholds defines the target usage threshold of resources
+	// HighThresholds defines the target usage threshold of node resources
 	HighThresholds ResourceThresholds
 
-	// LowThresholds defines the low usage threshold of resources
+	// LowThresholds defines the low usage threshold of node resources
 	LowThresholds ResourceThresholds
+
+	// ProdHighThresholds defines the target usage threshold of Prod resources
+	ProdHighThresholds ResourceThresholds
+
+	// ProdLowThresholds defines the low usage threshold of Prod resources
+	ProdLowThresholds ResourceThresholds
 
 	// ResourceWeights indicates the weights of resources.
 	// The weights of resources are both 1 by default.
@@ -97,11 +104,17 @@ type LowNodeLoadNodePool struct {
 	// A resource consumption above (resp. below) this window is considered as overutilization (resp. underutilization).
 	UseDeviationThresholds bool
 
-	// HighThresholds defines the target usage threshold of resources
+	// HighThresholds defines the target usage threshold of node resources
 	HighThresholds ResourceThresholds
 
-	// LowThresholds defines the low usage threshold of resources
+	// LowThresholds defines the low usage threshold of node resources
 	LowThresholds ResourceThresholds
+
+	// ProdHighThresholds defines the target usage threshold of Prod resources
+	ProdHighThresholds ResourceThresholds `json:"prodHighThresholds,omitempty"`
+
+	// ProdLowThresholds defines the low usage threshold of Prod resources
+	ProdLowThresholds ResourceThresholds `json:"prodLowThresholds,omitempty"`
 
 	// ResourceWeights indicates the weights of resources.
 	// The weights of resources are both 1 by default.

--- a/pkg/descheduler/apis/config/v1alpha2/conversion_plugins.go
+++ b/pkg/descheduler/apis/config/v1alpha2/conversion_plugins.go
@@ -33,6 +33,8 @@ func Convert_v1alpha2_LowNodeLoadArgs_To_config_LowNodeLoadArgs(in *LowNodeLoadA
 		UseDeviationThresholds: out.UseDeviationThresholds,
 		HighThresholds:         out.HighThresholds,
 		LowThresholds:          out.LowThresholds,
+		ProdHighThresholds:     out.ProdHighThresholds,
+		ProdLowThresholds:      out.ProdLowThresholds,
 		ResourceWeights:        out.ResourceWeights,
 		AnomalyCondition:       out.AnomalyCondition,
 	}

--- a/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_loadaware.go
@@ -36,6 +36,7 @@ type LowNodeLoadArgs struct {
 
 	// NumberOfNodes can be configured to activate the strategy only when the number of under utilized nodes are above the configured value.
 	// This could be helpful in large clusters where a few nodes could go under utilized frequently or for a short period of time.
+	// This parameter includes the sum of nodes with low node utilization, low prod utilization, and both.
 	// By default, NumberOfNodes is set to zero.
 	NumberOfNodes *int32 `json:"numberOfNodes,omitempty"`
 
@@ -64,11 +65,17 @@ type LowNodeLoadArgs struct {
 	// A resource consumption above (resp. below) this window is considered as overutilization (resp. underutilization).
 	UseDeviationThresholds *bool `json:"useDeviationThresholds,omitempty"`
 
-	// HighThresholds defines the target usage threshold of resources
+	// HighThresholds defines the target usage threshold of node resources
 	HighThresholds ResourceThresholds `json:"highThresholds,omitempty"`
 
-	// LowThresholds defines the low usage threshold of resources
+	// LowThresholds defines the low usage threshold of node resources
 	LowThresholds ResourceThresholds `json:"lowThresholds,omitempty"`
+
+	// ProdHighThresholds defines the target usage threshold of Prod resources
+	ProdHighThresholds ResourceThresholds `json:"prodHighThresholds,omitempty"`
+
+	// ProdLowThresholds defines the low usage threshold of Prod resources
+	ProdLowThresholds ResourceThresholds `json:"prodLowThresholds,omitempty"`
 
 	// ResourceWeights indicates the weights of resources.
 	// The weights of CPU and Memory are both 1 by default.
@@ -96,11 +103,17 @@ type LowNodeLoadNodePool struct {
 	// A resource consumption above (resp. below) this window is considered as overutilization (resp. underutilization).
 	UseDeviationThresholds bool `json:"useDeviationThresholds,omitempty"`
 
-	// HighThresholds defines the target usage threshold of resources
+	// HighThresholds defines the target usage threshold of node resources
 	HighThresholds ResourceThresholds `json:"highThresholds,omitempty"`
 
-	// LowThresholds defines the low usage threshold of resources
+	// LowThresholds defines the low usage threshold of node resources
 	LowThresholds ResourceThresholds `json:"lowThresholds,omitempty"`
+
+	// ProdHighThresholds defines the target usage threshold of Prod resources
+	ProdHighThresholds ResourceThresholds `json:"prodHighThresholds,omitempty"`
+
+	// ProdLowThresholds defines the low usage threshold of Prod resources
+	ProdLowThresholds ResourceThresholds `json:"prodLowThresholds,omitempty"`
 
 	// ResourceWeights indicates the weights of resources.
 	// The weights of resources are both 1 by default.

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -379,6 +379,8 @@ func autoConvert_v1alpha2_LowNodeLoadArgs_To_config_LowNodeLoadArgs(in *LowNodeL
 	}
 	out.HighThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.HighThresholds))
 	out.LowThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.LowThresholds))
+	out.ProdHighThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.ProdHighThresholds))
+	out.ProdLowThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.ProdLowThresholds))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
 	if in.AnomalyCondition != nil {
 		in, out := &in.AnomalyCondition, &out.AnomalyCondition
@@ -426,6 +428,8 @@ func autoConvert_config_LowNodeLoadArgs_To_v1alpha2_LowNodeLoadArgs(in *config.L
 	}
 	out.HighThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.HighThresholds))
 	out.LowThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.LowThresholds))
+	out.ProdHighThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.ProdHighThresholds))
+	out.ProdLowThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.ProdLowThresholds))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
 	if in.AnomalyCondition != nil {
 		in, out := &in.AnomalyCondition, &out.AnomalyCondition
@@ -462,6 +466,8 @@ func autoConvert_v1alpha2_LowNodeLoadNodePool_To_config_LowNodeLoadNodePool(in *
 	out.UseDeviationThresholds = in.UseDeviationThresholds
 	out.HighThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.HighThresholds))
 	out.LowThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.LowThresholds))
+	out.ProdHighThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.ProdHighThresholds))
+	out.ProdLowThresholds = *(*config.ResourceThresholds)(unsafe.Pointer(&in.ProdLowThresholds))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
 	if in.AnomalyCondition != nil {
 		in, out := &in.AnomalyCondition, &out.AnomalyCondition
@@ -486,6 +492,8 @@ func autoConvert_config_LowNodeLoadNodePool_To_v1alpha2_LowNodeLoadNodePool(in *
 	out.UseDeviationThresholds = in.UseDeviationThresholds
 	out.HighThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.HighThresholds))
 	out.LowThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.LowThresholds))
+	out.ProdHighThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.ProdHighThresholds))
+	out.ProdLowThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.ProdLowThresholds))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
 	if in.AnomalyCondition != nil {
 		in, out := &in.AnomalyCondition, &out.AnomalyCondition

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -225,6 +225,20 @@ func (in *LowNodeLoadArgs) DeepCopyInto(out *LowNodeLoadArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ProdHighThresholds != nil {
+		in, out := &in.ProdHighThresholds, &out.ProdHighThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdLowThresholds != nil {
+		in, out := &in.ProdLowThresholds, &out.ProdLowThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ResourceWeights != nil {
 		in, out := &in.ResourceWeights, &out.ResourceWeights
 		*out = make(map[corev1.ResourceName]int64, len(*in))
@@ -287,6 +301,20 @@ func (in *LowNodeLoadNodePool) DeepCopyInto(out *LowNodeLoadNodePool) {
 	}
 	if in.LowThresholds != nil {
 		in, out := &in.LowThresholds, &out.LowThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdHighThresholds != nil {
+		in, out := &in.ProdHighThresholds, &out.ProdHighThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdLowThresholds != nil {
+		in, out := &in.ProdLowThresholds, &out.ProdLowThresholds
 		*out = make(ResourceThresholds, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/descheduler/apis/config/validation/validation_loadaware.go
+++ b/pkg/descheduler/apis/config/validation/validation_loadaware.go
@@ -68,6 +68,23 @@ func ValidateLowLoadUtilizationArgs(path *field.Path, args *deschedulerconfig.Lo
 			}
 		}
 
+		for resourceName, percentage := range nodePool.ProdHighThresholds {
+			if percentage < 0 {
+				allErrs = append(allErrs, field.Invalid(nodePoolPath.Child("ProdHighThresholds").Key(string(resourceName)), percentage, "percentage must be greater than or equal to 0"))
+			}
+			if nodeHighPercentage, ok := nodePool.HighThresholds[resourceName]; ok && percentage > nodeHighPercentage {
+				allErrs = append(allErrs, field.Invalid(nodePoolPath.Child("ProdHighThresholds").Key(string(resourceName)), percentage, "node percentage must be greater than or equal to prodHighThresholds"))
+			}
+		}
+		for resourceName, percentage := range nodePool.ProdLowThresholds {
+			if percentage < 0 {
+				allErrs = append(allErrs, field.Invalid(nodePoolPath.Child("ProdLowThresholds").Key(string(resourceName)), percentage, "percentage must be greater than or equal to 0"))
+			}
+			if highProdPercentage, ok := nodePool.ProdHighThresholds[resourceName]; ok && percentage > highProdPercentage {
+				allErrs = append(allErrs, field.Invalid(nodePoolPath.Child("ProdLowThresholds").Key(string(resourceName)), percentage, "low percentage must be less than or equal to prodHighThresholds"))
+			}
+		}
+
 		if nodePool.AnomalyCondition.ConsecutiveAbnormalities <= 0 {
 			fieldPath := nodePoolPath.Child("anomalyDetectionThresholds").Child("consecutiveAbnormalities")
 			allErrs = append(allErrs, field.Invalid(fieldPath, nodePool.AnomalyCondition.ConsecutiveAbnormalities, "consecutiveAbnormalities must be greater than 0"))

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -201,6 +201,20 @@ func (in *LowNodeLoadArgs) DeepCopyInto(out *LowNodeLoadArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ProdHighThresholds != nil {
+		in, out := &in.ProdHighThresholds, &out.ProdHighThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdLowThresholds != nil {
+		in, out := &in.ProdLowThresholds, &out.ProdLowThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ResourceWeights != nil {
 		in, out := &in.ResourceWeights, &out.ResourceWeights
 		*out = make(map[corev1.ResourceName]int64, len(*in))
@@ -263,6 +277,20 @@ func (in *LowNodeLoadNodePool) DeepCopyInto(out *LowNodeLoadNodePool) {
 	}
 	if in.LowThresholds != nil {
 		in, out := &in.LowThresholds, &out.LowThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdHighThresholds != nil {
+		in, out := &in.ProdHighThresholds, &out.ProdHighThresholds
+		*out = make(ResourceThresholds, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ProdLowThresholds != nil {
+		in, out := &in.ProdLowThresholds, &out.ProdLowThresholds
 		*out = make(ResourceThresholds, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
@@ -108,7 +108,7 @@ func TestResourceUsagePercentages(t *testing.T) {
 			corev1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
 			corev1.ResourcePods:   resource.NewQuantity(11, resource.BinarySI),
 		},
-	})
+	}, false)
 
 	expectedUsageInIntPercentage := map[corev1.ResourceName]float64{
 		corev1.ResourceCPU:    63,
@@ -133,7 +133,7 @@ func TestSortNodesByUsageDescendingOrder(t *testing.T) {
 		corev1.ResourceMemory: 1,
 		corev1.ResourcePods:   1,
 	}
-	sortNodesByUsage(nodeList, weightMap, false)
+	sortNodesByUsage(nodeList, weightMap, false, false)
 
 	assert.Equal(t, expectedNodeList, nodeList)
 }
@@ -146,7 +146,7 @@ func TestSortNodesByUsageAscendingOrder(t *testing.T) {
 		corev1.ResourceMemory: 1,
 		corev1.ResourcePods:   1,
 	}
-	sortNodesByUsage(nodeList, weightMap, true)
+	sortNodesByUsage(nodeList, weightMap, true, false)
 
 	assert.Equal(t, expectedNodeList, nodeList)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Balance the usage of prod pods among nodes. Ensure that both the resource usage of prod pods on nodes and the overall node usage are balanced. This helps reduce the impact of node usage on prod applications.

### Ⅱ. Does this pull request fix one issue?
fix #2043 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
