### PR TITLE
scheduler: optimize secondary device well planned

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -365,3 +365,10 @@ func IsSecondaryDeviceWellPlanned(device *schedulingv1alpha1.Device) bool {
 	}
 	return device.Labels[LabelSecondaryDeviceWellPlanned] == "true"
 }
+
+func IsSecondaryDeviceNotWellPlanned(device *schedulingv1alpha1.Device) bool {
+	if device == nil {
+		return false
+	}
+	return device.Labels[LabelSecondaryDeviceWellPlanned] == "false"
+}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -29,6 +29,10 @@ import (
 	utilmetrics "github.com/koordinator-sh/koordinator/pkg/util/metrics"
 )
 
+const (
+	NodeNameKey = "node_name"
+)
+
 // All the histogram based metrics have 1ms as size for the smallest bucket.
 var (
 	SchedulingTimeout = metrics.NewCounterVec(
@@ -53,6 +57,12 @@ var (
 		},
 		[]string{"operation"},
 	)
+	SecondaryDeviceNotWellPlannedNodes = utilmetrics.NewGCGaugeVec("secondary_device_not_well_planned", prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: schedulermetrics.SchedulerSubsystem,
+			Name:      "secondary_device_not_well_planned",
+			Help:      "The number of secondary device not well planned",
+		}, []string{NodeNameKey}))
 
 	metricsList = []metrics.Registerable{
 		SchedulingTimeout,
@@ -61,6 +71,7 @@ var (
 
 	gcMetricsList = []prometheus.Collector{
 		ReservationStatusPhase.GetGaugeVec(),
+		SecondaryDeviceNotWellPlannedNodes.GetGaugeVec(),
 	}
 )
 
@@ -107,4 +118,8 @@ func RegisterGCMetrics(gcMetrics ...prometheus.Collector) {
 
 func RecordElasticQuotaProcessLatency(operation string, latency time.Duration) {
 	ElasticQuotaProcessLatency.WithLabelValues(operation).Observe(latency.Seconds())
+}
+
+func RecordSecondaryDeviceNotWellPlanned(nodeName string) {
+	SecondaryDeviceNotWellPlannedNodes.WithSet(prometheus.Labels{NodeNameKey: nodeName}, 1.0)
 }

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -34,6 +34,7 @@ import (
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -531,6 +532,9 @@ func (n *nodeDeviceCache) updateNodeDevice(nodeName string, device *schedulingv1
 	info.gpuPartitionIndexer = gpuPartitionIndexer
 	info.nodeHonorGPUPartition = apiext.GetGPUPartitionPolicy(device) == apiext.GPUPartitionPolicyHonor
 	info.secondaryDeviceWellPlanned = apiext.IsSecondaryDeviceWellPlanned(device)
+	if apiext.IsSecondaryDeviceNotWellPlanned(device) {
+		metrics.RecordSecondaryDeviceNotWellPlanned(device.Name)
+	}
 	info.gpuTopologyScope = gpuTopologyScope
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In a production environment, sufficient VF resources are usually planned for the GPU. Under this condition, you can skip the resource check of the VF in the Filter stage and only do it in the Reserve stage.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
