### PR TITLE
chore: fix e2e configs after the load-aware scheduling updated

### DIFF
--- a/test/e2e/slocontroller/batchresource.go
+++ b/test/e2e/slocontroller/batchresource.go
@@ -39,14 +39,14 @@ import (
 
 const colocationEnabledConfigData = `{
   "enable": true,
-  "cpuReclaimThresholdPercent": 80,
-  "memoryReclaimThresholdPercent": 80,
+  "cpuReclaimThresholdPercent": 95,
+  "memoryReclaimThresholdPercent": 95,
   "memoryCalculatePolicy": "usage"
 }`
 
 var (
-	cpuReclaimThresholdPercent    = 80
-	memoryReclaimThresholdPercent = 80
+	cpuReclaimThresholdPercent    = 95
+	memoryReclaimThresholdPercent = 95
 	maxNodeBatchCPUDiffPercent    = 10
 	maxNodeBatchMemoryDiffPercent = 5
 

--- a/test/e2e/testing-manifests/slocontroller/be-demo.yaml
+++ b/test/e2e/testing-manifests/slocontroller/be-demo.yaml
@@ -17,9 +17,9 @@ spec:
     command: ["sleep", "2000000000000"]
     resources:
       limits:
-        kubernetes.io/batch-cpu: "500"
-        kubernetes.io/batch-memory: 1Gi
-      requests:
         kubernetes.io/batch-cpu: "50"
-        kubernetes.io/batch-memory: 100Mi
+        kubernetes.io/batch-memory: 128Mi
+      requests:
+        kubernetes.io/batch-cpu: "25"
+        kubernetes.io/batch-memory: 64Mi
   restartPolicy: Never


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Revise the configurations of the E2E manifests to de-flaky E2E tests.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

- Fixes the issue where the E2E tests occasionally fail after #1992 merged.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
