### PR TITLE
scheduler: add OmitNodeLabelsForReservation, expose GetQuotaInformer

### DIFF
--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -64,6 +64,12 @@ const (
 	// LazyReservationRestore is used to restore reserved resources lazily to improve the scheduling performance.
 	LazyReservationRestore featuregate.Feature = "LazyReservationRestore"
 
+	// owner: @saintube @ZiMengSheng
+	// alpha: v1.6
+	//
+	// OmitNodeLabelsForReservation is used to omit node labels while matching reservation affinity.
+	OmitNodeLabelsForReservation featuregate.Feature = "OmitNodeLabelsForReservation"
+
 	CSIStorageCapacity featuregate.Feature = "CSIStorageCapacity"
 
 	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
@@ -85,6 +91,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	DisableDefaultQuota:                       {Default: false, PreRelease: featuregate.Alpha},
 	SupportParentQuotaSubmitPod:               {Default: false, PreRelease: featuregate.Alpha},
 	LazyReservationRestore:                    {Default: false, PreRelease: featuregate.Alpha},
+	OmitNodeLabelsForReservation:              {Default: false, PreRelease: featuregate.Alpha},
 	CSIStorageCapacity:                        {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 	GenericEphemeralVolume:                    {Default: true, PreRelease: featuregate.GA},
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -359,3 +359,7 @@ func (g *Plugin) Unreserve(ctx context.Context, state *framework.CycleState, p *
 	}
 	mgr.UnreservePod(quotaName, p)
 }
+
+func (g *Plugin) GetQuotaInformer() cache.SharedIndexInformer { // expose for extensions
+	return g.quotaInformer
+}

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -307,7 +307,7 @@ func (pl *Plugin) PreFilter(ctx context.Context, cycleState *framework.CycleStat
 			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonReservationAffinity)
 		}
 		preResult = &framework.PreFilterResult{
-			NodeNames: sets.Set[string]{},
+			NodeNames: make(sets.Set[string], len(state.nodeReservationStates)),
 		}
 		for nodeName := range state.nodeReservationStates {
 			preResult.NodeNames.Insert(nodeName)

--- a/pkg/util/hostport.go
+++ b/pkg/util/hostport.go
@@ -68,7 +68,7 @@ func CloneHostPorts(ports framework.HostPortInfo) framework.HostPortInfo {
 	if len(ports) == 0 {
 		return nil
 	}
-	r := framework.HostPortInfo{}
+	r := make(framework.HostPortInfo, len(ports))
 	for ip, protocolPorts := range ports {
 		for v := range protocolPorts {
 			r.Add(ip, v.Protocol, v.Port)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Add a feature-gate *OmitNodeLabelsForReservation*. It supposes the necessary node labels have been patched to reservations, so the pre-filter overhead of merging node labels can be reduced.
  - Expose the elastic quota informer for extensions.
  - Some minor perf improvement.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
