### PR TITLE
scheduler: refine reservation msg if matched filtered out by other plugins

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -252,7 +252,7 @@ func (p *Plugin) makeReasonsByReservation(reservationReasons []*framework.Status
 	var reasons []string
 	for _, status := range reservationReasons {
 		for _, r := range status.Reasons() {
-			reasons = append(reasons, fmt.Sprintf("Reservation(s) %s", r))
+			reasons = append(reasons, reservationutil.NewReservationReason(r))
 		}
 	}
 	return reasons

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -234,7 +234,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 		preemptible:              map[string]corev1.ResourceList{},
 		preemptibleInRRs:         map[string]map[types.UID]corev1.ResourceList{},
 		nodeReservationStates:    map[string]nodeReservationState{},
-		nodeReservationDiagnosis: map[string]nodeDiagnosisState{},
+		nodeReservationDiagnosis: map[string]*nodeDiagnosisState{},
 	}
 	pluginToNodeReservationRestoreState := frameworkext.PluginToNodeReservationRestoreStates{}
 	for index := range allNodeReservationStates {
@@ -254,7 +254,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 	}
 	for i := range allNodeDiagnosisStates {
 		v := allNodeDiagnosisStates[i]
-		state.nodeReservationDiagnosis[v.nodeName] = *v
+		state.nodeReservationDiagnosis[v.nodeName] = v
 	}
 	if extender != nil {
 		status := extender.RunReservationExtensionFinalRestoreReservation(ctx, cycleState, pod, pluginToNodeReservationRestoreState)

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -322,7 +322,7 @@ func TestRestoreReservation(t *testing.T) {
 				rAllocated: framework.NewResource(nil),
 			},
 		},
-		nodeReservationDiagnosis: map[string]nodeDiagnosisState{
+		nodeReservationDiagnosis: map[string]*nodeDiagnosisState{
 			node.Name: {
 				nodeName:                 node.Name,
 				ownerMatched:             1,

--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,9 @@ var (
 	// AnnotationReservationResizeAllocatable indicates the desired allocatable are to be updated.
 	AnnotationReservationResizeAllocatable = extension.SchedulingDomainPrefix + "/reservation-resize-allocatable"
 )
+
+// ErrReasonPrefix is the prefix of the reservation-level scheduling errors.
+const ErrReasonPrefix = "Reservation(s) "
 
 // NewReservePod returns a fake pod set as the reservation's specifications.
 // The reserve pod is only visible for the scheduler and does not make actual creation on nodes.
@@ -559,4 +563,14 @@ func GetReservationRestrictedResources(allocatableResources []corev1.ResourceNam
 		result = allocatableResources
 	}
 	return result
+}
+
+// NewReservationReason creates a reservation-level error reason with the given message.
+func NewReservationReason(msg string) string {
+	return ErrReasonPrefix + msg
+}
+
+// IsReservationReason checks if the error reason is at the reservation-level.
+func IsReservationReason(reason string) bool {
+	return strings.HasPrefix(reason, ErrReasonPrefix)
 }

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -809,3 +809,11 @@ func TestGetReservationRestrictedResources(t *testing.T) {
 		})
 	}
 }
+
+func TestNewReservationReason(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		reasonMsg := "node(s) didn't match the requested node name"
+		got := NewReservationReason(reasonMsg)
+		assert.True(t, IsReservationReason(got))
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Add a prefix to define the Reservation-level error reasons when scheduling failed.
- Append the failure reasons when other plugins filter out a pod specifying reservation affinities.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
