### PR TITLE
webhook: check quota that only allow max >= used for specific resources

### DIFF
--- a/apis/extension/elastic_quota.go
+++ b/apis/extension/elastic_quota.go
@@ -55,7 +55,7 @@ const (
 	AnnotationNonPreemptibleRequest      = QuotaKoordinatorPrefix + "/non-preemptible-request"
 	AnnotationNonPreemptibleUsed         = QuotaKoordinatorPrefix + "/non-preemptible-used"
 	AnnotationAdmission                  = QuotaKoordinatorPrefix + "/admission"
-	AnnotationCheckMaxGeUsedResourceKeys = QuotaKoordinatorPrefix + "/check-max-ge-used-resource-keys"
+	AnnotationMaxStrictCheckResourceKeys = QuotaKoordinatorPrefix + "/max-strict-check-resource-keys"
 )
 
 func GetParentQuotaName(quota *v1alpha1.ElasticQuota) string {
@@ -220,12 +220,12 @@ func GetAdmission(quota *v1alpha1.ElasticQuota) (corev1.ResourceList, error) {
 	return admission, nil
 }
 
-func GetCheckMaxGeUsedResourceKeys(quota *v1alpha1.ElasticQuota) ([]corev1.ResourceName, error) {
-	if quota.Annotations[AnnotationCheckMaxGeUsedResourceKeys] == "" {
+func GetMaxStrictCheckResourceKeys(quota *v1alpha1.ElasticQuota) ([]corev1.ResourceName, error) {
+	if quota.Annotations[AnnotationMaxStrictCheckResourceKeys] == "" {
 		return nil, nil
 	}
 	resources := []corev1.ResourceName{}
-	if err := json.Unmarshal([]byte(quota.Annotations[AnnotationCheckMaxGeUsedResourceKeys]), &resources); err != nil {
+	if err := json.Unmarshal([]byte(quota.Annotations[AnnotationMaxStrictCheckResourceKeys]), &resources); err != nil {
 		return nil, err
 	}
 	return resources, nil

--- a/apis/extension/elastic_quota.go
+++ b/apis/extension/elastic_quota.go
@@ -28,33 +28,34 @@ import (
 
 // RootQuotaName means quotaTree's root\head.
 const (
-	SystemQuotaName                 = "koordinator-system-quota"
-	RootQuotaName                   = "koordinator-root-quota"
-	DefaultQuotaName                = "koordinator-default-quota"
-	QuotaKoordinatorPrefix          = "quota.scheduling.koordinator.sh"
-	LabelQuotaIsParent              = QuotaKoordinatorPrefix + "/is-parent"
-	LabelQuotaParent                = QuotaKoordinatorPrefix + "/parent"
-	LabelAllowLentResource          = QuotaKoordinatorPrefix + "/allow-lent-resource"
-	LabelQuotaName                  = QuotaKoordinatorPrefix + "/name"
-	LabelQuotaProfile               = QuotaKoordinatorPrefix + "/profile"
-	LabelQuotaIsRoot                = QuotaKoordinatorPrefix + "/is-root"
-	LabelQuotaTreeID                = QuotaKoordinatorPrefix + "/tree-id"
-	LabelQuotaIgnoreDefaultTree     = QuotaKoordinatorPrefix + "/ignore-default-tree"
-	LabelPreemptible                = QuotaKoordinatorPrefix + "/preemptible"
-	LabelAllowForceUpdate           = QuotaKoordinatorPrefix + "/allow-force-update"
-	AnnotationSharedWeight          = QuotaKoordinatorPrefix + "/shared-weight"
-	AnnotationRuntime               = QuotaKoordinatorPrefix + "/runtime"
-	AnnotationRequest               = QuotaKoordinatorPrefix + "/request"
-	AnnotationChildRequest          = QuotaKoordinatorPrefix + "/child-request"
-	AnnotationResourceKeys          = QuotaKoordinatorPrefix + "/resource-keys"
-	AnnotationTotalResource         = QuotaKoordinatorPrefix + "/total-resource"
-	AnnotationUnschedulableResource = QuotaKoordinatorPrefix + "/unschedulable-resource"
-	AnnotationQuotaNamespaces       = QuotaKoordinatorPrefix + "/namespaces"
-	AnnotationGuaranteed            = QuotaKoordinatorPrefix + "/guaranteed"
-	AnnotationAllocated             = QuotaKoordinatorPrefix + "/allocated"
-	AnnotationNonPreemptibleRequest = QuotaKoordinatorPrefix + "/non-preemptible-request"
-	AnnotationNonPreemptibleUsed    = QuotaKoordinatorPrefix + "/non-preemptible-used"
-	AnnotationAdmission             = QuotaKoordinatorPrefix + "/admission"
+	SystemQuotaName                      = "koordinator-system-quota"
+	RootQuotaName                        = "koordinator-root-quota"
+	DefaultQuotaName                     = "koordinator-default-quota"
+	QuotaKoordinatorPrefix               = "quota.scheduling.koordinator.sh"
+	LabelQuotaIsParent                   = QuotaKoordinatorPrefix + "/is-parent"
+	LabelQuotaParent                     = QuotaKoordinatorPrefix + "/parent"
+	LabelAllowLentResource               = QuotaKoordinatorPrefix + "/allow-lent-resource"
+	LabelQuotaName                       = QuotaKoordinatorPrefix + "/name"
+	LabelQuotaProfile                    = QuotaKoordinatorPrefix + "/profile"
+	LabelQuotaIsRoot                     = QuotaKoordinatorPrefix + "/is-root"
+	LabelQuotaTreeID                     = QuotaKoordinatorPrefix + "/tree-id"
+	LabelQuotaIgnoreDefaultTree          = QuotaKoordinatorPrefix + "/ignore-default-tree"
+	LabelPreemptible                     = QuotaKoordinatorPrefix + "/preemptible"
+	LabelAllowForceUpdate                = QuotaKoordinatorPrefix + "/allow-force-update"
+	AnnotationSharedWeight               = QuotaKoordinatorPrefix + "/shared-weight"
+	AnnotationRuntime                    = QuotaKoordinatorPrefix + "/runtime"
+	AnnotationRequest                    = QuotaKoordinatorPrefix + "/request"
+	AnnotationChildRequest               = QuotaKoordinatorPrefix + "/child-request"
+	AnnotationResourceKeys               = QuotaKoordinatorPrefix + "/resource-keys"
+	AnnotationTotalResource              = QuotaKoordinatorPrefix + "/total-resource"
+	AnnotationUnschedulableResource      = QuotaKoordinatorPrefix + "/unschedulable-resource"
+	AnnotationQuotaNamespaces            = QuotaKoordinatorPrefix + "/namespaces"
+	AnnotationGuaranteed                 = QuotaKoordinatorPrefix + "/guaranteed"
+	AnnotationAllocated                  = QuotaKoordinatorPrefix + "/allocated"
+	AnnotationNonPreemptibleRequest      = QuotaKoordinatorPrefix + "/non-preemptible-request"
+	AnnotationNonPreemptibleUsed         = QuotaKoordinatorPrefix + "/non-preemptible-used"
+	AnnotationAdmission                  = QuotaKoordinatorPrefix + "/admission"
+	AnnotationCheckMaxGeUsedResourceKeys = QuotaKoordinatorPrefix + "/check-max-ge-used-resource-keys"
 )
 
 func GetParentQuotaName(quota *v1alpha1.ElasticQuota) string {
@@ -217,4 +218,15 @@ func GetAdmission(quota *v1alpha1.ElasticQuota) (corev1.ResourceList, error) {
 		}
 	}
 	return admission, nil
+}
+
+func GetCheckMaxGeUsedResourceKeys(quota *v1alpha1.ElasticQuota) ([]corev1.ResourceName, error) {
+	if quota.Annotations[AnnotationCheckMaxGeUsedResourceKeys] == "" {
+		return nil, nil
+	}
+	resources := []corev1.ResourceName{}
+	if err := json.Unmarshal([]byte(quota.Annotations[AnnotationCheckMaxGeUsedResourceKeys]), &resources); err != nil {
+		return nil, err
+	}
+	return resources, nil
 }

--- a/pkg/webhook/elasticquota/quota_topology_check.go
+++ b/pkg/webhook/elasticquota/quota_topology_check.go
@@ -81,7 +81,7 @@ func (qt *quotaTopology) validateQuotaSelfItem(quota *v1alpha1.ElasticQuota) err
 		} else if maxVal, exist := quota.Spec.Max[key]; !exist {
 			return fmt.Errorf("resourceKey %v of quota %v is included in used, which is not included in max but should check max >= used", key, quota.Name)
 		} else if maxVal.Cmp(usedVal) == -1 {
-			return fmt.Errorf("resourceKey %v of quota %v used,%v > max,%v", key, quota.Name, usedVal.String(), maxVal.String())
+			return fmt.Errorf("resourceKey %v of quota %v max %v < used %v", key, quota.Name, maxVal.String(), usedVal.String())
 		}
 	}
 	return nil

--- a/pkg/webhook/elasticquota/quota_topology_check.go
+++ b/pkg/webhook/elasticquota/quota_topology_check.go
@@ -70,10 +70,10 @@ func (qt *quotaTopology) validateQuotaSelfItem(quota *v1alpha1.ElasticQuota) err
 		}
 	}
 
-	// 1. check if all key in AnnotationCheckMaxGeUsedResourceKeys in max >= that in used
-	resourceKeys, err := extension.GetCheckMaxGeUsedResourceKeys(quota)
+	// 1. check if all key in AnnotationMaxStrictCheckResourceKeys in max >= that in used
+	resourceKeys, err := extension.GetMaxStrictCheckResourceKeys(quota)
 	if err != nil {
-		return fmt.Errorf("%v quota.Annotation[%v]'s value is invalid: %w", quota.Name, extension.AnnotationCheckMaxGeUsedResourceKeys, err)
+		return fmt.Errorf("%v quota.Annotation[%v]'s value is invalid: %w", quota.Name, extension.AnnotationMaxStrictCheckResourceKeys, err)
 	}
 	for _, key := range resourceKeys {
 		if usedVal, exist := quota.Status.Used[key]; !exist {

--- a/pkg/webhook/elasticquota/quota_topology_test.go
+++ b/pkg/webhook/elasticquota/quota_topology_test.go
@@ -95,23 +95,23 @@ func TestQuotaTopology_basicItemCheck(t *testing.T) {
 		},
 		{
 			name: "annotation check max >= used",
-			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationMaxStrictCheckResourceKeys: `["cpu","memory"]`}).
 				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
 			err: fmt.Errorf("resourceKey memory of quota temp max 1048576 < used 10485760"),
 		},
 		{
 			name: "annotation check max >= used, ignore other resources",
-			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu"]`}).
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationMaxStrictCheckResourceKeys: `["cpu"]`}).
 				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
 		},
 		{
 			name: "annotation check max >= used, ignore empty used",
-			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationMaxStrictCheckResourceKeys: `["cpu","memory"]`}).
 				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Obj()).Obj(),
 		},
 		{
 			name: "annotation check max >= used, check empty max",
-			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationMaxStrictCheckResourceKeys: `["cpu","memory"]`}).
 				Max(MakeResourceList().CPU(0).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
 			err: fmt.Errorf("resourceKey memory of quota temp is included in used, which is not included in max but should check max >= used"),
 		},

--- a/pkg/webhook/elasticquota/quota_topology_test.go
+++ b/pkg/webhook/elasticquota/quota_topology_test.go
@@ -97,7 +97,7 @@ func TestQuotaTopology_basicItemCheck(t *testing.T) {
 			name: "annotation check max >= used",
 			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
 				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
-			err: fmt.Errorf("resourceKey memory of quota temp used,10485760 > max,1048576"),
+			err: fmt.Errorf("resourceKey memory of quota temp max 1048576 < used 10485760"),
 		},
 		{
 			name: "annotation check max >= used, ignore other resources",

--- a/pkg/webhook/elasticquota/quota_topology_test.go
+++ b/pkg/webhook/elasticquota/quota_topology_test.go
@@ -93,6 +93,28 @@ func TestQuotaTopology_basicItemCheck(t *testing.T) {
 			quota: MakeQuota("temp").sharedWeight(MakeResourceList().CPU(-1).Mem(1048576).Obj()).Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Obj(),
 			err:   fmt.Errorf("%v quota.Annotation[%v]'s value < 0, in dimension :%v", "temp", extension.AnnotationSharedWeight, "[cpu]"),
 		},
+		{
+			name: "annotation check max >= used",
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
+			err: fmt.Errorf("resourceKey memory of quota temp used,10485760 > max,1048576"),
+		},
+		{
+			name: "annotation check max >= used, ignore other resources",
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu"]`}).
+				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
+		},
+		{
+			name: "annotation check max >= used, ignore empty used",
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+				Max(MakeResourceList().CPU(0).Mem(1048576).Obj()).Used(MakeResourceList().CPU(0).Obj()).Obj(),
+		},
+		{
+			name: "annotation check max >= used, check empty max",
+			quota: MakeQuota("temp").Annotations(map[string]string{extension.AnnotationCheckMaxGeUsedResourceKeys: `["cpu","memory"]`}).
+				Max(MakeResourceList().CPU(0).Obj()).Used(MakeResourceList().CPU(0).Mem(10485760).Obj()).Obj(),
+			err: fmt.Errorf("resourceKey memory of quota temp is included in used, which is not included in max but should check max >= used"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Adding an optional annotation `quota.scheduling.koordinator.sh/max-strict-check-resource-keys` for elastic quota that record resource keys that updates for quota spec should be checked max >= used in json format.

Example: `quota.scheduling.koordinator.sh/max-strict-check-resource-keys: '["cpu", "memory"]'`

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
