### PR TITLE
scheduler: support reservation ignored and nodenumaresource preemption

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -33,7 +33,6 @@ const (
 	// reserved resources unallocated of all reservations on the node. If a pod scheduled with this label on a node,
 	// the reservations of the node will not consider the pod as their owners. To avoid the pods setting with this label
 	// to block the other pods allocated reserved resources, it should be used with the reservation preemption.
-	// It is similar to match all reservations with the default allocate policy.
 	LabelReservationIgnored = SchedulingDomainPrefix + "/reservation-ignored"
 
 	// LabelReservationOrder controls the preference logic for Reservation.

--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -28,6 +28,14 @@ import (
 )
 
 const (
+	// LabelReservationIgnored indicates whether the pod should schedule ignoring resource reservations on the nodes.
+	// If a scheduling pod set this label, the pod can allocate the node unreserved resources unallocated and the
+	// reserved resources unallocated of all reservations on the node. If a pod scheduled with this label on a node,
+	// the reservations of the node will not consider the pod as their owners. To avoid the pods setting with this label
+	// to block the other pods allocated reserved resources, it should be used with the reservation preemption.
+	// It is similar to match all reservations with the default allocate policy.
+	LabelReservationIgnored = SchedulingDomainPrefix + "/reservation-ignored"
+
 	// LabelReservationOrder controls the preference logic for Reservation.
 	// Reservation with lower order is preferred to be selected before Reservation with higher order.
 	// But if it is 0, Reservation will be selected according to the capacity score.
@@ -76,6 +84,10 @@ type ReservationRestrictedOptions struct {
 	// If the Reservation's AllocatePolicy is Restricted, and no resources configured,
 	// by default the resources equal all reserved resources by the Reservation.
 	Resources []corev1.ResourceName `json:"resources,omitempty"`
+}
+
+func IsReservationIgnored(pod *corev1.Pod) bool {
+	return pod != nil && pod.Labels != nil && pod.Labels[LabelReservationIgnored] == "true"
 }
 
 func GetReservationAllocated(pod *corev1.Pod) (*ReservationAllocated, error) {

--- a/apis/extension/reservation_test.go
+++ b/apis/extension/reservation_test.go
@@ -28,6 +28,57 @@ import (
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
 
+func TestIsReservationIgnored(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod is nil",
+			arg:  nil,
+			want: false,
+		},
+		{
+			name: "pod labels is missing",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod label is empty",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-pod",
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod set label to true",
+			arg: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						LabelReservationIgnored: "true",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsReservationIgnored(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSetReservationAllocated(t *testing.T) {
 	reservation := &schedulingv1alpha1.Reservation{
 		ObjectMeta: metav1.ObjectMeta{

--- a/apis/scheduling/v1alpha1/reservation_types.go
+++ b/apis/scheduling/v1alpha1/reservation_types.go
@@ -76,6 +76,8 @@ type ReservationAllocatePolicy string
 const (
 	// ReservationAllocatePolicyDefault means that there is no restriction on the policy of reserved resources,
 	// and allocated from the Reservation first, and if it is insufficient, it is allocated from the node.
+	// DEPRECATED: ReservationAllocatePolicyDefault is deprecated, it is considered as Aligned if specified.
+	// Please try other polices or set LabelReservationIgnored instead.
 	ReservationAllocatePolicyDefault ReservationAllocatePolicy = ""
 	// ReservationAllocatePolicyAligned indicates that the Pod allocates resources from the Reservation first.
 	// If the remaining resources of the Reservation are insufficient, it can be allocated from the node,

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -317,7 +317,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
 	// TODO 当 NUMA 策略不为空时，关于 NUMA 下设备是否能分配其实已经在 NodeNUMAResource 的 FilterByNUMANode 中调用过，这里存在重复调用，待优化
-	allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, node, preemptible, state.hasReservationAffinity)
+	allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.hasReservationAffinity)
 	if !status.IsSuccess() {
 		return status
 	}
@@ -385,7 +385,7 @@ func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.Cy
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
 
-	_, status = p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched[allocIndex:allocIndex+1], nodeInfo.Node(), preemptible, true)
+	_, status = p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched[allocIndex:allocIndex+1], pod, nodeInfo.Node(), preemptible, true)
 	return status
 }
 
@@ -429,6 +429,7 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, 
 		numaNodes:  affinity.NUMANodeAffinity,
 	}
 
+	// TODO: de-duplicate logic done by the Filter phase and move head the pre-process of the resource options
 	reservationRestoreState := getReservationRestoreState(cycleState)
 	restoreState := reservationRestoreState.getNodeState(nodeName)
 	preemptible := appendAllocated(nil, restoreState.mergedUnmatchedUsed, state.preemptibleDevices[nodeName])

--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -278,19 +278,16 @@ func (p *Plugin) tryAllocateIgnoreReservation(
 	requiredFromReservation bool,
 ) (apiext.DeviceAllocations, *framework.Status) {
 	preemptibleFromIgnored := map[schedulingv1alpha1.DeviceType]deviceResources{}
-	allocatableFromIgnored := map[schedulingv1alpha1.DeviceType]deviceResources{}
 
 	// accumulate all ignored reserved resources which are not allocated to any owner pods
 	for _, alloc := range ignoredReservations {
 		preemptibleFromIgnored = appendAllocated(preemptibleFromIgnored,
 			state.preemptibleInRRs[node.Name][alloc.rInfo.UID()], alloc.remained)
-		allocatableFromIgnored = appendAllocated(allocatableFromIgnored, alloc.allocatable)
 	}
 
 	preemptibleFromIgnored = appendAllocated(preemptibleFromIgnored, basicPreemptible, restoreState.mergedMatchedAllocated)
-	preferred := newDeviceMinorMap(allocatableFromIgnored)
 
-	return allocator.Allocate(nil, preferred, nil, preemptibleFromIgnored)
+	return allocator.Allocate(nil, nil, nil, preemptibleFromIgnored)
 }
 
 func (p *Plugin) makeReasonsByReservation(reservationReasons []*framework.Status) []string {

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -682,6 +682,7 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 				tt.state,
 				tt.restoreState,
 				tt.restoreState.matched,
+				nil,
 				node,
 				basicPreemptible,
 				tt.requiredFromReservation,

--- a/pkg/scheduler/plugins/deviceshare/topology_hint.go
+++ b/pkg/scheduler/plugins/deviceshare/topology_hint.go
@@ -95,7 +95,7 @@ func (p *Plugin) Allocate(ctx context.Context, cycleState *framework.CycleState,
 
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
-	allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, node, preemptible, state.hasReservationAffinity)
+	allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.hasReservationAffinity)
 	if !status.IsSuccess() {
 		return status
 	}
@@ -163,7 +163,7 @@ func (p *Plugin) generateTopologyHints(cycleState *framework.CycleState, state *
 			}
 		}
 
-		allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, node, preemptible, state.hasReservationAffinity)
+		allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.hasReservationAffinity)
 		if !status.IsSuccess() {
 			return
 		}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -376,6 +376,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 		}
 	}
 
+	// FIXME: move it ahead the resourceManager.Allocate so that we can check with NUMA hints almost in the Filter
 	if numaTopologyPolicy != extension.NUMATopologyPolicyNone {
 		return p.FilterByNUMANode(ctx, cycleState, pod, node.Name, numaTopologyPolicy, podNUMAExclusive, topologyOptions)
 	}
@@ -402,6 +403,7 @@ func (p *Plugin) filterAmplifiedCPUs(podRequestMilliCPU int64, nodeInfo *framewo
 	}
 
 	// TODO(joseph): Reservations and preemption should be considered here.
+	// TODO: support allocate reserved cpus with amplified ratios
 	_, allocated, err := p.resourceManager.GetAvailableCPUs(node.Name, cpuset.CPUSet{})
 	if err != nil {
 		return framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
@@ -507,6 +509,7 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, 
 		}
 	}
 
+	// TODO: de-duplicate logic done by the Filter phase and move head the pre-process of the resource options
 	store := topologymanager.GetStore(cycleState)
 	affinity := store.GetAffinity(nodeName)
 	resourceOptions, err := p.getResourceOptions(state, node, pod, requestCPUBind, affinity, topologyOptions)

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -19,6 +19,7 @@ package nodenumaresource
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	topologylister "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha1"
@@ -177,19 +178,26 @@ func (p *Plugin) GetTopologyOptionsManager() TopologyOptionsManager {
 	return p.topologyOptionsManager
 }
 
-type preFilterState struct {
-	skip                        bool
-	requestCPUBind              bool
-	requests                    corev1.ResourceList
-	requiredCPUBindPolicy       schedulingconfig.CPUBindPolicy
-	preferredCPUBindPolicy      schedulingconfig.CPUBindPolicy
-	preferredCPUExclusivePolicy schedulingconfig.CPUExclusivePolicy
-	podNUMATopologyPolicy       extension.NUMATopologyPolicy
-	podNUMAExclusive            extension.NumaTopologyExclusive
-	numCPUsNeeded               int
-	allocation                  *PodAllocation
+// schedulingStateData is the data only kept in the scheduling cycle. It could be cleaned up
+// before entering the binding cycle to reduce memory cost.
+type schedulingStateData struct {
+	lock             sync.RWMutex
+	preemptibleState map[string]*preemptibleNodeState
+}
 
-	hasReservationAffinity bool
+type preFilterState struct {
+	schedulingStateData
+	skip                        bool                                // whether the pod should skip the scheduling by this plugin
+	requestCPUBind              bool                                // whether the pod requires cpu binding (e.g. qos=LSE and requests.cpu > 0)
+	requests                    corev1.ResourceList                 // the resource requests of the pod
+	requiredCPUBindPolicy       schedulingconfig.CPUBindPolicy      // the required binding policy if specified
+	preferredCPUBindPolicy      schedulingconfig.CPUBindPolicy      // the preferred binding policy if specified
+	preferredCPUExclusivePolicy schedulingconfig.CPUExclusivePolicy // the preferred exclusive policy if specified
+	podNUMATopologyPolicy       extension.NUMATopologyPolicy        // the pod-level NUMA topology policy if specified
+	podNUMAExclusive            extension.NumaTopologyExclusive     // the pod-level NUMA exclusive policy if specified
+	numCPUsNeeded               int                                 // the number of requested CPUs
+	allocation                  *PodAllocation                      // the CPU allocation reserved for the pod
+	hasReservationAffinity      bool                                // whether the pod has a required reservation affinity
 }
 
 func (s *preFilterState) Clone() framework.StateData {
@@ -199,12 +207,28 @@ func (s *preFilterState) Clone() framework.StateData {
 		requests:                    s.requests,
 		requiredCPUBindPolicy:       s.requiredCPUBindPolicy,
 		preferredCPUBindPolicy:      s.preferredCPUBindPolicy,
+		podNUMATopologyPolicy:       s.podNUMATopologyPolicy,
 		preferredCPUExclusivePolicy: s.preferredCPUExclusivePolicy,
 		numCPUsNeeded:               s.numCPUsNeeded,
 		allocation:                  s.allocation,
 		hasReservationAffinity:      s.hasReservationAffinity,
 	}
+	s.schedulingStateData.lock.RLock()
+	defer s.schedulingStateData.lock.RUnlock()
+	if s.preemptibleState != nil {
+		preemptibleState := make(map[string]*preemptibleNodeState, len(s.preemptibleState))
+		for nodeName, nodeState := range s.preemptibleState {
+			preemptibleState[nodeName] = nodeState.Clone()
+		}
+		ns.preemptibleState = preemptibleState
+	}
 	return ns
+}
+
+// CleanSchedulingData clears the scheduling cycle data in the stateData to reduce memory cost before entering
+// the binding cycle.
+func (s *preFilterState) CleanSchedulingData() {
+	s.schedulingStateData = schedulingStateData{}
 }
 
 func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, *framework.Status) {
@@ -289,7 +313,7 @@ func (p *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleState
 }
 
 func (p *Plugin) PreFilterExtensions() framework.PreFilterExtensions {
-	return nil
+	return p
 }
 
 func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
@@ -365,10 +389,8 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 			if podAllocation != nil {
 				return nil
 			}
-			resourceOptions.requiredResources = nil
-			resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed)
-			resourceOptions.preferredCPUs = cpuset.NewCPUSet()
-			_, status = p.resourceManager.Allocate(node, pod, resourceOptions)
+
+			_, status = tryAllocateFromNode(p.resourceManager, restoreState, resourceOptions, pod, node)
 			if !status.IsSuccess() {
 				return status
 			}
@@ -433,13 +455,16 @@ func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.Cy
 	if err != nil {
 		return framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
 	}
-
 	node := nodeInfo.Node()
+	if node == nil {
+		return framework.NewStatus(framework.Error, fmt.Sprintf("getting nil node %q from Snapshot", nodeName))
+	}
+
 	topologyOptions := p.topologyOptionsManager.GetTopologyOptions(node.Name)
 	nodeCPUBindPolicy := extension.GetNodeCPUBindPolicy(node.Labels, topologyOptions.Policy)
 	podNUMATopologyPolicy := state.podNUMATopologyPolicy
 	numaTopologyPolicy := getNUMATopologyPolicy(node.Labels, topologyOptions.NUMATopologyPolicy)
-	// we have check in filter, so we will not get error in reserve
+	// we have checked in filter, so we will not get error in reserve
 	numaTopologyPolicy, _ = mergeTopologyPolicy(numaTopologyPolicy, podNUMATopologyPolicy)
 	requestCPUBind, status := requestCPUBind(state, nodeCPUBindPolicy)
 	if !status.IsSuccess() {
@@ -476,6 +501,11 @@ func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.Cy
 }
 
 func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status {
+	reservationRestoreState := getReservationRestoreState(cycleState)
+	// ReservationRestoreState is O(n) complexity of node number of the cluster.
+	// clearData clears all nodes' data in the cycleState to reduce memory cost before entering the binding cycle.
+	defer reservationRestoreState.clearData()
+
 	state, status := getPreFilterState(cycleState)
 	if !status.IsSuccess() {
 		return status
@@ -516,17 +546,14 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState *framework.CycleState, 
 	if err != nil {
 		return framework.AsStatus(err)
 	}
-	reservationRestoreState := getReservationRestoreState(cycleState)
+
 	restoreState := reservationRestoreState.getNodeState(nodeName)
 	result, status := p.allocateWithNominatedReservation(restoreState, resourceOptions, pod, node)
 	if !status.IsSuccess() {
 		return status
 	}
 	if result == nil {
-		resourceOptions.requiredResources = nil
-		resourceOptions.preferredCPUs = cpuset.NewCPUSet()
-		resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed)
-		result, status = p.resourceManager.Allocate(node, pod, resourceOptions)
+		result, status = tryAllocateFromNode(p.resourceManager, restoreState, resourceOptions, pod, node)
 		if !status.IsSuccess() {
 			return status
 		}
@@ -614,6 +641,13 @@ func (p *Plugin) getResourceOptions(state *preFilterState, node *corev1.Node, po
 		return nil, err
 	}
 
+	var nodePreemptionState *preemptibleNodeState
+	state.schedulingStateData.lock.RLock()
+	if state.preemptibleState != nil && state.preemptibleState[node.Name] != nil {
+		nodePreemptionState = state.preemptibleState[node.Name].Clone()
+	}
+	state.schedulingStateData.lock.RUnlock()
+
 	options := &ResourceOptions{
 		requests:                requests,
 		originalRequests:        state.requests,
@@ -625,8 +659,31 @@ func (p *Plugin) getResourceOptions(state *preFilterState, node *corev1.Node, po
 		hint:                    affinity,
 		requiredFromReservation: state.hasReservationAffinity,
 		topologyOptions:         topologyOptions,
+		nodePreemptionState:     nodePreemptionState,
 	}
 	return options, nil
+}
+
+func tryAllocateFromNode(
+	manager ResourceManager,
+	restoreState *nodeReservationRestoreStateData,
+	resourceOptions *ResourceOptions,
+	pod *corev1.Pod,
+	node *corev1.Node,
+) (*PodAllocation, *framework.Status) {
+	resourceOptions.requiredResources = nil
+	resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed)
+	resourceOptions.preferredCPUs = cpuset.NewCPUSet()
+	resourceOptions.preemptibleCPUs = cpuset.NewCPUSet()
+
+	// update with node preemption state
+	if resourceOptions.nodePreemptionState != nil && resourceOptions.nodePreemptionState.nodeAlloc != nil {
+		nodePreemptionAlloc := resourceOptions.nodePreemptionState.nodeAlloc
+		resourceOptions.reusableResources = nodePreemptionAlloc.AppendNUMAResources(resourceOptions.reusableResources)
+		resourceOptions.preemptibleCPUs = nodePreemptionAlloc.AppendCPUSet(resourceOptions.preemptibleCPUs)
+	}
+
+	return manager.Allocate(node, pod, resourceOptions)
 }
 
 func appendResourceSpecIfMissed(object metav1.Object, state *preFilterState, node *corev1.Node, topologyOpts *TopologyOptions) error {

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -1023,6 +1023,66 @@ func TestFilterWithAmplifiedCPUs(t *testing.T) {
 	}
 }
 
+func TestPlugin_FilterReservation(t *testing.T) {
+	skipState := framework.NewCycleState()
+	skipState.Write(stateKey, &preFilterState{
+		skip: true,
+	})
+	testState := framework.NewCycleState()
+	testState.Write(stateKey, &preFilterState{
+		skip: false,
+	})
+	type fields struct {
+		nodes []*corev1.Node
+	}
+	type args struct {
+		cycleState      *framework.CycleState
+		pod             *corev1.Pod
+		reservationInfo *frameworkext.ReservationInfo
+		nodeName        string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *framework.Status
+	}{
+		{
+			name: "missing preFilterState",
+			args: args{
+				cycleState: framework.NewCycleState(),
+			},
+			want: framework.AsStatus(framework.ErrNotFound),
+		},
+		{
+			name: "skip",
+			args: args{
+				cycleState: skipState,
+			},
+			want: nil,
+		},
+		{
+			name: "failed to get node",
+			args: args{
+				cycleState: testState,
+				nodeName:   "test-node",
+			},
+			want: framework.NewStatus(framework.Error, `getting nil node "test-node" from Snapshot`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, tt.fields.nodes)
+			p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
+			assert.NotNil(t, p)
+			assert.Nil(t, err)
+			pl := p.(*Plugin)
+			got := pl.FilterReservation(context.TODO(), tt.args.cycleState, tt.args.pod, tt.args.reservationInfo, tt.args.nodeName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestPlugin_Reserve(t *testing.T) {
 	node0, _ := bitmask.NewBitMask(0)
 	node1, _ := bitmask.NewBitMask(1)
@@ -1158,7 +1218,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			},
 			matched: map[types.UID]reservationAlloc{
 				uuid.NewUUID(): {
-					reservedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
+					remainedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
 				},
 			},
 			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
@@ -1176,7 +1236,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			},
 			matched: map[types.UID]reservationAlloc{
 				uuid.NewUUID(): {
-					reservedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
+					remainedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
 				},
 			},
 			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
@@ -1195,7 +1255,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			},
 			matched: map[types.UID]reservationAlloc{
 				uuid.NewUUID(): {
-					reservedCPUs: cpuset.NewCPUSet(4, 5),
+					remainedCPUs: cpuset.NewCPUSet(4, 5),
 				},
 			},
 			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
@@ -1216,7 +1276,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			},
 			matched: map[types.UID]reservationAlloc{
 				uuid.NewUUID(): {
-					reservedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
+					remainedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
 					allocatable: map[int]corev1.ResourceList{
 						0: {
 							corev1.ResourceCPU: resource.MustParse("7"),
@@ -1249,7 +1309,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			},
 			matched: map[types.UID]reservationAlloc{
 				uuid.NewUUID(): {
-					reservedCPUs: cpuset.NewCPUSet(4, 5),
+					remainedCPUs: cpuset.NewCPUSet(4, 5),
 					allocatable: map[int]corev1.ResourceList{
 						0: {
 							corev1.ResourceCPU: resource.MustParse("2"),
@@ -1335,6 +1395,42 @@ func TestPlugin_Reserve(t *testing.T) {
 			want:                      framework.NewStatus(framework.Unschedulable, "Reservation(s) Insufficient NUMA cpu"),
 			wantCPUSet:                cpuset.NewCPUSet(),
 		},
+		{
+			name: "succeed allocate for a reservation-ignored pod",
+			state: &preFilterState{
+				requestCPUBind:         true,
+				numCPUsNeeded:          4,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reservationAlloc{
+				uuid.NewUUID(): {
+					remainedCPUs: cpuset.NewCPUSet(4, 5, 6, 7, 8, 9, 10),
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						extension.LabelReservationIgnored: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want:       nil,
+			wantCPUSet: cpuset.NewCPUSet(4, 5, 6, 7),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1378,7 +1474,7 @@ func TestPlugin_Reserve(t *testing.T) {
 				}
 				if len(tt.matched) > 0 {
 					for reservationUID, alloc := range tt.matched {
-						nodeAllocation.addCPUs(tt.cpuTopology, reservationUID, alloc.reservedCPUs, schedulingconfig.CPUExclusivePolicyNone)
+						nodeAllocation.addCPUs(tt.cpuTopology, reservationUID, alloc.remainedCPUs, schedulingconfig.CPUExclusivePolicyNone)
 						var numaResources []NUMANodeResource
 						for i, allocatable := range alloc.allocatable {
 							numaResources = append(numaResources, NUMANodeResource{
@@ -1388,7 +1484,7 @@ func TestPlugin_Reserve(t *testing.T) {
 						}
 						nodeAllocation.addPodAllocation(&PodAllocation{
 							UID:                reservationUID,
-							CPUSet:             alloc.reservedCPUs,
+							CPUSet:             alloc.remainedCPUs,
 							CPUExclusivePolicy: schedulingconfig.CPUExclusivePolicyNone,
 							NUMANodeResources:  numaResources,
 						}, tt.cpuTopology)
@@ -1748,12 +1844,14 @@ func TestRestoreReservation(t *testing.T) {
 
 	nodeReservationState, status := pl.RestoreReservation(context.TODO(), cycleState, testPod, []*frameworkext.ReservationInfo{rInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
-	assert.Equal(t, cpuset.NewCPUSet(8, 9), nodeReservationState.(*nodeReservationRestoreStateData).matched[reservation.UID].reservedCPUs)
+	assert.Equal(t, cpuset.NewCPUSet(8, 9), nodeReservationState.(*nodeReservationRestoreStateData).matched[reservation.UID].remainedCPUs)
 
 	rInfo.AddAssignedPod(podB)
 	nodeReservationState, status = pl.RestoreReservation(context.TODO(), cycleState, testPod, []*frameworkext.ReservationInfo{rInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
-	assert.Nil(t, nodeReservationState)
+	assert.NotNil(t, nodeReservationState)
+	assert.Equal(t, cpuset.NewCPUSet(), nodeReservationState.(*nodeReservationRestoreStateData).matched[reservation.UID].remainedCPUs)
+	assert.Equal(t, cpuset.NewCPUSet(6, 7, 8, 9), nodeReservationState.(*nodeReservationRestoreStateData).matched[reservation.UID].allocatedCPUs)
 }
 
 func Test_appendResourceSpecIfMissed(t *testing.T) {
@@ -2087,6 +2185,85 @@ func TestFilterWithNUMANodeScoring(t *testing.T) {
 			assert.True(t, status.IsSuccess())
 			hint := topologymanager.GetStore(cycleState).GetAffinity(tt.node.Name)
 			assert.Equal(t, tt.wantAffinity.GetBits(), hint.NUMANodeAffinity.GetBits())
+		})
+	}
+}
+
+func Test_preFilterState_Clone(t *testing.T) {
+	tests := []struct {
+		name  string
+		field *preFilterState
+		want  *preFilterState
+	}{
+		{
+			name: "normal state",
+			field: &preFilterState{
+				skip:                   false,
+				numCPUsNeeded:          4,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				hasReservationAffinity: false,
+			},
+			want: &preFilterState{
+				skip:                   false,
+				numCPUsNeeded:          4,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				hasReservationAffinity: false,
+			},
+		},
+		{
+			name: "state with preemption",
+			field: &preFilterState{
+				schedulingStateData: schedulingStateData{
+					preemptibleState: map[string]*preemptibleNodeState{
+						"node1": {
+							nodeAlloc: newPreemptibleAlloc(),
+							reservationsAlloc: map[types.UID]*preemptibleAlloc{
+								"reservation1": newPreemptibleAlloc(),
+							},
+						},
+						"node2": {
+							nodeAlloc: newPreemptibleAlloc(),
+						},
+					},
+				},
+				skip:                   false,
+				numCPUsNeeded:          4,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				hasReservationAffinity: false,
+			},
+			want: &preFilterState{
+				schedulingStateData: schedulingStateData{
+					preemptibleState: map[string]*preemptibleNodeState{
+						"node1": {
+							nodeAlloc: newPreemptibleAlloc(),
+							reservationsAlloc: map[types.UID]*preemptibleAlloc{
+								"reservation1": newPreemptibleAlloc(),
+							},
+						},
+						"node2": {
+							nodeAlloc: newPreemptibleAlloc(),
+						},
+					},
+				},
+				skip:                   false,
+				numCPUsNeeded:          4,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				hasReservationAffinity: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.field.Clone()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/scheduler/plugins/nodenumaresource/preempt.go
+++ b/pkg/scheduler/plugins/nodenumaresource/preempt.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+)
+
+type preemptibleAlloc struct {
+	cpusToAdd     cpuset.CPUSet
+	cpusToRemove  cpuset.CPUSet // only one CPUSet cannot store the removing info
+	numaResources map[int]corev1.ResourceList
+}
+
+func newPreemptibleAlloc() *preemptibleAlloc {
+	return &preemptibleAlloc{
+		cpusToAdd:     cpuset.NewCPUSet(),
+		cpusToRemove:  cpuset.NewCPUSet(),
+		numaResources: map[int]corev1.ResourceList{},
+	}
+}
+
+func (a *preemptibleAlloc) Clone() *preemptibleAlloc {
+	return &preemptibleAlloc{
+		cpusToAdd:     a.cpusToAdd.Clone(),
+		cpusToRemove:  a.cpusToRemove.Clone(),
+		numaResources: copyAllocated(a.numaResources),
+	}
+}
+
+func (a *preemptibleAlloc) AppendCPUSet(cpus cpuset.CPUSet) cpuset.CPUSet {
+	return cpus.Union(a.cpusToAdd).Difference(a.cpusToRemove)
+}
+
+func (a *preemptibleAlloc) AppendNUMAResources(numaResources map[int]corev1.ResourceList) map[int]corev1.ResourceList {
+	return appendAllocated(nil, a.numaResources, numaResources)
+}
+
+func (a *preemptibleAlloc) Accumulate(cpus cpuset.CPUSet, numaResources map[int]corev1.ResourceList) {
+	if len(numaResources) > 0 {
+		a.numaResources = appendAllocated(a.numaResources, numaResources)
+	}
+
+	if !cpus.IsEmpty() {
+		if !a.cpusToRemove.IsEmpty() {
+			cpusNotAdd := a.cpusToRemove.Intersection(cpus)
+			a.cpusToRemove = a.cpusToRemove.Difference(cpusNotAdd)
+			cpus = cpus.Difference(cpusNotAdd)
+		}
+		a.cpusToAdd = a.cpusToAdd.Union(cpus)
+	}
+}
+
+func (a *preemptibleAlloc) Subtract(cpus cpuset.CPUSet, numaResources map[int]corev1.ResourceList) {
+	if len(numaResources) > 0 {
+		a.numaResources = subtractAllocated(a.numaResources, numaResources, false)
+	}
+
+	if !cpus.IsEmpty() {
+		if !a.cpusToAdd.IsEmpty() {
+			cpusNotRemove := a.cpusToAdd.Intersection(cpus)
+			a.cpusToAdd = a.cpusToAdd.Difference(cpusNotRemove)
+			cpus = cpus.Difference(cpusNotRemove)
+		}
+		a.cpusToRemove = a.cpusToRemove.Union(cpus)
+	}
+}
+
+type preemptibleNodeState struct {
+	// always use a clone so that we don't need to lock the whole state
+	nodeAlloc         *preemptibleAlloc               // unallocated and unreserved resources of the node
+	reservationsAlloc map[types.UID]*preemptibleAlloc // reservation ID to unallocated resources of the reservation
+}
+
+func (ns *preemptibleNodeState) Clone() *preemptibleNodeState {
+	stateCopy := &preemptibleNodeState{}
+	if ns.nodeAlloc != nil {
+		stateCopy.nodeAlloc = ns.nodeAlloc.Clone()
+	}
+	if ns.reservationsAlloc != nil {
+		stateCopy.reservationsAlloc = map[types.UID]*preemptibleAlloc{}
+		for uid, alloc := range ns.reservationsAlloc {
+			stateCopy.reservationsAlloc[uid] = alloc.Clone()
+		}
+	}
+	return stateCopy
+}
+
+func (p *Plugin) AddPod(_ context.Context, cycleState *framework.CycleState, preemptor *corev1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	state, status := getPreFilterState(cycleState)
+	if !status.IsSuccess() {
+		return status
+	}
+	if state.skip {
+		return nil
+	}
+	if podInfoToAdd == nil || podInfoToAdd.Pod == nil {
+		return nil
+	}
+
+	pod := podInfoToAdd.Pod
+	nodeName := nodeInfo.Node().Name
+	podAllocatedCPUs, podAllocatedNUMAResources := p.getPodAllocated(pod, nodeName)
+	if podAllocatedCPUs.IsEmpty() && len(podAllocatedNUMAResources) == 0 {
+		return nil
+	}
+
+	state.schedulingStateData.lock.Lock()
+	if state.preemptibleState == nil {
+		state.preemptibleState = map[string]*preemptibleNodeState{}
+	}
+	nodeState := state.preemptibleState[nodeName]
+	if nodeState == nil {
+		nodeState = &preemptibleNodeState{
+			nodeAlloc:         nil,
+			reservationsAlloc: map[types.UID]*preemptibleAlloc{},
+		}
+		state.preemptibleState[nodeName] = nodeState
+	}
+	state.schedulingStateData.lock.Unlock()
+
+	rInfo := p.getPodNominatedReservationInfo(pod, nodeName)
+	if rInfo == nil { // preempt node unallocated resources
+		if nodeState.nodeAlloc == nil {
+			nodeState.nodeAlloc = newPreemptibleAlloc()
+		}
+		nodeState.nodeAlloc.Subtract(podAllocatedCPUs, podAllocatedNUMAResources)
+	} else { // preempt reservation resources
+		rAlloc := nodeState.reservationsAlloc[rInfo.UID()]
+		if rAlloc == nil {
+			rAlloc = newPreemptibleAlloc()
+			nodeState.reservationsAlloc[rInfo.UID()] = rAlloc
+		}
+		rAlloc.Subtract(podAllocatedCPUs, podAllocatedNUMAResources)
+	}
+
+	cycleState.Write(stateKey, state)
+	klog.V(6).InfoS("NodeNUMAResource add pod to preemption", "node", nodeName,
+		"preemptor", klog.KObj(preemptor), "podToAdd", klog.KObj(pod),
+		"podAllocatedCPUs", podAllocatedCPUs, "podAllocatedNUMAResources", podAllocatedNUMAResources,
+		"reservationInfo", rInfo)
+	return nil
+}
+
+func (p *Plugin) RemovePod(_ context.Context, cycleState *framework.CycleState, preemptor *corev1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	state, status := getPreFilterState(cycleState)
+	if !status.IsSuccess() {
+		return status
+	}
+	if state.skip {
+		return nil
+	}
+	if podInfoToRemove == nil || podInfoToRemove.Pod == nil {
+		return nil
+	}
+
+	pod := podInfoToRemove.Pod
+	nodeName := nodeInfo.Node().Name
+	podAllocatedCPUs, podAllocatedNUMAResources := p.getPodAllocated(pod, nodeName)
+	if podAllocatedCPUs.IsEmpty() && len(podAllocatedNUMAResources) == 0 {
+		return nil
+	}
+
+	state.schedulingStateData.lock.Lock()
+	if state.preemptibleState == nil {
+		state.preemptibleState = map[string]*preemptibleNodeState{}
+	}
+	nodeState := state.preemptibleState[nodeName]
+	if nodeState == nil {
+		nodeState = &preemptibleNodeState{
+			nodeAlloc:         nil,
+			reservationsAlloc: map[types.UID]*preemptibleAlloc{},
+		}
+		state.preemptibleState[nodeName] = nodeState
+	}
+	state.schedulingStateData.lock.Unlock()
+
+	rInfo := p.getPodNominatedReservationInfo(pod, nodeName)
+	if rInfo == nil { // preempt node unallocated resources
+		if nodeState.nodeAlloc == nil {
+			nodeState.nodeAlloc = newPreemptibleAlloc()
+		}
+		nodeState.nodeAlloc.Accumulate(podAllocatedCPUs, podAllocatedNUMAResources)
+	} else { // preempt reservation resources
+		rAlloc := nodeState.reservationsAlloc[rInfo.UID()]
+		if rAlloc == nil {
+			rAlloc = newPreemptibleAlloc()
+			nodeState.reservationsAlloc[rInfo.UID()] = rAlloc
+		}
+		rAlloc.Accumulate(podAllocatedCPUs, podAllocatedNUMAResources)
+	}
+
+	cycleState.Write(stateKey, state)
+	klog.V(6).InfoS("NodeNUMAResource remove pod to preemption", "node", nodeName,
+		"preemptor", klog.KObj(preemptor), "podToRemove", klog.KObj(pod),
+		"podAllocatedCPUs", podAllocatedCPUs, "podAllocatedNUMAResources", podAllocatedNUMAResources,
+		"reservationInfo", rInfo)
+	return nil
+}
+
+func (p *Plugin) getPodAllocated(pod *corev1.Pod, nodeName string) (cpus cpuset.CPUSet, numaResources map[int]corev1.ResourceList) {
+	podAllocatedCPUs, ok := p.resourceManager.GetAllocatedCPUSet(nodeName, pod.UID)
+	if ok && !podAllocatedCPUs.IsEmpty() {
+		cpus = podAllocatedCPUs
+	}
+	podAllocatedNUMAResources, ok := p.resourceManager.GetAllocatedNUMAResource(nodeName, pod.UID)
+	if ok && len(podAllocatedNUMAResources) > 0 {
+		numaResources = podAllocatedNUMAResources
+	}
+	return
+}

--- a/pkg/scheduler/plugins/nodenumaresource/preempt_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/preempt_test.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/utils/pointer"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+)
+
+func TestPlugin_AddPod(t *testing.T) {
+	skipState := framework.NewCycleState()
+	skipState.Write(stateKey, &preFilterState{
+		skip: true,
+	})
+	testState := framework.NewCycleState()
+	testState.Write(stateKey, &preFilterState{
+		skip: false,
+	})
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-1",
+			UID:  uuid.NewUUID(),
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				extension.LabelPodQoS: string(extension.QoSLSR),
+			},
+			UID: uuid.NewUUID(),
+		},
+		Spec: corev1.PodSpec{
+			Priority: pointer.Int32(extension.PriorityProdValueMax),
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+		},
+	}
+	testPodInfo, err := framework.NewPodInfo(testPod)
+	assert.NoError(t, err)
+	testNodeInfo := framework.NewNodeInfo(testPod)
+	testNodeInfo.SetNode(testNode)
+	cpuTopology := buildCPUTopologyForTest(2, 1, 4, 2)
+	topologyOptionsManager := NewTopologyOptionsManager()
+	topologyOptionsManager.UpdateTopologyOptions("test-node-1", func(options *TopologyOptions) {
+		options.CPUTopology = cpuTopology
+	})
+	testRM := &resourceManager{
+		topologyOptionsManager: topologyOptionsManager,
+		nodeAllocations:        map[string]*NodeAllocation{},
+	}
+	testRM.Update(testNode.Name, &PodAllocation{
+		UID:                testPod.UID,
+		CPUSet:             cpuset.NewCPUSet(0, 1, 8, 9),
+		CPUExclusivePolicy: schedulingconfig.CPUExclusivePolicyPCPULevel,
+		NUMANodeResources: []NUMANodeResource{
+			{
+				Node: 0,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			{
+				Node: 1,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+		},
+	})
+	type fields struct {
+		resourceManager ResourceManager
+	}
+	type args struct {
+		cycleState   *framework.CycleState
+		podInfoToAdd *framework.PodInfo
+		nodeInfo     *framework.NodeInfo
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *framework.Status
+		wantFn func(t *testing.T, state *framework.CycleState)
+	}{
+		{
+			name: "failed to get state",
+			args: args{
+				cycleState: framework.NewCycleState(),
+				nodeInfo:   testNodeInfo,
+			},
+			want: framework.AsStatus(framework.ErrNotFound),
+		},
+		{
+			name: "state skips",
+			args: args{
+				cycleState: skipState,
+				nodeInfo:   testNodeInfo,
+			},
+			want: nil,
+		},
+		{
+			name: "nil pod to add",
+			args: args{
+				cycleState:   testState,
+				podInfoToAdd: nil,
+				nodeInfo:     testNodeInfo,
+			},
+			want: nil,
+		},
+		{
+			name: "add pod for node resources",
+			fields: fields{
+				resourceManager: testRM,
+			},
+			args: args{
+				cycleState:   testState,
+				podInfoToAdd: testPodInfo,
+				nodeInfo:     testNodeInfo,
+			},
+			want: nil,
+			wantFn: func(t *testing.T, state *framework.CycleState) {
+				stateData, status := getPreFilterState(state)
+				assert.True(t, status.IsSuccess())
+				assert.False(t, stateData.skip)
+				assert.NotNil(t, stateData.preemptibleState)
+				assert.NotNil(t, stateData.preemptibleState[testNode.Name])
+				assert.NotNil(t, stateData.preemptibleState[testNode.Name].nodeAlloc)
+				assert.Equal(t, cpuset.NewCPUSet(), stateData.preemptibleState[testNode.Name].nodeAlloc.cpusToAdd)
+				assert.Equal(t, cpuset.NewCPUSet(0, 1, 8, 9), stateData.preemptibleState[testNode.Name].nodeAlloc.cpusToRemove)
+				assert.Equal(t, map[int]corev1.ResourceList{
+					0: {
+						corev1.ResourceCPU: *resource.NewQuantity(-2, resource.DecimalSI),
+					},
+					1: {
+						corev1.ResourceCPU: *resource.NewQuantity(-2, resource.DecimalSI),
+					},
+				}, stateData.preemptibleState[testNode.Name].nodeAlloc.numaResources)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, []*corev1.Node{tt.args.nodeInfo.Node()})
+			p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
+			assert.NotNil(t, p)
+			assert.Nil(t, err)
+			pl, ok := p.(*Plugin)
+			assert.True(t, ok)
+			pl.resourceManager = tt.fields.resourceManager
+			got := pl.AddPod(context.TODO(), tt.args.cycleState, &corev1.Pod{}, tt.args.podInfoToAdd, tt.args.nodeInfo)
+			assert.Equal(t, tt.want, got)
+			if tt.wantFn != nil {
+				tt.wantFn(t, tt.args.cycleState)
+			}
+		})
+	}
+}
+
+func TestPlugin_RemovePod(t *testing.T) {
+	skipState := framework.NewCycleState()
+	skipState.Write(stateKey, &preFilterState{
+		skip: true,
+	})
+	testState := framework.NewCycleState()
+	testState.Write(stateKey, &preFilterState{
+		skip: false,
+	})
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-1",
+			UID:  uuid.NewUUID(),
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				extension.LabelPodQoS: string(extension.QoSLSR),
+			},
+			UID: uuid.NewUUID(),
+		},
+		Spec: corev1.PodSpec{
+			Priority: pointer.Int32(extension.PriorityProdValueMax),
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+		},
+	}
+	testPodInfo, err := framework.NewPodInfo(testPod)
+	assert.NoError(t, err)
+	testNodeInfo := framework.NewNodeInfo(testPod)
+	testNodeInfo.SetNode(testNode)
+	cpuTopology := buildCPUTopologyForTest(2, 1, 4, 2)
+	topologyOptionsManager := NewTopologyOptionsManager()
+	topologyOptionsManager.UpdateTopologyOptions("test-node-1", func(options *TopologyOptions) {
+		options.CPUTopology = cpuTopology
+	})
+	testRM := &resourceManager{
+		topologyOptionsManager: topologyOptionsManager,
+		nodeAllocations:        map[string]*NodeAllocation{},
+	}
+	testRM.Update(testNode.Name, &PodAllocation{
+		UID:                testPod.UID,
+		CPUSet:             cpuset.NewCPUSet(0, 1, 8, 9),
+		CPUExclusivePolicy: schedulingconfig.CPUExclusivePolicyPCPULevel,
+		NUMANodeResources: []NUMANodeResource{
+			{
+				Node: 0,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			{
+				Node: 1,
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+		},
+	})
+	type fields struct {
+		resourceManager ResourceManager
+	}
+	type args struct {
+		cycleState      *framework.CycleState
+		podInfoToRemove *framework.PodInfo
+		nodeInfo        *framework.NodeInfo
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *framework.Status
+		wantFn func(t *testing.T, state *framework.CycleState)
+	}{
+		{
+			name: "failed to get state",
+			args: args{
+				cycleState: framework.NewCycleState(),
+				nodeInfo:   testNodeInfo,
+			},
+			want: framework.AsStatus(framework.ErrNotFound),
+		},
+		{
+			name: "state skips",
+			args: args{
+				cycleState: skipState,
+				nodeInfo:   testNodeInfo,
+			},
+			want: nil,
+		},
+		{
+			name: "nil pod to add",
+			args: args{
+				cycleState:      testState,
+				podInfoToRemove: nil,
+				nodeInfo:        testNodeInfo,
+			},
+			want: nil,
+		},
+		{
+			name: "add pod for node resources",
+			fields: fields{
+				resourceManager: testRM,
+			},
+			args: args{
+				cycleState:      testState,
+				podInfoToRemove: testPodInfo,
+				nodeInfo:        testNodeInfo,
+			},
+			want: nil,
+			wantFn: func(t *testing.T, state *framework.CycleState) {
+				stateData, status := getPreFilterState(state)
+				assert.True(t, status.IsSuccess())
+				assert.False(t, stateData.skip)
+				assert.NotNil(t, stateData.preemptibleState)
+				assert.NotNil(t, stateData.preemptibleState[testNode.Name])
+				assert.NotNil(t, stateData.preemptibleState[testNode.Name].nodeAlloc)
+				assert.Equal(t, cpuset.NewCPUSet(0, 1, 8, 9), stateData.preemptibleState[testNode.Name].nodeAlloc.cpusToAdd)
+				assert.Equal(t, cpuset.NewCPUSet(), stateData.preemptibleState[testNode.Name].nodeAlloc.cpusToRemove)
+				assert.Equal(t, map[int]corev1.ResourceList{
+					0: {
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+					1: {
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+				}, stateData.preemptibleState[testNode.Name].nodeAlloc.numaResources)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, []*corev1.Node{tt.args.nodeInfo.Node()})
+			p, err := suit.proxyNew(suit.nodeNUMAResourceArgs, suit.Handle)
+			assert.NotNil(t, p)
+			assert.Nil(t, err)
+			pl, ok := p.(*Plugin)
+			assert.True(t, ok)
+			pl.resourceManager = tt.fields.resourceManager
+			got := pl.RemovePod(context.TODO(), tt.args.cycleState, &corev1.Pod{}, tt.args.podInfoToRemove, tt.args.nodeInfo)
+			assert.Equal(t, tt.want, got)
+			if tt.wantFn != nil {
+				tt.wantFn(t, tt.args.cycleState)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/nodenumaresource/reservation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation.go
@@ -30,6 +30,7 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
@@ -44,17 +45,19 @@ type nodeReservationRestoreStateData struct {
 	matched   map[types.UID]reservationAlloc
 	unmatched map[types.UID]reservationAlloc
 
-	mergedMatchedReservedCPUs cpuset.CPUSet
-	mergedMatchedAllocatable  map[int]corev1.ResourceList
-	mergedMatchedAllocated    map[int]corev1.ResourceList
-	mergedUnmatchedUsed       map[int]corev1.ResourceList
+	mergedMatchedRemainCPUs    cpuset.CPUSet
+	mergedMatchedAllocatedCPUs cpuset.CPUSet
+	mergedMatchedAllocatable   map[int]corev1.ResourceList
+	mergedMatchedAllocated     map[int]corev1.ResourceList
+	mergedUnmatchedUsed        map[int]corev1.ResourceList
 }
 
 type reservationAlloc struct {
 	rInfo *frameworkext.ReservationInfo
 
-	// TODO CPUSet 预留目前尚未支持, 这里只是计算的时候留一个接口，后续再梳理
-	reservedCPUs cpuset.CPUSet
+	allocatableCPUs cpuset.CPUSet // allocatable/total reserved CPUs
+	allocatedCPUs   cpuset.CPUSet // allocated CPUs
+	remainedCPUs    cpuset.CPUSet // unallocated reserved CPUs
 
 	allocatable map[int]corev1.ResourceList
 	allocated   map[int]corev1.ResourceList
@@ -86,6 +89,10 @@ func (s *reservationRestoreStateData) getNodeState(nodeName string) *nodeReserva
 	return ns
 }
 
+func (s *reservationRestoreStateData) clearData() {
+	s.nodeToState = map[string]interface{}{}
+}
+
 func (rs *nodeReservationRestoreStateData) mergeReservationAllocations() {
 	unmatched := rs.unmatched
 	if len(unmatched) > 0 {
@@ -101,15 +108,18 @@ func (rs *nodeReservationRestoreStateData) mergeReservationAllocations() {
 	if len(matched) > 0 {
 		mergedMatchedAllocatable := map[int]corev1.ResourceList{}
 		mergedMatchedAllocated := map[int]corev1.ResourceList{}
-		mergedCPUSetBuilder := cpuset.NewCPUSetBuilder()
+		mergedRemainCPUSetBuilder := cpuset.NewCPUSetBuilder()
+		mergedAllocatedCPUSetBuilder := cpuset.NewCPUSetBuilder()
 		for _, alloc := range matched {
 			mergedMatchedAllocatable = appendAllocated(mergedMatchedAllocatable, alloc.allocatable)
 			mergedMatchedAllocated = appendAllocated(mergedMatchedAllocated, alloc.allocated)
-			mergedCPUSetBuilder.Add(alloc.reservedCPUs.ToSliceNoSort()...)
+			mergedRemainCPUSetBuilder.Add(alloc.remainedCPUs.ToSliceNoSort()...)
+			mergedAllocatedCPUSetBuilder.Add(alloc.allocatedCPUs.ToSliceNoSort()...)
 		}
 		rs.mergedMatchedAllocatable = mergedMatchedAllocatable
 		rs.mergedMatchedAllocated = mergedMatchedAllocated
-		rs.mergedMatchedReservedCPUs = mergedCPUSetBuilder.Result()
+		rs.mergedMatchedRemainCPUs = mergedRemainCPUSetBuilder.Result()
+		rs.mergedMatchedAllocatedCPUs = mergedAllocatedCPUSetBuilder.Result()
 	}
 
 	return
@@ -180,28 +190,33 @@ func (p *Plugin) RestoreReservation(ctx context.Context, cycleState *framework.C
 				}
 				remained = subtractAllocated(copyAllocated(allocatableNUMAResource), allocatedNUMAResource, false)
 			}()
-			var reservedCPUs cpuset.CPUSet
+			var remainCPUs, allocatableCPUs, allocatedCPUs cpuset.CPUSet
 			func() {
-				allocatedCPUs, ok := p.resourceManager.GetAllocatedCPUSet(nodeName, reservePod.UID)
-				if !ok || allocatedCPUs.IsEmpty() {
+				reservedCPUs, ok := p.resourceManager.GetAllocatedCPUSet(nodeName, reservePod.UID)
+				if !ok || reservedCPUs.IsEmpty() {
 					return
 				}
+				allocatableCPUs = reservedCPUs.Clone()
+				allocatedCPUs = reservedCPUs.Clone()
 				for _, pod := range rInfo.AssignedPods {
 					podCPUs, ok := p.resourceManager.GetAllocatedCPUSet(nodeName, pod.UID)
 					if !ok || podCPUs.IsEmpty() {
 						continue
 					}
-					allocatedCPUs = allocatedCPUs.Difference(podCPUs)
+					allocatedCPUs = allocatedCPUs.Union(allocatableCPUs.Intersection(podCPUs))
+					reservedCPUs = reservedCPUs.Difference(podCPUs)
 				}
-				reservedCPUs = allocatedCPUs
+				remainCPUs = reservedCPUs
 			}()
-			if allocatable != nil || !reservedCPUs.IsEmpty() {
+			if allocatable != nil || !remainCPUs.IsEmpty() || !allocatableCPUs.IsEmpty() {
 				result[rInfo.UID()] = reservationAlloc{
-					rInfo:        rInfo,
-					reservedCPUs: reservedCPUs,
-					allocatable:  allocatable,
-					allocated:    allocatedNUMAResource,
-					remained:     remained,
+					rInfo:           rInfo,
+					allocatableCPUs: allocatableCPUs,
+					allocatedCPUs:   allocatedCPUs,
+					remainedCPUs:    remainCPUs,
+					allocatable:     allocatable,
+					allocated:       allocatedNUMAResource,
+					remained:        remained,
 				}
 			}
 		}
@@ -249,15 +264,34 @@ func tryAllocateFromReservation(
 	var status *framework.Status
 
 	reusableResource := appendAllocated(nil, restoreState.mergedUnmatchedUsed, restoreState.mergedMatchedAllocated)
+	preferredCPUs := restoreState.mergedMatchedAllocatedCPUs.Clone()
+	preemptibleCPUs := cpuset.NewCPUSet()
+
+	// update with node preemption state
+	var nodePreemptionAlloc *preemptibleAlloc
+	if resourceOptions.nodePreemptionState != nil && resourceOptions.nodePreemptionState.nodeAlloc != nil {
+		nodePreemptionAlloc = resourceOptions.nodePreemptionState.nodeAlloc
+		reusableResource = nodePreemptionAlloc.AppendNUMAResources(reusableResource)
+		preemptibleCPUs = nodePreemptionAlloc.AppendCPUSet(preemptibleCPUs)
+	}
 
 	var reservationReasons []*framework.Status
 	for _, alloc := range matchedOrIgnoredReservations {
 		rInfo := alloc.rInfo
 
-		reservationReusableResource := appendAllocated(nil, reusableResource, alloc.remained)
-		resourceOptions.reusableResources = reservationReusableResource
-		resourceOptions.preferredCPUs = alloc.reservedCPUs
+		resourceOptions.reusableResources = appendAllocated(nil, reusableResource, alloc.remained)
+		resourceOptions.preferredCPUs = preferredCPUs.Union(alloc.remainedCPUs)
+		resourceOptions.preemptibleCPUs = preemptibleCPUs
 		resourceOptions.requiredResources = nil
+
+		// update with reservation preemption state
+		var reservationPreemptionAlloc *preemptibleAlloc
+		if resourceOptions.nodePreemptionState != nil && resourceOptions.nodePreemptionState.reservationsAlloc != nil &&
+			resourceOptions.nodePreemptionState.reservationsAlloc[rInfo.UID()] != nil {
+			reservationPreemptionAlloc = resourceOptions.nodePreemptionState.reservationsAlloc[rInfo.UID()]
+			resourceOptions.reusableResources = reservationPreemptionAlloc.AppendNUMAResources(resourceOptions.reusableResources)
+			resourceOptions.preemptibleCPUs = reservationPreemptionAlloc.AppendCPUSet(resourceOptions.preemptibleCPUs)
+		}
 
 		allocatePolicy := rInfo.GetAllocatePolicy()
 		// TODO: Currently the ReservationAllocatePolicyDefault is actually implemented as
@@ -266,6 +300,12 @@ func tryAllocateFromReservation(
 			allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyAligned {
 			result, status = manager.Allocate(node, pod, resourceOptions)
 			if !status.IsSuccess() {
+				klog.V(5).InfoS("failed to allocated from reservation",
+					"reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name,
+					"status", status.Message(), "hint", resourceOptions.hint,
+					"reusableResources", resourceOptions.reusableResources,
+					"preferredCPUs", resourceOptions.preferredCPUs,
+					"preemptibleCPUs", resourceOptions.preemptibleCPUs)
 				reservationReasons = append(reservationReasons, status)
 				continue
 			}
@@ -275,32 +315,77 @@ func tryAllocateFromReservation(
 
 		} else if allocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyRestricted {
 			// TODO 这里仿照 deviceShare 的逻辑这样处理，后续需要再琢磨一下是否有必要
-			_, status := manager.Allocate(node, pod, resourceOptions)
+			_, status = manager.Allocate(node, pod, resourceOptions)
 			if !status.IsSuccess() {
-				klog.V(5).InfoS("failed to allocated from reservation", "reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name, "status", status.Message(), "numaNode", resourceOptions.hint.NUMANodeAffinity.String())
-				logStruct(reflect.ValueOf(resourceOptions), "options", 6)
-				logStruct(reflect.ValueOf(restoreState), "restoreState", 6)
+				klog.V(5).InfoS("failed to allocated from reservation",
+					"reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name,
+					"policy", allocatePolicy, "status", status.Message(), "hint", resourceOptions.hint,
+					"reusableResources", resourceOptions.reusableResources,
+					"preferredCPUs", resourceOptions.preferredCPUs,
+					"preemptibleCPUs", resourceOptions.preemptibleCPUs)
+				if klog.V(6).Enabled() {
+					logStruct(reflect.ValueOf(resourceOptions), "options", 6)
+					logStruct(reflect.ValueOf(restoreState), "restoreState", 6)
+				}
 				reservationReasons = append(reservationReasons, status)
 				continue
 			}
 
+			reservedCPUs := alloc.remainedCPUs
+			// For a Restricted reservation, pod should allocate CPUSet cpus only from it.
 			resourceOptions.requiredResources = alloc.remained
-			if resourceOptions.requestCPUBind && resourceOptions.numCPUsNeeded > alloc.reservedCPUs.Size() {
+			resourceOptions.preferredCPUs = alloc.remainedCPUs
+			resourceOptions.preemptibleCPUs = cpuset.NewCPUSet()
+			if nodePreemptionAlloc != nil {
+				// Considering the reservation-ignored pod does not count in allocatedCPUs, we try preempting node CPUs
+				// which are overlapped with the reservation, while the preferred CPUs are already ready.
+				nodePreemptionAlloc = resourceOptions.nodePreemptionState.nodeAlloc
+				nodePreemptibleCPUs := nodePreemptionAlloc.AppendCPUSet(cpuset.NewCPUSet())
+				nodePreemptibleCPUs = alloc.allocatableCPUs.Intersection(nodePreemptibleCPUs)
+				resourceOptions.preemptibleCPUs = resourceOptions.preemptibleCPUs.Union(nodePreemptibleCPUs)
+			}
+			if reservationPreemptionAlloc != nil {
+				resourceOptions.requiredResources = reservationPreemptionAlloc.AppendNUMAResources(resourceOptions.requiredResources)
+				// For a Restricted reservation, we should restore the preemptible allocated CPUs twice, where one
+				// reference is by the reservation itself and the another is by the preempted owner pods.
+				reservationPreemptibleCPUs := reservationPreemptionAlloc.AppendCPUSet(cpuset.NewCPUSet())
+				reservationPreemptibleCPUs = alloc.allocatableCPUs.Intersection(reservationPreemptibleCPUs)
+				resourceOptions.preemptibleCPUs = resourceOptions.preemptibleCPUs.Union(reservationPreemptibleCPUs)
+				resourceOptions.preferredCPUs = resourceOptions.preferredCPUs.Union(reservationPreemptibleCPUs)
+				reservedCPUs = reservedCPUs.Union(reservationPreemptibleCPUs)
+			}
+
+			if resourceOptions.requestCPUBind && resourceOptions.numCPUsNeeded > reservedCPUs.Size() {
 				reservationReasons = append(reservationReasons, framework.NewStatus(framework.Unschedulable, "not enough cpus available to satisfy request"))
+				klog.V(5).InfoS("failed to allocated from reservation, not enough cpus available to satisfy request",
+					"reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name,
+					"policy", allocatePolicy, "numCPUsNeeded", resourceOptions.numCPUsNeeded,
+					"reservedCPUs", reservedCPUs.String(), "remainedCPUs", alloc.remainedCPUs.String(),
+					"preemptibleCPUs", resourceOptions.preemptibleCPUs.String())
 				continue
 			}
 
 			result, status = manager.Allocate(node, pod, resourceOptions)
 			if !status.IsSuccess() {
-				klog.V(5).InfoS("failed to allocated from reservation", "reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name, "status", status.Message(), "numaNode", resourceOptions.hint.NUMANodeAffinity.String())
-				logStruct(reflect.ValueOf(resourceOptions), "options", 6)
-				logStruct(reflect.ValueOf(restoreState), "restoreState", 6)
+				klog.V(5).InfoS("failed to allocated from reservation",
+					"reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name,
+					"policy", allocatePolicy, "status", status.Message(), "hint", resourceOptions.hint,
+					"reusableResources", resourceOptions.reusableResources,
+					"preferredCPUs", resourceOptions.preferredCPUs, "preemptibleCPUs", resourceOptions.preemptibleCPUs)
+				if klog.V(6).Enabled() {
+					logStruct(reflect.ValueOf(resourceOptions), "options", 6)
+					logStruct(reflect.ValueOf(restoreState), "restoreState", 6)
+				}
 				reservationReasons = append(reservationReasons, status)
 				continue
 			}
 
-			if result.CPUSet.Size() > alloc.reservedCPUs.Size() {
+			if result.CPUSet.Size() > reservedCPUs.Size() {
 				reservationReasons = append(reservationReasons, framework.NewStatus(framework.Unschedulable, "not enough cpus available to satisfy request"))
+				klog.V(5).InfoS("failed to allocated from reservation, not enough cpus available to satisfy request",
+					"reservation", rInfo.Reservation.Name, "pod", pod.Name, "node", node.Name,
+					"policy", allocatePolicy, "allocateCPUs", result.CPUSet.String(),
+					"reservedCPUs", reservedCPUs.String(), "remainedCPUs", alloc.remainedCPUs.String())
 				continue
 			}
 
@@ -332,21 +417,52 @@ func tryAllocateIgnoreReservation(manager ResourceManager,
 	pod *corev1.Pod,
 	node *corev1.Node,
 ) (*PodAllocation, *framework.Status) {
-	reusableResourcesFromIgnored := map[int]corev1.ResourceList{}
-	reservedCPUsFromIgnored := cpuset.NewCPUSet()
+	reusableResourcesFromIgnored := appendAllocated(nil, restoreState.mergedUnmatchedUsed, restoreState.mergedMatchedAllocated)
+	reservedCPUsFromIgnored := restoreState.mergedMatchedAllocatedCPUs.Clone()
+	preemptibleCPUs := cpuset.NewCPUSet()
+
+	// update with node preemption state
+	var nodePreemptionAlloc *preemptibleAlloc
+	if resourceOptions.nodePreemptionState != nil && resourceOptions.nodePreemptionState.nodeAlloc != nil {
+		nodePreemptionAlloc = resourceOptions.nodePreemptionState.nodeAlloc
+		reusableResourcesFromIgnored = nodePreemptionAlloc.AppendNUMAResources(reusableResourcesFromIgnored)
+		preemptibleCPUs = nodePreemptionAlloc.AppendCPUSet(preemptibleCPUs)
+	}
 
 	// accumulate all ignored reserved resources which are not allocated to any owner pods
 	for _, alloc := range ignoredReservations {
 		reusableResourcesFromIgnored = appendAllocated(reusableResourcesFromIgnored, alloc.remained)
-		reservedCPUsFromIgnored = reservedCPUsFromIgnored.Union(alloc.reservedCPUs)
+		reservedCPUsFromIgnored = reservedCPUsFromIgnored.Union(alloc.remainedCPUs)
+		if resourceOptions.nodePreemptionState != nil && resourceOptions.nodePreemptionState.reservationsAlloc != nil &&
+			resourceOptions.nodePreemptionState.reservationsAlloc[alloc.rInfo.UID()] != nil { // update with reservation preemption state
+			reservationPreemptionAlloc := resourceOptions.nodePreemptionState.reservationsAlloc[alloc.rInfo.UID()]
+			reusableResourcesFromIgnored = reservationPreemptionAlloc.AppendNUMAResources(reusableResourcesFromIgnored)
+			reservationPreemptibleCPUs := reservationPreemptionAlloc.AppendCPUSet(cpuset.NewCPUSet())
+			reservationPreemptibleCPUs = alloc.allocatableCPUs.Intersection(reservationPreemptibleCPUs)
+			preemptibleCPUs = preemptibleCPUs.Union(reservationPreemptibleCPUs)
+		}
 	}
 
-	resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed,
-		restoreState.mergedMatchedAllocated, resourceOptions.reusableResources, reusableResourcesFromIgnored)
+	// For a reservation-ignored pod, the pod can allocate resources from:
+	// (1) the node unallocated and unreserved;
+	// (2) the unallocated resources from the matched reservations.
+	// Since the nodeInfo snapshot double-calculate the allocated resources of the scheduled reservations,
+	// we should add this part to calculate the (1).
+	resourceOptions.reusableResources = reusableResourcesFromIgnored
 	resourceOptions.preferredCPUs = reservedCPUsFromIgnored
+	resourceOptions.preemptibleCPUs = preemptibleCPUs
 	resourceOptions.requiredResources = nil
 
-	return manager.Allocate(node, pod, resourceOptions)
+	podAllocation, status := manager.Allocate(node, pod, resourceOptions)
+	if !status.IsSuccess() {
+		klog.V(5).InfoS("failed to allocated with reservation ignored",
+			"pod", pod.Name, "node", node.Name,
+			"status", status.Message(), "hint", resourceOptions.hint,
+			"reusableResources", resourceOptions.reusableResources,
+			"preferredCPUs", resourceOptions.preferredCPUs,
+			"preemptibleCPUs", resourceOptions.preemptibleCPUs)
+	}
+	return podAllocation, status
 }
 
 func (p *Plugin) allocateWithNominatedReservation(
@@ -365,18 +481,34 @@ func (p *Plugin) allocateWithNominatedReservation(
 		return tryAllocateIgnoreReservation(p.resourceManager, restoreState, resourceOptions, restoreState.matched, pod, node)
 	}
 
-	reservation := p.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
-	if reservation == nil {
+	rInfo := p.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
+	if rInfo == nil {
 		if resourceOptions.requiredFromReservation {
 			return nil, framework.NewStatus(framework.Unschedulable, "no nominated reservation")
 		}
 
 		return nil, nil
 	}
-	nominatedReservationAlloc, ok := restoreState.matched[reservation.UID()]
+	nominatedReservationAlloc, ok := restoreState.matched[rInfo.UID()]
 	if !ok {
-		klog.V(5).Infof("nominated reservation %v doesn't reserve numa resource or cpuset", klog.KObj(reservation))
+		klog.V(5).Infof("nominated reservation %v doesn't reserve numa resource or cpuset", klog.KObj(rInfo))
 		return nil, nil
 	}
-	return tryAllocateFromReservation(p.resourceManager, restoreState, resourceOptions, map[types.UID]reservationAlloc{reservation.UID(): nominatedReservationAlloc}, pod, node)
+	return tryAllocateFromReservation(p.resourceManager, restoreState, resourceOptions, map[types.UID]reservationAlloc{rInfo.UID(): nominatedReservationAlloc}, pod, node)
+}
+
+func (p *Plugin) getPodNominatedReservationInfo(pod *corev1.Pod, nodeName string) *frameworkext.ReservationInfo {
+	rCache := reservation.GetReservationCache()
+	if rCache == nil {
+		return nil
+	}
+	rInfo := rCache.GetReservationInfoByPod(pod, nodeName)
+	if rInfo != nil {
+		return rInfo
+	}
+	nominator := p.handle.GetReservationNominator()
+	if nominator != nil {
+		return nominator.GetNominatedReservation(pod, nodeName)
+	}
+	return nil
 }

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
@@ -132,6 +132,7 @@ func (c *resourceManager) GetTopologyHints(node *corev1.Node, pod *corev1.Pod, o
 		return nil, fmt.Errorf("insufficient resources on NUMA Node")
 	}
 
+	// FIXME: restore reserved cpus according to reservations' allocatePolicy
 	options.reusableResources = appendAllocated(nil, restoreStateData.mergedUnmatchedUsed, restoreStateData.mergedMatchedAllocatable)
 	options.preferredCPUs = restoreStateData.mergedMatchedRemainCPUs
 	// update with preemptible resources

--- a/pkg/scheduler/plugins/nodenumaresource/scoring.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring.go
@@ -30,7 +30,6 @@ import (
 	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/util"
-	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
 // resourceStrategyTypeMap maps strategy to scorer implementation
@@ -110,10 +109,7 @@ func (p *Plugin) Score(ctx context.Context, cycleState *framework.CycleState, po
 		return 0, status
 	}
 	if podAllocation == nil {
-		resourceOptions.requiredResources = nil
-		resourceOptions.preferredCPUs = cpuset.NewCPUSet()
-		resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed)
-		podAllocation, status = p.resourceManager.Allocate(node, pod, resourceOptions)
+		podAllocation, status = tryAllocateFromNode(p.resourceManager, restoreState, resourceOptions, pod, node)
 		if !status.IsSuccess() {
 			return 0, status
 		}

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -199,7 +199,7 @@ func (pl *Plugin) NominateReservation(ctx context.Context, cycleState *framework
 	}
 
 	state := getStateData(cycleState)
-	reservationInfos := state.nodeReservationStates[nodeName].matched
+	reservationInfos := state.nodeReservationStates[nodeName].matchedOrIgnored
 	if len(reservationInfos) == 0 {
 		return nil, nil
 	}

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -302,7 +302,7 @@ func TestNominateReservation(t *testing.T) {
 				}
 				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
 				nodeRState.nodeName = reservation.Status.NodeName
-				nodeRState.matched = append(nodeRState.matched, rInfo)
+				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
 				pl.reservationCache.updateReservation(reservation)
 			}

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -566,7 +566,7 @@ func TestFilter(t *testing.T) {
 					hasAffinity: true,
 					nodeReservationStates: map[string]nodeReservationState{
 						testNode.Name: {
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								frameworkext.NewReservationInfo(reservation),
 							},
 						},
@@ -736,7 +736,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 0,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
 									ObjectMeta: metav1.ObjectMeta{
 										Name: "test-r",
@@ -783,7 +783,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 0,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
 									ObjectMeta: metav1.ObjectMeta{
 										Name: "test-r",
@@ -829,7 +829,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 0,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
 									ObjectMeta: metav1.ObjectMeta{
 										Name: "test-r",
@@ -876,7 +876,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 0,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
 									ObjectMeta: metav1.ObjectMeta{
 										Name: "test-r",
@@ -927,7 +927,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -979,7 +979,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1030,7 +1030,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1080,7 +1080,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1131,7 +1131,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1181,7 +1181,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1232,7 +1232,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 10000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1307,7 +1307,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1367,7 +1367,7 @@ func Test_filterWithReservations(t *testing.T) {
 							rAllocated: &framework.Resource{
 								MilliCPU: 6000,
 							},
-							matched: []*frameworkext.ReservationInfo{
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
 								{
 									Reservation: &schedulingv1alpha1.Reservation{
 										ObjectMeta: metav1.ObjectMeta{
@@ -1407,7 +1407,7 @@ func Test_filterWithReservations(t *testing.T) {
 			cycleState.Write(stateKey, tt.stateData)
 			nodeInfo := framework.NewNodeInfo()
 			nodeInfo.SetNode(node)
-			got := pl.filterWithReservations(context.TODO(), cycleState, &corev1.Pod{}, nodeInfo, tt.stateData.nodeReservationStates[node.Name].matched, tt.stateData.hasAffinity)
+			got := pl.filterWithReservations(context.TODO(), cycleState, &corev1.Pod{}, nodeInfo, tt.stateData.nodeReservationStates[node.Name].matchedOrIgnored, tt.stateData.hasAffinity)
 			assert.Equal(t, tt.wantStatus, got)
 		})
 	}
@@ -1883,7 +1883,7 @@ func TestFilterReservation(t *testing.T) {
 				rInfo := pl.reservationCache.getReservationInfoByUID(v.UID)
 				nodeRState := state.nodeReservationStates[v.Status.NodeName]
 				nodeRState.nodeName = v.Status.NodeName
-				nodeRState.matched = append(nodeRState.matched, rInfo)
+				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[v.Status.NodeName] = nodeRState
 			}
 			cycleState := framework.NewCycleState()
@@ -2098,6 +2098,26 @@ func TestPostFilter(t *testing.T) {
 				"1 Reservation(s) is unschedulable",
 				"1 Reservation(s) for node reason that Insufficient memory",
 				"6 Reservation(s) matched owner total"),
+		},
+		{
+			name: "ignore reservation ignored",
+			args: args{
+				hasStateData: true,
+				nodeReservationDiagnosis: map[string]*nodeDiagnosisState{
+					"test-node-0": {
+						ignored: 3,
+					},
+					"test-node-1": {
+						ignored: 1,
+					},
+				},
+				filteredNodeStatusMap: framework.NodeToStatusMap{
+					"test-node-0": {},
+					"test-node-1": {},
+				},
+			},
+			want:  nil,
+			want1: framework.NewStatus(framework.Unschedulable),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -445,6 +445,26 @@ func TestFilter(t *testing.T) {
 		},
 	}
 
+	testReservationIgnoredPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			Labels: map[string]string{
+				apiext.LabelReservationIgnored: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod
@@ -574,6 +594,16 @@ func TestFilter(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "Aligned policy can coexist with Restricted policy",
+			pod:  testReservationIgnoredPod,
+			reservations: []*schedulingv1alpha1.Reservation{
+				alignedReservation,
+				restrictedReservation,
+			},
+			nodeInfo: testNodeInfo,
+			want:     nil,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/reservation/scoring.go
+++ b/pkg/scheduler/plugins/reservation/scoring.go
@@ -44,6 +44,11 @@ func (pl *Plugin) PreScore(ctx context.Context, cycleState *framework.CycleState
 		return nil
 	}
 
+	// if the pod is reservation-ignored, it does not want a nominated reservation
+	if apiext.IsReservationIgnored(pod) {
+		return nil
+	}
+
 	state := getStateData(cycleState)
 	if len(state.nodeReservationStates) == 0 {
 		return nil
@@ -59,7 +64,7 @@ func (pl *Plugin) PreScore(ctx context.Context, cycleState *framework.CycleState
 	errCh := parallelize.NewErrorChannel()
 	pl.handle.Parallelizer().Until(ctx, len(nodes), func(piece int) {
 		node := nodes[piece]
-		reservationInfos := state.nodeReservationStates[node.Name].matched
+		reservationInfos := state.nodeReservationStates[node.Name].matchedOrIgnored
 		if len(reservationInfos) == 0 {
 			return
 		}
@@ -132,7 +137,7 @@ func (pl *Plugin) NormalizeScore(ctx context.Context, state *framework.CycleStat
 
 func (pl *Plugin) ScoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) (int64, *framework.Status) {
 	state := getStateData(cycleState)
-	reservationInfos := state.nodeReservationStates[nodeName].matched
+	reservationInfos := state.nodeReservationStates[nodeName].matchedOrIgnored
 
 	var rInfo *frameworkext.ReservationInfo
 	for _, v := range reservationInfos {

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -261,7 +261,7 @@ func TestScore(t *testing.T) {
 				}
 				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
 				nodeRState.nodeName = reservation.Status.NodeName
-				nodeRState.matched = append(nodeRState.matched, rInfo)
+				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
 				pl.reservationCache.updateReservation(reservation)
 			}
@@ -370,7 +370,7 @@ func TestScoreWithOrder(t *testing.T) {
 			rInfo := pl.reservationCache.getReservationInfoByUID(reservation.UID)
 			nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
 			nodeRState.nodeName = reservation.Status.NodeName
-			nodeRState.matched = append(nodeRState.matched, rInfo)
+			nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 			state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
 
 			_, err = suit.extenderFactory.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation.DeepCopy(), metav1.CreateOptions{})
@@ -387,7 +387,7 @@ func TestScoreWithOrder(t *testing.T) {
 		rInfo := pl.reservationCache.getReservationInfoByUID(reservationWithOrder.UID)
 		nodeRState := state.nodeReservationStates[reservationWithOrder.Status.NodeName]
 		nodeRState.nodeName = reservationWithOrder.Status.NodeName
-		nodeRState.matched = append(nodeRState.matched, rInfo)
+		nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 		state.nodeReservationStates[reservationWithOrder.Status.NodeName] = nodeRState
 		_, err = suit.extenderFactory.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservationWithOrder.DeepCopy(), metav1.CreateOptions{})
 		assert.NoError(t, err)
@@ -833,7 +833,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 				}
 				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
 				nodeRState.nodeName = reservation.Status.NodeName
-				nodeRState.matched = append(nodeRState.matched, rInfo)
+				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
 				pl.reservationCache.updateReservation(reservation)
 			}

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -839,6 +839,9 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 			}
 			cycleState.Write(stateKey, state)
 
+			// the usage of the lister requires the informers started
+			suit.start()
+
 			status := pl.PreScore(context.TODO(), cycleState, tt.pod, nodes)
 			assert.Equal(t, tt.wantStatus, status.IsSuccess())
 

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -108,9 +108,10 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			return
 		}
 
-		var unmatched, matched []*frameworkext.ReservationInfo
+		var unmatched, matchedOrIgnored []*frameworkext.ReservationInfo
 		diagnosisState := &nodeDiagnosisState{
 			nodeName:                 node.Name,
+			ignored:                  0,
 			ownerMatched:             0,
 			isUnschedulableUnmatched: 0,
 			affinityUnmatched:        0,
@@ -127,17 +128,22 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 				return true, nil
 			}
 
+			isIgnored := extension.IsReservationIgnored(pod)
 			isOwnerMatched := rInfo.Match(pod)
 			isUnschedulable := rInfo.IsUnschedulable()
 			isMatchReservationAffinity := matchReservationAffinity(node, rInfo, reservationAffinity)
 			isExactMatched := extension.ExactMatchReservation(podRequests, rInfo.Allocatable, exactMatchReservationSpec)
-			if !isReservedPod && !isUnschedulable && isOwnerMatched && isMatchReservationAffinity && isExactMatched {
-				matched = append(matched, rInfo.Clone())
+			if !isReservedPod && isIgnored {
+				matchedOrIgnored = append(matchedOrIgnored, rInfo.Clone())
+			} else if !isReservedPod && !isUnschedulable && isOwnerMatched && isMatchReservationAffinity && isExactMatched {
+				matchedOrIgnored = append(matchedOrIgnored, rInfo.Clone())
 
 			} else if len(rInfo.AssignedPods) > 0 {
 				unmatched = append(unmatched, rInfo.Clone())
 			}
-			if isOwnerMatched { // count owner-matched diagnosis state
+			if !isReservedPod && isIgnored { // count reservation-ignored diagnosis state
+				diagnosisState.ignored++
+			} else if !isReservedPod && isOwnerMatched { // count owner-matched diagnosis state
 				diagnosisState.ownerMatched++
 				if isUnschedulable {
 					diagnosisState.isUnschedulableUnmatched++
@@ -157,19 +163,19 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 			return
 		}
 
-		if diagnosisState.ownerMatched > 0 {
+		if diagnosisState.ignored > 0 || diagnosisState.ownerMatched > 0 {
 			idx := atomic.AddInt32(&diagnosisIndex, 1)
 			allNodeDiagnosisStates[idx-1] = diagnosisState
 		}
 
-		if len(matched) == 0 && len(unmatched) == 0 {
+		if len(matchedOrIgnored) == 0 && len(unmatched) == 0 {
 			return
 		}
 
 		// The Pod declares a ReservationAffinity, which means that the Pod must reuse the Reservation resources,
 		// but there are no matching Reservations, which means that the node itself does not need to be processed.
 		// We can end early to avoid meaningless operations.
-		if reservationAffinity != nil && len(matched) == 0 {
+		if reservationAffinity != nil && len(matchedOrIgnored) == 0 {
 			return
 		}
 
@@ -196,7 +202,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 		}
 
 		rAllocated := corev1.ResourceList{}
-		for _, rInfo := range matched {
+		for _, rInfo := range matchedOrIgnored {
 			if err = restoreMatchedReservation(nodeInfo, rInfo, podInfoMap); err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
 				return
@@ -208,20 +214,20 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 		var pluginToRestoreState frameworkext.PluginToReservationRestoreStates
 		if extender != nil {
 			var status *framework.Status
-			pluginToRestoreState, status = extender.RunReservationExtensionRestoreReservation(ctx, cycleState, pod, matched, unmatched, nodeInfo)
+			pluginToRestoreState, status = extender.RunReservationExtensionRestoreReservation(ctx, cycleState, pod, matchedOrIgnored, unmatched, nodeInfo)
 			if !status.IsSuccess() {
 				errCh.SendErrorWithCancel(err, cancel)
 				return
 			}
 		}
 
-		if len(matched) > 0 || len(unmatched) > 0 {
+		if len(matchedOrIgnored) > 0 || len(unmatched) > 0 {
 			index := atomic.AddInt32(&stateIndex, 1)
 			allNodeReservationStates[index-1] = &nodeReservationState{
-				nodeName:     node.Name,
-				matched:      matched,
-				podRequested: podRequested,
-				rAllocated:   framework.NewResource(rAllocated),
+				nodeName:         node.Name,
+				matchedOrIgnored: matchedOrIgnored,
+				podRequested:     podRequested,
+				rAllocated:       framework.NewResource(rAllocated),
 			}
 			allPluginToRestoreState[index-1] = pluginToRestoreState
 		}

--- a/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
@@ -148,7 +148,7 @@ func BenchmarkBeforePrefilterWithMatchedPod(b *testing.B) {
 		for _, v := range sd.nodeReservationStates {
 			nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(v.nodeName)
 			assert.NoError(b, err)
-			for _, ri := range v.matched {
+			for _, ri := range v.matchedOrIgnored {
 				p := reservePods[string(ri.UID())]
 				if p != nil {
 					nodeInfo.AddPod(p)

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -314,8 +314,8 @@ func TestRestoreReservation(t *testing.T) {
 			preemptibleInRRs:     map[string]map[types.UID]corev1.ResourceList{},
 			nodeReservationStates: map[string]nodeReservationState{
 				node.Name: {
-					nodeName: node.Name,
-					matched:  []*frameworkext.ReservationInfo{matchRInfo},
+					nodeName:         node.Name,
+					matchedOrIgnored: []*frameworkext.ReservationInfo{matchRInfo},
 					podRequested: &framework.Resource{
 						MilliCPU: 32000,
 						Memory:   68719476736,
@@ -669,19 +669,29 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 	}
 	var pods []*corev1.Pod
 	pods = append(pods, reservationutil.NewReservePod(matchedReservation))
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test-reservation": "true",
+			},
+		},
+	}
 
 	tests := []struct {
 		name         string
+		pod          *corev1.Pod
 		nodeAffinity *corev1.NodeAffinity
 		wantRestored bool
 	}{
 		{
 			name:         "pod has no affinity",
+			pod:          testPod.DeepCopy(),
 			nodeAffinity: nil,
 			wantRestored: true,
 		},
 		{
 			name: "pod has affinity with matchField",
+			pod:  testPod.DeepCopy(),
 			nodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
@@ -701,6 +711,7 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 		},
 		{
 			name: "pod has affinity with matchField but failed to match",
+			pod:  testPod.DeepCopy(),
 			nodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
@@ -720,6 +731,7 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 		},
 		{
 			name: "pod has affinity with matchExpressions",
+			pod:  testPod.DeepCopy(),
 			nodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
@@ -739,6 +751,7 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 		},
 		{
 			name: "pod has affinity with matchExpressions but failed to match",
+			pod:  testPod.DeepCopy(),
 			nodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
@@ -756,6 +769,33 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 			},
 			wantRestored: false,
 		},
+		{
+			name: "pod has affinity and set reservation ignored",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"test-reservation":             "true",
+						apiext.LabelReservationIgnored: "true",
+					},
+				},
+			},
+			nodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "test",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRestored: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -765,19 +805,10 @@ func TestBeforePreFilterWithNodeAffinity(t *testing.T) {
 			pl := p.(*Plugin)
 
 			pl.reservationCache.updateReservation(matchedReservation)
-
-			testPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"test-reservation": "true",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Affinity: &corev1.Affinity{
-						NodeAffinity: tt.nodeAffinity,
-					},
-				},
+			testPod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: tt.nodeAffinity,
 			}
+
 			cycleState := framework.NewCycleState()
 			_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, testPod)
 			assert.Equal(t, tt.wantRestored, restored)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Support a pod-level API that ignores the reserved resources on nodes during the scheduling.
- Implement the preemption logic for the NodeNUMAResource plugin.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
