### PR TITLE
webhook: support elasticquota enable update resource key

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -68,6 +68,11 @@ const (
 	// to belong to the users and will not be preempted back.
 	ElasticQuotaGuaranteeUsage featuregate.Feature = "ElasticQuotaGuaranteeUsage"
 
+	// ElasticQuotaEnableUpdateResourceKey allows to update resource key in standard operation
+	// when delete resource type: from child to parent
+	// when add resource type: from parent to child
+	ElasticQuotaEnableUpdateResourceKey featuregate.Feature = "ElasticQuotaEnableUpdateResourceKey"
+
 	// DisableDefaultQuota disable default quota.
 	DisableDefaultQuota featuregate.Feature = "DisableDefaultQuota"
 
@@ -94,6 +99,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MultiQuotaTree:                         {Default: false, PreRelease: featuregate.Alpha},
 	ElasticQuotaIgnorePodOverhead:          {Default: false, PreRelease: featuregate.Alpha},
 	ElasticQuotaGuaranteeUsage:             {Default: false, PreRelease: featuregate.Alpha},
+	ElasticQuotaEnableUpdateResourceKey:    {Default: false, PreRelease: featuregate.Alpha},
 	DisableDefaultQuota:                    {Default: false, PreRelease: featuregate.Alpha},
 	SupportParentQuotaSubmitPod:            {Default: false, PreRelease: featuregate.Alpha},
 	EnableQuotaAdmission:                   {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator.go
+++ b/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator.go
@@ -152,7 +152,6 @@ func (qt *quotaTree) iterationForRedistribution(totalRes, totalSharedWeight int6
 		// if totalSharedWeight is not larger than 0, no need to iterate anymore.
 		return
 	}
-
 	needAdjustQuotaNodes := make([]*quotaNode, 0)
 	toPartitionResource, needAdjustTotalSharedWeight := int64(0), int64(0)
 	for _, node := range nodes {

--- a/pkg/webhook/elasticquota/quota_topology.go
+++ b/pkg/webhook/elasticquota/quota_topology.go
@@ -195,7 +195,7 @@ func (qt *quotaTopology) ValidDeleteQuota(quota *v1alpha1.ElasticQuota) error {
 	return nil
 }
 
-// fillQuotaDefaultInformation fills quota with default information if not configure
+// fillQuotaDefaultInformation fills quota with default information if not be configured
 func (qt *quotaTopology) fillQuotaDefaultInformation(quota *v1alpha1.ElasticQuota) error {
 	if quota.Name == extension.RootQuotaName {
 		return nil
@@ -235,8 +235,20 @@ func (qt *quotaTopology) fillQuotaDefaultInformation(quota *v1alpha1.ElasticQuot
 	if sharedWeight, exist := quota.Annotations[extension.AnnotationSharedWeight]; !exist || len(sharedWeight) == 0 {
 		quota.Annotations[extension.AnnotationSharedWeight] = string(maxQuota)
 		klog.V(5).Infof("fill quota %v sharedWeight as max", quota.Name)
+	} else {
+		sharedWeightRL := make(corev1.ResourceList)
+		err = json.Unmarshal([]byte(sharedWeight), &sharedWeightRL)
+		if err != nil {
+			return fmt.Errorf("fillDefaultQuotaInfo unmarshal sharedWeight failed:%v", err)
+		}
+		if fixedSharedWeight(sharedWeightRL, quota.Spec.Max) {
+			fixedSharedWeightRL, err := json.Marshal(&sharedWeightRL)
+			if err != nil {
+				return fmt.Errorf("fillDefaultQuotaInfo marshal fixedSharedWeight max failed:%v", err)
+			}
+			quota.Annotations[extension.AnnotationSharedWeight] = string(fixedSharedWeightRL)
+		}
 	}
-
 	return nil
 }
 
@@ -285,4 +297,29 @@ func (qt *quotaTopology) getQuotaInfo(name, namespace string) *QuotaInfo {
 		return qt.quotaInfoMap[quotaName]
 	}
 	return nil
+}
+
+// fixedSharedWeight keep keys in sharedWeight and maxQuota same
+// if key in maxQuota not included in sharedWeight, add key/value in sharedWeight
+// if key in sharedWeight not included in maxQuota, delete key/value in sharedWeight
+// if fixed, return true
+func fixedSharedWeight(sharedWeight, maxQuota corev1.ResourceList) bool {
+	fixed := false
+	for key, value := range maxQuota {
+		if _, ok := sharedWeight[key]; !ok {
+			sharedWeight[key] = value
+			fixed = true
+		}
+	}
+	toDeleted := make([]corev1.ResourceName, 0)
+	for key := range sharedWeight {
+		if _, ok := maxQuota[key]; !ok {
+			toDeleted = append(toDeleted, key)
+		}
+	}
+	for _, key := range toDeleted {
+		fixed = true
+		delete(sharedWeight, key)
+	}
+	return fixed
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Currently, the consistency check for resource types in elastic quota's add, delete and update is insufficient and too rigid. For example, maxResourceKey requires parent-child consistency, which can lead to the following problems:
1. There is no unified logic to check the various resource types of *min/max*, which can easily lead to inconsistencies
2. Unable to flexibly support changing resource types, especially when adding new resources, limited by the initial creation status

However, considering the original intention of quota design and current computing logic, it does not affect related calculations while supporting resource type checks(also already added more unitTest cases). Among them:
1. The setting intentions of *min* and *max* are different and the calculation logic is not dependent. The resource types need to be checked separately
2. *Guaranteed* is affected by *min* calculation, so there is no need to check separately

### Ⅱ. Does this pull request fix one issue?

I propose to add a feature called *ElasticQuotaEnableUpdateResourceKey* to support changes to ElasticQuota Resource Key, with the following modifications:
1. Support *min* and *max* resourceKey checks during elasticQuota add and update: *checkSubAndParentGroupQuotaKey()*
2. Support AnnotationSharedWeight updated: when SharedWeight has a key which is not included in max, delete it; when SharedWeight does not have the key of max, it defaults to be filled in the quantity of max
3. Maintain compatibility of resourceKeys update logic: *updateResourceKeyNoLock()* 
4. Propose standard process operations for elastic quota resourceKey: add resourceKey from parent node to child node, delete resourceKey from child node to parent node

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
