### PR TITLE
koordlet: add ReadMemoryUsage method to improve generality of cgroup reader interface

### DIFF
--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -33,6 +33,7 @@ type CgroupReader interface {
 	ReadCPUSet(parentDir string) (*cpuset.CPUSet, error)
 	ReadCPUAcctUsage(parentDir string) (uint64, error)
 	ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, error)
+	ReadMemoryUsage(parentDir string) (uint64, error)
 	ReadMemoryLimit(parentDir string) (int64, error)
 	ReadMemoryStat(parentDir string) (*sysutil.MemoryStatRaw, error)
 	ReadMemoryNumaStat(parentDir string) ([]sysutil.NumaMemoryPages, error)
@@ -111,6 +112,14 @@ func (r *CgroupV1Reader) ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, err
 		return nil, fmt.Errorf("cannot parse cgroup value %s, err: %v", s, err)
 	}
 	return v, nil
+}
+
+func (r *CgroupV1Reader) ReadMemoryUsage(parentDir string) (uint64, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV1, sysutil.MemoryUsageName)
+	if !ok {
+		return 0, ErrResourceNotRegistered
+	}
+	return readCgroupAndParseUint64(parentDir, resource)
 }
 
 func (r *CgroupV1Reader) ReadMemoryLimit(parentDir string) (int64, error) {
@@ -346,6 +355,14 @@ func (r *CgroupV2Reader) ReadCPUStat(parentDir string) (*sysutil.CPUStatRaw, err
 		return nil, fmt.Errorf("cannot parse cgroup value %s, err: %v", s, err)
 	}
 	return v, nil
+}
+
+func (r *CgroupV2Reader) ReadMemoryUsage(parentDir string) (uint64, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV2, sysutil.MemoryUsageName)
+	if !ok {
+		return 0, ErrResourceNotRegistered
+	}
+	return readCgroupAndParseUint64(parentDir, resource)
 }
 
 func (r *CgroupV2Reader) ReadMemoryLimit(parentDir string) (int64, error) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The CgroupReader interface under the resourceexecutor module is missing a method to read memory usage for cgroups. We need this method to obtain memory usage information for a specific cgroup.


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
