### PR TITLE
koord-descheduler: add nil check for podMetric in NodeFit of loadaware plugin

### DIFF
--- a/pkg/descheduler/framework/plugins/loadaware/utilization_util.go
+++ b/pkg/descheduler/framework/plugins/loadaware/utilization_util.go
@@ -440,6 +440,10 @@ func balancePods(ctx context.Context,
 				}
 				podNamespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 				podMetric := srcNode.podMetrics[podNamespacedName]
+				if podMetric == nil {
+					klog.V(4).InfoS("Failed to find PodMetric", "pod", klog.KObj(pod), "node", klog.KObj(srcNode.node), "nodePool", nodePoolName)
+					return false
+				}
 				return podFitsAnyNodeWithThreshold(nodeIndexer, pod, targetNodes, nodeUsages, nodeThresholds, prod, podMetric)
 			}),
 		)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

https://github.com/koordinator-sh/koordinator/blob/bc78bd2034248aa143e90537536be08073fc3198/pkg/descheduler/framework/plugins/loadaware/utilization_util.go#L747

This will cause a panic when `podMetric` is nil here.
Added nil check and logging before calling podFitsAnyNodeWithThreshold.

<details><summary>panic log</summary>
<p>

```
E0415 14:02:12.302754       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 308 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x214daa0?, 0x3b96350})
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00374d340?})
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/runtime/runtime.go:49 +0x75
panic({0x214daa0, 0x3b96350})
    /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.podFitsAnyNodeWithThreshold(0x2122a80?, 0xc0020be1e0?, {0xc00278c4f8, 0x3, 0xc0021f3e80?}, 0x80?, 0x80?, 0x0, 0x0)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:747 +0x7ca
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.balancePods.func1(0xc0021669d8)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:443 +0x10e
github.com/koordinator-sh/koordinator/pkg/descheduler/pod.WrapFilterFuncs.func1(0xc0010eac80?)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/pod/pods.go:44 +0x52
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.classifyPods({0xc0009b4600, 0x3e, 0x2?}, 0xc000e5a060)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:644 +0xc4
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.balancePods({0x285f7e8, 0xc0016dba70}, {0x24f0bbd, 0x15}, {0xc001f310e0, 0x1, 0xc00379ec00?}, {0xc00278c4f8, 0x3, 0x3}, ...)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:435 +0x308
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.evictPodsFromSourceNodes({0x285f7e8, 0xc0016dba70}, {0x24f0bbd, 0x15}, {0xc001f310e0, 0x1, 0x1}, {0x0, 0x0, 0x0}, ...)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:352 +0xbb8
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.(*LowNodeLoad).processOneNodePool(0xc000c98140, {0x285f7e8, 0xc0016dba70}, 0xc000eb3ac8, {0xc00152a9c0?, 0x0?, 0x0?}, 0x11?)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/low_node_load.go:240 +0xcf7
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.(*LowNodeLoad).Balance(0xc000c98140, {0x285f7e8, 0xc0016dba70}, {0xc00152a9c0, 0x17, 0x17})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/low_node_load.go:146 +0x365
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime.(*frameworkImpl).RunBalancePlugins(0xc000eb3ce8?, {0x285f740, 0xc0023d2050}, {0xc00152a9c0, 0x17, 0x17})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime/framework.go:334 +0x164
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).deschedulerOnce(0xc000368ba0, {0x285f740, 0xc0023d2050})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:279 +0x24a
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).Start.func1()
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:246 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0027fa450?)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:226 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000be8060?, {0x283dc80, 0xc0027fa450}, 0x0, 0xc000be8060)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:227 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0023d2050?, 0xdf8475800, 0x0, 0x18?, 0x2265240?)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:204 +0x89
k8s.io/apimachinery/pkg/util/wait.NonSlidingUntil(...)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:180
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).Start(0xc000368ba0, {0x285f740?, 0xc0005edea0?})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:245 +0xe9
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002cd360)
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/manager/runnable_group.go:223 +0xdb
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/manager/runnable_group.go:207 +0x1ad
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1df4e6a]

goroutine 308 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00374d340?})
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/runtime/runtime.go:56 +0xd7
panic({0x214daa0, 0x3b96350})
    /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.podFitsAnyNodeWithThreshold(0x2122a80?, 0xc0020be1e0?, {0xc00278c4f8, 0x3, 0xc0021f3e80?}, 0x80?, 0x80?, 0x0, 0x0)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:747 +0x7ca
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.balancePods.func1(0xc0021669d8)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:443 +0x10e
github.com/koordinator-sh/koordinator/pkg/descheduler/pod.WrapFilterFuncs.func1(0xc0010eac80?)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/pod/pods.go:44 +0x52
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.classifyPods({0xc0009b4600, 0x3e, 0x2?}, 0xc000e5a060)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:644 +0xc4
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.balancePods({0x285f7e8, 0xc0016dba70}, {0x24f0bbd, 0x15}, {0xc001f310e0, 0x1, 0xc00379ec00?}, {0xc00278c4f8, 0x3, 0x3}, ...)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:435 +0x308
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.evictPodsFromSourceNodes({0x285f7e8, 0xc0016dba70}, {0x24f0bbd, 0x15}, {0xc001f310e0, 0x1, 0x1}, {0x0, 0x0, 0x0}, ...)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/utilization_util.go:352 +0xbb8
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.(*LowNodeLoad).processOneNodePool(0xc000c98140, {0x285f7e8, 0xc0016dba70}, 0xc000eb3ac8, {0xc00152a9c0?, 0x0?, 0x0?}, 0x11?)
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/low_node_load.go:240 +0xcf7
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.(*LowNodeLoad).Balance(0xc000c98140, {0x285f7e8, 0xc0016dba70}, {0xc00152a9c0, 0x17, 0x17})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/low_node_load.go:146 +0x365
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime.(*frameworkImpl).RunBalancePlugins(0xc000eb3ce8?, {0x285f740, 0xc0023d2050}, {0xc00152a9c0, 0x17, 0x17})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime/framework.go:334 +0x164
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).deschedulerOnce(0xc000368ba0, {0x285f740, 0xc0023d2050})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:279 +0x24a
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).Start.func1()
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:246 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0027fa450?)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:226 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000be8060?, {0x283dc80, 0xc0027fa450}, 0x0, 0xc000be8060)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:227 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0023d2050?, 0xdf8475800, 0x0, 0x18?, 0x2265240?)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:204 +0x89
k8s.io/apimachinery/pkg/util/wait.NonSlidingUntil(...)
    /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:180
github.com/koordinator-sh/koordinator/pkg/descheduler.(*Descheduler).Start(0xc000368ba0, {0x285f740?, 0xc0005edea0?})
    /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/descheduler.go:245 +0xe9
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002cd360)
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/manager/runnable_group.go:223 +0xdb
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/manager/runnable_group.go:207 +0x1ad
```

</p>
</details> 

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
