### PR TITLE
scheduler: fix monitor terminating pod

### DIFF
--- a/pkg/scheduler/frameworkext/scheduler_monitor.go
+++ b/pkg/scheduler/frameworkext/scheduler_monitor.go
@@ -91,6 +91,15 @@ func (m *SchedulerMonitor) RecordNextPod(podInfo *framework.QueuedPodInfo) {
 		return
 	}
 	pod := podInfo.Pod
+
+	// clean up from the cache when the pod is terminating
+	if pod.DeletionTimestamp != nil {
+		m.lock.Lock()
+		delete(m.schedulingPods, pod.UID)
+		m.lock.Unlock()
+		return
+	}
+
 	now := time.Now()
 	scheduleState := podScheduleState{
 		namespace:       pod.Namespace,

--- a/pkg/scheduler/frameworkext/scheduler_monitor_test.go
+++ b/pkg/scheduler/frameworkext/scheduler_monitor_test.go
@@ -125,4 +125,17 @@ func TestSchedulerMonitor_StartAndCompleteMonitoring(t *testing.T) {
 	if _, exists := monitor.schedulingPods[pod.UID]; exists {
 		t.Errorf("Pod should be removed from schedulingPods after Complete")
 	}
+
+	terminatingPod := podInfo.DeepCopy()
+	deleted := metav1.Now()
+	terminatingPod.Pod.DeletionTimestamp = &deleted
+	queuePodInfo = &framework.QueuedPodInfo{
+		Timestamp: time.Now(),
+		PodInfo:   terminatingPod,
+	}
+	monitor.RecordNextPod(queuePodInfo)
+	_, ok = monitor.schedulingPods[pod.UID]
+	if ok {
+		t.Fatal("Pod should be removed in schedulingPods when terminating")
+	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

scheduler: Fix a bug where the pod is leaked in the schedulerMonitor's cache if it is terminating and then dequeues.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
