### PR TITLE
koord-descheduler: support node selector for each descheduler profile

### DIFF
--- a/pkg/descheduler/apis/config/types.go
+++ b/pkg/descheduler/apis/config/types.go
@@ -77,6 +77,7 @@ type DeschedulerProfile struct {
 	Name         string
 	PluginConfig []PluginConfig
 	Plugins      *Plugins
+	NodeSelector *metav1.LabelSelector
 }
 
 type Plugins struct {

--- a/pkg/descheduler/apis/config/v1alpha2/types.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types.go
@@ -103,9 +103,10 @@ func (c *DeschedulerConfiguration) EncodeNestedObjects(e runtime.Encoder) error 
 
 // DeschedulerProfile is a descheduling profile.
 type DeschedulerProfile struct {
-	Name         string         `json:"name,omitempty"`
-	PluginConfig []PluginConfig `json:"pluginConfig,omitempty"`
-	Plugins      *Plugins       `json:"plugins,omitempty"`
+	Name         string                `json:"name,omitempty"`
+	PluginConfig []PluginConfig        `json:"pluginConfig,omitempty"`
+	Plugins      *Plugins              `json:"plugins,omitempty"`
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 
 type Plugins struct {

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -301,6 +301,7 @@ func autoConvert_v1alpha2_DeschedulerProfile_To_config_DeschedulerProfile(in *De
 		out.PluginConfig = nil
 	}
 	out.Plugins = (*config.Plugins)(unsafe.Pointer(in.Plugins))
+	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	return nil
 }
 
@@ -323,6 +324,7 @@ func autoConvert_config_DeschedulerProfile_To_v1alpha2_DeschedulerProfile(in *co
 		out.PluginConfig = nil
 	}
 	out.Plugins = (*Plugins)(unsafe.Pointer(in.Plugins))
+	out.NodeSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NodeSelector))
 	return nil
 }
 

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -131,6 +131,11 @@ func (in *DeschedulerProfile) DeepCopyInto(out *DeschedulerProfile) {
 		*out = new(Plugins)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *DeschedulerProfile) DeepCopyInto(out *DeschedulerProfile) {
 		*out = new(Plugins)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/descheduler/framework/runtime/framework_test.go
+++ b/pkg/descheduler/framework/runtime/framework_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -225,6 +226,36 @@ func TestNewFramework(t *testing.T) {
 							{Name: testPlugin1},
 							{Name: evictorPluginName},
 						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "normal register with node selector",
+			profile: &deschedulerconfig.DeschedulerProfile{
+				Name: testProfileName,
+				Plugins: &deschedulerconfig.Plugins{
+					Evict: deschedulerconfig.PluginSet{
+						Enabled: []deschedulerconfig.Plugin{
+							{Name: evictorPluginName},
+						},
+					},
+					Filter: deschedulerconfig.PluginSet{
+						Enabled: []deschedulerconfig.Plugin{
+							{Name: evictorPluginName},
+						},
+					},
+					Deschedule: deschedulerconfig.PluginSet{
+						Enabled: []deschedulerconfig.Plugin{
+							{Name: testPlugin1},
+							{Name: deschedulePluginWithEvictor},
+						},
+					},
+				},
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"xxx": "yyy",
 					},
 				},
 			},

--- a/pkg/descheduler/framework/types.go
+++ b/pkg/descheduler/framework/types.go
@@ -45,6 +45,8 @@ type Handle interface {
 	GetPodsAssignedToNodeFunc() GetPodsAssignedToNodeFunc
 
 	SharedInformerFactory() informers.SharedInformerFactory
+
+	NodeSelector() *metav1.LabelSelector
 }
 
 type PluginsRunner interface {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The `DeschedulerConfiguration` supports users to config multiple profiles with different plugin enabled with different pluginConfigs. There are user cases such as to config `HighNodeUtilization` plugin with different threshold in different group of nodes, e.g. nodepools. However, most of the plugins only supports to filter pods through specific filters.

When dealing with nodes, it is the descheduler framework to decide which nodes can be plugins' checking target through a global `nodeSelector`. This PR enables configuration of `nodeSelector` further into each profile. Note that the descheduler framework will first select nodes at a global level through the outer `nodeSelector`, then select nodes according to each profile's inside `nodeSelector`. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
