### PR TITLE
koordlet: fix nri reconnect params

### DIFF
--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	RuntimeHooksNRIBackOffFactor    float64
 	RuntimeHooksNRIBackOffSteps     int
 	RuntimeHooksNRISocketPath       string
+	RuntimeHooksNRIPluginName       string
+	RuntimeHooksNRIPluginIndex      string
 	RuntimeHookReconcileInterval    time.Duration
 }
 
@@ -139,6 +141,8 @@ func NewDefaultConfig() *Config {
 		RuntimeHooksNRIBackOffSteps:     math.MaxInt32,
 		RuntimeHooksNRIBackOffFactor:    2,
 		RuntimeHooksNRISocketPath:       "nri/nri.sock",
+		RuntimeHooksNRIPluginName:       "koordlet_nri",
+		RuntimeHooksNRIPluginIndex:      "00",
 		RuntimeHookReconcileInterval:    10 * time.Second,
 	}
 }
@@ -155,6 +159,9 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.RuntimeHooksNRIBackOffCap, "runtime-hooks-nri-backoff-cap", c.RuntimeHooksNRIBackOffCap, "nri server backoff cap")
 	fs.IntVar(&c.RuntimeHooksNRIBackOffSteps, "runtime-hooks-nri-backoff-steps", c.RuntimeHooksNRIBackOffSteps, "nri server backoff steps")
 	fs.Float64Var(&c.RuntimeHooksNRIBackOffFactor, "runtime-hooks-nri-backoff-factor", c.RuntimeHooksNRIBackOffFactor, "nri server reconnect backoff factor")
+	fs.StringVar(&c.RuntimeHooksNRISocketPath, "runtime-hooks-nri-socket-path", c.RuntimeHooksNRISocketPath, "nri server socket path")
+	fs.StringVar(&c.RuntimeHooksNRIPluginName, "runtime-hooks-nri-plugin-name", c.RuntimeHooksNRISocketPath, "nri plugin name of the koordlet runtime hooks")
+	fs.StringVar(&c.RuntimeHooksNRIPluginIndex, "runtime-hooks-nri-plugin-index", c.RuntimeHooksNRIPluginIndex, "nri plugin index of the koordlet runtime hooks")
 	fs.Var(cliflag.NewStringSlice(&c.RuntimeHookDisableStages), "runtime-hooks-disable-stages", "disable stages for runtime hooks")
 	fs.BoolVar(&c.RuntimeHooksNRI, "enable-nri-runtime-hook", c.RuntimeHooksNRI, "enable/disable runtime hooks nri mode")
 	fs.DurationVar(&c.RuntimeHookReconcileInterval, "runtime-hooks-reconcile-interval", c.RuntimeHookReconcileInterval, "reconcile interval for each plugins")

--- a/pkg/koordlet/runtimehooks/config_test.go
+++ b/pkg/koordlet/runtimehooks/config_test.go
@@ -43,6 +43,8 @@ func Test_NewDefaultConfig(t *testing.T) {
 		RuntimeHooksNRIBackOffSteps:     math.MaxInt32,
 		RuntimeHooksNRIBackOffFactor:    2,
 		RuntimeHooksNRISocketPath:       "nri/nri.sock",
+		RuntimeHooksNRIPluginName:       "koordlet_nri",
+		RuntimeHooksNRIPluginIndex:      "00",
 		RuntimeHookReconcileInterval:    10 * time.Second,
 	}
 	defaultConfig := NewDefaultConfig()

--- a/pkg/koordlet/runtimehooks/runtimehooks.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks.go
@@ -114,6 +114,8 @@ func NewRuntimeHook(si statesinformer.StatesInformer, cfg *Config) (RuntimeHook,
 	var nriServer *nri.NriServer
 	if cfg.RuntimeHooksNRI {
 		nriServerOptions := nri.Options{
+			NriPluginName:       cfg.RuntimeHooksNRIPluginName,
+			NriPluginIdx:        cfg.RuntimeHooksNRIPluginIndex,
 			NriSocketPath:       cfg.RuntimeHooksNRISocketPath,
 			NriConnectTimeout:   cfg.RuntimeHooksNRIConnectTimeout,
 			PluginFailurePolicy: pluginFailurePolicy,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Fix the koordlet NRI plugin parameters which may leak during the reconnections.
- Fix a flaky test `TestNriServer_Start` in the koordlet NRI module.
- Add arguments for the koordlet NRI plugin.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
