### PR TITLE
scheduler: fix reservation cache leak when terminated and deleted

### DIFF
--- a/pkg/scheduler/plugins/reservation/eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler_test.go
@@ -184,25 +184,28 @@ func TestEventHandlerUpdate(t *testing.T) {
 			name:            "pending to failed",
 			oldReservation:  pendingReservation,
 			newReservation:  failedReservation,
-			wantReservation: failedReservation,
+			wantReservation: nil,
 		},
 		{
 			name:            "pending to succeeded",
 			oldReservation:  pendingReservation,
 			newReservation:  succeededReservation,
-			wantReservation: succeededReservation,
+			wantReservation: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cache := newReservationCache(nil)
 			eh := &reservationEventHandler{cache: cache, rrNominator: newNominator(nil, nil)}
+			eh.OnAdd(tt.oldReservation, false)
+
 			eh.OnUpdate(tt.oldReservation, tt.newReservation)
 			if tt.wantReservation == nil {
 				rInfo := cache.getReservationInfoByUID(tt.newReservation.UID)
 				assert.Nil(t, rInfo)
 			} else {
 				rInfo := cache.getReservationInfoByUID(tt.wantReservation.UID)
+				assert.NotNil(t, rInfo)
 				assert.Equal(t, tt.wantReservation, rInfo.Reservation)
 			}
 		})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Fix a leakage issue for the reservation cache when a reservation is almost concurrently updated to Succeeded/Failed and deleted, causing by the inconsistent logic between the event handlers of the plugin and of the scheduler cache.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
