### PR TITLE
chore: fix wrong event type

### DIFF
--- a/pkg/quota-controller/profile/profile_controller.go
+++ b/pkg/quota-controller/profile/profile_controller.go
@@ -214,7 +214,7 @@ func (r *QuotaProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if !quotaExist {
 		err = r.Client.Create(context.TODO(), quota)
 		if err != nil {
-			r.Recorder.Eventf(profile, "Warning", ReasonCreateQuotaFailed, "failed to create quota, err: %s", err)
+			r.Recorder.Eventf(profile, corev1.EventTypeWarning, ReasonCreateQuotaFailed, "failed to create quota, err: %s", err)
 			klog.Errorf("failed create quota for profile %v, error: %v", req.NamespacedName, err)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
@@ -222,7 +222,7 @@ func (r *QuotaProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if !reflect.DeepEqual(quota.Labels, oldQuota.Labels) || !reflect.DeepEqual(quota.Annotations, oldQuota.Annotations) || !reflect.DeepEqual(quota.Spec, oldQuota.Spec) {
 			err = r.Client.Update(context.TODO(), quota)
 			if err != nil {
-				r.Recorder.Eventf(profile, "Warning", ReasonUpdateQuotaFailed, "failed to update quota, err: %s", err)
+				r.Recorder.Eventf(profile, corev1.EventTypeWarning, ReasonUpdateQuotaFailed, "failed to update quota, err: %s", err)
 				klog.Errorf("failed update quota for profile %v, error: %v", req.NamespacedName, err)
 				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 			}

--- a/pkg/slo-controller/config/colocation_cm_event_handler.go
+++ b/pkg/slo-controller/config/colocation_cm_event_handler.go
@@ -102,7 +102,7 @@ func (p *ColocationHandlerForConfigMapEvent) syncConfig(configMap *corev1.Config
 		//if controller restart ,cache will unavailable, else use old cfg
 		klog.Errorf("syncConfig failed since parse colocation error, use old Cfg ,configmap %s/%s, err: %s",
 			sloconfig.ConfigNameSpace, sloconfig.SLOCtrlConfigMap, err)
-		p.recorder.Eventf(configMap, "Warning", ReasonColocationConfigUnmarshalFailed, "failed to unmarshal colocation config, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, ReasonColocationConfigUnmarshalFailed, "failed to unmarshal colocation config, err: %s", err)
 		p.cfgCache.errorStatus = true
 		return false
 	}

--- a/pkg/slo-controller/noderesource/plugins/cpunormalization/configmap_event_handler.go
+++ b/pkg/slo-controller/noderesource/plugins/cpunormalization/configmap_event_handler.go
@@ -166,7 +166,7 @@ func (h *configHandler) syncConfig(configMap *corev1.ConfigMap) bool {
 
 	if err := json.Unmarshal([]byte(cfgStr), &mergedCfg); err != nil {
 		klog.Errorf("failed to unmarshal config %s, keep the old config, err: %s", configuration.CPUNormalizationConfigKey, err)
-		h.recorder.Eventf(configMap, "Warning", ReasonCPUNormalizationConfigUnmarshalFailed, "failed to unmarshal CPUNormalizationCfg, err: %s", err)
+		h.recorder.Eventf(configMap, corev1.EventTypeWarning, ReasonCPUNormalizationConfigUnmarshalFailed, "failed to unmarshal CPUNormalizationCfg, err: %s", err)
 		return false
 	}
 

--- a/pkg/slo-controller/noderesource/plugins/resourceamplification/configmap_event_handler.go
+++ b/pkg/slo-controller/noderesource/plugins/resourceamplification/configmap_event_handler.go
@@ -164,7 +164,7 @@ func (h *configHandler) syncConfig(configMap *corev1.ConfigMap) bool {
 
 	if err := json.Unmarshal([]byte(cfgStr), &mergedCfg); err != nil {
 		klog.Errorf("failed to unmarshal config %s, keep the old config, err: %s", configuration.ResourceAmplificationConfigKey, err)
-		h.recorder.Eventf(configMap, "Warning", ReasonResourceAmplificationConfigUnmarshalFailed, "failed to unmarshal amplificationCfg, err: %s", err)
+		h.recorder.Eventf(configMap, corev1.EventTypeWarning, ReasonResourceAmplificationConfigUnmarshalFailed, "failed to unmarshal amplificationCfg, err: %s", err)
 		return false
 	}
 

--- a/pkg/slo-controller/nodeslo/nodeslo_cm_event_handler.go
+++ b/pkg/slo-controller/nodeslo/nodeslo_cm_event_handler.go
@@ -129,27 +129,27 @@ func (p *SLOCfgHandlerForConfigMapEvent) syncConfig(configMap *corev1.ConfigMap)
 	newSLOCfg.ThresholdCfgMerged, err = calculateResourceThresholdCfgMerged(oldSLOCfgCopy.ThresholdCfgMerged, configMap)
 	if err != nil {
 		klog.V(5).Infof("failed to get ThresholdCfg, err: %s", err)
-		p.recorder.Eventf(configMap, "Warning", config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal ThresholdCfg, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal ThresholdCfg, err: %s", err)
 	}
 	newSLOCfg.ResourceQOSCfgMerged, err = calculateResourceQOSCfgMerged(oldSLOCfgCopy.ResourceQOSCfgMerged, configMap)
 	if err != nil {
 		klog.V(5).Infof("failed to get ResourceQOSCfg, err: %s", err)
-		p.recorder.Eventf(configMap, "Warning", config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal ResourceQOSCfg, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal ResourceQOSCfg, err: %s", err)
 	}
 	newSLOCfg.CPUBurstCfgMerged, err = calculateCPUBurstCfgMerged(oldSLOCfgCopy.CPUBurstCfgMerged, configMap)
 	if err != nil {
 		klog.V(5).Infof("failed to get CPUBurstCfg, err: %s", err)
-		p.recorder.Eventf(configMap, "Warning", config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal CPUBurstCfg, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal CPUBurstCfg, err: %s", err)
 	}
 	newSLOCfg.SystemCfgMerged, err = calculateSystemConfigMerged(oldSLOCfgCopy.SystemCfgMerged, configMap)
 	if err != nil {
 		klog.V(5).Infof("failed to get SystemCfg, err: %s", err)
-		p.recorder.Eventf(configMap, "Warning", config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal SystemCfg, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal SystemCfg, err: %s", err)
 	}
 	newSLOCfg.HostAppCfgMerged, err = calculateHostAppConfigMerged(oldSLOCfgCopy.HostAppCfgMerged, configMap)
 	if err != nil {
 		klog.V(5).Infof("failed to get HostApplicationCfg, err: %s", err)
-		p.recorder.Eventf(configMap, "Warning", config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal HostApplicationCfg, err: %s", err)
+		p.recorder.Eventf(configMap, corev1.EventTypeWarning, config.ReasonSLOConfigUnmarshalFailed, "failed to unmarshal HostApplicationCfg, err: %s", err)
 	}
 	newSLOCfg.ExtensionCfgMerged = calculateExtensionsCfgMerged(oldSLOCfgCopy.ExtensionCfgMerged, configMap, p.recorder)
 	return p.updateCacheIfChanged(newSLOCfg)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

- if evicting pod successfully, we should use `Normal` type

```go
// Valid values for event types (new types could be added in future)
const (
	// Information only and will not cause any problems
	EventTypeNormal string = "Normal"
	// These events are to warn that something might go wrong
	EventTypeWarning string = "Warning"
)
```

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
