### PR TITLE
scheduler: add reservation preemption

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -4,6 +4,8 @@ pkg/descheduler/controllers/migration/controllerfinder
 pkg/scheduler/plugins/coscheduling
 pkg/scheduler/plugins/nodenumaresource/least_allocated.go
 pkg/scheduler/plugins/nodenumaresource/most_allocated.go
+pkg/scheduler/plugins/reservation/preemption.go
+pkg/scheduler/plugins/reservation/preemption_test.go
 pkg/scheduler/frameworkext/topologymanager/policy.go
 pkg/scheduler/frameworkext/topologymanager/policy_test.go
 pkg/scheduler/frameworkext/topologymanager/policy_best_effort.go

--- a/apis/extension/preemption.go
+++ b/apis/extension/preemption.go
@@ -23,6 +23,9 @@ const (
 	// PreemptionPolicyTransformer is enabled.
 	// When PreemptionPolicyTransformer is enabled but the pod does not set the label, DefaultPreemptionPolicy is used.
 	LabelPodPreemptionPolicy = SchedulingDomainPrefix + "/preemption-policy"
+
+	// LabelDisablePreemptible determines whether the pod disables being a victim during the reservation preemption.
+	LabelDisablePreemptible = SchedulingDomainPrefix + "/disable-preemptible"
 )
 
 func GetPodKoordPreemptionPolicy(pod *corev1.Pod) *corev1.PreemptionPolicy {
@@ -39,4 +42,15 @@ func GetPodKoordPreemptionPolicy(pod *corev1.Pod) *corev1.PreemptionPolicy {
 
 func GetPreemptionPolicyPtr(policy corev1.PreemptionPolicy) *corev1.PreemptionPolicy {
 	return &policy
+}
+
+func IsPodPreemptible(pod *corev1.Pod) bool {
+	if pod == nil || pod.Labels == nil {
+		return true
+	}
+	v, ok := pod.Labels[LabelDisablePreemptible]
+	if !ok {
+		return true
+	}
+	return v != "true"
 }

--- a/apis/extension/preemption_test.go
+++ b/apis/extension/preemption_test.go
@@ -92,3 +92,56 @@ func TestGetPodKoordPreemptionPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPodPreemptible(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod is nil",
+			arg:  nil,
+			want: true,
+		},
+		{
+			name: "pod has no label",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod is marked as non-preemptible",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						LabelDisablePreemptible: "true",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod is marked as preemptible",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						LabelDisablePreemptible: "false",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPodPreemptible(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -160,6 +160,19 @@ type ReservationArgs struct {
 
 	// EnablePreemption indicates whether to enable preemption for reservations.
 	EnablePreemption bool
+	// MinCandidateNodesPercentage is the minimum number of candidates to
+	// shortlist when dry running preemption as a percentage of number of nodes.
+	// Must be in the range [0, 100]. Defaults to 10% of the cluster size if
+	// unspecified.
+	MinCandidateNodesPercentage int32
+	// MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+	// shortlist. The likely number of candidates enumerated for dry running
+	// preemption is given by the formula:
+	// numCandidates = max(numNodes * minCandidateNodesPercentage, minCandidateNodesAbsolute)
+	// We say "likely" because there are other factors such as PDB violations
+	// that play a role in the number of candidates shortlisted. Must be at least
+	// 0 nodes. Defaults to 100 nodes if unspecified.
+	MinCandidateNodesAbsolute int32
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -155,6 +155,19 @@ type ReservationArgs struct {
 
 	// EnablePreemption indicates whether to enable preemption for reservations.
 	EnablePreemption *bool `json:"enablePreemption,omitempty"`
+	// MinCandidateNodesPercentage is the minimum number of candidates to
+	// shortlist when dry running preemption as a percentage of number of nodes.
+	// Must be in the range [0, 100]. Defaults to 10% of the cluster size if
+	// unspecified.
+	MinCandidateNodesPercentage *int32 `json:"minCandidateNodesPercentage,omitempty"`
+	// MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+	// shortlist. The likely number of candidates enumerated for dry running
+	// preemption is given by the formula:
+	// numCandidates = max(numNodes * minCandidateNodesPercentage, minCandidateNodesAbsolute)
+	// We say "likely" because there are other factors such as PDB violations
+	// that play a role in the number of candidates shortlisted. Must be at least
+	// 0 nodes. Defaults to 100 nodes if unspecified.
+	MinCandidateNodesAbsolute *int32 `json:"minCandidateNodesAbsolute,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -364,6 +364,12 @@ func autoConvert_v1_ReservationArgs_To_config_ReservationArgs(in *ReservationArg
 	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnablePreemption, &out.EnablePreemption, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -374,6 +380,12 @@ func Convert_v1_ReservationArgs_To_config_ReservationArgs(in *ReservationArgs, o
 
 func autoConvert_config_ReservationArgs_To_v1_ReservationArgs(in *config.ReservationArgs, out *ReservationArgs, s conversion.Scope) error {
 	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnablePreemption, &out.EnablePreemption, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -322,6 +322,16 @@ func (in *ReservationArgs) DeepCopyInto(out *ReservationArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MinCandidateNodesPercentage != nil {
+		in, out := &in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MinCandidateNodesAbsolute != nil {
+		in, out := &in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -49,7 +49,9 @@ var (
 
 	defaultPreferredCPUBindPolicy = CPUBindPolicyFullPCPUs
 
-	defaultEnablePreemption = pointer.Bool(false)
+	defaultEnablePreemption            = pointer.Bool(false)
+	defaultMinCandidateNodesPercentage = pointer.Int32(10)
+	defaultMinCandidateNodesAbsolute   = pointer.Int32(100)
 
 	defaultDelayEvictTime       = 120 * time.Second
 	defaultRevokePodInterval    = 1 * time.Second
@@ -142,6 +144,12 @@ func SetDefaults_NodeNUMAResourceArgs(obj *NodeNUMAResourceArgs) {
 func SetDefaults_ReservationArgs(obj *ReservationArgs) {
 	if obj.EnablePreemption == nil {
 		obj.EnablePreemption = defaultEnablePreemption
+	}
+	if obj.MinCandidateNodesPercentage == nil {
+		obj.MinCandidateNodesPercentage = defaultMinCandidateNodesPercentage
+	}
+	if obj.MinCandidateNodesAbsolute == nil {
+		obj.MinCandidateNodesAbsolute = defaultMinCandidateNodesAbsolute
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -155,6 +155,19 @@ type ReservationArgs struct {
 
 	// EnablePreemption indicates whether to enable preemption for reservations.
 	EnablePreemption *bool `json:"enablePreemption,omitempty"`
+	// MinCandidateNodesPercentage is the minimum number of candidates to
+	// shortlist when dry running preemption as a percentage of number of nodes.
+	// Must be in the range [0, 100]. Defaults to 10% of the cluster size if
+	// unspecified.
+	MinCandidateNodesPercentage *int32 `json:"minCandidateNodesPercentage,omitempty"`
+	// MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+	// shortlist. The likely number of candidates enumerated for dry running
+	// preemption is given by the formula:
+	// numCandidates = max(numNodes * minCandidateNodesPercentage, minCandidateNodesAbsolute)
+	// We say "likely" because there are other factors such as PDB violations
+	// that play a role in the number of candidates shortlisted. Must be at least
+	// 0 nodes. Defaults to 100 nodes if unspecified.
+	MinCandidateNodesAbsolute *int32 `json:"minCandidateNodesAbsolute,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -359,6 +359,12 @@ func autoConvert_v1beta3_ReservationArgs_To_config_ReservationArgs(in *Reservati
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnablePreemption, &out.EnablePreemption, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -369,6 +375,12 @@ func Convert_v1beta3_ReservationArgs_To_config_ReservationArgs(in *ReservationAr
 
 func autoConvert_config_ReservationArgs_To_v1beta3_ReservationArgs(in *config.ReservationArgs, out *ReservationArgs, s conversion.Scope) error {
 	if err := v1.Convert_bool_To_Pointer_bool(&in.EnablePreemption, &out.EnablePreemption, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -322,6 +322,16 @@ func (in *ReservationArgs) DeepCopyInto(out *ReservationArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MinCandidateNodesPercentage != nil {
+		in, out := &in.MinCandidateNodesPercentage, &out.MinCandidateNodesPercentage
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MinCandidateNodesAbsolute != nil {
+		in, out := &in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -324,7 +324,9 @@ func (ri *ReservationInfo) UpdateReservation(r *schedulingv1alpha1.Reservation) 
 	ri.Reservation = r
 	ri.Pod = reservationutil.NewReservePod(r)
 	ri.AllocatablePorts = util.RequestedHostPorts(ri.Pod)
-	ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
+	if ri.Allocated != nil {
+		ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
+	}
 	ownerMatchers, err := reservationutil.ParseReservationOwnerMatchers(r.Spec.Owners)
 	if err != nil {
 		klog.ErrorS(err, "Failed to parse reservation owner matchers", "reservation", klog.KObj(r))

--- a/pkg/scheduler/frameworkext/reservation_info_test.go
+++ b/pkg/scheduler/frameworkext/reservation_info_test.go
@@ -384,7 +384,6 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 			want: &ReservationInfo{
 				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
 				AssignedPods:  map[types.UID]*PodRequirement{},
 				OwnerMatchers: ownerMatchers,
 				ParseError:    parseError,
@@ -407,7 +406,6 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 			want: &ReservationInfo{
 				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
 				AssignedPods:  map[types.UID]*PodRequirement{},
 				OwnerMatchers: func() []reservationutil.ReservationOwnerMatcher {
 					m, _ := reservationutil.ParseReservationOwnerMatchers([]schedulingv1alpha1.ReservationOwner{
@@ -444,7 +442,6 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 			want: &ReservationInfo{
 				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
 				AssignedPods:  map[types.UID]*PodRequirement{},
 				OwnerMatchers: nil,
 				ParseError: func() error {
@@ -481,7 +478,6 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 					corev1.ResourceCPU:    resource.MustParse("8"),
 					corev1.ResourceMemory: resource.MustParse("16Gi"),
 				},
-				Allocated:     corev1.ResourceList{},
 				AssignedPods:  map[types.UID]*PodRequirement{},
 				OwnerMatchers: ownerMatchers,
 				ParseError:    nil,

--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -96,7 +96,6 @@ func TestCacheUpdateReservation(t *testing.T) {
 	reservationInfos = cache.listAvailableReservationInfosOnNode(reservation.Status.NodeName)
 	assert.Len(t, reservationInfos, 1)
 	rInfo = reservationInfos[0]
-	expectReservationInfo.Allocated = corev1.ResourceList{}
 	sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 		return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
 	})

--- a/pkg/scheduler/plugins/reservation/eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler_test.go
@@ -196,7 +196,7 @@ func TestEventHandlerUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cache := newReservationCache(nil)
-			eh := &reservationEventHandler{cache: cache, rrNominator: newNominator()}
+			eh := &reservationEventHandler{cache: cache, rrNominator: newNominator(nil, nil)}
 			eh.OnUpdate(tt.oldReservation, tt.newReservation)
 			if tt.wantReservation == nil {
 				rInfo := cache.getReservationInfoByUID(tt.newReservation.UID)
@@ -241,7 +241,7 @@ func TestEventHandlerDelete(t *testing.T) {
 		},
 	}
 	cache := newReservationCache(nil)
-	eh := &reservationEventHandler{cache: cache, rrNominator: newNominator()}
+	eh := &reservationEventHandler{cache: cache, rrNominator: newNominator(nil, nil)}
 	eh.OnAdd(activeReservation, true)
 	rInfo := cache.getReservationInfoByUID(activeReservation.UID)
 	assert.NotNil(t, rInfo)

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -409,6 +409,8 @@ func TestMultiReservationsOnSameNode(t *testing.T) {
 		ReservationSelector: labels,
 	}
 	assert.NoError(t, apiext.SetReservationAffinity(pod, affinity))
+	_, err = suit.fw.ClientSet().CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
 
 	p, err := suit.pluginFactory()
 	assert.NoError(t, err)
@@ -420,15 +422,15 @@ func TestMultiReservationsOnSameNode(t *testing.T) {
 		cycleState := framework.NewCycleState()
 		pl.BeforePreFilter(context.TODO(), cycleState, pod)
 		pl.PreFilter(context.TODO(), cycleState, pod)
-		nominator := pl.handle.(frameworkext.FrameworkExtender).GetReservationNominator()
-		rInfo, status := nominator.NominateReservation(context.TODO(), cycleState, pod, node.Name)
+		nm := pl.handle.(frameworkext.FrameworkExtender).GetReservationNominator()
+		rInfo, status := nm.NominateReservation(context.TODO(), cycleState, pod, node.Name)
 		assert.True(t, status.IsSuccess())
-		nominator.AddNominatedReservation(pod, node.Name, rInfo)
+		nm.AddNominatedReservation(pod, node.Name, rInfo)
 		rInfo = pl.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
 		assert.NotNil(t, rInfo)
 		pl.Reserve(context.TODO(), cycleState, pod, node.Name)
 		nominatedReservationCount[rInfo.UID()]++
-		nominator.RemoveNominatedReservations(pod)
+		nm.RemoveNominatedReservations(pod)
 	}
 
 	assert.Len(t, nominatedReservationCount, len(reservations))
@@ -461,6 +463,7 @@ func TestReservationsNominator(t *testing.T) {
 	var pods []*corev1.Pod
 	for i := 0; i < 3; i++ {
 		r := newTestReservation(t, fmt.Sprintf("test-r-%d", i), labels, labels, node.Name, resourceList)
+		r.Status.Phase = "" // set to inactive
 		pods = append(pods, reservationutil.NewReservePod(r))
 		_, err := suit.extenderFactory.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), r, metav1.CreateOptions{})
 		assert.NoError(t, err)

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -88,7 +88,8 @@ type Plugin struct {
 	client           clientschedulingv1alpha1.SchedulingV1alpha1Interface
 	reservationCache *reservationCache
 
-	nominator *nominator
+	nominator     *nominator
+	preemptionMgr *PreemptionMgr
 }
 
 func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -121,6 +122,14 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		client:           extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
 		reservationCache: cache,
 		nominator:        nominator,
+	}
+
+	if pluginArgs.EnablePreemption {
+		preemptionMgr, err := newPreemptionMgr(pluginArgs, extendedHandle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to new preemption, err: %w", err)
+		}
+		p.preemptionMgr = preemptionMgr
 	}
 
 	return p, nil
@@ -554,10 +563,29 @@ func fitsNode(podRequest *framework.Resource, nodeInfo *framework.NodeInfo, node
 	return insufficientResources
 }
 
-func (pl *Plugin) PostFilter(_ context.Context, cycleState *framework.CycleState, _ *corev1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
+func (pl *Plugin) PostFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
+	var result *framework.PostFilterResult
+	var reasons []string
+
+	// If Reservation Preemption is enabled, try preemption before aggregating failure reasons.
+	if pl.preemptionMgr != nil {
+		preemptionResult, preemptionStatus := pl.preemptionMgr.PostFilter(ctx, cycleState, pod, filteredNodeStatusMap)
+		if preemptionStatus.IsSuccess() ||
+			preemptionStatus.Code() == framework.UnschedulableAndUnresolvable ||
+			!preemptionStatus.IsUnschedulable() {
+			return preemptionResult, preemptionStatus
+		}
+		if preemptionResult != nil && preemptionResult.Mode() != framework.ModeNoop {
+			result = preemptionResult
+		}
+
+		reasons = append(reasons, preemptionStatus.Reasons()...)
+	}
+
 	state := getStateData(cycleState)
-	reasons := pl.makePostFilterReasons(state, filteredNodeStatusMap)
-	return nil, framework.NewStatus(framework.Unschedulable, reasons...)
+	postFilterReasons := pl.makePostFilterReasons(state, filteredNodeStatusMap)
+	reasons = append(reasons, postFilterReasons...)
+	return result, framework.NewStatus(framework.Unschedulable, reasons...)
 }
 
 func (pl *Plugin) makePostFilterReasons(state *stateData, filteredNodeStatusMap framework.NodeToStatusMap) []string {

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -29,12 +29,13 @@ import (
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 func TestPodEventHandler(t *testing.T) {
 	handler := &podEventHandler{
 		cache:     newReservationCache(nil),
-		nominator: newNominator(),
+		nominator: newNominator(nil, nil),
 	}
 	reservationUID := uuid.NewUUID()
 	reservationName := "test-reservation"
@@ -61,6 +62,10 @@ func TestPodEventHandler(t *testing.T) {
 			Name:      "test-pod",
 			Namespace: "default",
 			UID:       uuid.NewUUID(),
+			Annotations: map[string]string{
+				reservationutil.AnnotationReservePod:      "true",
+				reservationutil.AnnotationReservationName: "test-pod",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -149,7 +154,7 @@ func TestPodEventHandler(t *testing.T) {
 func TestPodEventHandlerWithOperatingPod(t *testing.T) {
 	handler := &podEventHandler{
 		cache:     newReservationCache(nil),
-		nominator: newNominator(),
+		nominator: newNominator(nil, nil),
 	}
 	reservationUID := uuid.NewUUID()
 	reservationName := "test-reservation"

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2022 The Koordinator Authors.
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	policylisters "k8s.io/client-go/listers/policy/v1"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
+	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	listerschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/scheduling/v1alpha1"
+	koordfeature "github.com/koordinator-sh/koordinator/pkg/features"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+var (
+	_ framework.PostFilterPlugin = &PreemptionMgr{}
+	_ preemption.Interface       = &PreemptionMgr{}
+)
+
+// PreemptionMgr is a wrapper of defaultpreemption.DefaultPreemption, supporting the following preemption behaviors:
+// 1. a pod preempt a pod.
+// 2. a reservation preempt a pod.
+// TODO: support the reservation being preempted
+type PreemptionMgr struct {
+	*defaultpreemption.DefaultPreemption
+	fh                frameworkext.ExtendedHandle
+	podLister         corelisters.PodLister
+	pdbLister         policylisters.PodDisruptionBudgetLister
+	reservationLister listerschedulingv1alpha1.ReservationLister
+}
+
+func newPreemptionMgr(pluginArgs *config.ReservationArgs, extendedHandle frameworkext.ExtendedHandle) (*PreemptionMgr, error) {
+	preemptionArgs, err := getPreemptionArgs(pluginArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	fts := plfeature.Features{
+		EnablePodDisruptionConditions: k8sfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions),
+	}
+
+	pl, err := defaultpreemption.New(preemptionArgs, extendedHandle, fts)
+	if err != nil {
+		return nil, err
+	}
+
+	preemptionPl := pl.(*defaultpreemption.DefaultPreemption)
+	podLister := extendedHandle.SharedInformerFactory().Core().V1().Pods().Lister()
+	reservationLister := extendedHandle.KoordinatorSharedInformerFactory().Scheduling().V1alpha1().Reservations().Lister()
+	var pdbLister policylisters.PodDisruptionBudgetLister
+	if k8sfeature.DefaultFeatureGate.Enabled(koordfeature.PodDisruptionBudget) {
+		pdbLister = extendedHandle.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister()
+	}
+
+	return &PreemptionMgr{
+		DefaultPreemption: preemptionPl,
+		fh:                extendedHandle,
+		podLister:         podLister,
+		pdbLister:         pdbLister,
+		reservationLister: reservationLister,
+	}, nil
+}
+
+func (pm *PreemptionMgr) Name() string {
+	return Name
+}
+
+func (pm *PreemptionMgr) PostFilter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, m framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
+	defer func() {
+		metrics.PreemptionAttempts.Inc()
+	}()
+
+	pe := preemption.Evaluator{
+		PluginName: Name,
+		Handler:    pm.fh,
+		PodLister:  newDelegatingPodLister(pm.podLister, pm.reservationLister, pod),
+		PdbLister:  pm.pdbLister,
+		State:      state,
+		Interface:  pm,
+	}
+
+	result, status := pe.Preempt(ctx, pod, m)
+	if status.Message() != "" {
+		return result, framework.NewStatus(status.Code(), "preemption: "+status.Message())
+	}
+	return result, status
+}
+
+// SelectVictimsOnNode finds minimum set of pods on the given node that should be preempted in order to make enough room
+// for "pod" to be scheduled.
+// Note that both `state` and `nodeInfo` are deep-copied.
+// We delegate the function to extend the preemption rules:
+// If a pod is marked as non-preemptible, it will not be selected as the victim.
+func (pm *PreemptionMgr) SelectVictimsOnNode(
+	ctx context.Context,
+	state *framework.CycleState,
+	pod *corev1.Pod,
+	nodeInfo *framework.NodeInfo,
+	pdbs []*policy.PodDisruptionBudget) ([]*corev1.Pod, int, *framework.Status) {
+	logger := klog.FromContext(ctx)
+	var potentialVictims []*framework.PodInfo
+	removePod := func(rpi *framework.PodInfo) error {
+		if err := nodeInfo.RemovePod(rpi.Pod); err != nil {
+			return err
+		}
+		status := pm.fh.RunPreFilterExtensionRemovePod(ctx, state, pod, rpi, nodeInfo)
+		if !status.IsSuccess() {
+			return status.AsError()
+		}
+		return nil
+	}
+	addPod := func(api *framework.PodInfo) error {
+		nodeInfo.AddPodInfo(api)
+		status := pm.fh.RunPreFilterExtensionAddPod(ctx, state, pod, api, nodeInfo)
+		if !status.IsSuccess() {
+			return status.AsError()
+		}
+		return nil
+	}
+	// As the first step, remove all the lower priority pods from the node and
+	// check if the given pod can be scheduled.
+	podPriority := corev1helpers.PodPriority(pod)
+	for _, pi := range nodeInfo.Pods {
+		// NOTE: Ignore the non-preemptible pod.
+		if !extension.IsPodPreemptible(pi.Pod) ||
+			corev1helpers.PodPriority(pi.Pod) >= podPriority {
+			continue
+		}
+
+		potentialVictims = append(potentialVictims, pi)
+		if err := removePod(pi); err != nil {
+			return nil, 0, framework.AsStatus(err)
+		}
+	}
+
+	// No potential victims are found, and so we don't need to evaluate the node again since its state didn't change.
+	if len(potentialVictims) == 0 {
+		message := fmt.Sprintf("No preemption victims found for incoming pod")
+		return nil, 0, framework.NewStatus(framework.UnschedulableAndUnresolvable, message)
+	}
+
+	// If the new pod does not fit after removing all the lower priority pods,
+	// we are almost done and this node is not suitable for preemption. The only
+	// condition that we could check is if the "pod" is failing to schedule due to
+	// inter-pod affinity to one or more victims, but we have decided not to
+	// support this case for performance reasons. Having affinity to lower
+	// priority pods is not a recommended configuration anyway.
+	if status := pm.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo); !status.IsSuccess() {
+		return nil, 0, status
+	}
+	var victims []*corev1.Pod
+	numViolatingVictim := 0
+	sort.Slice(potentialVictims, func(i, j int) bool { return util.MoreImportantPod(potentialVictims[i].Pod, potentialVictims[j].Pod) })
+	// Try to reprieve as many pods as possible. We first try to reprieve the PDB
+	// violating victims and then other non-violating ones. In both cases, we start
+	// from the highest priority victims.
+	violatingVictims, nonViolatingVictims := filterPodsWithPDBViolation(potentialVictims, pdbs)
+	reprievePod := func(pi *framework.PodInfo) (bool, error) {
+		if err := addPod(pi); err != nil {
+			return false, err
+		}
+		status := pm.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+		fits := status.IsSuccess()
+		if !fits {
+			if err := removePod(pi); err != nil {
+				return false, err
+			}
+			rpi := pi.Pod
+			victims = append(victims, rpi)
+			logger.V(5).Info("Pod is a potential preemption victim on node", "pod", klog.KObj(rpi), "node", klog.KObj(nodeInfo.Node()))
+		}
+		return fits, nil
+	}
+	for _, p := range violatingVictims {
+		if fits, err := reprievePod(p); err != nil {
+			return nil, 0, framework.AsStatus(err)
+		} else if !fits {
+			numViolatingVictim++
+		}
+	}
+	// Now we try to reprieve non-violating victims.
+	for _, p := range nonViolatingVictims {
+		if _, err := reprievePod(p); err != nil {
+			return nil, 0, framework.AsStatus(err)
+		}
+	}
+	return victims, numViolatingVictim, framework.NewStatus(framework.Success)
+}
+
+var _ corelisters.PodLister = &delegatingPodLister{}
+
+// delegatingPodLister delegates the PodLister interface to get a Pod or a Reservation from the reserve pod.
+type delegatingPodLister struct {
+	corelisters.PodLister
+	reservationLister listerschedulingv1alpha1.ReservationLister
+	cachedPod         *corev1.Pod
+}
+
+func newDelegatingPodLister(podLister corelisters.PodLister,
+	reservationLister listerschedulingv1alpha1.ReservationLister,
+	pod *corev1.Pod) corelisters.PodLister {
+	if !reservationutil.IsReservePod(pod) {
+		return podLister
+	}
+
+	return &delegatingPodLister{
+		PodLister:         podLister,
+		reservationLister: reservationLister,
+		cachedPod:         pod,
+	}
+}
+
+func (dp *delegatingPodLister) Pods(namespace string) corelisters.PodNamespaceLister {
+	// only delegate the default namespace since reserve pod is forced to the namespace
+	if namespace != "" && namespace != corev1.NamespaceDefault ||
+		dp.cachedPod == nil || namespace != dp.cachedPod.Namespace {
+		return dp.PodLister.Pods(namespace)
+	}
+
+	return &delegatingPodNamespaceLister{
+		PodNamespaceLister: dp.PodLister.Pods(namespace),
+		reservationLister:  dp.reservationLister,
+		cachedPod:          dp.cachedPod,
+	}
+}
+
+var _ corelisters.PodNamespaceLister = &delegatingPodNamespaceLister{}
+
+type delegatingPodNamespaceLister struct {
+	corelisters.PodNamespaceLister
+	reservationLister listerschedulingv1alpha1.ReservationLister
+	cachedPod         *corev1.Pod
+}
+
+func (dpn *delegatingPodNamespaceLister) Get(name string) (*corev1.Pod, error) {
+	pod, err := dpn.PodNamespaceLister.Get(name)
+	if err == nil {
+		return pod, nil
+	}
+	if !errors.IsNotFound(err) {
+		return pod, err
+	}
+
+	// if the cached pod not found from the informer, try to get a corresponding reservation
+	if dpn.cachedPod == nil || dpn.cachedPod.Name != name {
+		return pod, err
+	}
+	reservationName := reservationutil.GetReservationNameFromReservePod(dpn.cachedPod)
+	if len(reservationName) <= 0 {
+		klog.ErrorS(fmt.Errorf("missing a reservationName"), "Failed to get reservation for cachedPod",
+			"pod", name, "cachedPod", klog.KObj(dpn.cachedPod))
+		return pod, err
+	}
+
+	reservation, err1 := dpn.reservationLister.Get(reservationName)
+	if err1 != nil {
+		return pod, utilerrors.NewAggregate([]error{err, err1})
+	}
+	// Is it necessary to regenerate the reserve pod?
+	reservePod := reservationutil.NewReservePod(reservation)
+	return reservePod, nil
+}
+
+// filterPodsWithPDBViolation groups the given "pods" into two groups of "violatingPods"
+// and "nonViolatingPods" based on whether their PDBs will be violated if they are
+// preempted.
+// This function is stable and does not change the order of received pods. So, if it
+// receives a sorted list, grouping will preserve the order of the input list.
+func filterPodsWithPDBViolation(podInfos []*framework.PodInfo, pdbs []*policy.PodDisruptionBudget) (violatingPodInfos, nonViolatingPodInfos []*framework.PodInfo) {
+	pdbsAllowed := make([]int32, len(pdbs))
+	for i, pdb := range pdbs {
+		pdbsAllowed[i] = pdb.Status.DisruptionsAllowed
+	}
+
+	for _, podInfo := range podInfos {
+		pod := podInfo.Pod
+		pdbForPodIsViolated := false
+		// A pod with no labels will not match any PDB. So, no need to check.
+		if len(pod.Labels) != 0 {
+			for i, pdb := range pdbs {
+				if pdb.Namespace != pod.Namespace {
+					continue
+				}
+				selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+				if err != nil {
+					// This object has an invalid selector, it does not match the pod
+					continue
+				}
+				// A PDB with a nil or empty selector matches nothing.
+				if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
+					continue
+				}
+
+				// Existing in DisruptedPods means it has been processed in API server,
+				// we don't treat it as a violating case.
+				if _, exist := pdb.Status.DisruptedPods[pod.Name]; exist {
+					continue
+				}
+				// Only decrement the matched pdb when it's not in its <DisruptedPods>;
+				// otherwise we may over-decrement the budget number.
+				pdbsAllowed[i]--
+				// We have found a matching PDB.
+				if pdbsAllowed[i] < 0 {
+					pdbForPodIsViolated = true
+				}
+			}
+		}
+		if pdbForPodIsViolated {
+			violatingPodInfos = append(violatingPodInfos, podInfo)
+		} else {
+			nonViolatingPodInfos = append(nonViolatingPodInfos, podInfo)
+		}
+	}
+	return violatingPodInfos, nonViolatingPodInfos
+}
+
+func getPreemptionArgs(pluginArgs *config.ReservationArgs) (*schedulerconfig.DefaultPreemptionArgs, error) {
+	preemptionArgs := &schedulerconfig.DefaultPreemptionArgs{
+		MinCandidateNodesPercentage: pluginArgs.MinCandidateNodesPercentage,
+		MinCandidateNodesAbsolute:   pluginArgs.MinCandidateNodesAbsolute,
+	}
+	return preemptionArgs, nil
+}

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -67,7 +67,8 @@ type PreemptionMgr struct {
 	reservationLister listerschedulingv1alpha1.ReservationLister
 }
 
-func newPreemptionMgr(pluginArgs *config.ReservationArgs, extendedHandle frameworkext.ExtendedHandle) (*PreemptionMgr, error) {
+func newPreemptionMgr(pluginArgs *config.ReservationArgs, extendedHandle frameworkext.ExtendedHandle,
+	podLister corelisters.PodLister, rLister listerschedulingv1alpha1.ReservationLister) (*PreemptionMgr, error) {
 	preemptionArgs, err := getPreemptionArgs(pluginArgs)
 	if err != nil {
 		return nil, err
@@ -83,8 +84,6 @@ func newPreemptionMgr(pluginArgs *config.ReservationArgs, extendedHandle framewo
 	}
 
 	preemptionPl := pl.(*defaultpreemption.DefaultPreemption)
-	podLister := extendedHandle.SharedInformerFactory().Core().V1().Pods().Lister()
-	reservationLister := extendedHandle.KoordinatorSharedInformerFactory().Scheduling().V1alpha1().Reservations().Lister()
 	var pdbLister policylisters.PodDisruptionBudgetLister
 	if k8sfeature.DefaultFeatureGate.Enabled(koordfeature.PodDisruptionBudget) {
 		pdbLister = extendedHandle.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister()
@@ -95,7 +94,7 @@ func newPreemptionMgr(pluginArgs *config.ReservationArgs, extendedHandle framewo
 		fh:                extendedHandle,
 		podLister:         podLister,
 		pdbLister:         pdbLister,
-		reservationLister: reservationLister,
+		reservationLister: rLister,
 	}, nil
 }
 

--- a/pkg/scheduler/plugins/reservation/preemption_test.go
+++ b/pkg/scheduler/plugins/reservation/preemption_test.go
@@ -1,0 +1,477 @@
+/*
+Copyright 2022 The Koordinator Authors.
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+func Test_newPreemptionMgr(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		suit := newPluginTestSuitWith(t,
+			nil,
+			nil,
+			func(args *config.ReservationArgs) {
+				args.EnablePreemption = true
+			})
+		p, err := suit.pluginFactory()
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+		pl, ok := p.(*Plugin)
+		assert.True(t, ok)
+		assert.NotNil(t, pl.preemptionMgr)
+		assert.Equal(t, Name, pl.preemptionMgr.Name())
+	})
+}
+
+func TestPostFilterWithPreemption(t *testing.T) {
+	preemptionPolicyNever := corev1.PreemptNever
+	testFilterReservationStatus := framework.NewStatus(framework.Unschedulable,
+		reservationutil.NewReservationReason("Insufficient nvidia.com/gpu"),
+		reservationutil.NewReservationReason("Insufficient koordinator.sh/gpu-mem-ratio"))
+	testFilterReservationStatus1 := framework.NewStatus(framework.Unschedulable,
+		reservationutil.NewReservationReason("Insufficient cpu"),
+		"Insufficient memory")
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-0",
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("128Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("128Gi"),
+			},
+		},
+	}
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+			Priority:         pointer.Int32(extension.PriorityProdValueMax),
+			PreemptionPolicy: &preemptionPolicyNever,
+		},
+	}
+	testReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "reservation2C4G",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Priority:         pointer.Int32(extension.PriorityProdValueMin),
+					PreemptionPolicy: &preemptionPolicyNever,
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: testNode.Name,
+		},
+	}
+	testReservePod := reservationutil.NewReservePod(testReservation)
+	type fields struct {
+		pods         []*corev1.Pod
+		reservePods  []*corev1.Pod
+		nodes        []*corev1.Node
+		reservations []*schedulingv1alpha1.Reservation
+	}
+	type args struct {
+		hasStateData             bool
+		hasAffinity              bool
+		nodeReservationDiagnosis map[string]*nodeDiagnosisState
+		filteredNodeStatusMap    framework.NodeToStatusMap
+		enablePreemption         bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *framework.PostFilterResult
+		want1  *framework.Status
+	}{
+		{
+			name: "no reservation filtering",
+			args: args{
+				hasStateData:          false,
+				filteredNodeStatusMap: framework.NodeToStatusMap{},
+			},
+			want:  nil,
+			want1: framework.NewStatus(framework.Unschedulable),
+		},
+		{
+			name: "show reservation reasons without preemption",
+			args: args{
+				hasStateData: true,
+				nodeReservationDiagnosis: map[string]*nodeDiagnosisState{
+					"test-node-0": {
+						ownerMatched:             3,
+						isUnschedulableUnmatched: 0,
+						affinityUnmatched:        1,
+					},
+					"test-node-1": {
+						ownerMatched:             3,
+						isUnschedulableUnmatched: 1,
+						affinityUnmatched:        0,
+					},
+				},
+				filteredNodeStatusMap: framework.NodeToStatusMap{
+					"test-node-0": testFilterReservationStatus,
+					"test-node-1": testFilterReservationStatus1,
+				},
+				enablePreemption: false,
+			},
+			want: nil,
+			want1: framework.NewStatus(framework.Unschedulable,
+				"1 Reservation(s) didn't match affinity rules",
+				"1 Reservation(s) is unschedulable",
+				"1 Reservation(s) for node reason that Insufficient memory",
+				"6 Reservation(s) matched owner total"),
+		},
+		{
+			name: "show reservation reasons with preemption",
+			fields: fields{
+				pods: []*corev1.Pod{
+					testPod,
+				},
+				reservePods: []*corev1.Pod{
+					testReservePod,
+				},
+				nodes: []*corev1.Node{
+					testNode,
+				},
+				reservations: []*schedulingv1alpha1.Reservation{
+					testReservation,
+				},
+			},
+			args: args{
+				hasStateData: true,
+				nodeReservationDiagnosis: map[string]*nodeDiagnosisState{
+					"test-node-0": {
+						ownerMatched:             3,
+						isUnschedulableUnmatched: 0,
+						affinityUnmatched:        1,
+					},
+					"test-node-1": {
+						ownerMatched:             3,
+						isUnschedulableUnmatched: 1,
+						affinityUnmatched:        0,
+					},
+				},
+				filteredNodeStatusMap: framework.NodeToStatusMap{
+					"test-node-0": testFilterReservationStatus,
+					"test-node-1": testFilterReservationStatus1,
+				},
+				enablePreemption: true,
+			},
+			want: nil,
+			want1: framework.NewStatus(framework.Unschedulable,
+				"preemption: not eligible due to preemptionPolicy=Never.",
+				"1 Reservation(s) didn't match affinity rules",
+				"1 Reservation(s) is unschedulable",
+				"1 Reservation(s) for node reason that Insufficient memory",
+				"6 Reservation(s) matched owner total"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t,
+				append(tt.fields.pods, tt.fields.reservePods...),
+				tt.fields.nodes,
+				func(args *config.ReservationArgs) {
+					args.EnablePreemption = tt.args.enablePreemption
+				})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
+			pl, ok := p.(*Plugin)
+			assert.True(t, ok)
+			for _, pod := range tt.fields.pods {
+				_, err = pl.handle.ClientSet().CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tt.fields.nodes {
+				_, err = pl.handle.ClientSet().CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, reservation := range tt.fields.reservations {
+				_, err = pl.handle.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			suit.start()
+
+			cycleState := framework.NewCycleState()
+			if tt.args.hasStateData {
+				cycleState.Write(stateKey, &stateData{
+					schedulingStateData: schedulingStateData{
+						hasAffinity:              tt.args.hasAffinity,
+						nodeReservationDiagnosis: tt.args.nodeReservationDiagnosis,
+					},
+				})
+			}
+			got, got1 := pl.PostFilter(context.TODO(), cycleState, testPod, tt.args.filteredNodeStatusMap)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want1, got1)
+		})
+	}
+}
+
+func TestPreemptionMgrSelectVictimsOnNode(t *testing.T) {
+	preemptionPolicyLowerPriority := corev1.PreemptLowerPriority
+	preemptionPolicyNever := corev1.PreemptNever
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-0",
+			UID:  uuid.NewUUID(),
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("128Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("128Gi"),
+			},
+		},
+	}
+	testHPPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hp-pod",
+			Namespace: "test-ns",
+			UID:       uuid.NewUUID(),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+			Priority:         pointer.Int32(extension.PriorityProdValueMax),
+			PreemptionPolicy: &preemptionPolicyNever,
+			NodeName:         testNode.Name,
+		},
+	}
+	testLPPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lp-pod",
+			Namespace: "test-ns",
+			UID:       uuid.NewUUID(),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+			Priority:         pointer.Int32(extension.PriorityProdValueMin),
+			PreemptionPolicy: &preemptionPolicyLowerPriority,
+			NodeName:         testNode.Name,
+		},
+	}
+	testReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "reservation2C4G",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Priority:         pointer.Int32(extension.PriorityProdValueMax),
+					PreemptionPolicy: &preemptionPolicyLowerPriority,
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationPending,
+		},
+	}
+	testReservePod := reservationutil.NewReservePod(testReservation)
+	testNodeInfo := framework.NewNodeInfo()
+	testNodeInfo.SetNode(testNode)
+	testNodeInfo.AddPod(testLPPod)
+	testNodeInfo.AddPod(testHPPod)
+	testNodeInfo1 := framework.NewNodeInfo()
+	testNodeInfo1.SetNode(testNode)
+	testNodeInfo1.AddPod(testLPPod)
+	type fields struct {
+		pods         []*corev1.Pod
+		reservePods  []*corev1.Pod
+		nodes        []*corev1.Node
+		reservations []*schedulingv1alpha1.Reservation
+	}
+	type args struct {
+		state    *framework.CycleState
+		pod      *corev1.Pod
+		nodeInfo *framework.NodeInfo
+		pdbs     []*policy.PodDisruptionBudget
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []*corev1.Pod
+		want1  int
+		want2  *framework.Status
+	}{
+		{
+			name: "reserve pod preempt successfully",
+			fields: fields{
+				pods: []*corev1.Pod{
+					testLPPod,
+					testHPPod,
+				},
+				reservePods: []*corev1.Pod{
+					testReservePod,
+				},
+				nodes: []*corev1.Node{
+					testNode,
+				},
+				reservations: []*schedulingv1alpha1.Reservation{
+					testReservation,
+				},
+			},
+			args: args{
+				state:    framework.NewCycleState(),
+				pod:      testReservePod,
+				nodeInfo: testNodeInfo.Clone(),
+				pdbs:     nil,
+			},
+			want:  nil,
+			want1: 0,
+			want2: framework.NewStatus(framework.Success),
+		},
+		{
+			name: "compatible to pod preemption",
+			fields: fields{
+				pods: []*corev1.Pod{
+					testLPPod,
+				},
+				nodes: []*corev1.Node{
+					testNode,
+				},
+			},
+			args: args{
+				state:    framework.NewCycleState(),
+				pod:      testHPPod,
+				nodeInfo: testNodeInfo1.Clone(),
+				pdbs:     nil,
+			},
+			want:  nil,
+			want1: 0,
+			want2: framework.NewStatus(framework.Success),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t,
+				append(tt.fields.pods, tt.fields.reservePods...),
+				tt.fields.nodes,
+				func(args *config.ReservationArgs) {
+					args.EnablePreemption = true
+				})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
+			pl, ok := p.(*Plugin)
+			assert.True(t, ok)
+			for _, pod := range tt.fields.pods {
+				_, err = pl.handle.ClientSet().CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tt.fields.nodes {
+				_, err = pl.handle.ClientSet().CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, reservation := range tt.fields.reservations {
+				_, err = pl.handle.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			suit.start()
+
+			got, got1, got2 := pl.preemptionMgr.SelectVictimsOnNode(context.TODO(), tt.args.state, tt.args.pod, tt.args.nodeInfo, tt.args.pdbs)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want1, got1)
+			assert.Equal(t, tt.want2, got2)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -475,8 +475,8 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState *framework.CycleS
 			if !status.IsSuccess() {
 				return pod, nodeInfo, false, status
 			}
-			klog.V(4).Infof("nodeName: %s, to schedule nominated reserve pod: %s, added reservation: %s",
-				nodeInfo.Node().Name,
+			klog.V(4).Infof("nodeName %s, to schedule pod %s (reserve pod %s) with nominated reservation %s",
+				nodeInfo.Node().Name, klog.KObj(pod),
 				reservationutil.GetReservationNameFromReservePod(pod),
 				reservationutil.GetReservationNameFromReservePod(rInfo.Pod))
 		}

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -454,10 +454,7 @@ func parseSpecificNodesFromAffinity(pod *corev1.Pod) (sets.String, *framework.St
 }
 
 func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) (*corev1.Pod, *framework.NodeInfo, bool, *framework.Status) {
-	if !reservationutil.IsReservePod(pod) {
-		return pod, nodeInfo, false, nil
-	}
-
+	// Both the reserve pod or the normal pod should consider the nominated reserve pods.
 	nominatedReservationInfos := pl.nominator.NominatedReservePodForNode(nodeInfo.Node().Name)
 	if len(nominatedReservationInfos) == 0 {
 		return pod, nodeInfo, false, nil
@@ -470,12 +467,6 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState *framework.CycleS
 
 	nodeInfoOut := nodeInfo.Clone()
 
-	rName := reservationutil.GetReservationNameFromReservePod(pod)
-	_, err := pl.rLister.Get(rName)
-	if err != nil {
-		return pod, nodeInfo, false, framework.NewStatus(framework.Error, "reservation not found")
-	}
-
 	for _, rInfo := range nominatedReservationInfos {
 		if schedulingcorev1.PodPriority(rInfo.Pod) >= schedulingcorev1.PodPriority(pod) && rInfo.Pod.UID != pod.UID {
 			pInfo, _ := framework.NewPodInfo(rInfo.Pod)
@@ -484,7 +475,7 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState *framework.CycleS
 			if !status.IsSuccess() {
 				return pod, nodeInfo, false, status
 			}
-			klog.V(4).Infof("nodeName: %s,toschedule reservation: %s, added reservation: %s",
+			klog.V(4).Infof("nodeName: %s, to schedule nominated reserve pod: %s, added reservation: %s",
 				nodeInfo.Node().Name,
 				reservationutil.GetReservationNameFromReservePod(pod),
 				reservationutil.GetReservationNameFromReservePod(rInfo.Pod))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Support the reservation preemption (Currently, only support a reservation preempt pods).

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

- Q: Why not adopt the DefaultPreemption?
- A: We want to support the case where a reservation preempts scheduled pods on a node. Perhaps, support the case where a pod preempts available reservations in the future. However, the DefaultPreemption relies on a real pod of the preemptor to [work](https://github.com/kubernetes/kubernetes/blob/release-1.28/pkg/scheduler/framework/preemption/preemption.go#L154). In this patch, we leverage the framework's preemption package and overwrite the SelectVictimsOnNode and PodLister of the DefaultPreemption to achieve the reservation preemption.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
