### PR TITLE
chore: fix koordlet dockerfile

### DIFF
--- a/docker/koordlet.dockerfile
+++ b/docker/koordlet.dockerfile
@@ -11,8 +11,8 @@ RUN apt update && apt install -y bash build-essential cmake wget
 RUN wget https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.13.0.tar.gz && \
   echo "bcb52090f02bc7bcb5ac066494cd55bbd5084e65  libpfm-4.13.0.tar.gz" | sha1sum -c && \
   tar -xzf libpfm-4.13.0.tar.gz && \
-  rm libpfm-4.13.0.tar.gz
-RUN export DBG="-g -Wall" && \
+  rm libpfm-4.13.0.tar.gz && \
+  export DBG="-g -Wall" && \
   make -e -C libpfm-4.13.0 && \
   make install -C libpfm-4.13.0
 
@@ -35,8 +35,7 @@ RUN go build -a -o koordlet cmd/koordlet/main.go
 
 FROM --platform=$TARGETPLATFORM nvidia/cuda:11.8.0-base-ubuntu22.04
 WORKDIR /
-RUN apt-get update && apt-get install -y lvm2 && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y iptables
+RUN apt-get update && apt-get install -y lvm2 iptables && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /go/src/github.com/koordinator-sh/koordinator/koordlet .
 COPY --from=builder /usr/local/lib /usr/lib
 ENTRYPOINT ["/koordlet"]


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixes the E2E failures like:

```bash
Run export KUBECONFIG=/home/runner/.kube/config
GOBIN=/home/runner/work/koordinator/koordinator/bin go install github.com/onsi/ginkgo/ginkgo@v1.16.4
Failed to compile e2e:

# github.com/koordinator-sh/koordinator/test/e2e.test
/opt/hostedtoolcache/go/1.20.14/x64/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device

Ginkgo ran 1 suite in 34.075041123s
Test Suite Failed
koord-manager has not restarted
Error: Process completed with exit code 1.
```

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
