### PR TITLE
koordlet: remove useless stateInformer.impl StateInformer interface

### DIFF
--- a/pkg/koordlet/statesinformer/impl/callback_runner.go
+++ b/pkg/koordlet/statesinformer/impl/callback_runner.go
@@ -33,7 +33,7 @@ type UpdateCbCtx struct{}
 type callbackRunner struct {
 	callbackChans        map[statesinformer.RegisterType]chan UpdateCbCtx
 	stateUpdateCallbacks map[statesinformer.RegisterType][]updateCallback
-	statesInformer       StatesInformer
+	statesInformer       statesinformer.StatesInformer
 }
 
 func NewCallbackRunner() *callbackRunner {
@@ -53,7 +53,7 @@ func NewCallbackRunner() *callbackRunner {
 	return c
 }
 
-func (s *callbackRunner) Setup(i StatesInformer) {
+func (s *callbackRunner) Setup(i statesinformer.StatesInformer) {
 	s.statesInformer = i
 }
 

--- a/pkg/koordlet/statesinformer/impl/states_informer.go
+++ b/pkg/koordlet/statesinformer/impl/states_informer.go
@@ -45,23 +45,6 @@ const (
 	HTTPSScheme = "https"
 )
 
-type StatesInformer interface {
-	Run(stopCh <-chan struct{}) error
-	HasSynced() bool
-
-	GetNode() *corev1.Node
-	GetNodeSLO() *slov1alpha1.NodeSLO
-	GetNodeMetricSpec() *slov1alpha1.NodeMetricSpec
-
-	GetAllPods() []*statesinformer.PodMeta
-
-	GetNodeTopo() *topov1alpha1.NodeResourceTopology
-
-	GetVolumeName(pvcNamespace, pvcName string) string
-
-	RegisterCallbacks(objType statesinformer.RegisterType, name, description string, callbackFn statesinformer.UpdateCbFn)
-}
-
 type PluginName string
 
 type PluginOption struct {
@@ -102,11 +85,11 @@ type informerPlugin interface {
 	HasSynced() bool
 }
 
-var _ StatesInformer = &statesInformer{}
+var _ statesinformer.StatesInformer = &statesInformer{}
 
 // TODO merge all clients into one struct
 func NewStatesInformer(config *Config, kubeClient clientset.Interface, crdClient koordclientset.Interface, topologyClient topologyclientset.Interface,
-	metricsCache metriccache.MetricCache, nodeName string, schedulingClient schedv1alpha1.SchedulingV1alpha1Interface, predictorFactory prediction.PredictorFactory) StatesInformer {
+	metricsCache metriccache.MetricCache, nodeName string, schedulingClient schedv1alpha1.SchedulingV1alpha1Interface, predictorFactory prediction.PredictorFactory) statesinformer.StatesInformer {
 	opt := &PluginOption{
 		config:      config,
 		KubeClient:  kubeClient,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

clean up stateInformer.impl StateInformer interface
use api.StateInformer interface instead

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
