### PR TITLE
manager: sync rdma resource to node

### DIFF
--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin_test.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin_test.go
@@ -602,6 +602,14 @@ func TestPluginCalculate(t *testing.T) {
 			},
 		},
 	}
+	deviceMissingGPU := &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNode.Name,
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{},
+		},
+	}
 	type fields struct {
 		client ctrlclient.Client
 	}
@@ -805,6 +813,43 @@ func TestPluginCalculate(t *testing.T) {
 			name: "calculate resetting device resources",
 			fields: fields{
 				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want: []framework.ResourceItem{
+				{
+					Name:    extension.ResourceGPU,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
+					Name:    extension.ResourceGPUCore,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
+					Name:    extension.ResourceGPUMemory,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
+					Name:    extension.ResourceGPUMemoryRatio,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
+					Name:    extension.ResourceGPUShared,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate resetting device resources",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, deviceMissingGPU).Build(),
 			},
 			args: args{
 				node: testNode,

--- a/pkg/slo-controller/noderesource/plugins/rdmadevicereource/device_event_handler.go
+++ b/pkg/slo-controller/noderesource/plugins/rdmadevicereource/device_event_handler.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdmadeviceresource
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+var _ handler.EventHandler = &DeviceHandler{}
+
+type DeviceHandler struct{}
+
+func (d *DeviceHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	device := e.Object.(*schedulingv1alpha1.Device)
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: device.Name,
+		},
+	})
+}
+
+func (d *DeviceHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	newDevice := e.ObjectNew.(*schedulingv1alpha1.Device)
+	oldDevice := e.ObjectOld.(*schedulingv1alpha1.Device)
+	if reflect.DeepEqual(newDevice.Spec, oldDevice.Spec) {
+		return
+	}
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: newDevice.Name,
+		},
+	})
+}
+
+func (d *DeviceHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	device, ok := e.Object.(*schedulingv1alpha1.Device)
+	if !ok {
+		return
+	}
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: device.Name,
+		},
+	})
+}
+
+func (d *DeviceHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+}

--- a/pkg/slo-controller/noderesource/plugins/rdmadevicereource/device_event_handler_test.go
+++ b/pkg/slo-controller/noderesource/plugins/rdmadevicereource/device_event_handler_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdmadeviceresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func Test_EnqueueRequestForNodeMetricMetric(t *testing.T) {
+	tests := []struct {
+		name      string
+		fn        func(handler handler.EventHandler, q workqueue.RateLimitingInterface)
+		hasEvent  bool
+		eventName string
+	}{
+		{
+			name: "create device event",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Create(context.TODO(), event.CreateEvent{
+					Object: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node1",
+						},
+					},
+				}, q)
+			},
+			hasEvent:  true,
+			eventName: "node1",
+		},
+		{
+			name: "delete device event",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Delete(context.TODO(), event.DeleteEvent{
+					Object: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node1",
+						},
+					},
+				}, q)
+			},
+			hasEvent:  true,
+			eventName: "node1",
+		},
+		{
+			name: "delete event not device",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Delete(context.TODO(), event.DeleteEvent{
+					Object: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node1",
+						},
+					},
+				}, q)
+			},
+			hasEvent: false,
+		},
+		{
+			name: "generic event ignore",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Generic(context.TODO(), event.GenericEvent{}, q)
+			},
+			hasEvent: false,
+		},
+		{
+			name: "update device event",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Update(context.TODO(), event.UpdateEvent{
+					ObjectOld: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "node1",
+							ResourceVersion: "100",
+						},
+						Spec: schedulingv1alpha1.DeviceSpec{
+							Devices: []schedulingv1alpha1.DeviceInfo{
+								{},
+							},
+						},
+					},
+					ObjectNew: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "node1",
+							ResourceVersion: "101",
+						},
+						Spec: schedulingv1alpha1.DeviceSpec{
+							Devices: []schedulingv1alpha1.DeviceInfo{
+								{},
+								{},
+							},
+						},
+					},
+				}, q)
+			},
+			hasEvent:  true,
+			eventName: "node1",
+		},
+		{
+			name: "update device event ignore",
+			fn: func(handler handler.EventHandler, q workqueue.RateLimitingInterface) {
+				handler.Update(context.TODO(), event.UpdateEvent{
+					ObjectOld: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "node1",
+							ResourceVersion: "100",
+						},
+						Spec: schedulingv1alpha1.DeviceSpec{
+							Devices: []schedulingv1alpha1.DeviceInfo{
+								{},
+							},
+						},
+					},
+					ObjectNew: &schedulingv1alpha1.Device{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "node1",
+							ResourceVersion: "100",
+						},
+						Spec: schedulingv1alpha1.DeviceSpec{
+							Devices: []schedulingv1alpha1.DeviceInfo{
+								{},
+							},
+						},
+					},
+				}, q)
+			},
+			hasEvent: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			h := &DeviceHandler{}
+			tt.fn(h, queue)
+			assert.Equal(t, tt.hasEvent, queue.Len() > 0, "unexpected event")
+			if tt.hasEvent {
+				assert.True(t, queue.Len() >= 0, "expected event")
+				e, _ := queue.Get()
+				assert.Equal(t, tt.eventName, e.(reconcile.Request).Name)
+			}
+		})
+	}
+
+}

--- a/pkg/slo-controller/noderesource/plugins/rdmadevicereource/plugin.go
+++ b/pkg/slo-controller/noderesource/plugins/rdmadevicereource/plugin.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gpudeviceresource
+package rdmadeviceresource
 
 import (
 	"context"
@@ -31,21 +31,23 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/configuration"
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
-	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
 	"github.com/koordinator-sh/koordinator/pkg/util"
-	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
-const PluginName = "GPUDeviceResource"
+const PluginName = "RDMADeviceResource"
 
 const (
-	ResetResourcesMsg  = "reset node gpu resources"
-	UpdateResourcesMsg = "node gpu resources from device"
-	UpdateLabelsMsg    = "node gpu labels from device"
+	ResetResourcesMsg  = "reset node rdma resources"
+	UpdateResourcesMsg = "node rdma resources from device"
 
-	NeedSyncForResourceDiffMsg = "gpu resource diff is big than threshold"
-	NeedSyncForGPUModelMsgFmt  = "gpu device label %s changed"
+	NeedSyncForResourceDiffMsg = "rdma resource diff is big than threshold"
+)
+
+var (
+	ResourceNames = []corev1.ResourceName{
+		extension.ResourceRDMA,
+	}
 )
 
 var client ctrlclient.Client
@@ -66,7 +68,6 @@ func (p *Plugin) Name() string {
 func (p *Plugin) Setup(opt *framework.Option) error {
 	client = opt.Client
 
-	// schedulingv1alpha1.AddToScheme(opt.Scheme)
 	opt.Builder = opt.Builder.Watches(&schedulingv1alpha1.Device{}, &DeviceHandler{})
 
 	return nil
@@ -79,18 +80,6 @@ func (p *Plugin) NeedSync(strategy *configuration.ColocationStrategy, oldNode, n
 			klog.V(4).InfoS("need sync node since resource diff bigger than threshold", "node", newNode.Name,
 				"resource", resourceName, "threshold", *strategy.ResourceDiffThreshold)
 			return true, NeedSyncForResourceDiffMsg
-		}
-	}
-
-	return false, ""
-}
-
-func (p *Plugin) NeedSyncMeta(_ *configuration.ColocationStrategy, oldNode, newNode *corev1.Node) (bool, string) {
-	for _, label := range Labels {
-		if oldNode.Labels[label] != newNode.Labels[label] {
-			klog.V(4).InfoS("need sync node metadata since label change", "node", newNode.Name,
-				"label", label, "old", oldNode.Labels[label], "new", newNode.Labels[label])
-			return true, fmt.Sprintf(NeedSyncForGPUModelMsgFmt, label)
 		}
 	}
 
@@ -115,18 +104,6 @@ func (p *Plugin) Prepare(_ *configuration.ColocationStrategy, node *corev1.Node,
 		node.Status.Allocatable[resourceName] = *q
 		node.Status.Capacity[resourceName] = *q
 	}
-
-	// prepare node labels
-	// TBD: shall we reset labels if not exist in the NR
-	if nr.Labels != nil {
-		if _, ok := nr.Labels[extension.LabelGPUModel]; ok {
-			node.Labels[extension.LabelGPUModel] = nr.Labels[extension.LabelGPUModel]
-		}
-		if _, ok := nr.Labels[extension.LabelGPUDriverVersion]; ok {
-			node.Labels[extension.LabelGPUDriverVersion] = nr.Labels[extension.LabelGPUDriverVersion]
-		}
-	}
-
 	return nil
 }
 
@@ -147,19 +124,20 @@ func (p *Plugin) Calculate(_ *configuration.ColocationStrategy, node *corev1.Nod
 			return nil, fmt.Errorf("failed to get device resources: %w", err)
 		}
 
-		// device not found, reset gpu resources on node
-		return p.resetGPUNodeResource()
+		// device not found, reset rdma resources on node
+		return p.resetRDMANodeResource()
 	}
 
-	existsGPU := false
+	// Check whether the rdma device exists
+	existsRDMA := false
 	for _, d := range device.Spec.Devices {
-		if d.Type == schedulingv1alpha1.GPU && d.Health {
-			existsGPU = true
+		if d.Type == schedulingv1alpha1.RDMA && d.Health {
+			existsRDMA = true
 		}
 	}
-	if !existsGPU {
-		klog.V(5).InfoS("gpu not found in device, reset gpu resources on node", "node", node.Name)
-		return p.resetGPUNodeResource()
+	if !existsRDMA {
+		klog.V(5).InfoS("rdma not found in device, reset rdma resources on node", "node", node.Name)
+		return p.resetRDMANodeResource()
 	}
 
 	// TODO: calculate NUMA-level resources against NRT
@@ -171,29 +149,20 @@ func (p *Plugin) calculate(node *corev1.Node, device *schedulingv1alpha1.Device)
 		return nil, fmt.Errorf("invalid device")
 	}
 
-	// calculate gpu resources
-	gpuResources := make(corev1.ResourceList)
-	totalKoordGPU := resource.NewQuantity(0, resource.DecimalSI)
-	healthGPUNum := 0
+	// calculate rdma resources
+	rdmaPFNum := 0
 	for _, d := range device.Spec.Devices {
-		if d.Type != schedulingv1alpha1.GPU || !d.Health {
+		if d.Type != schedulingv1alpha1.RDMA || !d.Health {
 			continue
 		}
-
-		healthGPUNum++
-		util.AddResourceList(gpuResources, d.Resources)
-		totalKoordGPU.Add(d.Resources[extension.ResourceGPUCore])
+		rdmaPFNum++
 	}
-
-	gpuResources[extension.ResourceGPU] = *totalKoordGPU
-	if utilfeature.DefaultFeatureGate.Enabled(features.EnableSyncGPUSharedResource) {
-		gpuResources[extension.ResourceGPUShared] = *resource.NewQuantity(int64(healthGPUNum)*100, resource.DecimalSI)
-	}
-
+	rdmaResources := make(corev1.ResourceList)
+	rdmaResources[extension.ResourceRDMA] = *resource.NewQuantity(int64(rdmaPFNum)*100, resource.DecimalSI)
 	var items []framework.ResourceItem
 	// FIXME: shall we add node resources in devices but not in ResourceNames?
-	for resourceName := range gpuResources {
-		q := gpuResources[resourceName]
+	for resourceName := range rdmaResources {
+		q := rdmaResources[resourceName]
 		items = append(items, framework.ResourceItem{
 			Name:     resourceName,
 			Quantity: &q,
@@ -201,29 +170,12 @@ func (p *Plugin) calculate(node *corev1.Node, device *schedulingv1alpha1.Device)
 		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
-	klog.V(5).InfoS("calculate gpu resources", "node", node.Name, "resources", gpuResources)
-
-	// calculate labels about gpu driver and model
-	updatedLabels := map[string]string{}
-	if gpuModel, ok := device.Labels[extension.LabelGPUModel]; ok {
-		updatedLabels[extension.LabelGPUModel] = gpuModel
-	}
-	if gpuDriverVersion, ok := device.Labels[extension.LabelGPUDriverVersion]; ok {
-		updatedLabels[extension.LabelGPUDriverVersion] = gpuDriverVersion
-	}
-	if len(updatedLabels) != 0 {
-		items = append(items, framework.ResourceItem{
-			Name:    PluginName,
-			Labels:  updatedLabels,
-			Message: UpdateLabelsMsg,
-		})
-	}
-	klog.V(5).InfoS("calculate gpu labels", "node", node.Name, "labels", device.Labels)
+	klog.V(5).InfoS("calculate rdma resources", "node", node.Name, "resources", rdmaResources)
 
 	return items, nil
 }
 
-func (p *Plugin) resetGPUNodeResource() ([]framework.ResourceItem, error) {
+func (p *Plugin) resetRDMANodeResource() ([]framework.ResourceItem, error) {
 	items := make([]framework.ResourceItem, len(ResourceNames))
 	// FIXME: shall we reset node resources in devices but not in ResourceNames?
 	for i := range ResourceNames {

--- a/pkg/slo-controller/noderesource/plugins/rdmadevicereource/plugin_test.go
+++ b/pkg/slo-controller/noderesource/plugins/rdmadevicereource/plugin_test.go
@@ -1,0 +1,514 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdmadeviceresource
+
+import (
+	"testing"
+
+	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/framework"
+	"github.com/koordinator-sh/koordinator/pkg/util/testutil"
+)
+
+func TestPlugin(t *testing.T) {
+	t.Run("test", func(t *testing.T) {
+		p := &Plugin{}
+		assert.Equal(t, PluginName, p.Name())
+
+		testScheme := runtime.NewScheme()
+		testOpt := &framework.Option{
+			Scheme:  testScheme,
+			Client:  fake.NewClientBuilder().WithScheme(testScheme).Build(),
+			Builder: builder.ControllerManagedBy(&testutil.FakeManager{}),
+		}
+		err := p.Setup(testOpt)
+		assert.NoError(t, err)
+
+		got := p.Reset(nil, "")
+		assert.Nil(t, got)
+	})
+}
+
+func TestPluginNeedSync(t *testing.T) {
+	testStrategy := &configuration.ColocationStrategy{
+		Enable:                        pointer.Bool(true),
+		CPUReclaimThresholdPercent:    pointer.Int64(65),
+		MemoryReclaimThresholdPercent: pointer.Int64(65),
+		DegradeTimeMinutes:            pointer.Int64(15),
+		UpdateTimeThresholdSeconds:    pointer.Int64(300),
+		ResourceDiffThreshold:         pointer.Float64(0.1),
+	}
+	testNodeWithoutDevice := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	testNodeWithDevice := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	testNodeWithDeviceDriverUpdate := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	testNodeWithDeviceResourceUpdate := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(300, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(300, resource.DecimalSI),
+			},
+		},
+	}
+	t.Run("test", func(t *testing.T) {
+		p := &Plugin{}
+
+		// nothing change, both have no gpu device
+		got, got1 := p.NeedSync(testStrategy, testNodeWithoutDevice, testNodeWithoutDevice)
+		assert.False(t, got)
+		assert.Equal(t, "", got1)
+		// nothing change, both has gpu devices
+		got, got1 = p.NeedSync(testStrategy, testNodeWithDevice, testNodeWithDevice)
+		assert.False(t, got)
+		assert.Equal(t, "", got1)
+		// ignore labels change
+		got, got1 = p.NeedSync(testStrategy, testNodeWithDevice, testNodeWithDeviceDriverUpdate)
+		assert.False(t, got)
+		assert.Equal(t, "", got1)
+
+		// add resources
+		got, got1 = p.NeedSync(testStrategy, testNodeWithoutDevice, testNodeWithDevice)
+		assert.True(t, got)
+		assert.Equal(t, NeedSyncForResourceDiffMsg, got1)
+		// resource update
+		got, got1 = p.NeedSync(testStrategy, testNodeWithDevice, testNodeWithDeviceResourceUpdate)
+		assert.True(t, got)
+		assert.Equal(t, NeedSyncForResourceDiffMsg, got1)
+
+		// delete resources
+		got, got1 = p.NeedSync(testStrategy, testNodeWithDevice, testNodeWithoutDevice)
+		assert.True(t, got)
+		assert.Equal(t, NeedSyncForResourceDiffMsg, got1)
+	})
+}
+
+func TestPluginPrepare(t *testing.T) {
+	testNodeWithoutDevice := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	testNodeWithDevice := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	testNodeWithoutDeviceResources := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	type args struct {
+		node *corev1.Node
+		nr   *framework.NodeResource
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		wantField *corev1.Node
+	}{
+		{
+			name: "nothing to prepare",
+			args: args{
+				node: testNodeWithoutDevice,
+				nr:   framework.NewNodeResource(),
+			},
+			wantErr:   false,
+			wantField: testNodeWithoutDevice,
+		},
+		{
+			name: "update resources and labels correctly",
+			args: args{
+				node: testNodeWithoutDevice,
+				nr: &framework.NodeResource{
+					Resources: map[corev1.ResourceName]*resource.Quantity{
+						extension.ResourceRDMA: resource.NewQuantity(200, resource.DecimalSI),
+					},
+					ZoneResources: map[string]corev1.ResourceList{},
+					Messages:      map[corev1.ResourceName]string{},
+					Resets:        map[corev1.ResourceName]bool{},
+				},
+			},
+			wantErr:   false,
+			wantField: testNodeWithDevice,
+		},
+		{
+			name: "reset resources correctly",
+			args: args{
+				node: testNodeWithDevice,
+				nr: &framework.NodeResource{
+					Resets: map[corev1.ResourceName]bool{
+						extension.ResourceRDMA: true,
+					},
+				},
+			},
+			wantErr:   false,
+			wantField: testNodeWithoutDeviceResources,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			gotErr := p.Prepare(nil, tt.args.node, tt.args.nr)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			assert.Equal(t, tt.wantField, tt.args.node)
+		})
+	}
+}
+
+func TestPluginCalculate(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := clientgoscheme.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	err = topov1alpha1.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	err = schedulingv1alpha1.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	testDevice := &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNode.Name,
+			Labels: map[string]string{
+				extension.LabelGPUModel:         "A100",
+				extension.LabelGPUDriverVersion: "480",
+			},
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{
+				{
+					UUID:   "1",
+					Minor:  pointer.Int32(0),
+					Health: true,
+					Type:   schedulingv1alpha1.RDMA,
+					Resources: map[corev1.ResourceName]resource.Quantity{
+						extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+					},
+				},
+				{
+					UUID:   "2",
+					Minor:  pointer.Int32(1),
+					Health: true,
+					Type:   schedulingv1alpha1.RDMA,
+					Resources: map[corev1.ResourceName]resource.Quantity{
+						extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+					},
+				},
+			},
+		},
+	}
+	deviceMissingRDMA := &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNode.Name,
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{},
+		},
+	}
+	type fields struct {
+		client ctrlclient.Client
+	}
+	type args struct {
+		node *corev1.Node
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []framework.ResourceItem
+		wantErr bool
+	}{
+		{
+			name: "args missing essential fields",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).Build(),
+			},
+			args: args{
+				node: &corev1.Node{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "get device object error",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "calculate device resources correctly",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want: []framework.ResourceItem{
+				{
+					Name:     extension.ResourceRDMA,
+					Quantity: resource.NewQuantity(200, resource.DecimalSI),
+					Message:  UpdateResourcesMsg,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate device resources correctly",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want: []framework.ResourceItem{
+				{
+					Name:     extension.ResourceRDMA,
+					Quantity: resource.NewQuantity(200, resource.DecimalSI),
+					Message:  UpdateResourcesMsg,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate resetting device resources",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want: []framework.ResourceItem{
+				{
+					Name:    extension.ResourceRDMA,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "calculate resetting device resources",
+			fields: fields{
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, deviceMissingRDMA).Build(),
+			},
+			args: args{
+				node: testNode,
+			},
+			want: []framework.ResourceItem{
+				{
+					Name:    extension.ResourceRDMA,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			client = tt.fields.client
+			defer testPluginCleanup()
+			got, gotErr := p.Calculate(nil, tt.args.node, nil, nil)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_cleanupGPUNodeResource(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := clientgoscheme.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	err = topov1alpha1.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	err = schedulingv1alpha1.AddToScheme(testScheme)
+	assert.NoError(t, err)
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	testNodeWithoutLabels := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:     resource.MustParse("100"),
+				corev1.ResourceMemory:  resource.MustParse("400Gi"),
+				extension.ResourceRDMA: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	t.Run("cleanup success", func(t *testing.T) {
+		p := &Plugin{}
+		client = fake.NewClientBuilder().WithScheme(testScheme).Build()
+		defer testPluginCleanup()
+		node := testNodeWithoutLabels.DeepCopy()
+		resourceItems, err := p.Calculate(nil, node, nil, nil)
+		assert.NoError(t, err, "expect calculate success")
+		nr := framework.NewNodeResource(resourceItems...)
+		err = p.Prepare(nil, node, nr)
+		assert.NoError(t, err)
+		assert.Equal(t, testNode, node)
+	})
+}
+
+func testPluginCleanup() {
+	client = nil
+}

--- a/pkg/slo-controller/noderesource/plugins_profile.go
+++ b/pkg/slo-controller/noderesource/plugins_profile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/cpunormalization"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/gpudeviceresource"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/midresource"
+	rdmadeviceresource "github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/rdmadevicereource"
 	"github.com/koordinator-sh/koordinator/pkg/slo-controller/noderesource/plugins/resourceamplification"
 )
 
@@ -34,6 +35,7 @@ func init() {
 	addPluginOption(&cpunormalization.Plugin{}, true)
 	addPluginOption(&resourceamplification.Plugin{}, true)
 	addPluginOption(&gpudeviceresource.Plugin{}, true)
+	addPluginOption(&rdmadeviceresource.Plugin{}, true)
 }
 
 func addPlugins(filter framework.FilterFn) {
@@ -53,6 +55,7 @@ var (
 		&resourceamplification.Plugin{},
 		&batchresource.Plugin{},
 		&gpudeviceresource.Plugin{},
+		&rdmadeviceresource.Plugin{},
 	}
 	// NodePreUpdatePlugin implements node resource pre-updating.
 	nodePreUpdatePlugins = []framework.NodePreUpdatePlugin{
@@ -65,12 +68,14 @@ var (
 		&midresource.Plugin{},
 		&batchresource.Plugin{},
 		&gpudeviceresource.Plugin{},
+		&rdmadeviceresource.Plugin{},
 	}
 	// NodeSyncPlugin implements the check of resource updating.
 	nodeStatusCheckPlugins = []framework.NodeStatusCheckPlugin{
 		&midresource.Plugin{},
 		&batchresource.Plugin{},
 		&gpudeviceresource.Plugin{},
+		&rdmadeviceresource.Plugin{},
 	}
 	// nodeMetaCheckPlugins implements the check of node meta updating.
 	nodeMetaCheckPlugins = []framework.NodeMetaCheckPlugin{
@@ -85,5 +90,6 @@ var (
 		&midresource.Plugin{},
 		&batchresource.Plugin{},
 		&gpudeviceresource.Plugin{},
+		&rdmadeviceresource.Plugin{},
 	}
 )


### PR DESCRIPTION
[koord-manager-rdma]
### Ⅰ. Describe what this PR does

In order to implement the end-to-end scheme of the rdma device, it is necessary to add an rdma resource controller to update the status of node nodes in time, including Capacity and Allocatable. The koordinator.sh/rdma resources are mainly updated.

### Ⅱ. Does this pull request fix one issue?

Fixed loss of functionality for rdma resource registration and update to nodes

### Ⅲ. Describe how to verify it

1. In the k8s cluster, prepare one or more servers that support rdma network adapters as cluster nodes. Install the new version of the koordlet component on each node and install the new version of the koord-manager component. Check whether the number of rdma resources in a node is updated to the actual number of rdma nics on the node.

2. Uninstall one or more RDMA network cards of the node and restart the server. After the node is added to the cluster and the cluster is stable, check whether the number of rdma network cards in the node resource is updated to the actual number of rdma network cards of the node.

### Ⅳ. Special notes for reviews
Updating RDMA device resources to nodes requires the koordlet component on the end. Therefore, you must install the koordlet version that supports RDMA on each node in the cluster. In this way, the koord-manager component can be used to test the effect

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
