### PR TITLE
scheduler: support reserving pods resources

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -1343,6 +1343,13 @@ func Test_generatePodEventOnReservationLevel(t *testing.T) {
 			wantIsReserve: true,
 		},
 		{
+			name: "reservation too many pods",
+			errorMsg: "0/21 nodes are available: 2 Reservation(s) Too many pods. " +
+				"1 Reservation(s) is unschedulable, 3 Reservation(s) matched owner total",
+			wantMsg:       "0/3 reservations are available: 2 Reservation(s) Too many pods, 1 Reservation(s) is unschedulable.",
+			wantIsReserve: true,
+		},
+		{
 			name: "pod topology spread constraints missing required label errors",
 			errorMsg: "0/5 nodes are available: 3 node(s) didn't match pod topology spread constraints (missing required label), " +
 				"1 Insufficient cpu, 1 Insufficient memory, " +

--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -243,6 +243,10 @@ func (ri *ReservationInfo) GetPriority() int32 {
 	return 0
 }
 
+func (ri *ReservationInfo) GetAllocatedPods() int {
+	return len(ri.AssignedPods)
+}
+
 func (ri *ReservationInfo) GetPodOwners() []schedulingv1alpha1.ReservationOwner {
 	if ri.Reservation != nil {
 		return ri.Reservation.Spec.Owners

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -184,7 +184,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 
 			// In this case, the Controller has not yet updated the status of the Reservation to Succeeded,
 			// but in fact it can no longer be used for allocation. So it's better to skip first.
-			if rInfo.IsAllocateOnce() && len(rInfo.AssignedPods) > 0 {
+			if rInfo.IsAllocateOnce() && rInfo.GetAllocatedPods() > 0 {
 				return true, nil
 			}
 
@@ -193,7 +193,7 @@ func (pl *Plugin) prepareMatchReservationState(ctx context.Context, cycleState *
 
 			if isMatchedOrIgnored { // reservation is matched or ignored for the pod
 				matchedOrIgnored = append(matchedOrIgnored, rInfo.Clone())
-			} else if len(rInfo.AssignedPods) > 0 { // reservation is unmatched and not ignored
+			} else if rInfo.GetAllocatedPods() > 0 { // reservation is unmatched and not ignored
 				unmatched = append(unmatched, rInfo.Clone())
 			}
 
@@ -359,7 +359,7 @@ func restoreMatchedReservation(nodeInfo *framework.NodeInfo, rInfo *frameworkext
 
 func restoreUnmatchedReservations(nodeInfo *framework.NodeInfo, rInfo *frameworkext.ReservationInfo) error {
 	// Here len(rInfo.AssignedPods) == 0 is always false because it was checked before.
-	if len(rInfo.AssignedPods) == 0 {
+	if rInfo.GetAllocatedPods() == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Reservation supports reserving "pods" resources. It helps when we want to limit the allocatable "pods" of the reservation owners.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
