### PR TITLE
fix(scheduler/api): register missing NodeResourcesFitPlusArgs in v1 c…

### DIFF
--- a/pkg/scheduler/apis/config/v1/register.go
+++ b/pkg/scheduler/apis/config/v1/register.go
@@ -40,6 +40,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ElasticQuotaArgs{},
 		&CoschedulingArgs{},
 		&DeviceShareArgs{},
+		&NodeResourcesFitPlusArgs{},
+		&ScarceResourceAvoidanceArgs{},
 	)
 	return nil
 }


### PR DESCRIPTION
…onfig

### Ⅰ. Describe what this PR does
**Summary**

This PR resolves the missing registration of NodeResourcesFitPlusArgs and ScarceResourceAvoidanceArgs in the v1 API configuration for the Koordinator scheduler. These types are now added to the AddKnownTypes function in pkg/scheduler/apis/config/v1/register.go, ensuring the v1 API correctly recognizes these plugin arguments 

**Changed Logic**

The AddKnownTypes method now includes:
```go
scheme.AddKnownTypes(SchemeGroupVersion,
    // ... existing types
    &NodeResourcesFitPlusArgs{},
    &ScarceResourceAvoidanceArgs{},
)
```
This aligns the v1 API with internal and v1beta3 versions, which already registered these types.

**Limitations**

This fix only addresses the v1 API. Other versions (e.g., internal/v1beta3) were already functional and are unaffected

### Ⅱ. Does this pull request fix one issue?

fixes #2352

### Ⅲ. Describe how to verify it

Run make test to ensure all tests pass

### Ⅳ. Special notes for reviews

The change is backward-compatible but critical for users relying on the v1 API for these plugins.

### V. Checklist
- [✅] All checks passed in `make test`
