### PR TITLE
scheduler: Add hook plugins logic in ReplaceQuotas and OnQuotaUpdate methods of ElasticQuota plugin.

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -418,7 +418,7 @@ func (gqm *GroupQuotaManager) UpdateQuota(quota *v1alpha1.ElasticQuota) error {
 	// update the local quotaInfo's crd
 	if localQuotaInfo, exist := gqm.quotaInfoMap[quotaName]; exist {
 		if !localQuotaInfo.IsQuotaChange(newQuotaInfo) &&
-			!gqm.isQuotaUpdated(localQuotaInfo, newQuotaInfo, quota) {
+			!gqm.IsQuotaUpdated(localQuotaInfo, newQuotaInfo, quota) {
 			return nil
 		}
 

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
@@ -302,6 +302,9 @@ func (gqm *GroupQuotaManager) IsQuotaUpdated(oldQuotaInfo, newQuotaInfo *QuotaIn
 
 // ResetQuotasForHookPlugins resets quotas with pre-update and post-update hooks
 func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alpha1.ElasticQuota) {
+	if len(gqm.hookPlugins) == 0 {
+		return
+	}
 	startTime := time.Now()
 	defer func() {
 		klog.Infof("reset hook plugins for tree %s, took %v", gqm.GetTreeID(), time.Since(startTime))

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
@@ -290,7 +290,7 @@ func (gqm *GroupQuotaManager) runPodUpdateHooks(quotaName string, oldPod, newPod
 	}
 }
 
-func (gqm *GroupQuotaManager) isQuotaUpdated(oldQuotaInfo, newQuotaInfo *QuotaInfo,
+func (gqm *GroupQuotaManager) IsQuotaUpdated(oldQuotaInfo, newQuotaInfo *QuotaInfo,
 	newQuota *v1alpha1.ElasticQuota) bool {
 	for _, hook := range gqm.hookPlugins {
 		if hook.IsQuotaUpdated(oldQuotaInfo, newQuotaInfo, newQuota) {
@@ -298,4 +298,25 @@ func (gqm *GroupQuotaManager) isQuotaUpdated(oldQuotaInfo, newQuotaInfo *QuotaIn
 		}
 	}
 	return false
+}
+
+// ResetQuotasForHookPlugins resets quotas with pre-update and post-update hooks
+func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alpha1.ElasticQuota) {
+	startTime := time.Now()
+	defer func() {
+		klog.Infof("reset hook plugins for tree %s, took %v", gqm.GetTreeID(), time.Since(startTime))
+	}()
+
+	gqm.hierarchyUpdateLock.Lock()
+	defer gqm.hierarchyUpdateLock.Unlock()
+
+	for quotaName, quotaInfo := range gqm.quotaInfoMap {
+		quota := quotas[quotaInfo.Name]
+		if quota == nil {
+			klog.Warningf("skip resetting inconsistent quota %s for hook plugins", quotaName)
+			continue
+		}
+		hookState := gqm.runPreQuotaUpdateHooks(nil, quotaInfo, quota)
+		gqm.runPostQuotaUpdateHooks(nil, quotaInfo, quota, hookState)
+	}
 }

--- a/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	schetesting "k8s.io/kubernetes/pkg/scheduler/testing"
 
@@ -112,6 +114,143 @@ func TestCheckPodHook(t *testing.T) {
 	assert.Equal(t, "CheckPod failed for hook plugin mockPlugin, err: test error", status.Message())
 }
 
+// TestUpdateQuota_IsQuotaUpdated tests the IsQuotaUpdated condition in UpdateQuota method
+func TestUpdateQuota_IsQuotaUpdated(t *testing.T) {
+	// init plugin and gqm
+	_, plugin := initPluginSuit(t)
+	gqm := plugin.groupQuotaManager
+	assert.Equal(t, 1, len(gqm.GetHookPlugins()))
+
+	// init quota
+	q1 := CreateQuota2("q1", extension.RootQuotaName, 10, 10, 0, 0, 0, 0, false, "")
+	plugin.OnQuotaAdd(q1)
+
+	// get mock hook plugin
+	mockHook := gqm.GetHookPlugins()[0].(*core.MetricsWrapper).GetPlugin().(*MockHookPlugin)
+
+	// test case 1: quota has no changes and IsQuotaUpdated returns false
+	// PreQuotaUpdate and PostQuotaUpdate should not be called
+	mockHook.Reset()
+	mockHook.IsQuotaUpdatedFn = func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool {
+		return false
+	}
+
+	// update with the same quota (no changes)
+	plugin.OnQuotaUpdate(q1, q1)
+	assert.False(t, mockHook.PreQuotaUpdateCalled, "PreQuotaUpdate should not be called when quota unchanged and IsQuotaUpdated returns false")
+	assert.False(t, mockHook.PostQuotaUpdateCalled, "PostQuotaUpdate should not be called when quota unchanged and IsQuotaUpdated returns false")
+
+	// test case 2: quota has no changes but IsQuotaUpdated returns true
+	// PreQuotaUpdate and PostQuotaUpdate should be called
+	mockHook.Reset()
+	mockHook.IsQuotaUpdatedFn = func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool {
+		// Verify that the hook receives correct parameters
+		assert.NotNil(t, oldQuotaInfo, "oldQuotaInfo should not be nil")
+		assert.NotNil(t, newQuotaInfo, "newQuotaInfo should not be nil")
+		assert.NotNil(t, newQuota, "newQuota should not be nil")
+		assert.Equal(t, oldQuotaInfo.Name, newQuotaInfo.Name, "newQuotaInfo name should match")
+		assert.Equal(t, newQuotaInfo.Name, newQuota.Name, "newQuota name should match")
+		return true
+	}
+
+	// validation functions for PreQuotaUpdate and PostQuotaUpdate
+	validateHookParameters := func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, quota *v1alpha1.ElasticQuota, state *core.QuotaUpdateState) {
+		assert.NotNil(t, oldQuotaInfo, "oldQuotaInfo should not be nil")
+		assert.NotNil(t, newQuotaInfo, "newQuotaInfo should not be nil")
+		assert.NotNil(t, quota, "quota should not be nil")
+		assert.NotNil(t, state, "state should not be nil")
+	}
+
+	mockHook.PreQuotaUpdateValidateFn = validateHookParameters
+	mockHook.PostQuotaUpdateValidateFn = validateHookParameters
+
+	// update with the same quota (no changes), but IsQuotaUpdated returns true
+	plugin.OnQuotaUpdate(q1, q1)
+	assert.True(t, mockHook.PreQuotaUpdateCalled, "PreQuotaUpdate should be called when IsQuotaUpdated returns true")
+	assert.True(t, mockHook.PostQuotaUpdateCalled, "PostQuotaUpdate should be called when IsQuotaUpdated returns true")
+
+	// test case 3: quota has changes, IsQuotaUpdated should not affect the result
+	// PreQuotaUpdate and PostQuotaUpdate should be called regardless of IsQuotaUpdated return value
+	mockHook.Reset()
+	mockHook.IsQuotaUpdatedFn = func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool {
+		return false // Even if this returns false, hooks should still be called because quota has changes
+	}
+
+	// create a modified quota
+	q1Modified := q1.DeepCopy()
+	q1Modified.Spec.Max = v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("20"),
+		v1.ResourceMemory: resource.MustParse("20Gi"),
+	}
+
+	validateHookParameters = func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo,
+		quota *v1alpha1.ElasticQuota, state *core.QuotaUpdateState) {
+		assert.NotNil(t, oldQuotaInfo, "oldQuotaInfo should not be nil")
+		assert.NotNil(t, newQuotaInfo, "newQuotaInfo should not be nil")
+		assert.NotNil(t, quota, "quota should not be nil")
+		assert.NotNil(t, state, "state should not be nil")
+		assert.Equal(t, q1Modified.Name, quota.Name, "quota name should match")
+		// verify that the new quota has the updated max values
+		assert.True(t, quotav1.Equals(newQuotaInfo.CalculateInfo.Max, q1Modified.Spec.Max),
+			"newQuotaInfo should have updated max values")
+	}
+	mockHook.PreQuotaUpdateValidateFn = validateHookParameters
+	mockHook.PostQuotaUpdateValidateFn = validateHookParameters
+
+	// update with modified quota
+	plugin.OnQuotaUpdate(q1, q1Modified)
+	assert.True(t, mockHook.PreQuotaUpdateCalled, "PreQuotaUpdate should be called when quota has changes")
+	assert.True(t, mockHook.PostQuotaUpdateCalled, "PostQuotaUpdate should be called when quota has changes")
+}
+
+func TestReplaceQuotasWithHookPlugins(t *testing.T) {
+	// register a mock hook plugin factory for testing
+	core.RegisterHookPluginFactory("mockFactory",
+		func(qiProvider *core.QuotaInfoReader, key, args string) (core.QuotaHookPlugin, error) {
+			return &MockHookPlugin{key: key}, nil
+		})
+
+	// create test suit with hook plugin configuration
+	suit := newPluginTestSuit(t, nil,
+		func(elasticQuotaArgs *config.ElasticQuotaArgs) {
+			elasticQuotaArgs.HookPlugins = []config.HookPluginConf{
+				{
+					Key:        "mockPlugin",
+					FactoryKey: "mockFactory",
+				},
+			}
+		})
+	p, err := suit.proxyNew(suit.elasticQuotaArgs, suit.Handle)
+	assert.Nil(t, err)
+	plugin := p.(*Plugin)
+
+	// prepare test quotas
+	quotas := []interface{}{
+		CreateQuota2("test1", extension.RootQuotaName, 100, 200, 40, 80, 1, 1, true, ""),
+		CreateQuota2("test2", extension.RootQuotaName, 200, 400, 80, 160, 1, 1, true, ""),
+		CreateQuota2("test11", "test1", 100, 200, 40, 80, 1, 1, false, ""),
+	}
+
+	// call ReplaceQuotas which should trigger ResetQuotasForHookPlugins
+	err = plugin.ReplaceQuotas(quotas)
+	assert.Nil(t, err)
+
+	// Verify hook plugins were called
+	hookPlugins := plugin.groupQuotaManager.GetHookPlugins()
+	assert.Equal(t, 1, len(hookPlugins))
+
+	mockHook := hookPlugins[0].(*core.MetricsWrapper).GetPlugin().(*MockHookPlugin)
+
+	// Verify that the quotas were processed correctly
+	expectedQuotaNames := []string{"test1", "test2", "test11"}
+	for _, expectedName := range expectedQuotaNames {
+		assert.Contains(t, mockHook.PreQuotaUpdateQuotas, expectedName,
+			"Quota %s should be processed in PreQuotaUpdate", expectedName)
+		assert.Contains(t, mockHook.PostQuotaUpdateQuotas, expectedName,
+			"Quota %s should be processed in PostQuotaUpdate", expectedName)
+	}
+}
+
 func initPluginSuit(t *testing.T) (*pluginTestSuit, *Plugin) {
 	core.RegisterHookPluginFactory("mockFactory",
 		func(qiProvider *core.QuotaInfoReader, key, args string) (core.QuotaHookPlugin, error) {
@@ -144,10 +283,27 @@ type MockHookPlugin struct {
 
 	CheckPodCalled bool
 	CheckPodFn     func(quotaName string, pod *v1.Pod) error
+
+	PreQuotaUpdateCalled     bool
+	PreQuotaUpdateQuotas     []string
+	PreQuotaUpdateValidateFn func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, quota *v1alpha1.ElasticQuota, state *core.QuotaUpdateState)
+
+	PostQuotaUpdateCalled     bool
+	PostQuotaUpdateQuotas     []string
+	PostQuotaUpdateValidateFn func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, quota *v1alpha1.ElasticQuota, state *core.QuotaUpdateState)
+
+	IsQuotaUpdatedFn func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool
 }
 
 func (m *MockHookPlugin) Reset() {
 	m.CheckPodCalled = false
+	m.PreQuotaUpdateCalled = false
+	m.PreQuotaUpdateQuotas = nil
+	m.PostQuotaUpdateCalled = false
+	m.PostQuotaUpdateQuotas = nil
+	m.PreQuotaUpdateValidateFn = nil
+	m.PostQuotaUpdateValidateFn = nil
+	m.IsQuotaUpdatedFn = nil
 }
 
 func (m *MockHookPlugin) GetKey() string {
@@ -168,16 +324,29 @@ func (m *MockHookPlugin) CheckPod(quotaName string, pod *v1.Pod) error {
 
 // The following methods of MockHookPlugin are tested in the core package instead of this file
 
-func (m *MockHookPlugin) IsQuotaUpdated(_, _ *core.QuotaInfo, _ *v1alpha1.ElasticQuota) bool {
+func (m *MockHookPlugin) IsQuotaUpdated(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool {
+	if m.IsQuotaUpdatedFn != nil {
+		return m.IsQuotaUpdatedFn(oldQuotaInfo, newQuotaInfo, newQuota)
+	}
 	return false
 }
 
-func (m *MockHookPlugin) PreQuotaUpdate(_ *core.QuotaInfo, _ *core.QuotaInfo, _ *v1alpha1.ElasticQuota,
-	_ *core.QuotaUpdateState) {
+func (m *MockHookPlugin) PreQuotaUpdate(oldQuotaInfo, newQuotaInfo *core.QuotaInfo,
+	quota *v1alpha1.ElasticQuota, state *core.QuotaUpdateState) {
+	m.PreQuotaUpdateCalled = true
+	m.PreQuotaUpdateQuotas = append(m.PreQuotaUpdateQuotas, quota.Name)
+	if m.PreQuotaUpdateValidateFn != nil {
+		m.PreQuotaUpdateValidateFn(oldQuotaInfo, newQuotaInfo, quota, state)
+	}
 }
 
-func (m *MockHookPlugin) PostQuotaUpdate(_ *core.QuotaInfo, _ *core.QuotaInfo, _ *v1alpha1.ElasticQuota,
-	_ *core.QuotaUpdateState) {
+func (m *MockHookPlugin) PostQuotaUpdate(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, quota *v1alpha1.ElasticQuota,
+	state *core.QuotaUpdateState) {
+	m.PostQuotaUpdateCalled = true
+	m.PostQuotaUpdateQuotas = append(m.PostQuotaUpdateQuotas, quota.Name)
+	if m.PostQuotaUpdateValidateFn != nil {
+		m.PostQuotaUpdateValidateFn(oldQuotaInfo, newQuotaInfo, quota, state)
+	}
 }
 
 func (m *MockHookPlugin) OnPodUpdated(_ string, _, _ *v1.Pod) {

--- a/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
@@ -144,7 +144,7 @@ func TestUpdateQuota_IsQuotaUpdated(t *testing.T) {
 	// PreQuotaUpdate and PostQuotaUpdate should be called
 	mockHook.Reset()
 	mockHook.IsQuotaUpdatedFn = func(oldQuotaInfo, newQuotaInfo *core.QuotaInfo, newQuota *v1alpha1.ElasticQuota) bool {
-		// Verify that the hook receives correct parameters
+		// verify that the hook receives correct parameters
 		assert.NotNil(t, oldQuotaInfo, "oldQuotaInfo should not be nil")
 		assert.NotNil(t, newQuotaInfo, "newQuotaInfo should not be nil")
 		assert.NotNil(t, newQuota, "newQuota should not be nil")
@@ -231,17 +231,19 @@ func TestReplaceQuotasWithHookPlugins(t *testing.T) {
 		CreateQuota2("test11", "test1", 100, 200, 40, 80, 1, 1, false, ""),
 	}
 
+	// ReplaceQuotas will conflict with QuotaEventHandler. sleep 1 seconds to avoid it.
+	time.Sleep(time.Second)
 	// call ReplaceQuotas which should trigger ResetQuotasForHookPlugins
 	err = plugin.ReplaceQuotas(quotas)
 	assert.Nil(t, err)
 
-	// Verify hook plugins were called
+	// verify hook plugins were called
 	hookPlugins := plugin.groupQuotaManager.GetHookPlugins()
 	assert.Equal(t, 1, len(hookPlugins))
 
 	mockHook := hookPlugins[0].(*core.MetricsWrapper).GetPlugin().(*MockHookPlugin)
 
-	// Verify that the quotas were processed correctly
+	// verify that the quotas were processed correctly
 	expectedQuotaNames := []string{"test1", "test2", "test11"}
 	for _, expectedName := range expectedQuotaNames {
 		assert.Contains(t, mockHook.PreQuotaUpdateQuotas, expectedName,


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
There are 2 locations in quota_handler.go that need to be made compatible with hook plugins:
1) OnQuotaUpdate method: Add a GroupQuotaManager#IsQuotaUpdated call to determine whether the quota has been updated for hook plugins.
2) ReplaceQuotas method: Add a GroupQuotaManager#ResetQuotasForHookPlugins call to reset quotas during the initial phase for hook plugins.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
