### PR TITLE
koordlet: add GetNodeMetricSpec in statesInformer interface

### DIFF
--- a/pkg/koordlet/prediction/prediction_test.go
+++ b/pkg/koordlet/prediction/prediction_test.go
@@ -43,7 +43,12 @@ func (m *mockStatesInformer) HasSynced() bool {
 func (m *mockStatesInformer) GetNode() *v1.Node {
 	return m.node
 }
+
 func (m *mockStatesInformer) GetNodeSLO() *slov1alpha1.NodeSLO {
+	return nil
+}
+
+func (m *mockStatesInformer) GetNodeMetricSpec() *slov1alpha1.NodeMetricSpec {
 	return nil
 }
 

--- a/pkg/koordlet/statesinformer/api.go
+++ b/pkg/koordlet/statesinformer/api.go
@@ -120,6 +120,7 @@ type StatesInformer interface {
 
 	GetNode() *corev1.Node
 	GetNodeSLO() *slov1alpha1.NodeSLO
+	GetNodeMetricSpec() *slov1alpha1.NodeMetricSpec
 
 	GetAllPods() []*PodMeta
 

--- a/pkg/koordlet/statesinformer/impl/states_informer.go
+++ b/pkg/koordlet/statesinformer/impl/states_informer.go
@@ -51,6 +51,7 @@ type StatesInformer interface {
 
 	GetNode() *corev1.Node
 	GetNodeSLO() *slov1alpha1.NodeSLO
+	GetNodeMetricSpec() *slov1alpha1.NodeMetricSpec
 
 	GetAllPods() []*statesinformer.PodMeta
 
@@ -100,6 +101,8 @@ type informerPlugin interface {
 	Start(stopCh <-chan struct{})
 	HasSynced() bool
 }
+
+var _ StatesInformer = &statesInformer{}
 
 // TODO merge all clients into one struct
 func NewStatesInformer(config *Config, kubeClient clientset.Interface, crdClient koordclientset.Interface, topologyClient topologyclientset.Interface,
@@ -223,6 +226,16 @@ func (s *statesInformer) GetNodeSLO() *slov1alpha1.NodeSLO {
 		return nil
 	}
 	return nodeSLOInformer.GetNodeSLO()
+}
+
+func (s *statesInformer) GetNodeMetricSpec() *slov1alpha1.NodeMetricSpec {
+	nodeMetricInformerIf := s.states.informerPlugins[nodeMetricInformerName]
+	nodeMetricInformer, ok := nodeMetricInformerIf.(*nodeMetricInformer)
+	if !ok {
+		klog.Errorf("node metric informer format error")
+		return nil
+	}
+	return nodeMetricInformer.getNodeMetricSpec()
 }
 
 func (s *statesInformer) GetNodeTopo() *topov1alpha1.NodeResourceTopology {

--- a/pkg/koordlet/statesinformer/impl/states_informer_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_informer_test.go
@@ -130,6 +130,81 @@ func Test_statesInformer_GetNodeSLO(t *testing.T) {
 	}
 }
 
+func Test_statesInformer_GetNodeMetricSpec(t *testing.T) {
+	type fields struct {
+		nodeMetric *slov1alpha1.NodeMetric
+	}
+	collectPolicy := slov1alpha1.UsageWithoutPageCache
+	tests := []struct {
+		name   string
+		fields fields
+		want   *slov1alpha1.NodeMetricSpec
+	}{
+		{
+			name: "get node metric spec with default",
+			fields: fields{
+				nodeMetric: nil,
+			},
+			want: &defaultNodeMetricSpec,
+		},
+		{
+			name: "get node metric spec",
+			fields: fields{
+				nodeMetric: &slov1alpha1.NodeMetric{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node-slo-name",
+						UID:  "test-node-slo-uid",
+					},
+					Spec: slov1alpha1.NodeMetricSpec{
+						CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{},
+					},
+				},
+			},
+			want: &slov1alpha1.NodeMetricSpec{
+				CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{},
+			},
+		},
+		{
+			name: "get node metric spec",
+			fields: fields{
+				nodeMetric: &slov1alpha1.NodeMetric{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node-slo-name",
+						UID:  "test-node-slo-uid",
+					},
+					Spec: slov1alpha1.NodeMetricSpec{
+						CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{
+							NodeMemoryCollectPolicy: &collectPolicy,
+						},
+					},
+				},
+			},
+			want: &slov1alpha1.NodeMetricSpec{
+				CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{
+					NodeMemoryCollectPolicy: &collectPolicy,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeMetricInformer := &nodeMetricInformer{
+				nodeMetric: tt.fields.nodeMetric,
+			}
+			s := &statesInformer{
+				states: &PluginState{
+					informerPlugins: map[PluginName]informerPlugin{
+						nodeMetricInformerName: nodeMetricInformer,
+					},
+				},
+			}
+			if got := s.GetNodeMetricSpec(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetNodeMetricSpec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_statesInformer_GetNodeTopo(t *testing.T) {
 	type fields struct {
 		nodeTopo *topov1alpha1.NodeResourceTopology

--- a/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
+++ b/pkg/koordlet/statesinformer/mockstatesinformer/mock.go
@@ -83,6 +83,20 @@ func (mr *MockStatesInformerMockRecorder) GetNode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockStatesInformer)(nil).GetNode))
 }
 
+// GetNodeMetricSpec mocks base method.
+func (m *MockStatesInformer) GetNodeMetricSpec() *v1alpha10.NodeMetricSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeMetricSpec")
+	ret0, _ := ret[0].(*v1alpha10.NodeMetricSpec)
+	return ret0
+}
+
+// GetNodeMetricSpec indicates an expected call of GetNodeMetricSpec.
+func (mr *MockStatesInformerMockRecorder) GetNodeMetricSpec() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeMetricSpec", reflect.TypeOf((*MockStatesInformer)(nil).GetNodeMetricSpec))
+}
+
 // GetNodeSLO mocks base method.
 func (m *MockStatesInformer) GetNodeSLO() *v1alpha10.NodeSLO {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
add func GetNodeMetricSpec, so we can get nodeMetricSpec conveniently by statesInformer interface

### Ⅰ. Describe what this PR does

add GetNodeMetricSpec in statesInformer interface
prepare for https://github.com/koordinator-sh/koordinator/pull/2273

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
