### PR TITLE
koordlet: fix unsafe conversion in net_cls

### DIFF
--- a/pkg/koordlet/resourceexecutor/cgroup.go
+++ b/pkg/koordlet/resourceexecutor/cgroup.go
@@ -150,6 +150,24 @@ func readCgroupAndParseInt64(parentDir string, r sysutil.Resource) (int64, error
 	return v, nil
 }
 
+func readCgroupAndParseUint32(parentDir string, r sysutil.Resource) (uint32, error) {
+	// TODO: refactor with generics
+	s, err := cgroupFileRead(parentDir, r)
+	if err != nil {
+		return 0, err
+	}
+
+	// "max" means unlimited
+	if strings.Trim(s, "\n ") == CgroupMaxSymbolStr {
+		return math.MaxInt32, nil
+	}
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse cgroup value %s, err: %v", s, err)
+	}
+	return uint32(v), nil
+}
+
 func readCgroupAndParseUint64(parentDir string, r sysutil.Resource) (uint64, error) {
 	s, err := cgroupFileRead(parentDir, r)
 	if err != nil {

--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -40,7 +40,7 @@ type CgroupReader interface {
 	ReadCPUProcs(parentDir string) ([]uint32, error)
 	ReadPSI(parentDir string) (*sysutil.PSIByResource, error)
 	ReadMemoryColdPageUsage(parentDir string) (uint64, error)
-	ReadNetClsId(parentDir string) (uint64, error)
+	ReadNetClsId(parentDir string) (uint32, error)
 }
 
 var _ CgroupReader = &CgroupV1Reader{}
@@ -231,12 +231,12 @@ func (r *CgroupV1Reader) ReadPSI(parentDir string) (*sysutil.PSIByResource, erro
 	return psi, nil
 }
 
-func (r *CgroupV1Reader) ReadNetClsId(parentDir string) (uint64, error) {
+func (r *CgroupV1Reader) ReadNetClsId(parentDir string) (uint32, error) {
 	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV1, sysutil.NetClsClassIdName)
 	if !ok {
 		return 0, ErrResourceNotRegistered
 	}
-	return readCgroupAndParseUint64(parentDir, resource)
+	return readCgroupAndParseUint32(parentDir, resource)
 }
 
 var _ CgroupReader = &CgroupV2Reader{}
@@ -445,12 +445,12 @@ func (r *CgroupV2Reader) ReadPSI(parentDir string) (*sysutil.PSIByResource, erro
 	return psi, nil
 }
 
-func (r *CgroupV2Reader) ReadNetClsId(parentDir string) (uint64, error) {
+func (r *CgroupV2Reader) ReadNetClsId(parentDir string) (uint32, error) {
 	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV2, sysutil.NetClsClassIdName)
 	if !ok {
 		return 0, ErrResourceNotRegistered
 	}
-	return readCgroupAndParseUint64(parentDir, resource)
+	return readCgroupAndParseUint32(parentDir, resource)
 }
 
 func NewCgroupReader() CgroupReader {

--- a/pkg/koordlet/runtimehooks/hooks/tc/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/tc/rule.go
@@ -165,8 +165,8 @@ func (p *tcPlugin) ruleUpdateCbForPod(target *statesinformer.CallbackTarget) err
 			if err != nil || netClsId == 0 {
 				continue
 			}
-			r.uidToHandle[pod.Pod.UID] = uint32(netClsId)
-			r.handleToUid[uint32(netClsId)] = pod.Pod.UID
+			r.uidToHandle[pod.Pod.UID] = netClsId
+			r.handleToUid[netClsId] = pod.Pod.UID
 			p.updateRule(r)
 		}
 	})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koordlet: Fix the unsafe conversion in the tc runtime hook plugin.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Resolve code scanning alerts [#40](https://github.com/koordinator-sh/koordinator/security/code-scanning/40), [#41](https://github.com/koordinator-sh/koordinator/security/code-scanning/41),

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
