### PR TITLE
koord-scheduler: Pod updates should not update the timestamp

### DIFF
--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
@@ -61,9 +61,14 @@ func (p *podAssignCache) assign(nodeName string, pod *corev1.Pod) {
 		m = make(map[types.UID]*podAssignInfo)
 		p.podInfoItems[nodeName] = m
 	}
-	m[pod.UID] = &podAssignInfo{
-		timestamp: timeNowFn(),
-		pod:       pod,
+
+	if _, ok := m[pod.UID]; ok {
+		m[pod.UID].pod = pod
+	} else {
+		m[pod.UID] = &podAssignInfo{
+			timestamp: timeNowFn(),
+			pod:       pod,
+		}
 	}
 }
 

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -193,6 +193,64 @@ func TestPodAssignCache_OnUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "update scheduled running pod, timestamp won't be updated",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "123456789",
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			assignCache: &podAssignCache{
+				podInfoItems: map[string]map[types.UID]*podAssignInfo{
+					"test-node": {
+						"123456789": &podAssignInfo{
+							pod: &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									UID:       "123456789",
+									Namespace: "default",
+									Name:      "test",
+								},
+								Spec: corev1.PodSpec{
+									NodeName: "test-node",
+								},
+								Status: corev1.PodStatus{
+									Phase: corev1.PodRunning,
+								},
+							},
+							timestamp: fakeTimeNowFn().Add(1000),
+						},
+					},
+				},
+			},
+			wantCache: map[string]map[types.UID]*podAssignInfo{
+				"test-node": {
+					"123456789": &podAssignInfo{
+						pod: &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								UID:       "123456789",
+								Namespace: "default",
+								Name:      "test",
+							},
+							Spec: corev1.PodSpec{
+								NodeName: "test-node",
+							},
+							Status: corev1.PodStatus{
+								Phase: corev1.PodRunning,
+							},
+						},
+						timestamp: fakeTimeNowFn().Add(1000),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Pod updates should not update the timestamp in loadaware cache. This would cause pods that have been in the cache for a while to estimate resource during scheduling instead of using the actual resource reported on nodemetric. This discrepancy arises from the timestamp change without timely updating of nodemetric.


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
