### PR TITLE
descheduler: return the unmatched cases first

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -97,9 +97,6 @@ func (o *Options) BuildFilterFunc() (FilterFunc, error) {
 		}
 	}
 	return func(pod *corev1.Pod) bool {
-		if o.filter != nil && !o.filter(pod) {
-			return false
-		}
 		if len(o.includedNamespaces) > 0 && !o.includedNamespaces.Has(pod.Namespace) {
 			klog.V(4).InfoS("Pod fails the following checks", "pod", klog.KObj(pod), "checks", "includedNamespaces")
 			return false
@@ -110,6 +107,9 @@ func (o *Options) BuildFilterFunc() (FilterFunc, error) {
 		}
 		if s != nil && !s.Matches(labels.Set(pod.GetLabels())) {
 			klog.V(4).InfoS("Pod fails the following checks", "pod", klog.KObj(pod), "checks", "labelSelector")
+			return false
+		}
+		if o.filter != nil && !o.filter(pod) {
 			return false
 		}
 		return true


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

We should return the unmatched cases first,and leave the filter method for last, because it is computationally expensive.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
