### PR TITLE
scheduler: support allocating from reservation when no resource matched

### DIFF
--- a/pkg/scheduler/frameworkext/topologymanager/manager.go
+++ b/pkg/scheduler/frameworkext/topologymanager/manager.go
@@ -70,7 +70,8 @@ func (m *topologyManager) Admit(ctx context.Context, cycleState *framework.Cycle
 	if !ok || extensionPointBeingExecuted == schedulingphase.PostFilter {
 		var admit bool
 		bestHint, admit = m.calculateAffinity(ctx, cycleState, policy, pod, nodeName, exclusivePolicy, allNUMANodeStatus)
-		klog.V(5).Infof("Best TopologyHint for (pod: %v): %v on node: %v", klog.KObj(pod), bestHint, nodeName)
+		klog.V(4).Infof("Best TopologyHint for (pod: %v): %+v on node %s, policy %s, exclusivePolicy %s, admit %v",
+			klog.KObj(pod), bestHint, nodeName, policy, exclusivePolicy, admit)
 		if !admit {
 			return framework.NewStatus(framework.Unschedulable, "node(s) NUMA Topology affinity error")
 		}
@@ -107,7 +108,7 @@ func (m *topologyManager) accumulateProvidersHints(ctx context.Context, cycleSta
 		// Get the TopologyHints for a Pod from a provider.
 		hints, _ := provider.GetPodTopologyHints(ctx, cycleState, pod, nodeName)
 		providersHints = append(providersHints, hints)
-		klog.V(5).Infof("TopologyHints for pod '%v': %v on node: %v", klog.KObj(pod), hints, nodeName)
+		klog.V(4).Infof("TopologyHints for pod '%v' by provider %T: %v on node: %v", klog.KObj(pod), provider, hints, nodeName)
 	}
 	return providersHints
 }

--- a/pkg/scheduler/plugins/reservation/scoring.go
+++ b/pkg/scheduler/plugins/reservation/scoring.go
@@ -189,7 +189,6 @@ func findMostPreferredReservationByOrder(rOnNode []*frameworkext.ReservationInfo
 }
 
 func scoreReservation(pod *corev1.Pod, rInfo *frameworkext.ReservationInfo, allocated corev1.ResourceList) int64 {
-	// TODO(joseph): we should support zero-request pods
 	requested := resourceapi.PodRequests(pod, resourceapi.PodResourcesOptions{})
 	requested = quotav1.Add(requested, allocated)
 	resources := quotav1.RemoveZeros(rInfo.Allocatable)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

scheduler:
- Support a pod with no matched resource to allocate reserved resources when it specifies a reservation affinity.
- Improve logs of the topology-aware scheduling for diagnosis.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

It helps when a pod want to bind to a reservation even if it does not request any reserved resource.

e.g. A Batch pod can allocate to a reservation if there are sufficient resources from the node, even when batch resources are not reserved.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
