### PR TITLE
scheduler: pre-calculate reservation info for perf

### DIFF
--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -73,6 +73,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 	reservationInfos := cache.listAvailableReservationInfosOnNode(reservation.Status.NodeName)
 	assert.Len(t, reservationInfos, 1)
 	rInfo := reservationInfos[0]
+	rInfo.RefreshAvailable()
 	expectReservationInfo := &frameworkext.ReservationInfo{
 		Reservation: reservation,
 		Pod:         reservationutil.NewReservePod(reservation),
@@ -87,6 +88,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 		Allocated:    nil,
 		AssignedPods: map[types.UID]*frameworkext.PodRequirement{},
 	}
+	expectReservationInfo.RefreshAvailable()
 	sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 		return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
 	})
@@ -259,6 +261,7 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 			},
 		},
 	}
+	expectReservationInfo.RefreshAvailable()
 	assert.Equal(t, expectReservationInfo, rInfo)
 
 	cache.updatePod(reservation.UID, pod, pod)
@@ -282,5 +285,6 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("0"),
 	}
 	expectReservationInfo.AssignedPods = map[types.UID]*frameworkext.PodRequirement{}
+	expectReservationInfo.RefreshAvailable()
 	assert.Equal(t, expectReservationInfo, rInfo)
 }

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -861,6 +861,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 				sort.Slice(wantReservationInfo.ResourceNames, func(i, j int) bool {
 					return wantReservationInfo.ResourceNames[i] < wantReservationInfo.ResourceNames[j]
 				})
+				wantReservationInfo.RefreshAvailable()
 				rInfo := pl.handle.GetReservationNominator().GetNominatedReservation(tt.pod, nodeName)
 				if rInfo != nil {
 					sort.Slice(rInfo.ResourceNames, func(i, j int) bool {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

scheduler: pre-calculate the available resources and remove useless processing to improve reservation filter performance.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
