### PR TITLE
koordlet: skip reconcile containers in runtime hooks for kata pods

### DIFF
--- a/pkg/koordlet/runtimehooks/protocol/filters.go
+++ b/pkg/koordlet/runtimehooks/protocol/filters.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import corev1 "k8s.io/api/core/v1"
+
+// NOTE: functions in this file can be overwritten for extension
+
+const (
+	runtimeClassKata = "kata"
+)
+
+func ContainerReconcileIgnoreFilter(pod *corev1.Pod, container *corev1.Container, containerStat *corev1.ContainerStatus) bool {
+	// for containers in kata pod, no need to reconcile container cgroup
+	// TODO define filters as runtime hook plugin level
+	if pod.Spec.RuntimeClassName != nil && *pod.Spec.RuntimeClassName == runtimeClassKata {
+		return true
+	}
+	return false
+}

--- a/pkg/koordlet/runtimehooks/protocol/filters_test.go
+++ b/pkg/koordlet/runtimehooks/protocol/filters_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestContainerReconcileIgnoreFilter(t *testing.T) {
+	type args struct {
+		pod           *corev1.Pod
+		container     *corev1.Container
+		containerStat *corev1.ContainerStatus
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ignore kata container",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						RuntimeClassName: func() *string {
+							s := "kata"
+							return &s
+						}(),
+					},
+				},
+				container: &corev1.Container{},
+				containerStat: &corev1.ContainerStatus{
+					Name: "test",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "reconcile normal container",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+				container: &corev1.Container{},
+				containerStat: &corev1.ContainerStatus{
+					Name: "test",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, ContainerReconcileIgnoreFilter(tt.args.pod, tt.args.container, tt.args.containerStat), "ContainerReconcileIgnoreFilter(%v, %v, %v)", tt.args.pod, tt.args.container, tt.args.containerStat)
+		})
+	}
+}

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -59,7 +59,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 	}
 
 	// get runtime type and dir names of known containers
-	containerSubDirNames := make(map[string]struct{}, len(pod.Status.ContainerStatuses))
+	containerSubDirNames := make(map[string]struct{}, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
 	containerRuntime := system.RuntimeTypeUnknown
 	for _, containerStat := range pod.Status.InitContainerStatuses {
 		runtimeType, containerDirName, err := system.CgroupPathFormatter.ContainerDirFn(containerStat.ContainerID)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

skip reconcile containers in runtime hooks if match the ignore condition.

conditions are defined as ignore filters in independent files, which can be easily overwritten for extension.

filters can be defined as plugin level in future.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
