### PR TITLE
scheduler: split quota PreFilter and fix preemption

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/quota_info.go
+++ b/pkg/scheduler/plugins/elasticquota/core/quota_info.go
@@ -125,7 +125,7 @@ func (qi *QuotaInfo) DeepCopy() *QuotaInfo {
 		IsParent:          qi.IsParent,
 		AllowLentResource: qi.AllowLentResource,
 		RuntimeVersion:    qi.RuntimeVersion,
-		PodCache:          make(map[string]*PodInfo),
+		PodCache:          make(map[string]*PodInfo, len(qi.PodCache)),
 		CalculateInfo: QuotaCalculateInfo{
 			Max:                       qi.CalculateInfo.Max.DeepCopy(),
 			AutoScaleMin:              qi.CalculateInfo.AutoScaleMin.DeepCopy(),
@@ -180,6 +180,7 @@ func (qi *QuotaInfo) GetQuotaSummary(treeID string, includePods bool) *QuotaInfo
 	quotaInfoSummary.SelfNonPreemptibleRequest = qi.CalculateInfo.SelfNonPreemptibleRequest.DeepCopy()
 
 	if includePods {
+		quotaInfoSummary.PodCache = make(map[string]*SimplePodInfo, len(qi.PodCache))
 		for podName, podInfo := range qi.PodCache {
 			quotaInfoSummary.PodCache[podName] = &SimplePodInfo{
 				IsAssigned: podInfo.isAssigned,
@@ -526,7 +527,7 @@ func (qi *QuotaInfo) GetPodCache() map[string]*v1.Pod {
 	qi.lock.RLock()
 	defer qi.lock.RUnlock()
 
-	pods := make(map[string]*v1.Pod)
+	pods := make(map[string]*v1.Pod, len(qi.PodCache))
 	for name, podInfo := range qi.PodCache {
 		pods[name] = podInfo.pod
 	}
@@ -551,7 +552,7 @@ func (qi *QuotaInfo) GetPodThatIsAssigned() []*v1.Pod {
 	qi.lock.RLock()
 	defer qi.lock.RUnlock()
 
-	pods := make([]*v1.Pod, 0)
+	pods := make([]*v1.Pod, 0, len(qi.PodCache))
 	for _, podInfo := range qi.PodCache {
 		if podInfo.isAssigned {
 			pods = append(pods, podInfo.pod)

--- a/pkg/scheduler/plugins/elasticquota/preempt.go
+++ b/pkg/scheduler/plugins/elasticquota/preempt.go
@@ -187,6 +187,7 @@ func (g *Plugin) SelectVictimsOnNode(
 			klog.V(5).InfoS("Pod is a potential preemption victim on node", "pod", klog.KObj(rpi), "node", klog.KObj(nodeInfo.Node()))
 		}
 
+		// TODO: support quota recursive check
 		newUsed := quotav1.Mask(quotav1.Add(postFilterState.used, podReq), quotav1.ResourceNames(podReq))
 		if isLessEqual, _ := quotav1.LessThanOrEqual(newUsed, postFilterState.usedLimit); !isLessEqual {
 			if err := removePod(pi); err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Split ElasticQuota PreFilter to AfterPreFilter, so that the snapshotted quota stats can be adjusted before the real check.
  - Fix the quota recursive check and non-preemptible check with preemption. 
  - Reduce quotaInfo lock overhead by RWMutex.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
