### PR TITLE
scheduler: optimize reservation perf with lazy restoring

### DIFF
--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -58,6 +58,12 @@ const (
 	// ResizePod is used to enable resize pod feature
 	ResizePod featuregate.Feature = "ResizePod"
 
+	// owner: @saintube @ZiMengSheng
+	// alpha: v1.5
+	//
+	// LazyReservationRestore is used to restore reserved resources lazily to improve the scheduling performance.
+	LazyReservationRestore featuregate.Feature = "LazyReservationRestore"
+
 	CSIStorageCapacity featuregate.Feature = "CSIStorageCapacity"
 
 	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
@@ -78,6 +84,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	ElasticQuotaGuaranteeUsage:                {Default: false, PreRelease: featuregate.Alpha},
 	DisableDefaultQuota:                       {Default: false, PreRelease: featuregate.Alpha},
 	SupportParentQuotaSubmitPod:               {Default: false, PreRelease: featuregate.Alpha},
+	LazyReservationRestore:                    {Default: false, PreRelease: featuregate.Alpha},
 	CSIStorageCapacity:                        {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 	GenericEphemeralVolume:                    {Default: true, PreRelease: featuregate.GA},
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -219,7 +219,7 @@ func (ext *frameworkExtenderImpl) RunPreFilterPlugins(ctx context.Context, cycle
 
 	for _, transformer := range ext.preFilterTransformersEnabled {
 		startTime := time.Now()
-		status = transformer.AfterPreFilter(ctx, cycleState, pod)
+		status = transformer.AfterPreFilter(ctx, cycleState, pod, result)
 		ext.metricsRecorder.ObservePluginDurationAsync("AfterPreFilter", transformer.Name(), status.Code().String(), metrics.SinceInSeconds(startTime))
 		if !status.IsSuccess() {
 			klog.ErrorS(status.AsError(), "Failed to run AfterPreFilter", "pod", klog.KObj(pod), "plugin", transformer.Name())

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -80,7 +80,7 @@ func (h *TestTransformer) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 
-func (h *TestTransformer) AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status {
+func (h *TestTransformer) AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, preFilterResult *framework.PreFilterResult) *framework.Status {
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}
@@ -721,6 +721,7 @@ func TestReservationRestorePlugin(t *testing.T) {
 				nodeRestoreStates["test-node-1"] = pluginState
 			}
 
+			// TODO: remove deprecated methods
 			status = extender.RunReservationExtensionFinalRestoreReservation(context.TODO(), cycleState, &corev1.Pod{}, pluginToNodeReservationRestoreState)
 			assert.Equal(t, tt.wantStatus2, status.IsSuccess())
 			val, err := cycleState.Read(fakeReservationRestoreStateKey)

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -60,6 +60,8 @@ type FrameworkExtender interface {
 
 	RunReservationExtensionPreRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status
 	RunReservationExtensionRestoreReservation(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, matched []*ReservationInfo, unmatched []*ReservationInfo, nodeInfo *framework.NodeInfo) (PluginToReservationRestoreStates, *framework.Status)
+	// RunReservationExtensionFinalRestoreReservation is deprecated, and will be removed next version.
+	// DEPRECATED: use RunReservationExtensionRestoreReservation instead.
 	RunReservationExtensionFinalRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, states PluginToNodeReservationRestoreStates) *framework.Status
 
 	RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
@@ -82,7 +84,7 @@ type PreFilterTransformer interface {
 	BeforePreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool, *framework.Status)
 	// AfterPreFilter is executed after PreFilter.
 	// There is a chance to trigger the correction of the State data of each plugin after the PreFilter.
-	AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status
+	AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, preFilterResult *framework.PreFilterResult) *framework.Status
 }
 
 // FilterTransformer is executed before Filter.
@@ -103,7 +105,7 @@ type PluginToReservationRestoreStates map[string]interface{}
 // PluginToNodeReservationRestoreStates declares a map from plugin name to its NodeReservationRestoreStates.
 type PluginToNodeReservationRestoreStates map[string]NodeReservationRestoreStates
 
-// NodeReservationRestoreStates declares a map from plugin name to its ReservationRestoreState.
+// NodeReservationRestoreStates declares a map from node name to its ReservationRestoreState.
 type NodeReservationRestoreStates map[string]interface{}
 
 // ReservationRestorePlugin is used to support the return of fine-grained resources
@@ -113,6 +115,7 @@ type ReservationRestorePlugin interface {
 	framework.Plugin
 	PreRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) *framework.Status
 	RestoreReservation(ctx context.Context, cycleState *framework.CycleState, podToSchedule *corev1.Pod, matched []*ReservationInfo, unmatched []*ReservationInfo, nodeInfo *framework.NodeInfo) (interface{}, *framework.Status)
+	// DEPRECATED
 	FinalRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, states NodeReservationRestoreStates) *framework.Status
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -189,7 +189,7 @@ func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleSta
 	return nil, nil
 }
 
-func (cs *Coscheduling) AfterPreFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod) *framework.Status {
+func (cs *Coscheduling) AfterPreFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, preFilterResult *framework.PreFilterResult) *framework.Status {
 	return nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -155,6 +155,7 @@ func Test_Plugin_ReservationRestore(t *testing.T) {
 	nodeRestoreState, status := pl.RestoreReservation(context.TODO(), cycleState, pod, []*frameworkext.ReservationInfo{reservationInfo}, nil, nodeInfo)
 	assert.True(t, status.IsSuccess())
 	assert.NotNil(t, nodeRestoreState)
+	// TODO: remove deprecated methods
 	pl.FinalRestoreReservation(context.TODO(), cycleState, pod, frameworkext.NodeReservationRestoreStates{
 		"test-node-1": nodeRestoreState,
 	})

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -199,7 +199,12 @@ func (pl *Plugin) NominateReservation(ctx context.Context, cycleState *framework
 	}
 
 	state := getStateData(cycleState)
-	reservationInfos := state.nodeReservationStates[nodeName].matchedOrIgnored
+
+	var reservationInfos []*frameworkext.ReservationInfo
+	if nodeRState := state.nodeReservationStates[nodeName]; nodeRState != nil {
+		reservationInfos = nodeRState.matchedOrIgnored
+	}
+
 	if len(reservationInfos) == 0 {
 		return nil, nil
 	}

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	resourceapi "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -39,6 +40,7 @@ import (
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	clientschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/typed/scheduling/v1alpha1"
 	listerschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation/controller"
@@ -83,14 +85,14 @@ var (
 )
 
 type Plugin struct {
-	handle           frameworkext.ExtendedHandle
-	args             *config.ReservationArgs
-	rLister          listerschedulingv1alpha1.ReservationLister
-	client           clientschedulingv1alpha1.SchedulingV1alpha1Interface
-	reservationCache *reservationCache
-
-	nominator     *nominator
-	preemptionMgr *PreemptionMgr
+	handle                       frameworkext.ExtendedHandle
+	args                         *config.ReservationArgs
+	rLister                      listerschedulingv1alpha1.ReservationLister
+	client                       clientschedulingv1alpha1.SchedulingV1alpha1Interface
+	reservationCache             *reservationCache
+	nominator                    *nominator
+	preemptionMgr                *PreemptionMgr
+	enableLazyReservationRestore bool
 }
 
 func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -118,12 +120,13 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	SetReservationCache(cache)
 
 	p := &Plugin{
-		handle:           extendedHandle,
-		args:             pluginArgs,
-		rLister:          reservationLister,
-		client:           extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
-		reservationCache: cache,
-		nominator:        nm,
+		handle:                       extendedHandle,
+		args:                         pluginArgs,
+		rLister:                      reservationLister,
+		client:                       extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
+		reservationCache:             cache,
+		nominator:                    nm,
+		enableLazyReservationRestore: k8sfeature.DefaultFeatureGate.Enabled(features.LazyReservationRestore),
 	}
 
 	if pluginArgs.EnablePreemption {
@@ -181,7 +184,7 @@ type schedulingStateData struct {
 	preemptible          map[string]corev1.ResourceList
 	preemptibleInRRs     map[string]map[types.UID]corev1.ResourceList
 
-	nodeReservationStates    map[string]nodeReservationState
+	nodeReservationStates    map[string]*nodeReservationState
 	nodeReservationDiagnosis map[string]*nodeDiagnosisState
 	preferredNode            string
 }
@@ -196,6 +199,10 @@ type nodeReservationState struct {
 	podRequested *framework.Resource
 	// rAllocated represents the allocated resources of matched reservations
 	rAllocated *framework.Resource
+
+	unmatched     []*frameworkext.ReservationInfo
+	preRestored   bool // restore in PreFilter or Filter
+	finalRestored bool // restore in Filter
 }
 
 type nodeDiagnosisState struct {
@@ -419,19 +426,23 @@ func (pl *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, 
 		}
 	}
 
+	state := getStateData(cycleState)
+	nodeRState := state.nodeReservationStates[node.Name]
+	if nodeRState == nil {
+		nodeRState = &nodeReservationState{}
+	}
+
+	if len(nodeRState.matchedOrIgnored) <= 0 && state.hasAffinity {
+		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity)
+	}
+
 	if reservationutil.IsReservePod(pod) {
 		// TODO: handle pre-allocation cases
 		return nil
 	}
 
-	state := getStateData(cycleState)
-	nodeRState := state.nodeReservationStates[node.Name]
 	matchedReservations := nodeRState.matchedOrIgnored
 	if len(matchedReservations) == 0 {
-		if state.hasAffinity {
-			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity)
-		}
-
 		status := func() *framework.Status {
 			state.preemptLock.RLock()
 			defer state.preemptLock.RUnlock()
@@ -439,7 +450,7 @@ func (pl *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, 
 			if len(state.preemptible[node.Name]) > 0 || len(state.preemptibleInRRs[node.Name]) > 0 {
 				preemptible := state.preemptible[node.Name]
 				preemptibleResource := framework.NewResource(preemptible)
-				insufficientResources := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, nil, preemptibleResource)
+				insufficientResources := fitsNode(state.podRequestsResources, nodeInfo, nodeRState, nil, preemptibleResource)
 				if len(insufficientResources) != 0 {
 					return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPreemptionFailed)
 				}
@@ -483,7 +494,7 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 		preemptibleInRR := state.preemptibleInRRs[node.Name][rInfo.UID()]
 		preemptible := framework.NewResource(preemptibleInRR)
 		preemptible.Add(state.preemptible[node.Name])
-		insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo, &nodeRState, rInfo, preemptible)
+		insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo, nodeRState, rInfo, preemptible)
 		state.preemptLock.RUnlock()
 
 		nodeFits := len(insufficientResourcesByNode) == 0
@@ -776,7 +787,11 @@ func (pl *Plugin) makePostFilterReasons(state *stateData, filteredNodeStatusMap 
 func (pl *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
 	// TODO(joseph): We can consider optimizing these codes. It seems that there is no need to exist at present.
 	state := getStateData(cycleState)
+
 	nodeRState := state.nodeReservationStates[nodeName]
+	if nodeRState == nil {
+		nodeRState = &nodeReservationState{}
+	}
 
 	var rInfo *frameworkext.ReservationInfo
 	for _, v := range nodeRState.matchedOrIgnored {

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -115,6 +115,7 @@ func (pm *PreemptionMgr) PostFilter(ctx context.Context, state *framework.CycleS
 		State:      state,
 		Interface:  pm,
 	}
+	klog.V(4).InfoS("Attempt to do reservation preemption in the PostFilter", "pod", klog.KObj(pod))
 
 	result, status := pe.Preempt(ctx, pod, m)
 	if status.Message() != "" {

--- a/pkg/scheduler/plugins/reservation/scoring.go
+++ b/pkg/scheduler/plugins/reservation/scoring.go
@@ -64,7 +64,10 @@ func (pl *Plugin) PreScore(ctx context.Context, cycleState *framework.CycleState
 	errCh := parallelize.NewErrorChannel()
 	pl.handle.Parallelizer().Until(ctx, len(nodes), func(piece int) {
 		node := nodes[piece]
-		reservationInfos := state.nodeReservationStates[node.Name].matchedOrIgnored
+		var reservationInfos []*frameworkext.ReservationInfo
+		if nodeRState := state.nodeReservationStates[node.Name]; nodeRState != nil {
+			reservationInfos = nodeRState.matchedOrIgnored
+		}
 		if len(reservationInfos) == 0 {
 			return
 		}

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -249,7 +249,7 @@ func TestScore(t *testing.T) {
 			cycleState := framework.NewCycleState()
 			state := &stateData{
 				schedulingStateData: schedulingStateData{
-					nodeReservationStates: map[string]nodeReservationState{},
+					nodeReservationStates: map[string]*nodeReservationState{},
 				},
 			}
 			state.podRequests = apiresource.PodRequests(tt.pod, apiresource.PodResourcesOptions{})
@@ -260,6 +260,9 @@ func TestScore(t *testing.T) {
 					rInfo.Allocated = allocated
 				}
 				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
+				if nodeRState == nil {
+					nodeRState = &nodeReservationState{}
+				}
 				nodeRState.nodeName = reservation.Status.NodeName
 				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
@@ -353,7 +356,7 @@ func TestScoreWithOrder(t *testing.T) {
 
 		state := &stateData{
 			schedulingStateData: schedulingStateData{
-				nodeReservationStates: map[string]nodeReservationState{},
+				nodeReservationStates: map[string]*nodeReservationState{},
 			},
 		}
 		state.podRequests = apiresource.PodRequests(normalPod, apiresource.PodResourcesOptions{})
@@ -369,6 +372,9 @@ func TestScoreWithOrder(t *testing.T) {
 			pl.reservationCache.updateReservation(reservation)
 			rInfo := pl.reservationCache.getReservationInfoByUID(reservation.UID)
 			nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
+			if nodeRState == nil {
+				nodeRState = &nodeReservationState{}
+			}
 			nodeRState.nodeName = reservation.Status.NodeName
 			nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 			state.nodeReservationStates[reservation.Status.NodeName] = nodeRState
@@ -386,6 +392,9 @@ func TestScoreWithOrder(t *testing.T) {
 		pl.reservationCache.updateReservation(reservationWithOrder)
 		rInfo := pl.reservationCache.getReservationInfoByUID(reservationWithOrder.UID)
 		nodeRState := state.nodeReservationStates[reservationWithOrder.Status.NodeName]
+		if nodeRState == nil {
+			nodeRState = &nodeReservationState{}
+		}
 		nodeRState.nodeName = reservationWithOrder.Status.NodeName
 		nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 		state.nodeReservationStates[reservationWithOrder.Status.NodeName] = nodeRState
@@ -820,7 +829,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 			cycleState := framework.NewCycleState()
 			state := &stateData{
 				schedulingStateData: schedulingStateData{
-					nodeReservationStates: map[string]nodeReservationState{},
+					nodeReservationStates: map[string]*nodeReservationState{},
 				},
 			}
 			state.podRequests = apiresource.PodRequests(tt.pod, apiresource.PodResourcesOptions{})
@@ -832,6 +841,9 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 					rInfo.Allocated = allocated
 				}
 				nodeRState := state.nodeReservationStates[reservation.Status.NodeName]
+				if nodeRState == nil {
+					nodeRState = &nodeReservationState{}
+				}
 				nodeRState.nodeName = reservation.Status.NodeName
 				nodeRState.matchedOrIgnored = append(nodeRState.matchedOrIgnored, rInfo)
 				state.nodeReservationStates[reservation.Status.NodeName] = nodeRState


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

When reservations are widely used in the cluster, the resource restoration in the Reservation plugin can have a negligible overhead.
We added a feature called LazyReservationRestore, which improves scheduling performance by delaying the restoration after the PreFilter. When there is no need to restore resources for all nodes, e.g., if plugins give preFilterResult in the PreFilter phase, we can limit the reservation restoration to the necessary nodes.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
