### PR TITLE
koord-descheduler: support max migrating globally limitation

### DIFF
--- a/pkg/descheduler/apis/config/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/types_pluginargs.go
@@ -66,13 +66,16 @@ type MigrationControllerArgs struct {
 	// NodeSelector for a set of nodes to operate over
 	NodeSelector string
 
-	// MaxMigratingPerNode represents he maximum number of pods that can be migrating during migrate per node.
+	// MaxMigratingGlobally represents the maximum number of pods that can be migrating during migrate globally.
+	MaxMigratingGlobally *int32
+
+	// MaxMigratingPerNode represents the maximum number of pods that can be migrating during migrate per node.
 	MaxMigratingPerNode *int32
 
-	// MaxMigratingPerNamespace represents he maximum number of pods that can be migrating during migrate per namespace.
+	// MaxMigratingPerNamespace represents the maximum number of pods that can be migrating during migrate per namespace.
 	MaxMigratingPerNamespace *int32
 
-	// MaxMigratingPerWorkload represents he maximum number of pods that can be migrating during migrate per workload.
+	// MaxMigratingPerWorkload represents the maximum number of pods that can be migrating during migrate per workload.
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	MaxMigratingPerWorkload *intstr.IntOrString
 

--- a/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
@@ -68,6 +68,9 @@ type MigrationControllerArgs struct {
 	// NodeSelector for a set of nodes to operate over
 	NodeSelector string `json:"nodeSelector,omitempty"`
 
+	// MaxMigratingGlobally represents the maximum number of pods that can be migrating during migrate globally.
+	MaxMigratingGlobally *int32
+
 	// MaxMigratingPerNode represents he maximum number of pods that can be migrating during migrate per node.
 	MaxMigratingPerNode *int32 `json:"maxMigratingPerNode,omitempty"`
 

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -551,6 +551,7 @@ func autoConvert_v1alpha2_MigrationControllerArgs_To_config_MigrationControllerA
 	out.Namespaces = (*config.Namespaces)(unsafe.Pointer(in.Namespaces))
 	out.NodeFit = in.NodeFit
 	out.NodeSelector = in.NodeSelector
+	out.MaxMigratingGlobally = (*int32)(unsafe.Pointer(in.MaxMigratingGlobally))
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))
 	out.MaxMigratingPerWorkload = (*intstr.IntOrString)(unsafe.Pointer(in.MaxMigratingPerWorkload))
@@ -592,6 +593,7 @@ func autoConvert_config_MigrationControllerArgs_To_v1alpha2_MigrationControllerA
 	out.Namespaces = (*Namespaces)(unsafe.Pointer(in.Namespaces))
 	out.NodeFit = in.NodeFit
 	out.NodeSelector = in.NodeSelector
+	out.MaxMigratingGlobally = (*int32)(unsafe.Pointer(in.MaxMigratingGlobally))
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))
 	out.MaxMigratingPerWorkload = (*intstr.IntOrString)(unsafe.Pointer(in.MaxMigratingPerWorkload))

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -395,6 +395,11 @@ func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 		*out = new(Namespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MaxMigratingGlobally != nil {
+		in, out := &in.MaxMigratingGlobally, &out.MaxMigratingGlobally
+		*out = new(int32)
+		**out = **in
+	}
 	if in.MaxMigratingPerNode != nil {
 		in, out := &in.MaxMigratingPerNode, &out.MaxMigratingPerNode
 		*out = new(int32)

--- a/pkg/descheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/descheduler/apis/config/validation/validation_pluginargs.go
@@ -30,6 +30,10 @@ import (
 func ValidateMigrationControllerArgs(path *field.Path, args *deschedulerconfig.MigrationControllerArgs) error {
 	var allErrs field.ErrorList
 
+	if args.MaxMigratingGlobally != nil && *args.MaxMigratingGlobally < 0 {
+		allErrs = append(allErrs, field.Invalid(path.Child("maxMigratingGlobally"), *args.MaxMigratingGlobally, "maxMigratingGlobally should be greater or equal 0"))
+	}
+
 	if args.MaxMigratingPerNamespace != nil && *args.MaxMigratingPerNamespace < 0 {
 		allErrs = append(allErrs, field.Invalid(path.Child("maxMigratingPerNamespace"), *args.MaxMigratingPerNamespace, "maxMigratingPerNamespace should be greater or equal 0"))
 	}

--- a/pkg/descheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/descheduler/apis/config/validation/validation_pluginargs_test.go
@@ -146,6 +146,46 @@ func TestValidateMigrationControllerArgs_MaxMigratingPerNamespace(t *testing.T) 
 	}
 }
 
+func TestValidateMigrationControllerArgs_MaxMigratingGlobally(t *testing.T) {
+	testCases := []struct {
+		maxMigratingGlobally *int32
+		wantErr              bool
+	}{
+		{
+			maxMigratingGlobally: int32Ptr(10),
+			wantErr:              false,
+		},
+		{
+			maxMigratingGlobally: int32Ptr(100),
+			wantErr:              false,
+		},
+		{
+			maxMigratingGlobally: int32Ptr(0),
+			wantErr:              false,
+		},
+		{
+			maxMigratingGlobally: int32Ptr(-1),
+			wantErr:              true,
+		},
+	}
+
+	for _, tc := range testCases {
+		argsDefault := &v1alpha2.MigrationControllerArgs{}
+		v1alpha2.SetDefaults_MigrationControllerArgs(argsDefault)
+		args := &deschedulerconfig.MigrationControllerArgs{}
+		assert.NoError(t, v1alpha2.Convert_v1alpha2_MigrationControllerArgs_To_config_MigrationControllerArgs(argsDefault, args, nil))
+		args.MaxMigratingGlobally = tc.maxMigratingGlobally
+
+		err := ValidateMigrationControllerArgs(nil, args)
+		if tc.wantErr {
+			assert.Error(t, err, "Expected an error for invalid MaxMigratingGlobally")
+			assert.Contains(t, err.Error(), "maxMigratingGlobally should be greater or equal 0", "Expected specific error message")
+		} else {
+			assert.Nil(t, err, "Expected no error for valid configuration")
+		}
+	}
+}
+
 func TestValidateMigrationControllerArgs_MaxMigratingPerNode(t *testing.T) {
 	testCases := []struct {
 		maxMigratingPerNode *int32

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -366,6 +366,11 @@ func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 		*out = new(Namespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MaxMigratingGlobally != nil {
+		in, out := &in.MaxMigratingGlobally, &out.MaxMigratingGlobally
+		*out = new(int32)
+		**out = **in
+	}
 	if in.MaxMigratingPerNode != nil {
 		in, out := &in.MaxMigratingPerNode, &out.MaxMigratingPerNode
 		*out = new(int32)

--- a/pkg/descheduler/controllers/migration/arbitrator/filter.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/filter.go
@@ -136,6 +136,7 @@ func (f *filter) initFilters(args *deschedulerconfig.MigrationControllerArgs, ha
 		return err
 	}
 	retryablePodFilters := podutil.WrapFilterFuncs(
+		f.filterMaxMigratingGlobally,
 		f.filterMaxMigratingPerNode,
 		f.filterMaxMigratingPerNamespace,
 		f.filterMaxMigratingOrUnavailablePerWorkload,
@@ -222,6 +223,37 @@ func (f *filter) existingPodMigrationJob(pod *corev1.Pod, expectedPhaseContexts 
 		}, expectedPhaseContexts...)
 	}
 	return existing
+}
+
+func (f *filter) filterMaxMigratingGlobally(pod *corev1.Pod) bool {
+	if f.args.MaxMigratingGlobally == nil || *f.args.MaxMigratingGlobally <= 0 {
+		return true
+	}
+
+	var expectedPhaseContexts []phaseContext
+	if checkPodArbitrating(pod) {
+		expectedPhaseContexts = []phaseContext{
+			{phase: sev1alpha1.PodMigrationJobRunning, checkArbitration: false},
+			{phase: sev1alpha1.PodMigrationJobPending, checkArbitration: true},
+		}
+	}
+
+	count := 0
+	listOpts := &client.ListOptions{}
+	f.forEachAvailableMigrationJobs(listOpts, func(job *sev1alpha1.PodMigrationJob) bool {
+		if podRef := job.Spec.PodRef; podRef != nil && podRef.UID != pod.UID {
+			count++
+		}
+		return true
+	}, expectedPhaseContexts...)
+
+	maxMigratingGlobally := int(*f.args.MaxMigratingGlobally)
+	exceeded := count >= maxMigratingGlobally
+	if exceeded {
+		klog.V(4).InfoS("Pod fails the following checks", "pod", klog.KObj(pod),
+			"checks", "maxMigratingGlobally", "count", count, "maxMigratingGlobally", maxMigratingGlobally)
+	}
+	return !exceeded
 }
 
 func (f *filter) filterMaxMigratingPerNode(pod *corev1.Pod) bool {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
If descheduler is first time used in some clusters, it might cause a bunch of Pods being evicted and re-scheduled through all namespaces, workloads and nodes. This might bring a big pressure to api-server.

This PR add a new config arg in MigrationController `MaxMigratingGlobally`  to limit the max number of pods being evicted in total. Default is set to 0, which means not enable this limitation. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
