### PR TITLE
scheduler: support secondary device well planned

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -54,9 +54,10 @@ const (
 )
 
 const (
-	LabelGPUPartitionPolicy string = NodeDomainPrefix + "/gpu-partition-policy"
-	LabelGPUModel           string = NodeDomainPrefix + "/gpu-model"
-	LabelGPUDriverVersion   string = NodeDomainPrefix + "/gpu-driver-version"
+	LabelGPUPartitionPolicy         string = NodeDomainPrefix + "/gpu-partition-policy"
+	LabelGPUModel                   string = NodeDomainPrefix + "/gpu-model"
+	LabelGPUDriverVersion           string = NodeDomainPrefix + "/gpu-driver-version"
+	LabelSecondaryDeviceWellPlanned string = NodeDomainPrefix + "/secondary-device-well-planned"
 )
 
 // DeviceAllocations would be injected into Pod as form of annotation during Pre-bind stage.
@@ -330,4 +331,11 @@ func GetGPUPartitionPolicy(device *schedulingv1alpha1.Device) GPUPartitionPolicy
 		return GPUPartitionPolicyHonor
 	}
 	return GPUPartitionPolicyPrefer
+}
+
+func IsSecondaryDeviceWellPlanned(device *schedulingv1alpha1.Device) bool {
+	if device == nil {
+		return false
+	}
+	return device.Labels[LabelSecondaryDeviceWellPlanned] == "true"
 }

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -277,6 +277,7 @@ func (ext *frameworkExtenderImpl) RunScorePlugins(ctx context.Context, state *fr
 
 func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (_ *framework.PostFilterResult, status *framework.Status) {
 	schedulingphase.RecordPhase(state, schedulingphase.PostFilter)
+	defer func() { schedulingphase.RecordPhase(state, "") }()
 	return ext.Framework.RunPostFilterPlugins(ctx, state, pod, filteredNodeStatusMap)
 }
 
@@ -484,6 +485,8 @@ func (ext *frameworkExtenderImpl) RunReservePluginsReserve(ctx context.Context, 
 			return nil
 		}
 	}
+	schedulingphase.RecordPhase(cycleState, schedulingphase.Reserve)
+	defer func() { schedulingphase.RecordPhase(cycleState, "") }()
 	status := ext.Framework.RunReservePluginsReserve(ctx, cycleState, pod, nodeName)
 	ext.GetReservationNominator().RemoveNominatedReservations(pod)
 	ext.GetReservationNominator().DeleteNominatedReservePod(pod)

--- a/pkg/scheduler/frameworkext/schedulingphase/scheduling_phase.go
+++ b/pkg/scheduler/frameworkext/schedulingphase/scheduling_phase.go
@@ -28,6 +28,7 @@ const (
 
 const (
 	PostFilter = "PostFilter"
+	Reserve    = "Reserve"
 )
 
 type SchedulingPhase struct {
@@ -40,7 +41,7 @@ func (s *SchedulingPhase) Clone() framework.StateData {
 
 func RecordPhase(cycleState *framework.CycleState, extensionPoint string) {
 	cycleState.Write(phaseStateKey, &SchedulingPhase{
-		extensionPoint: PostFilter,
+		extensionPoint: extensionPoint,
 	})
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -49,7 +49,8 @@ type nodeDevice struct {
 	allocateSet   map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]deviceResources
 	deviceInfos   map[schedulingv1alpha1.DeviceType][]*schedulingv1alpha1.DeviceInfo
 
-	numaTopology *NUMATopology
+	numaTopology               *NUMATopology
+	secondaryDeviceWellPlanned bool
 
 	nodeHonorGPUPartition bool
 	gpuPartitionIndexer   GPUPartitionIndexer
@@ -398,6 +399,7 @@ func (n *nodeDevice) filter(
 	r.deviceInfos = n.deviceInfos
 	r.gpuPartitionIndexer = n.gpuPartitionIndexer
 	r.nodeHonorGPUPartition = n.nodeHonorGPUPartition
+	r.secondaryDeviceWellPlanned = n.secondaryDeviceWellPlanned
 	r.gpuTopologyScope = n.gpuTopologyScope
 	return r
 }
@@ -520,6 +522,7 @@ func (n *nodeDeviceCache) updateNodeDevice(nodeName string, device *schedulingv1
 	info.deviceInfos = deviceInfos
 	info.gpuPartitionIndexer = gpuPartitionIndexer
 	info.nodeHonorGPUPartition = apiext.GetGPUPartitionPolicy(device) == apiext.GPUPartitionPolicyHonor
+	info.secondaryDeviceWellPlanned = apiext.IsSecondaryDeviceWellPlanned(device)
 	info.gpuTopologyScope = gpuTopologyScope
 }
 

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -315,6 +315,9 @@ func preparePod(pod *corev1.Pod) (state *preFilterState, status *framework.Statu
 		if err != nil {
 			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
 		}
+		if state.jointAllocate != nil && len(state.jointAllocate.DeviceTypes) >= 1 {
+			state.primaryDeviceType = state.jointAllocate.DeviceTypes[0]
+		}
 		state.gpuRequirements, err = parseGPURequirements(pod, requests, state.hints[schedulingv1alpha1.GPU])
 		if err != nil {
 			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

在 RDMA 和 GPU 联合分配中，RDMA 一般已经提前规划好满足 Pod 的诉求，只要能够保证 GPU 同 PCIE 下面有足够多的 VF 即可。这意味着调度器没必要再 Filter &Score 中分配 RDMA 资源，而只需要考虑 Device CR 是否已经规划好 RDMA 设备就行了，后者可以再Device CR 的事件处理函数中计算并缓存

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
