### PR TITLE
koordlet: reduce unnecessary call of Err() for better performance

### DIFF
--- a/pkg/koordlet/metriccache/metric_result.go
+++ b/pkg/koordlet/metriccache/metric_result.go
@@ -105,8 +105,8 @@ func (r *aggregateResult) AddSeries(series promstorage.Series) error {
 	}
 	it := series.Iterator()
 	for it.Next() {
-		if it.Err() != nil {
-			return it.Err()
+		if err := it.Err(); err != nil {
+			return err
 		}
 		t, v := it.At()
 		r.points = append(r.points, &Point{


### PR DESCRIPTION

![image](https://github.com/koordinator-sh/koordinator/assets/18183953/ab7f905e-c871-4e19-a61c-9e2652541254)


func AddSeries is called frequently, it's within multiple loops.
it.Err() will take a lot of time when the data is huge, we'd better reduce calling it.