### PR TITLE
scheduler: run pod-update hooks for elastic-quota regardless of whether used resources have changed

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -707,6 +707,8 @@ func (gqm *GroupQuotaManager) updatePodUsedNoLock(quotaName string, oldPod, newP
 			quotaName, getPodName(oldPod, newPod))
 		return
 	}
+	// run pod-update hooks regardless of whether used resources have changed.
+	gqm.runPodUpdateHooks(quotaName, oldPod, newPod)
 
 	var oldPodUsed, newPodUsed, oldNonPreemptibleUsed, newNonPreemptibleUsed v1.ResourceList
 	if oldPod != nil {
@@ -735,7 +737,6 @@ func (gqm *GroupQuotaManager) updatePodUsedNoLock(quotaName string, oldPod, newP
 			quotaName, getPodName(oldPod, newPod), util.DumpJSON(newPodUsed), util.DumpJSON(newNonPreemptibleUsed))
 	}
 	gqm.updateGroupDeltaUsedNoLock(quotaName, deltaUsed, deltaNonPreemptibleUsed, 0)
-	gqm.runPodUpdateHooks(quotaName, oldPod, newPod)
 }
 
 func (gqm *GroupQuotaManager) updatePodCacheNoLock(quotaName string, pod *v1.Pod, isAdd bool) {

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
@@ -286,7 +286,7 @@ func TestOnPodUpdateHook(t *testing.T) {
 		assert.True(t, updatedPod1 == newPod, "New pod should match")
 	}
 	gqm.OnPodUpdate(q1.Name, q1.Name, updatedPod1, pod1)
-	assert.False(t, mockHook.OnPodUpdatedCalled, "OnPodUpdated should be called")
+	assert.True(t, mockHook.OnPodUpdatedCalled, "OnPodUpdated should be called")
 
 	// validate Pod Delete operation
 	mockHook.Reset()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In #2415, pod-update hooks for elastic-quota were expected to be triggered when a pod changed regardless of whether used resources have changed, since there maybe some used-resource-regardless actions to be done in pod-update hooks.
But the action has been changed in #2456 :  when the used resources of the pod have not changed, pod-update hooks for elastic-quota won't be triggered.
This PR will move the GroupQuotaManager#runPodUpdateHooks before calculating the used resources to make sure the pod-update hooks must be triggered when a pod changed.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
