### PR TITLE
gpu: setting default gpu partition policy

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -323,11 +323,11 @@ func GetGPUPartitionTable(device *schedulingv1alpha1.Device) (GPUPartitionTable,
 	return nil, nil
 }
 
-func GetGPUPartitionPolicy(device *schedulingv1alpha1.Device) GPUPartitionPolicy {
-	if device == nil {
+func GetGPUPartitionPolicy(nodeOrDevice metav1.Object) GPUPartitionPolicy {
+	if nodeOrDevice == nil {
 		return GPUPartitionPolicyPrefer
 	}
-	if allocatePolicy := device.Labels[LabelGPUPartitionPolicy]; GPUPartitionPolicy(allocatePolicy) == GPUPartitionPolicyHonor {
+	if allocatePolicy := nodeOrDevice.GetLabels()[LabelGPUPartitionPolicy]; GPUPartitionPolicy(allocatePolicy) == GPUPartitionPolicyHonor {
 		return GPUPartitionPolicyHonor
 	}
 	return GPUPartitionPolicyPrefer

--- a/apis/extension/device_share_test.go
+++ b/apis/extension/device_share_test.go
@@ -290,11 +290,6 @@ func TestGetNodeLevelGPUAllocatePolicy(t *testing.T) {
 		expected GPUPartitionPolicy
 	}{
 		{
-			name:     "Nil node",
-			node:     nil,
-			expected: GPUPartitionPolicyPrefer,
-		},
-		{
 			name: "Node with Honor policy",
 			node: &schedulingv1alpha1.Device{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu.go
@@ -76,10 +76,7 @@ func (a *GPUAllocator) Allocate(requestCtx *requestContext, nodeDevice *nodeDevi
 	nodeHonorPartition := nodeDevice.nodeHonorGPUPartition
 	gpuPartitionIndexer := nodeDevice.gpuPartitionIndexer
 	if gpuPartitionIndexer == nil {
-		gpuPartitionIndexer = GetDesignatedGPUPartitionIndexer(requestCtx.node)
-		if gpuPartitionIndexer != nil {
-			nodeHonorPartition = true
-		}
+		gpuPartitionIndexer, nodeHonorPartition = GetDesignatedGPUPartitionIndexer(requestCtx.node)
 	}
 	honorGPUPartition := gpuRequirements.honorGPUPartition || nodeHonorPartition
 	realUsed := getRealUsed(requestCtx.nodeDevice.deviceUsed[schedulingv1alpha1.GPU], nodeDevice.deviceTotal[schedulingv1alpha1.GPU], nodeDevice.deviceUsed[schedulingv1alpha1.GPU])

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu_helper.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu_helper.go
@@ -147,13 +147,15 @@ var (
 		},
 	}
 
-	GetDesignatedGPUPartitionIndexer = func(node *corev1.Node) GPUPartitionIndexer {
+	GetDesignatedGPUPartitionIndexer = func(node *corev1.Node) (GPUPartitionIndexer, bool) {
+		var partitionIndexer GPUPartitionIndexer
+		partitionPolicy := apiext.GetGPUPartitionPolicy(node)
 		model := node.Labels[apiext.LabelGPUModel]
 		switch model {
 		case "H100", "H800", "H20":
-			return gpuPartitionIndexOfNVIDIAHopper
+			partitionIndexer = gpuPartitionIndexOfNVIDIAHopper
 		}
-		return nil
+		return partitionIndexer, partitionPolicy == apiext.GPUPartitionPolicyHonor
 	}
 )
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

在非 VM 情况下，gpu 不需要按照 Partition 分配，这种情况即使卡型匹配到了默认的 PartitionIndexer，需要根据 Node Or Device 上的 Label 来决定是否按照 Partition 分配

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
