### PR TITLE
scheduler: revise ReservationFilterPlugin and fix preempting pods resources

### DIFF
--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -64,7 +64,8 @@ type FrameworkExtender interface {
 	// DEPRECATED: use RunReservationExtensionRestoreReservation instead.
 	RunReservationExtensionFinalRestoreReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, states PluginToNodeReservationRestoreStates) *framework.Status
 
-	RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
+	RunReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeInfo *framework.NodeInfo) *framework.Status
+	RunNominateReservationFilterPlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
 	RunReservationScorePlugins(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfos []*ReservationInfo, nodeName string) (PluginToReservationScores, *framework.Status)
 
 	RunNUMATopologyManagerAdmit(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeName string, numaNodes []int, policyType apiext.NUMATopologyPolicy, exclusivePolicy apiext.NumaTopologyExclusive, allNUMANodeStatus []apiext.NumaNodeStatus) *framework.Status
@@ -120,10 +121,14 @@ type ReservationRestorePlugin interface {
 }
 
 // ReservationFilterPlugin is an interface for Filter Reservation plugins.
-// These plugins will be called during the Reserve phase to determine whether the Reservation can participate in the Reserve
+// FilterReservation will be called in the Filter phase for determining which reservations are available.
+// FilterNominateReservation will be called in the PreScore or the Reserve phase to nominate a reservation whether it
+// can participate the Reserve.
+// TODO: Looking forward a merged method.
 type ReservationFilterPlugin interface {
 	framework.Plugin
-	FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
+	FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeInfo *framework.NodeInfo) *framework.Status
+	FilterNominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
 }
 
 // ReservationNominator nominates a more suitable Reservation in the Reserve stage and Pod will bind this Reservation.

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -348,7 +348,11 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 	return status
 }
 
-func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
+func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	return nil
+}
+
+func (p *Plugin) FilterNominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
 	state, status := getPreFilterState(cycleState)
 	if !status.IsSuccess() {
 		return status

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -2194,7 +2194,7 @@ func Test_Plugin_Filter(t *testing.T) {
 	}
 }
 
-func Test_Plugin_FilterReservation(t *testing.T) {
+func Test_Plugin_FilterNominateReservation(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node-1",
@@ -2294,7 +2294,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 	})
 	assert.True(t, status.IsSuccess())
 
-	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
+	status = pl.FilterNominateReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
 	assert.True(t, status.IsSuccess())
 
 	allocatedPod := &corev1.Pod{
@@ -2334,7 +2334,7 @@ func Test_Plugin_FilterReservation(t *testing.T) {
 	})
 	assert.True(t, status.IsSuccess())
 
-	status = pl.FilterReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
+	status = pl.FilterNominateReservation(context.TODO(), cycleState, pod, reservationInfo, "test-node-1")
 	assert.Equal(t, framework.NewStatus(framework.Unschedulable, "Reservation(s) Insufficient gpu devices"), status)
 }
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -443,7 +443,11 @@ func (p *Plugin) filterAmplifiedCPUs(podRequestMilliCPU int64, nodeInfo *framewo
 	return nil
 }
 
-func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
+func (p *Plugin) FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	return nil
+}
+
+func (p *Plugin) FilterNominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *frameworkext.ReservationInfo, nodeName string) *framework.Status {
 	state, status := getPreFilterState(cycleState)
 	if !status.IsSuccess() {
 		return status

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -1023,7 +1023,7 @@ func TestFilterWithAmplifiedCPUs(t *testing.T) {
 	}
 }
 
-func TestPlugin_FilterReservation(t *testing.T) {
+func TestPlugin_FilterNominateReservation(t *testing.T) {
 	skipState := framework.NewCycleState()
 	skipState.Write(stateKey, &preFilterState{
 		skip: true,
@@ -1077,7 +1077,7 @@ func TestPlugin_FilterReservation(t *testing.T) {
 			assert.NotNil(t, p)
 			assert.Nil(t, err)
 			pl := p.(*Plugin)
-			got := pl.FilterReservation(context.TODO(), tt.args.cycleState, tt.args.pod, tt.args.reservationInfo, tt.args.nodeName)
+			got := pl.FilterNominateReservation(context.TODO(), tt.args.cycleState, tt.args.pod, tt.args.reservationInfo, tt.args.nodeName)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -225,7 +225,7 @@ func (pl *Plugin) NominateReservation(ctx context.Context, cycleState *framework
 
 	reservations := make([]*frameworkext.ReservationInfo, 0, len(reservationInfos))
 	for i := range reservationInfos {
-		status := extender.RunReservationFilterPlugins(ctx, cycleState, pod, reservationInfos[i], nodeName)
+		status := extender.RunNominateReservationFilterPlugins(ctx, cycleState, pod, reservationInfos[i], nodeName)
 		if !status.IsSuccess() {
 			continue
 		}

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -1907,7 +1907,11 @@ func Test_filterWithReservations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pl := &Plugin{}
+			suit := newPluginTestSuit(t)
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+			suit.start()
 			cycleState := framework.NewCycleState()
 			if tt.stateData.podRequestsResources == nil {
 				resources := framework.NewResource(tt.stateData.podRequests)
@@ -2224,7 +2228,7 @@ func TestPreFilterExtensionRemovePod(t *testing.T) {
 	}
 }
 
-func TestFilterReservation(t *testing.T) {
+func TestFilterNominateReservation(t *testing.T) {
 	reservation4C8G := &schedulingv1alpha1.Reservation{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  uuid.NewUUID(),
@@ -2415,7 +2419,7 @@ func TestFilterReservation(t *testing.T) {
 			cycleState.Write(stateKey, state)
 
 			rInfo := frameworkext.NewReservationInfo(tt.targetReservation)
-			status := pl.FilterReservation(context.TODO(), cycleState, pod, rInfo, node.Name)
+			status := pl.FilterNominateReservation(context.TODO(), cycleState, pod, rInfo, node.Name)
 			assert.Equal(t, tt.wantStatus, status)
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Koord-Scheduler: 

1. Revise the ReservationFilterPlugin interface to make it extensible and provide more accurate filtering results. Please see the section "Special notes" for the details.
2. Support node reservation API in a Reservation object.
3. Fix a bug about counting reservation's "pods" resources during the preemption.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

Rename the ReservationFilterPlugin method `FilterReservation` to `FilterNominateReservation` since only the NominateReservation calls it during the PreScore or the Reserve phase.

Re-define the method `FilterReservation` that is invoked in the Filter phase:

```go
type ReservationFilterPlugin interface {
	framework.Plugin
	FilterReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeInfo *framework.NodeInfo) *framework.Status
	FilterNominateReservation(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, reservationInfo *ReservationInfo, nodeName string) *framework.Status
}
```

Compared with the current FilterReservation which runs in the PreScore or Reserve, the new method is invoked during the Filter phase of the reservation plugin. It should show more concise reasons when the scheduling fails, and it is helpful for internal extensions.

In this version, we keep the FilterNominateReservation and will move the current implementation to the Filter phase in the future.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
