### PR TITLE
koord-descheduler: enhance LowNodeLoad scorer

### DIFF
--- a/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/utilization_util_test.go
@@ -226,6 +226,6 @@ func TestSortPodsOnOneOverloadedNode(t *testing.T) {
 		corev1.ResourceCPU:    int64(1),
 		corev1.ResourceMemory: int64(1),
 	}
-	sortPodsOnOneOverloadedNode(nodeInfo, removablePods, resourceWeights)
+	sortPodsOnOneOverloadedNode(nodeInfo, removablePods, resourceWeights, false)
 	assert.Equal(t, expectedResult, removablePods)
 }

--- a/pkg/descheduler/utils/sorter/scorer_test.go
+++ b/pkg/descheduler/utils/sorter/scorer_test.go
@@ -1,0 +1,94 @@
+package sorter
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestFunctions(t *testing.T) {
+	resToWeightMap := map[corev1.ResourceName]int64{
+		corev1.ResourceCPU:    2,
+		corev1.ResourceMemory: 3,
+	}
+
+	requested1 := corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+	}
+	allocatable1 := corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+	}
+
+	scorer1 := ResourceUsageScorer(resToWeightMap)
+	score1 := scorer1(requested1, allocatable1)
+	if score1 != 500 {
+		t.Fatal("ResourceUsageScorer score1")
+	}
+
+	score2 := mostRequestedScore(800, 1000)
+	if score2 != 800 {
+		t.Fatal("ResourceUsageScorer score2")
+	}
+	score3 := mostRequestedScore(1200, 1000)
+	if score3 != 1000 {
+		t.Fatal("ResourceUsageScorer score3")
+	}
+
+	score4 := mostRequestedScore(1200, 0)
+	if score4 != 0 {
+		t.Fatal("ResourceUsageScorer score4")
+	}
+
+	resToWeightMap = map[corev1.ResourceName]int64{
+		corev1.ResourceCPU:    0,
+		corev1.ResourceMemory: 0,
+	}
+
+	scorer1 = ResourceUsageScorer(resToWeightMap)
+	score1 = scorer1(requested1, allocatable1)
+	if score1 != 0 {
+		t.Fatal("ResourceUsageScorer score5")
+	}
+
+	qCPU := resource.NewMilliQuantity(500, resource.DecimalSI)
+	valueCPU := getResourceValue(corev1.ResourceCPU, *qCPU)
+	if valueCPU != 500 {
+		t.Fatal("ResourceUsageScorer score6")
+	}
+
+	qMem := resource.NewQuantity(1024, resource.BinarySI)
+	valueMem := getResourceValue(corev1.ResourceMemory, *qMem)
+	if valueMem != 1024 {
+		t.Fatal("ResourceUsageScorer score7")
+	}
+}
+
+func TestResourceUsageScorerPod(t *testing.T) {
+	resToWeightMap := map[corev1.ResourceName]int64{
+		corev1.ResourceCPU:    0,
+		corev1.ResourceMemory: 0,
+	}
+
+	scorer1 := ResourceUsageScorerPod(resToWeightMap)
+	requested1 := corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+	}
+	allocatable1 := corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+	}
+
+	score1 := scorer1(requested1, allocatable1)
+	if score1 != 0 {
+		t.Fatal("TestResourceUsageScorerPod ResourceUsageScorerPod fail")
+	}
+
+	score := mostRequestedScorePod(100, 0)
+	if score != 0 {
+		t.Fatal("TestResourceUsageScorerPod mostRequestedScorePod fail")
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
What is your proposal:
When descheduler evaluates which pod to expel to reduce the utilization of high-load nodes to a reasonable level, can descheduler perform matching calculations on the actual usage of the pod and the amount of eviction resources in advance?

Why is this needed:
This can reduce the number of times a single node is repeatedly entered into the eviction logical unit, reduce the number of single node eviction instances, and indirectly improve the accuracy of the eviction results and the stability of the business while ensuring that hot issues are solved.

Is there a suggested solution, if so, please add it:
evict pod priority selector：podNowResourceUsages >= nodeNowResourceUsages - nodeHighResourceThresholds * nodeResourceAllocatable

### Ⅱ. Does this pull request fix one issue?
issue链接：https://github.com/koordinator-sh/koordinator/issues/1975

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
I added unit tests

### Ⅳ. Special notes for reviews
none

### V. Checklist

✅ I have written necessary docs and comments
✅ I have added necessary unit tests and integration tests
✅ All checks passed in `make test`
