### PR TITLE
scheduler: gang scheduling add closeHistoryEvaluate annotation

### DIFF
--- a/apis/extension/coscheduling.go
+++ b/apis/extension/coscheduling.go
@@ -37,6 +37,9 @@ const (
 	// If not specified,it will be set with the AnnotationGangMinNum
 	AnnotationGangTotalNum = AnnotationGangPrefix + "/total-number"
 
+	// AnnotationGangCloseHistoryEvaluate If AnnotationGangCloseHistoryEvaluate is true, it means that the pod that was destroyed and rebuilt will again comply with the gang policy restrictions.
+	AnnotationGangCloseHistoryEvaluate = AnnotationGangPrefix + "/close-history-evaluate"
+
 	// AnnotationGangMode defines the Gang Scheduling operation when failed scheduling
 	// Support GangModeStrict and GangModeNonStrict, default is GangModeStrict
 	AnnotationGangMode = AnnotationGangPrefix + "/mode"
@@ -51,6 +54,8 @@ const (
 
 	GangModeStrict    = "Strict"
 	GangModeNonStrict = "NonStrict"
+
+	GangCloseHistoryEvaluate = "true"
 
 	// AnnotationGangMatchPolicy defines the Gang Scheduling operation of taking which status pod into account
 	// Support GangMatchPolicyOnlyWaiting, GangMatchPolicyWaitingAndRunning, GangMatchPolicyOnceSatisfied, default is GangMatchPolicyOnceSatisfied

--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -283,8 +283,9 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, state *framework.Cy
 		return fmt.Errorf("gang has not init, gangName: %v, podName: %v", gang.Name,
 			util.GetId(pod.Namespace, pod.Name))
 	}
+
 	// resourceSatisfied means pod will directly pass the PreFilter
-	if gang.getGangMatchPolicy() == extension.GangMatchPolicyOnceSatisfied && gang.isGangOnceResourceSatisfied() {
+	if gang.getGangMatchPolicy() == extension.GangMatchPolicyOnceSatisfied && gang.isGangOnceResourceSatisfied() && !gang.CloseHistoryEvaluate {
 		return nil
 	}
 

--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -46,13 +46,15 @@ type Gang struct {
 	CreateTime time.Time
 
 	// strict-mode or non-strict-mode
-	Mode              string
-	MinRequiredNumber int
-	TotalChildrenNum  int
-	GangGroupId       string
-	GangGroup         []string
-	GangGroupInfo     *GangGroupInfo
-	Children          map[string]*v1.Pod
+	Mode string
+	// If CloseHistoryEvaluate is true, it means that the pod that was destroyed and rebuilt will again comply with the gang policy restrictions.
+	CloseHistoryEvaluate bool
+	MinRequiredNumber    int
+	TotalChildrenNum     int
+	GangGroupId          string
+	GangGroup            []string
+	GangGroupInfo        *GangGroupInfo
+	Children             map[string]*v1.Pod
 	// pods that have already assumed(waiting in Permit stage)
 	WaitingForBindChildren map[string]*v1.Pod
 	// pods that have already bound
@@ -188,6 +190,13 @@ func (gang *Gang) tryInitByPodGroup(pg *v1alpha1.PodGroup, args *config.Coschedu
 		mode = extension.GangModeStrict
 	}
 	gang.Mode = mode
+
+	closeHistoryEvaluate := pg.Annotations[extension.AnnotationGangCloseHistoryEvaluate]
+	if closeHistoryEvaluate == extension.GangCloseHistoryEvaluate {
+		klog.Infof("podGroup's annotation GangCloseHistoryEvaluateAnnotation is true, gangName: %v, value: %v",
+			gang.Name, pg.Annotations[extension.AnnotationGangCloseHistoryEvaluate])
+		gang.CloseHistoryEvaluate = true
+	}
 
 	matchPolicy := pg.Annotations[extension.AnnotationGangMatchPolicy]
 	if matchPolicy != extension.GangMatchPolicyOnlyWaiting && matchPolicy != extension.GangMatchPolicyWaitingAndRunning &&


### PR DESCRIPTION
<!-- Please only use this template for submitting proposal -->

**What is your proposal**:
Add user wishes comments to the logic in the gang policy to prevent the gang policy from directly invalidating after the pod is destroyed and rebuilt.
`if gang.getGangMatchPolicy() == extension.GangMatchPolicyOnceSatisfied && gang.isGangOnceResourceSatisfied() {
		return nil
	}`

**Why is this needed**:
The gang policy immediately becomes invalid after the pod is destroyed and rebuilt. The newly created pod becomes running even when the total number of pods does not meet the MinRequiredNumber. However, some users think this does not meet their expectations. They believe that the semantics of the gang policy are still followed in this scenario. , so it is recommended to add user intention judgment logic

**Is there a suggested solution, if so, please add it**:
Annotation can be added to the podGroup, for example: gang.scheduling.koordinator.sh/close-history-evaluate. At this time, the rebuilt pod is destroyed. When the total number of pods does not meet the MinRequiredNumber, it is still pending, maintaining gang semantics.

Checklist

- [ ✅] I have written necessary docs and comments
- [ ✅] I have added necessary unit tests and integration tests
- [ ✅] All checks passed in `make test`
