### PR TITLE
koord-scheduler: fix gpu name to nvidia/gpu in reservation level event

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -169,7 +169,11 @@ func generatePodEventOnReservationLevel(errorMsg string) (string, bool) {
 			}
 		} else if reserveDetailRe.MatchString(trimItem) {
 			// not total item, append to details, e.g. " 1 Reservation(s) ..."
-			resultDetails = append(resultDetails, trimItem)
+
+			// for 1 Reservation(s) Insufficient nvidia, replace nvidia with nvidia.com/gpu
+			// TODO support other extend resource fields like kubernetes.io/batch-cpu
+			itemReplaced := strings.Replace(trimItem, "nvidia", "nvidia.com/gpu", -1)
+			resultDetails = append(resultDetails, itemReplaced)
 		} else {
 			// other node items, record affinity errors on reservation level as:
 			// "at least 3 didn't match pod topology spread constraints Reservation(s)"

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -1336,6 +1336,13 @@ func Test_generatePodEventOnReservationLevel(t *testing.T) {
 			wantIsReserve: true,
 		},
 		{
+			name: "reservation gpu resource not enough",
+			errorMsg: "0/21 nodes are available: 1 Insufficient nvidia.com/gpu by node, 4 Reservation(s) Insufficient nvidia.com/gpu. " +
+				"1 Reservation(s) is unschedulable, 5 Reservation(s) matched owner total",
+			wantMsg:       "0/5 reservations are available: 4 Reservation(s) Insufficient nvidia.com/gpu, 1 Reservation(s) is unschedulable.",
+			wantIsReserve: true,
+		},
+		{
 			name: "pod topology spread constraints missing required label errors",
 			errorMsg: "0/5 nodes are available: 3 node(s) didn't match pod topology spread constraints (missing required label)," +
 				"1 Insufficient cpu, 1 Insufficient memory, 2 Reservation(s) Insufficient cpu, 1 Reservation(s) Insufficient memory. " +


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

fixed before: 0/5 reservations are available: 4 Reservation(s) Insufficient nvidia, 1 Reservation(s) is unschedulable.
after fix: 0/5 reservations are available: 4 Reservation(s) Insufficient nvidia.com/gpu, 1 Reservation(s) is unschedulable.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
