### PR TITLE
webhook: Support setting quota admission to zero for special usage scenarios, such as temporarily pausing pod submissions.

### DIFF
--- a/pkg/webhook/quotaevaluate/util.go
+++ b/pkg/webhook/quotaevaluate/util.go
@@ -18,7 +18,6 @@ package quotaevaluate
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
@@ -30,8 +29,8 @@ func GetQuotaAdmission(quota *v1alpha1.ElasticQuota) (corev1.ResourceList, error
 		return nil, err
 	}
 
-	// admission is zero, return max
-	if quotav1.IsZero(admission) {
+	// admission is empty (it may not be configured or may have no content), return max
+	if len(admission) == 0 {
 		return quota.Spec.Max, nil
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Currently admission will be set to max when the parsed value of it is zero, here including 3 situations:
(1) not configured.
(2) configured with no content.
(3) configured with specified-zero resources.
Situation (1) and (2) are suitable to use max since we better have a default limitation for pods. But for Situation (3), we have a usage scenario that new pod submissions should be pausing temporarily and keep running pods going, the most simplest approach is to set admission to zero without updating min/max (may be unable to recover it later for some verifications like checkMinQuotaSum). And I think it's reasonable to use configured admission even if it's zero.

If possible, we can change the condition that chooses to use max for admission, from "admission is zero" to "admission is empty", to exclude the situation (3) which may be depended for some special usage scenarios.

Dose that make sense? Hope to hear your thoughts!

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

UT

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
