### PR TITLE
scheduler: support besteffort policy

### DIFF
--- a/pkg/scheduler/frameworkext/topologymanager/policy_best_effort.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_best_effort.go
@@ -17,7 +17,10 @@ limitations under the License.
 
 package topologymanager
 
-import apiext "github.com/koordinator-sh/koordinator/apis/extension"
+import (
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
+)
 
 type bestEffortPolicy struct {
 	//List of NUMA Nodes available on the underlying machine
@@ -45,6 +48,16 @@ func (p *bestEffortPolicy) canAdmitPodResult(hint *NUMATopologyHint) bool {
 func (p *bestEffortPolicy) Merge(providersHints []map[string][]NUMATopologyHint, exclusivePolicy apiext.NumaTopologyExclusive, allNUMANodeStatus []apiext.NumaNodeStatus) (NUMATopologyHint, bool) {
 	filteredProvidersHints := filterProvidersHints(providersHints)
 	bestHint := mergeFilteredHints(p.numaNodes, filteredProvidersHints, exclusivePolicy, allNUMANodeStatus)
+	// 如果 bestHint 不是一个所有资源都可分的 numa affinity，则应该返回 bestHint 为亲和所有 NUMANode，即放弃任何 NUMA 倾向
+	if bestHint.Unsatisfied {
+		affinityAllNUMANodes, _ := bitmask.NewBitMask(p.numaNodes...)
+		bestHint = NUMATopologyHint{
+			NUMANodeAffinity: affinityAllNUMANodes,
+			Unsatisfied:      false,
+			Preferred:        bestHint.Preferred,
+			Score:            0,
+		}
+	}
 	admit := p.canAdmitPodResult(&bestHint)
 	return bestHint, admit
 }

--- a/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_best_effort_test.go
@@ -29,12 +29,12 @@ func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false, 0},
+			hint:     NUMATopologyHint{nil, false, false, 0},
 			expected: true,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true, 0},
+			hint:     NUMATopologyHint{nil, false, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_none_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_none_test.go
@@ -49,12 +49,12 @@ func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false, 0},
+			hint:     NUMATopologyHint{nil, false, false, 0},
 			expected: true,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true, 0},
+			hint:     NUMATopologyHint{nil, false, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_restricted_test.go
@@ -47,12 +47,12 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false, 0},
+			hint:     NUMATopologyHint{nil, false, false, 0},
 			expected: false,
 		},
 		{
 			name:     "Preferred is set to true in topology hints",
-			hint:     NUMATopologyHint{nil, true, 0},
+			hint:     NUMATopologyHint{nil, false, true, 0},
 			expected: true,
 		},
 	}

--- a/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node.go
@@ -71,7 +71,7 @@ func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]NUMATopologyH
 
 	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
 	if bestHint.NUMANodeAffinity.IsEqual(defaultAffinity) {
-		bestHint = NUMATopologyHint{nil, bestHint.Preferred, 0}
+		bestHint = NUMATopologyHint{nil, false, bestHint.Preferred, 0}
 	}
 
 	admit := p.canAdmitPodResult(&bestHint)

--- a/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/scheduler/frameworkext/topologymanager/policy_single_numa_node_test.go
@@ -30,7 +30,7 @@ func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
 	}{
 		{
 			name:     "Preferred is set to false in topology hints",
-			hint:     NUMATopologyHint{nil, false, 0},
+			hint:     NUMATopologyHint{nil, false, false, 0},
 			expected: false,
 		},
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. BestEffort 策略下，当多种资源 merge 出的 NUMA 资源不足时，直接返回所有 NUMA Node 作为 Hint
2. DeviceShare 中，如果判断已经打开了 NUMA 感知调度，则后续 Filter 逻辑可以忽略

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
