### PR TITLE
chore(statesInformer):  remove useless code and use generateQueryDuration() func in collectMetric() func

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_node.go
+++ b/pkg/koordlet/statesinformer/impl/states_node.go
@@ -127,32 +127,6 @@ func newNodeInformer(client clientset.Interface, nodeName string) cache.SharedIn
 	)
 }
 
-func (s *nodeInformer) setupNodeInformer() {
-	s.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			node, ok := obj.(*corev1.Node)
-			if ok {
-				s.syncNode(node)
-			} else {
-				klog.Errorf("node informer add func parse Node failed, obj %T", obj)
-			}
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldNode, oldOK := oldObj.(*corev1.Node)
-			newNode, newOK := newObj.(*corev1.Node)
-			if !oldOK || !newOK {
-				klog.Errorf("unable to convert object to *corev1.Node, old %T, new %T", oldObj, newObj)
-				return
-			}
-			if reflect.DeepEqual(oldNode, newNode) {
-				klog.V(5).Infof("find node %s has not changed", newNode.Name)
-				return
-			}
-			s.syncNode(newNode)
-		},
-	})
-}
-
 func (s *nodeInformer) syncNode(newNode *corev1.Node) {
 	klog.V(5).Infof("node update detail %v", newNode)
 	s.nodeRWMutex.Lock()

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric.go
@@ -341,9 +341,7 @@ func (r *nodeMetricInformer) generateQueryDuration() (start time.Time, end time.
 func (r *nodeMetricInformer) collectMetric() (*slov1alpha1.NodeMetricInfo, []*slov1alpha1.PodMetricInfo,
 	[]*slov1alpha1.HostApplicationMetricInfo, *slov1alpha1.ReclaimableMetric) {
 	spec := r.getNodeMetricSpec()
-	endTime := time.Now()
-	startTime := endTime.Add(-time.Duration(*spec.CollectPolicy.AggregateDurationSeconds) * time.Second)
-
+	startTime, endTime := r.generateQueryDuration()
 	nodeMetricInfo := &slov1alpha1.NodeMetricInfo{
 		NodeUsage:              r.queryNodeMetric(startTime, endTime, metriccache.AggregationTypeAVG, false),
 		AggregatedNodeUsages:   r.collectNodeAggregateMetric(endTime, spec.CollectPolicy.NodeAggregatePolicy),


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
- remove useless code and use generateQueryDuration() func in collectMetric() func
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
