### PR TITLE
koord-descheduler: limit the total number of pod evictions

### DIFF
--- a/cmd/koord-descheduler/app/server.go
+++ b/cmd/koord-descheduler/app/server.go
@@ -307,7 +307,8 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 
 	evictionLimiter := evictions.NewEvictionLimiter(
 		cc.ComponentConfig.MaxNoOfPodsToEvictPerNode,
-		cc.ComponentConfig.MaxNoOfPodsToEvictPerNamespace)
+		cc.ComponentConfig.MaxNoOfPodsToEvictPerNamespace,
+		cc.ComponentConfig.MaxNoOfPodsToEvictTotal)
 
 	desched, err := descheduler.New(
 		cc.Client,

--- a/pkg/descheduler/apis/config/types.go
+++ b/pkg/descheduler/apis/config/types.go
@@ -67,6 +67,9 @@ type DeschedulerConfiguration struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint
+
+	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
+	MaxNoOfPodsToEvictTotal *uint
 }
 
 // DeschedulerProfile is a descheduling profile.

--- a/pkg/descheduler/apis/config/v1alpha2/types.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types.go
@@ -68,6 +68,9 @@ type DeschedulerConfiguration struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint `json:"maxNoOfPodsToEvictPerNamespace,omitempty"`
+
+	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
+	MaxNoOfPodsToEvictTotal *uint `json:"maxNoOfPodsToEvictTotal,omitempty"`
 }
 
 // DecodeNestedObjects decodes plugin args for known types.

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -247,6 +247,7 @@ func autoConvert_v1alpha2_DeschedulerConfiguration_To_config_DeschedulerConfigur
 	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
 	return nil
 }
 
@@ -282,6 +283,7 @@ func autoConvert_config_DeschedulerConfiguration_To_v1alpha2_DeschedulerConfigur
 	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
 	return nil
 }
 

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *DeschedulerConfiguration) DeepCopyInto(out *DeschedulerConfiguration) 
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MaxNoOfPodsToEvictTotal != nil {
+		in, out := &in.MaxNoOfPodsToEvictTotal, &out.MaxNoOfPodsToEvictTotal
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -79,6 +79,11 @@ func (in *DeschedulerConfiguration) DeepCopyInto(out *DeschedulerConfiguration) 
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MaxNoOfPodsToEvictTotal != nil {
+		in, out := &in.MaxNoOfPodsToEvictTotal, &out.MaxNoOfPodsToEvictTotal
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
We want to limit the total number of pods rescheduled in each iteration. Currently, we have restrictions at the node and namespace levels, but there is no cluster-level restriction in place.

### Ⅱ. Does this pull request fix one issue?
fixes #2086 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
