### PR TITLE
koord-manager: support manually configured default cpu normalization settings

### DIFF
--- a/apis/configuration/slo_controller_config.go
+++ b/apis/configuration/slo_controller_config.go
@@ -275,6 +275,8 @@ type CPUNormalizationStrategy struct {
 	// Enable defines whether the cpu normalization is enabled.
 	// If set to false, the node cpu normalization ratio will be removed.
 	Enable *bool `json:"enable,omitempty"`
+	// DefaultRatio defines the default cpu normalization.
+	DefaultRatio *float64 `json:"defaultRatio,omitempty"`
 	// RatioModel defines the cpu normalization ratio of each CPU model.
 	// It maps the CPUModel of BasicInfo into the ratios.
 	RatioModel map[string]ModelRatioCfg `json:"ratioModel,omitempty"`

--- a/apis/configuration/zz_generated.deepcopy.go
+++ b/apis/configuration/zz_generated.deepcopy.go
@@ -83,6 +83,11 @@ func (in *CPUNormalizationStrategy) DeepCopyInto(out *CPUNormalizationStrategy) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DefaultRatio != nil {
+		in, out := &in.DefaultRatio, &out.DefaultRatio
+		*out = new(float64)
+		**out = **in
+	}
 	if in.RatioModel != nil {
 		in, out := &in.RatioModel, &out.RatioModel
 		*out = make(map[string]ModelRatioCfg, len(*in))


### PR DESCRIPTION
In some dedicated clusters, we don't need complex CPU models; instead, we prefer manually configured default  CPU normalization settings for greater flexibility.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
