### PR TITLE
scheduler: optimize numa affinity store

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -31,6 +31,7 @@ import (
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/features"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/schedulingphase"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
@@ -247,6 +248,11 @@ func (ext *frameworkExtenderImpl) RunScorePlugins(ctx context.Context, state *fr
 		debugScores(debugTopNScores, pod, pluginToNodeScores, nodes)
 	}
 	return pluginToNodeScores, status
+}
+
+func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (_ *framework.PostFilterResult, status *framework.Status) {
+	schedulingphase.RecordPhase(state, schedulingphase.PostFilter)
+	return ext.Framework.RunPostFilterPlugins(ctx, state, pod, filteredNodeStatusMap)
 }
 
 // RunPreBindPlugins supports PreBindReservation for Reservation

--- a/pkg/scheduler/frameworkext/schedulingphase/scheduling_phase.go
+++ b/pkg/scheduler/frameworkext/schedulingphase/scheduling_phase.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulingphase
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+const (
+	phaseStateKey = extension.SchedulingDomainPrefix + "/scheduling-phase"
+)
+
+const (
+	PostFilter = "PostFilter"
+)
+
+type SchedulingPhase struct {
+	extensionPoint string
+}
+
+func (s *SchedulingPhase) Clone() framework.StateData {
+	return s
+}
+
+func RecordPhase(cycleState *framework.CycleState, extensionPoint string) {
+	cycleState.Write(phaseStateKey, &SchedulingPhase{
+		extensionPoint: PostFilter,
+	})
+}
+
+func GetExtensionPointBeingExecuted(cycleState *framework.CycleState) string {
+	s, err := cycleState.Read(phaseStateKey)
+	if err != nil || s == nil {
+		return ""
+	}
+	return s.(*SchedulingPhase).extensionPoint
+}

--- a/pkg/scheduler/frameworkext/topologymanager/manager.go
+++ b/pkg/scheduler/frameworkext/topologymanager/manager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/schedulingphase"
 )
 
 type Interface interface {
@@ -64,18 +65,25 @@ func (m *topologyManager) Admit(ctx context.Context, cycleState *framework.Cycle
 
 	policy := createNUMATopologyPolicy(policyType, numaNodes)
 	bestHint, ok := store.GetAffinity(nodeName)
-	if !ok {
+	extensionPointBeingExecuted := schedulingphase.GetExtensionPointBeingExecuted(cycleState)
+	klog.V(5).Infof("extensionPointBeingExecuted: %v, bestHint: %v, nodeName: %v, pod: %v", extensionPointBeingExecuted, bestHint, nodeName, pod.Name)
+	if !ok || extensionPointBeingExecuted == schedulingphase.PostFilter {
 		var admit bool
 		bestHint, admit = m.calculateAffinity(ctx, cycleState, policy, pod, nodeName, exclusivePolicy, allNUMANodeStatus)
 		klog.V(5).Infof("Best TopologyHint for (pod: %v): %v on node: %v", klog.KObj(pod), bestHint, nodeName)
 		if !admit {
 			return framework.NewStatus(framework.Unschedulable, "node(s) NUMA Topology affinity error")
 		}
+		status := m.allocateResources(ctx, cycleState, bestHint, pod, nodeName)
+		if !status.IsSuccess() {
+			return status
+		}
 		store.SetAffinity(nodeName, bestHint)
-	}
-	status := m.allocateResources(ctx, cycleState, bestHint, pod, nodeName)
-	if !status.IsSuccess() {
-		return status
+	} else {
+		status := m.allocateResources(ctx, cycleState, bestHint, pod, nodeName)
+		if !status.IsSuccess() {
+			return status
+		}
 	}
 	return nil
 }

--- a/pkg/scheduler/frameworkext/topologymanager/store.go
+++ b/pkg/scheduler/frameworkext/topologymanager/store.go
@@ -44,12 +44,7 @@ func GetStore(cycleState *framework.CycleState) *Store {
 }
 
 func (s *Store) Clone() framework.StateData {
-	ss := &Store{}
-	s.affinityMap.Range(func(key, value any) bool {
-		ss.affinityMap.Store(key, value)
-		return true
-	})
-	return ss
+	return s
 }
 
 func (s *Store) SetAffinity(nodeName string, affinity NUMATopologyHint) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

当前每个节点的最佳 NUMA Affinity 再 Filter 阶段判断之后保存在 CycleState 中，这在通常调度场景下没有问题。但是在如下场景下会有问题，我们提供抢占者为 preemptor、被抢占者为 victim，两者都申请 NUMA 感知、绑核、8卡，并且亲和同一个 8 卡 节点。
1. Victim 调度成功
2. Preemptor 调度触发抢占，删除掉 Victim
3. Preemptor 开始调度，由于目标节点存在 NonimatingPod，所以会在 Filter 时：
    a. 带 Nominating Filter：在 Filter 时候做一次 state.Clone，然后用 clone 的 state 去过 Filter，这时候 numa Affinity 保存到了 clone 的state 中
    b. 不带 Nominating Filter：由于判断到 a 中并没有执行实际的 AddPod，所以这里逻辑认为 a Filter 结果有效，直接返回

上述流程就导致 NUMA Affinity 没有实际保存下来，倒是本来要申请双 NUMA 的节点只分到了单 NUMA 资源，看起来就像没有开启 NUMA 感知调度一样。

本 PR 将 affinityStore 的clone 方式改为浅拷贝，并：
1. 在调度阶段第一次带着抢占成功的 Pod 为当前 Pod 调度成功时时记录下来，调度流程中的后续阶段都复用该结果就好了
2. 抢占时忽略已经记录的结果，每次都重新判断是否满足 NUMA 对齐规则

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
