### PR TITLE
all: support priority and preemption policy transformer

### DIFF
--- a/apis/extension/preemption.go
+++ b/apis/extension/preemption.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// LabelPodPreemptionPolicy is used to set the PreemptionPolicy of a Pod when the feature
+	// PreemptionPolicyTransformer is enabled.
+	// When PreemptionPolicyTransformer is enabled but the pod does not set the label, DefaultPreemptionPolicy is used.
+	LabelPodPreemptionPolicy = SchedulingDomainPrefix + "/preemption-policy"
+)
+
+func GetPodKoordPreemptionPolicy(pod *corev1.Pod) *corev1.PreemptionPolicy {
+	if pod == nil || pod.Labels == nil {
+		return nil
+	}
+	switch s := corev1.PreemptionPolicy(pod.Labels[LabelPodPreemptionPolicy]); s {
+	case corev1.PreemptNever, corev1.PreemptLowerPriority:
+		return &s
+	default:
+		return nil
+	}
+}
+
+func GetPreemptionPolicyPtr(policy corev1.PreemptionPolicy) *corev1.PreemptionPolicy {
+	return &policy
+}

--- a/apis/extension/preemption_test.go
+++ b/apis/extension/preemption_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPodKoordPreemptionPolicy(t *testing.T) {
+	policyNever := corev1.PreemptNever
+	policyPreemptLowerPriority := corev1.PreemptLowerPriority
+	tests := []struct {
+		name string
+		arg  *corev1.Pod
+		want *corev1.PreemptionPolicy
+	}{
+		{
+			name: "pod is nil",
+			arg:  nil,
+			want: nil,
+		},
+		{
+			name: "pod labels is empty",
+			arg:  &corev1.Pod{},
+			want: nil,
+		},
+		{
+			name: "pod label is not set",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "never preempt",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPreemptionPolicy: string(corev1.PreemptNever),
+					},
+				},
+			},
+			want: &policyNever,
+		},
+		{
+			name: "preempt lower priority",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPreemptionPolicy: string(corev1.PreemptLowerPriority),
+					},
+				},
+			},
+			want: &policyPreemptLowerPriority,
+		},
+		{
+			name: "policy unknown",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodPreemptionPolicy: "unknownPolicy",
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodKoordPreemptionPolicy(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/apis/extension/preemption_utils.go
+++ b/apis/extension/preemption_utils.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import corev1 "k8s.io/api/core/v1"
+
+// NOTE: functions in this file can be overwritten for extension
+
+var DefaultPreemptionPolicy = GetPreemptionPolicyPtr(corev1.PreemptNever)
+
+func GetPodKoordPreemptionPolicyWithDefault(pod *corev1.Pod) *corev1.PreemptionPolicy {
+	if preemptionPolicy := GetPodKoordPreemptionPolicy(pod); preemptionPolicy != nil {
+		return preemptionPolicy
+	}
+
+	// If the PreemptionPolicy feature enabled but the preemption-policy label is not set, use
+	// the DefaultPreemptionPolicy.
+	return DefaultPreemptionPolicy
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -98,9 +98,25 @@ var defaultDeschedulerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	DisablePVCReservation: {Default: false, PreRelease: featuregate.Beta},
 }
 
+const (
+	// PriorityTransformer is used to map the pod priority to priority classes defined by Koordinator.
+	// If a pod does not set a priorityClass, it will be mapped to the DefaultPriorityClass.
+	PriorityTransformer featuregate.Feature = "PriorityTransformer"
+	// PreemptionPolicyTransformer is used to take over the pod preemption policy with the specified label.
+	// If a pod does not set a preemptionPolicy, it will be mapped to the DefaultPreemptionPolicy.
+	PreemptionPolicyTransformer featuregate.Feature = "PreemptionPolicyTransformer"
+)
+
+var transformerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	PriorityTransformer:         {Default: false, PreRelease: featuregate.Alpha},
+	PreemptionPolicyTransformer: {Default: false, PreRelease: featuregate.Alpha},
+}
+
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultDeschedulerFeatureGates))
+	// TODO: use a unified feature-gate
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(transformerFeatureGates))
 }
 
 func SetDefaultFeatureGates() {

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -83,4 +83,6 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 
 func init() {
 	runtime.Must(k8sfeature.DefaultMutableFeatureGate.Add(defaultSchedulerFeatureGates))
+	// TODO: use a unified feature-gate
+	runtime.Must(k8sfeature.DefaultMutableFeatureGate.Add(transformerFeatureGates))
 }

--- a/pkg/util/transformer/pod_transformer_test.go
+++ b/pkg/util/transformer/pod_transformer_test.go
@@ -23,15 +23,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/utils/pointer"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
 func TestTransformPod(t *testing.T) {
 	tests := []struct {
-		name    string
-		pod     *corev1.Pod
-		wantPod *corev1.Pod
+		name      string
+		prepareFn func() func()
+		pod       *corev1.Pod
+		wantPod   *corev1.Pod
 	}{
 		{
 			name: "normal pod",
@@ -195,10 +200,208 @@ func TestTransformPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod transform priority and preemption policy",
+			prepareFn: func() func() {
+				cleanFn := utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultFeatureGate, features.PriorityTransformer, true)
+				cleanFn1 := utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultFeatureGate, features.PreemptionPolicyTransformer, true)
+				return func() {
+					cleanFn1()
+					cleanFn()
+				}
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelPodQoS:              string(apiext.QoSLSR),
+						apiext.LabelPodPreemptionPolicy: string(corev1.PreemptNever),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU:    resource.MustParse("500"),
+						apiext.BatchMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelPodQoS:              string(apiext.QoSLSR),
+						apiext.LabelPodPreemptionPolicy: string(corev1.PreemptNever),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU:    resource.MustParse("500"),
+						apiext.BatchMemory: resource.MustParse("2Gi"),
+					},
+					Priority:         pointer.Int32(apiext.PriorityProdValueDefault),
+					PreemptionPolicy: apiext.GetPreemptionPolicyPtr(corev1.PreemptNever),
+				},
+			},
+		},
+		{
+			name: "pod disable priority transform and use default preemption policy",
+			prepareFn: func() func() {
+				cleanFn := utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultFeatureGate, features.PriorityTransformer, false)
+				cleanFn1 := utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultFeatureGate, features.PreemptionPolicyTransformer, true)
+				return func() {
+					cleanFn1()
+					cleanFn()
+				}
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSLSR),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU:    resource.MustParse("500"),
+						apiext.BatchMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSLSR),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"resources":{"koordinator.sh/gpu-core":"60","koordinator.sh/gpu-memory":"8Gi","koordinator.sh/gpu-memory-ratio":"50"}}]}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU:               resource.MustParse("1000"),
+									apiext.BatchMemory:            resource.MustParse("1Gi"),
+									apiext.ResourceGPUCore:        resource.MustParse("100"),
+									apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU:    resource.MustParse("500"),
+						apiext.BatchMemory: resource.MustParse("2Gi"),
+					},
+					PreemptionPolicy: apiext.DefaultPreemptionPolicy,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obj, err := TransformPod(tt.pod)
+			if tt.prepareFn != nil {
+				defer tt.prepareFn()()
+			}
+			obj, err := TransformPodFactory()(tt.pod)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPod, obj)
 		})

--- a/pkg/util/transformer/transformers.go
+++ b/pkg/util/transformer/transformers.go
@@ -29,8 +29,13 @@ import (
 
 var transformers = map[schema.GroupVersionResource]cache.TransformFunc{
 	corev1.SchemeGroupVersion.WithResource("nodes"):               TransformNode,
-	corev1.SchemeGroupVersion.WithResource("pods"):                TransformPod,
 	schedulingv1alpha1.SchemeGroupVersion.WithResource("devices"): TransformDevice,
+}
+
+type TransformFactory func() cache.TransformFunc
+
+var transformerFactories = map[schema.GroupVersionResource]TransformFactory{
+	corev1.SchemeGroupVersion.WithResource("pods"): TransformPodFactory,
 }
 
 func SetupTransformers(informerFactory informers.SharedInformerFactory, koordInformerFactory koordinformers.SharedInformerFactory) {
@@ -42,6 +47,20 @@ func SetupTransformers(informerFactory informers.SharedInformerFactory, koordInf
 				klog.Fatalf("Failed to create informer for resource %v, err: %v", resource.String(), err)
 			}
 		}
+		if err := informer.Informer().SetTransform(transformFn); err != nil {
+			klog.Fatalf("Failed to SetTransform in informer, resource: %v, err: %v", resource, err)
+		}
+	}
+	for resource, transformFactory := range transformerFactories {
+		informer, err := informerFactory.ForResource(resource)
+		if err != nil {
+			informer, err = koordInformerFactory.ForResource(resource)
+			if err != nil {
+				klog.Fatalf("Failed to create informer for resource %v, err: %v", resource.String(), err)
+			}
+		}
+		// new transformFunc after initialization
+		transformFn := transformFactory()
 		if err := informer.Informer().SetTransform(transformFn); err != nil {
 			klog.Fatalf("Failed to SetTransform in informer, resource: %v, err: %v", resource, err)
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Support features PriorityTransformer and PreemptionPolicyTransformer:

- PriorityTransformer: transform the priority value of the pod according to its priority class, allowing us to adapt the pods existing in the cluster that have not set priorities.
- PreemptionPolicyTransformer: transform the preemption policy of the pod according to a preemption label and the global default policy, allowing us to take over the pods existing in the cluster that may set the default preemptible policy. It helps when the cluster has many kinds of pods set the PreemptLowPriority by default priority classes but we want to enable the preemption only for specific pods.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
