### PR TITLE
util: add defaulting to blkio qos to improve robustness

### DIFF
--- a/pkg/util/sloconfig/nodeslo_config.go
+++ b/pkg/util/sloconfig/nodeslo_config.go
@@ -223,6 +223,10 @@ func DefaultResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 				Enable:    pointer.Bool(false),
 				MemoryQOS: *DefaultMemoryQOS(apiext.QoSLSR),
 			},
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
+			},
 			NetworkQOS: &slov1alpha1.NetworkQOSCfg{
 				Enable:     pointer.Bool(false),
 				NetworkQOS: *NoneNetworkQOS(),
@@ -240,6 +244,10 @@ func DefaultResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 			MemoryQOS: &slov1alpha1.MemoryQOSCfg{
 				Enable:    pointer.Bool(false),
 				MemoryQOS: *DefaultMemoryQOS(apiext.QoSLS),
+			},
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
 			},
 			NetworkQOS: &slov1alpha1.NetworkQOSCfg{
 				Enable:     pointer.Bool(false),
@@ -259,6 +267,10 @@ func DefaultResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 				Enable:    pointer.Bool(false),
 				MemoryQOS: *DefaultMemoryQOS(apiext.QoSBE),
 			},
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
+			},
 			NetworkQOS: &slov1alpha1.NetworkQOSCfg{
 				Enable:     pointer.Bool(false),
 				NetworkQOS: *NoneNetworkQOS(),
@@ -277,15 +289,34 @@ func DefaultResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 				Enable:    pointer.Bool(false),
 				MemoryQOS: *DefaultMemoryQOS(apiext.QoSSystem),
 			},
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
+			},
 			NetworkQOS: &slov1alpha1.NetworkQOSCfg{
 				Enable:     pointer.Bool(false),
 				NetworkQOS: *NoneNetworkQOS(),
+			},
+		},
+		CgroupRoot: &slov1alpha1.ResourceQOS{
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
 			},
 		},
 	}
 }
 
 func NoneResourceQOS(qos apiext.QoSClass) *slov1alpha1.ResourceQOS {
+	// cgroup root case: only used by blkio qos
+	if qos == apiext.QoSNone {
+		return &slov1alpha1.ResourceQOS{
+			BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+				Enable:   pointer.Bool(false),
+				BlkIOQOS: *NoneBlkIOQOS(),
+			},
+		}
+	}
 	return &slov1alpha1.ResourceQOS{
 		CPUQOS: &slov1alpha1.CPUQOSCfg{
 			Enable: pointer.Bool(false),
@@ -298,6 +329,10 @@ func NoneResourceQOS(qos apiext.QoSClass) *slov1alpha1.ResourceQOS {
 		MemoryQOS: &slov1alpha1.MemoryQOSCfg{
 			Enable:    pointer.Bool(false),
 			MemoryQOS: *NoneMemoryQOS(),
+		},
+		BlkIOQOS: &slov1alpha1.BlkIOQOSCfg{
+			Enable:   pointer.Bool(false),
+			BlkIOQOS: *NoneBlkIOQOS(),
 		},
 		NetworkQOS: &slov1alpha1.NetworkQOSCfg{
 			Enable:     pointer.Bool(false),
@@ -337,6 +372,20 @@ func NoneMemoryQOS() *slov1alpha1.MemoryQOS {
 	}
 }
 
+func NoneBlkIOQOS() *slov1alpha1.BlkIOQOS {
+	return &slov1alpha1.BlkIOQOS{}
+}
+
+func NoneNetworkQOS() *slov1alpha1.NetworkQOS {
+	zero := intstr.FromInt32(0)
+	return &slov1alpha1.NetworkQOS{
+		IngressRequest: &zero,
+		IngressLimit:   &zero,
+		EgressRequest:  &zero,
+		EgressLimit:    &zero,
+	}
+}
+
 func NoneResourceQOSPolicies() *slov1alpha1.ResourceQOSPolicies {
 	noneCPUPolicy := slov1alpha1.CPUQOSPolicyGroupIdentity
 	defaultNetQoSPolicy := slov1alpha1.NETQOSPolicyTC
@@ -354,6 +403,7 @@ func NoneResourceQOSStrategy() *slov1alpha1.ResourceQOSStrategy {
 		LSClass:     NoneResourceQOS(apiext.QoSLS),
 		BEClass:     NoneResourceQOS(apiext.QoSBE),
 		SystemClass: NoneResourceQOS(apiext.QoSSystem),
+		CgroupRoot:  NoneResourceQOS(apiext.QoSNone),
 	}
 }
 
@@ -384,14 +434,4 @@ func DefaultSystemStrategy() *slov1alpha1.SystemStrategy {
 
 func DefaultExtensions() *slov1alpha1.ExtensionsMap {
 	return getDefaultExtensionsMap()
-}
-
-func NoneNetworkQOS() *slov1alpha1.NetworkQOS {
-	zero := intstr.FromInt(0)
-	return &slov1alpha1.NetworkQOS{
-		IngressRequest: &zero,
-		IngressLimit:   &zero,
-		EgressRequest:  &zero,
-		EgressLimit:    &zero,
-	}
 }

--- a/pkg/util/sloconfig/nodeslo_config_test.go
+++ b/pkg/util/sloconfig/nodeslo_config_test.go
@@ -44,6 +44,7 @@ func Test_NoneResourceQOSStrategy(t *testing.T) {
 		LSClass:     NoneResourceQOS(apiext.QoSLS),
 		BEClass:     NoneResourceQOS(apiext.QoSBE),
 		SystemClass: NoneResourceQOS(apiext.QoSSystem),
+		CgroupRoot:  NoneResourceQOS(apiext.QoSNone),
 	}
 	got := NoneResourceQOSStrategy()
 	assert.Equal(t, expect, got)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

We've found a case that if we configure the resource qos config to `..."cgroupRoot":{"blkioQOS":{}}...`, koordlet would crash due to a NPE panic in [blkio reconcile](https://github.com/koordinator-sh/koordinator/blob/main/pkg/koordlet/qosmanager/plugins/blkio/blkio_reconcile.go#L166).

This PR add the previously missing defaulting to blkio qos to solve this issue.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
