### PR TITLE
koord-descheduler: update k8s descheduler to 0.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.16.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231005234617-5771399a8ce5
-	sigs.k8s.io/descheduler v0.26.0
+	sigs.k8s.io/descheduler v0.28.0
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -297,5 +297,4 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.28.7
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.28.7
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.16.5
-	sigs.k8s.io/descheduler => sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194
 )

--- a/go.sum
+++ b/go.sum
@@ -1993,8 +1993,8 @@ sigs.k8s.io/controller-runtime v0.16.5 h1:yr1cEJbX08xsTW6XEIzT13KHHmIyX8Umvme2cU
 sigs.k8s.io/controller-runtime v0.16.5/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231005234617-5771399a8ce5 h1:q6JvS/AwlDfe9sHMTo1KOMdI376+mlB21pV7Xhfy5uA=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231005234617-5771399a8ce5/go.mod h1:B6HLcvOy2S1qq2eWOFm9xepiKPMIc8Z9OXSPsnUDaR4=
-sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194 h1:xPrRjhoJr6pst13/3UHNwATYAsJROWcv+vvGRa+Fk1Q=
-sigs.k8s.io/descheduler v0.26.1-0.20230402001301-90905d2c2194/go.mod h1:/z7jjqyhgYDSd+LclGulcqX/JgfGIOTNB7ohFlGNQAQ=
+sigs.k8s.io/descheduler v0.28.0 h1:ahB8Epb2txHa9WV2AWxYSIJV9Fr/8N6Ejyfplpl78j0=
+sigs.k8s.io/descheduler v0.28.0/go.mod h1:GmzDGIeFdVQqw7fXS2kt5PAJEXq+5AHNnYPRFq0Uh8g=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kustomize/api v0.13.4/go.mod h1:Bkaavz5RKK6ZzP0zgPrB7QbpbBJKiHuD3BB0KujY7Ls=

--- a/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor.go
@@ -21,7 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8sdeschedulerevictions "sigs.k8s.io/descheduler/pkg/descheduler/evictions"
-	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework"
+	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"
 	frameworkruntime "github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime"

--- a/pkg/descheduler/framework/plugins/kubernetes/adaptor/framework.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/adaptor/framework.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
-	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework"
+	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"
 )

--- a/pkg/descheduler/framework/plugins/kubernetes/defaultevictor/evictor.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/defaultevictor/evictor.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/defaultevictor"
+	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config/v1alpha2"
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/evictions"

--- a/pkg/descheduler/framework/plugins/kubernetes/plugin.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/plugin.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/nodeutilization"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/podlifetime"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removeduplicates"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingnodeaffinity"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingnodetaints"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint"
+	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config/v1alpha2"
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"

--- a/pkg/descheduler/framework/plugins/kubernetes/plugin_test.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/plugin_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/nodeutilization"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/podlifetime"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removeduplicates"
@@ -36,6 +35,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingnodeaffinity"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingnodetaints"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint"
+	k8sdeschedulerframework "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	deschedulerconfig "github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Koordinator has update k8s version to 1.28.7 and koord-descheduler was adapted to Kubernetes Descheduler v0.26.0 which relies on k8s version 1.26.0.

This PR updates the k8s descheduler version to 0.28.0. In this version the k8s descheduler relies on k8s version 1.28.0, fixes some bugs and add more args in descheduler plugins. 
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
