### PR TITLE
scheduler: add ElasticQuota arg to control preemption of default quota (#2413)

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -215,6 +215,9 @@ type ElasticQuotaArgs struct {
 	// EnableRuntimeQuota if false, use max instead of runtime for all checks.
 	EnableRuntimeQuota bool
 
+	// DisableDefaultQuotaPreemption if true, will not preempt pods in default quota.
+	DisableDefaultQuotaPreemption bool
+
 	// HookPlugins is expected to be configured with enabled hook plugins
 	HookPlugins []HookPluginConf
 }

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -69,9 +69,10 @@ var (
 
 	defaultQuotaGroupNamespace = "koordinator-system"
 
-	defaultMonitorAllQuotas       = pointer.Bool(false)
-	defaultEnableCheckParentQuota = pointer.Bool(false)
-	defaultEnableRuntimeQuota     = pointer.Bool(true)
+	defaultMonitorAllQuotas              = pointer.Bool(false)
+	defaultEnableCheckParentQuota        = pointer.Bool(false)
+	defaultEnableRuntimeQuota            = pointer.Bool(true)
+	defaultDisableDefaultQuotaPreemption = pointer.Bool(true)
 
 	defaultTimeout           = 600 * time.Second
 	defaultControllerWorkers = 1
@@ -189,6 +190,9 @@ func SetDefaults_ElasticQuotaArgs(obj *ElasticQuotaArgs) {
 	}
 	if obj.EnableRuntimeQuota == nil {
 		obj.EnableRuntimeQuota = defaultEnableRuntimeQuota
+	}
+	if obj.DisableDefaultQuotaPreemption == nil {
+		obj.DisableDefaultQuotaPreemption = defaultDisableDefaultQuotaPreemption
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -209,6 +209,9 @@ type ElasticQuotaArgs struct {
 	// EnableRuntimeQuota if false, use max instead of runtime for all checks.
 	EnableRuntimeQuota *bool `json:"enableRuntimeQuota,omitempty"`
 
+	// DisableDefaultQuotaPreemption if true, will not preempt pods in default quota.
+	DisableDefaultQuotaPreemption *bool `json:"disableDefaultQuotaPreemption,omitempty"`
+
 	// HookPlugins is expected to be configured with enabled hook plugins
 	HookPlugins []HookPluginConf `json:"hookPlugins,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -243,6 +243,9 @@ func autoConvert_v1_ElasticQuotaArgs_To_config_ElasticQuotaArgs(in *ElasticQuota
 	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption, s); err != nil {
+		return err
+	}
 	out.HookPlugins = *(*[]config.HookPluginConf)(unsafe.Pointer(&in.HookPlugins))
 	return nil
 }
@@ -269,6 +272,9 @@ func autoConvert_config_ElasticQuotaArgs_To_v1_ElasticQuotaArgs(in *config.Elast
 		return err
 	}
 	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption, s); err != nil {
 		return err
 	}
 	out.HookPlugins = *(*[]HookPluginConf)(unsafe.Pointer(&in.HookPlugins))

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *ElasticQuotaArgs) DeepCopyInto(out *ElasticQuotaArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableDefaultQuotaPreemption != nil {
+		in, out := &in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HookPlugins != nil {
 		in, out := &in.HookPlugins, &out.HookPlugins
 		*out = make([]HookPluginConf, len(*in))

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -69,9 +69,10 @@ var (
 
 	defaultQuotaGroupNamespace = "koordinator-system"
 
-	defaultMonitorAllQuotas       = pointer.Bool(false)
-	defaultEnableCheckParentQuota = pointer.Bool(false)
-	defaultEnableRuntimeQuota     = pointer.Bool(true)
+	defaultMonitorAllQuotas              = pointer.Bool(false)
+	defaultEnableCheckParentQuota        = pointer.Bool(false)
+	defaultEnableRuntimeQuota            = pointer.Bool(true)
+	defaultDisableDefaultQuotaPreemption = pointer.Bool(true)
 
 	defaultTimeout           = 600 * time.Second
 	defaultControllerWorkers = 1
@@ -189,6 +190,9 @@ func SetDefaults_ElasticQuotaArgs(obj *ElasticQuotaArgs) {
 	}
 	if obj.EnableRuntimeQuota == nil {
 		obj.EnableRuntimeQuota = defaultEnableRuntimeQuota
+	}
+	if obj.DisableDefaultQuotaPreemption == nil {
+		obj.DisableDefaultQuotaPreemption = defaultDisableDefaultQuotaPreemption
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -209,6 +209,9 @@ type ElasticQuotaArgs struct {
 	// EnableRuntimeQuota if false, use max instead of runtime for all checks.
 	EnableRuntimeQuota *bool `json:"enableRuntimeQuota,omitempty"`
 
+	// DisableDefaultQuotaPreemption if true, will not preempt pods in default quota.
+	DisableDefaultQuotaPreemption *bool `json:"disableDefaultQuotaPreemption,omitempty"`
+
 	// HookPlugins is expected to be configured with enabled hook plugins
 	HookPlugins []HookPluginConf `json:"hookPlugins,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -243,6 +243,9 @@ func autoConvert_v1beta3_ElasticQuotaArgs_To_config_ElasticQuotaArgs(in *Elastic
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption, s); err != nil {
+		return err
+	}
 	out.HookPlugins = *(*[]config.HookPluginConf)(unsafe.Pointer(&in.HookPlugins))
 	return nil
 }
@@ -269,6 +272,9 @@ func autoConvert_config_ElasticQuotaArgs_To_v1beta3_ElasticQuotaArgs(in *config.
 		return err
 	}
 	if err := v1.Convert_bool_To_Pointer_bool(&in.EnableRuntimeQuota, &out.EnableRuntimeQuota, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_bool_To_Pointer_bool(&in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption, s); err != nil {
 		return err
 	}
 	out.HookPlugins = *(*[]HookPluginConf)(unsafe.Pointer(&in.HookPlugins))

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *ElasticQuotaArgs) DeepCopyInto(out *ElasticQuotaArgs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableDefaultQuotaPreemption != nil {
+		in, out := &in.DisableDefaultQuotaPreemption, &out.DisableDefaultQuotaPreemption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HookPlugins != nil {
 		in, out := &in.HookPlugins, &out.HookPlugins
 		*out = make([]HookPluginConf, len(*in))

--- a/pkg/scheduler/plugins/elasticquota/preempt.go
+++ b/pkg/scheduler/plugins/elasticquota/preempt.go
@@ -290,5 +290,15 @@ func (g *Plugin) canPreempt(pod, victim *corev1.Pod) bool {
 	podQuotaName := g.getPodAssociateQuotaName(pod)
 	vicQuotaName := g.getPodAssociateQuotaName(victim)
 
+	// The quota of pods that do not actively set through annotation will be recognized as the default quota.
+	// In some scenarios, many important pods are not scheduled by Koordinator, and their quotas are
+	// also recognized as default quota, this will cause the eviction operation to identify these important
+	// pods as victim pods, which is risky. When DisableDefaultQuotaPreemption is set to true, these pods can
+	// be avoided from being evicted.
+	if g.pluginArgs.DisableDefaultQuotaPreemption &&
+		extension.DefaultQuotaName == vicQuotaName {
+		return false
+	}
+
 	return podPri > vicPri && podQuotaName == vicQuotaName
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

koord-scheduler

- The quota of pods that do not actively set through annotation will be recognized as the default quota. In some scenarios, many important pods are not scheduled by Koordinator, and their quotas are also recognized as default quota, this will cause the eviction operation to identify these important pods as victim pods, which is risky. We introduced a new argument `DisableDefaultQuotaPreemption` in ElasticQuota, when `DisableDefaultQuotaPreemption` is set to true, these pods can be avoided from being evicted.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

unit tests passed.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
