### PR TITLE
api: supply id for minor meaningless device

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -80,14 +80,32 @@ const (
         "koordinator.sh/gpu-memory": "16Gi"
       }
     }
+  ],
+  "rdma": [
+    {
+      "minor": 0,
+      "id": "0000:09:00.0",
+      "resources": {
+        "koordinator.sh/rdma": 100,
+      }
+    },
+    {
+      "minor": 1,
+      "id": "0000:10:00.0",
+      "resources": {
+        "koordinator.sh/rdma": 100,
+      }
+    }
   ]
 }
 */
 type DeviceAllocations map[schedulingv1alpha1.DeviceType][]*DeviceAllocation
 
 type DeviceAllocation struct {
-	Minor     int32                      `json:"minor"`
-	Resources corev1.ResourceList        `json:"resources"`
+	Minor     int32               `json:"minor"`
+	Resources corev1.ResourceList `json:"resources"`
+	// ID is the well known identifier for device, because for some device, such as rdma, Minor is meaningless
+	ID        string                     `json:"id,omitempty"`
 	Extension *DeviceAllocationExtension `json:"extension,omitempty"`
 }
 

--- a/apis/extension/device_share_test.go
+++ b/apis/extension/device_share_test.go
@@ -89,6 +89,33 @@ func Test_GetDeviceAllocations(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "correct annotations with busID",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "123456789",
+					Namespace: "default",
+					Name:      "test",
+					Annotations: map[string]string{
+						AnnotationDeviceAllocated: `{"gpu":[{"minor":1,"id": "0000:08.00.0","resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"}}]}`,
+					},
+				},
+			},
+			want: DeviceAllocations{
+				schedulingv1alpha1.GPU: []*DeviceAllocation{
+					{
+						Minor: 1,
+						ID:    "0000:08.00.0",
+						Resources: corev1.ResourceList{
+							ResourceGPUCore:        resource.MustParse("100"),
+							ResourceGPUMemoryRatio: resource.MustParse("100"),
+							ResourceGPUMemory:      resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/proposals/scheduling/20220629-fine-grained-device-scheduling.md
+++ b/docs/proposals/scheduling/20220629-fine-grained-device-scheduling.md
@@ -218,7 +218,7 @@ resources:
 
 ##### DeviceAllocation
 
-In the PreBind stage, the scheduler will update the device (including GPU) allocation results, including the device's Minor and resource allocation information, to the Pod in the form of annotations.
+In the PreBind stage, the scheduler will update the device (including GPU) allocation results, including the device's Minor, ID, resource allocation information, to the Pod in the form of annotations.
 
 ```go
 /*
@@ -226,7 +226,7 @@ In the PreBind stage, the scheduler will update the device (including GPU) alloc
   "gpu": [
     {
       "minor": 0,
-      "resouurces": {
+      "resources": {
         "koordinator.sh/gpu-core": 100,
         "koordinator.sh/gpu-memory-ratio": 100,
         "koordinator.sh/gpu-memory": "16Gi"
@@ -234,18 +234,38 @@ In the PreBind stage, the scheduler will update the device (including GPU) alloc
     },
     {
       "minor": 1,
-      "resouurces": {
+      "resources": {
         "koordinator.sh/gpu-core": 100,
         "koordinator.sh/gpu-memory-ratio": 100,
         "koordinator.sh/gpu-memory": "16Gi"
       }
     }
+  ],
+  "rdma": [
+    {
+      "minor": 0,
+      "id": "0000:09:00.0",
+      "resources": {
+        "koordinator.sh/rdma": 100,
+      }
+    },
+    {
+      "minor": 1,
+      "id": "0000:10:00.0",
+      "resources": {
+        "koordinator.sh/rdma": 100,
+      }
+    }
   ]
 }
 */
+
 type DeviceAllocation struct {
-    Minor     int32
-    Resources map[string]resource.Quantity
+    Minor     int32               `json:"minor"`
+    Resources corev1.ResourceList `json:"resources"`
+    // ID is the well known identifier for device, because for some device, such as rdma, Minor is meaningless
+    ID        string                     `json:"id,omitempty"`
+    Extension *DeviceAllocationExtension `json:"extension,omitempty"`
 }
 
 type DeviceAllocations map[DeviceType][]*DeviceAllocation


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The RDMA device is mounted inside the container based on the scheduling assignment result.

### Ⅱ. Does this pull request fix one issue?

The scheduling framework already supports joint allocation of Gpus and RDMA devices, but several semantics need to be tested in practice, including preference and samePCIE. In order to allow RDMA devices to access the container, we need to fix the lack of BDF addresses in the results assigned by the scheduling algorithm to RDMA devices

### Ⅲ. Describe how to verify it

1. In the k8s cluster, prepare one or more servers that support rdma network adapters as cluster nodes. Install the new version of the koordlet component, koord-manager, and the revamped multus-cni on each node, and check the node status. The number of resources is displayed as the actual number of RDMA nics on the node.

2. Write a pod.YAML to apply for RDMA network card resources, kubectl apply-f pod. On pod note (device-allocated), check whether the rdma device bdf address (busID field) is included in the rdma allocation result, and check the accuracy.

3. When the pod is in the running state, enter the container and run the ifconfig command to check the number of network cards. If the case is correct, multiple network card lists will be output, such as net1, net2, net3, and so on.

### Ⅳ. Special notes for reviews

1. Deploy components that support RDMA, including koordlet, koord-manager, koord-scheduler, and multus-cni.

2. Due to the complete end-to-end passthrough, multi-CNI plug-in is also required, which complies with CNI specifications and supports multi-NIC allocation. Assigning the RDMA network card PF/VF to the Pod mentioned here requires the device ID to be injected into the component, otherwise it will not work. This change will be maintained separately in the multi-cni project or another PR

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`