### PR TITLE
webhook: revise elasticquota mutating when validating disabled

### DIFF
--- a/pkg/webhook/elasticquota/mutating/webhooks.go
+++ b/pkg/webhook/elasticquota/mutating/webhooks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mutating
 
 import (
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -45,8 +46,13 @@ func (b *quotaMutateBuilder) WithControllerManager(mgr ctrl.Manager) framework.H
 }
 
 func (b *quotaMutateBuilder) Build() admission.Handler {
-	return &ElasticQuotaMutatingHandler{
+	h := &ElasticQuotaMutatingHandler{
 		Client:  b.mgr.GetClient(),
 		Decoder: admission.NewDecoder(b.mgr.GetScheme()),
 	}
+	err := h.InjectCache(b.mgr.GetCache())
+	if err != nil {
+		klog.Fatal("failed to inject cache for quotaMutateBuilder: %v", err)
+	}
+	return h
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

In the current version of the koord-manager, the event handler of the elastic quota reconciling the quota topology cache is only instantiated by the elastic quota validating handler. It means the handler cannot work well when we enable the quota mutating but disable quota validating since the topology cache is invalid.
To fix this issue, we also try instantiating the event handler of the elastic quota in the quota mutating handler when it has not been instantiated.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
