### PR TITLE
scheduler: fine-grained device scheduling support Huawei Ascend NPU (full card)

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -58,11 +58,17 @@ const (
 
 const (
 	LabelGPUPartitionPolicy         string = NodeDomainPrefix + "/gpu-partition-policy"
+	LabelGPUVendor                  string = NodeDomainPrefix + "/gpu-vendor"
 	LabelGPUModel                   string = NodeDomainPrefix + "/gpu-model"
 	LabelGPUDriverVersion           string = NodeDomainPrefix + "/gpu-driver-version"
 	LabelSecondaryDeviceWellPlanned string = NodeDomainPrefix + "/secondary-device-well-planned"
 
 	LabelGPUIsolationProvider = DomainPrefix + "gpu-isolation-provider"
+)
+
+const (
+	GPUVendorNVIDIA = "nvidia"
+	GPUVendorHuawei = "huawei"
 )
 
 // DeviceAllocations would be injected into Pod as form of annotation during Pre-bind stage.

--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -41,9 +41,10 @@ const (
 )
 
 const (
-	ResourceNvidiaGPU      corev1.ResourceName = "nvidia.com/gpu"
-	ResourceHygonDCU       corev1.ResourceName = "dcu.com/gpu"
-	ResourceAMDGPU         corev1.ResourceName = "amd.com/gpu"
+	ResourceNvidiaGPU corev1.ResourceName = "nvidia.com/gpu"
+	ResourceHygonDCU  corev1.ResourceName = "dcu.com/gpu"
+	ResourceAMDGPU    corev1.ResourceName = "amd.com/gpu"
+
 	ResourceRDMA           corev1.ResourceName = DomainPrefix + "rdma"
 	ResourceFPGA           corev1.ResourceName = DomainPrefix + "fpga"
 	ResourceGPU            corev1.ResourceName = DomainPrefix + "gpu"
@@ -51,6 +52,8 @@ const (
 	ResourceGPUCore        corev1.ResourceName = DomainPrefix + "gpu-core"
 	ResourceGPUMemory      corev1.ResourceName = DomainPrefix + "gpu-memory"
 	ResourceGPUMemoryRatio corev1.ResourceName = DomainPrefix + "gpu-memory-ratio"
+
+	ResourceHuaweiNPUCore = "huawei.com/npu-core"
 )
 
 const (

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -93,6 +93,9 @@ const (
 
 	// ValidatePodDeviceResource enables validate pod device resource
 	ValidatePodDeviceResource featuregate.Feature = "ValidatePodDeviceResource"
+
+	// DevicePluginAdaption enables adaption for third party device plugins within device share scheduling.
+	DevicePluginAdaption featuregate.Feature = "DevicePluginAdaption"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -116,6 +119,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	EnableSyncGPUSharedResource:            {Default: false, PreRelease: featuregate.Alpha},
 	ColocationProfileController:            {Default: false, PreRelease: featuregate.Alpha},
 	ValidatePodDeviceResource:              {Default: false, PreRelease: featuregate.Alpha},
+	DevicePluginAdaption:                   {Default: false, PreRelease: featuregate.Alpha},
 }
 
 const (

--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -105,6 +105,8 @@ func (s *statesInformer) fillGPUDevice(device *schedulingv1alpha1.Device,
 	if device.Labels == nil {
 		device.Labels = make(map[string]string)
 	}
+	// currently the built-in informer only supports NVIDIA GPUs
+	device.Labels[extension.LabelGPUVendor] = extension.GPUVendorNVIDIA
 	if gpuModel != "" {
 		device.Labels[extension.LabelGPUModel] = gpuModel
 	}

--- a/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
@@ -161,6 +161,7 @@ func Test_reportGPUDevice(t *testing.T) {
 	device, err = fakeClient.Get(context.TODO(), "test", metav1.GetOptions{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, device.Spec.Devices, expectedDevices)
+	assert.Equal(t, device.Labels[extension.LabelGPUVendor], extension.GPUVendorNVIDIA)
 	assert.Equal(t, device.Labels[extension.LabelGPUModel], "A100")
 	assert.Equal(t, device.Labels[extension.LabelGPUDriverVersion], "470")
 }

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu_helper.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu_helper.go
@@ -150,10 +150,13 @@ var (
 	GetDesignatedGPUPartitionIndexer = func(node *corev1.Node) (GPUPartitionIndexer, bool) {
 		var partitionIndexer GPUPartitionIndexer
 		partitionPolicy := apiext.GetGPUPartitionPolicy(node)
-		model := node.Labels[apiext.LabelGPUModel]
-		switch model {
-		case "H100", "H800", "H20":
-			partitionIndexer = GPUPartitionIndexOfNVIDIAHopper
+		vendor := node.Labels[apiext.LabelGPUVendor]
+		// treat empty vendor as nvidia for compatibility
+		if vendor == "" || vendor == apiext.GPUVendorNVIDIA {
+			switch node.Labels[apiext.LabelGPUModel] {
+			case "H100", "H800", "H20":
+				partitionIndexer = GPUPartitionIndexOfNVIDIAHopper
+			}
 		}
 		return partitionIndexer, partitionPolicy == apiext.GPUPartitionPolicyHonor
 	}

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+)
+
+const (
+	// AnnotationBindTimestamp represents the bind time (unix nano) of the pod which can be used by
+	// custom device plugins which are adapted for koord-scheduler to determine pod.
+	//
+	// Background: Device plugins cannot get pod manifest (including annotations) from kubelet so they have to
+	// use the bind time to determine the target pod when multiple pods are assigned to the same node at the same time.
+	AnnotationBindTimestamp = apiext.SchedulingDomainPrefix + "/bind-timestamp"
+
+	// AnnotationPredicateTime represents the bind time (unix nano) of the pod which is used by
+	// Huawei NPU device plugins to determine pod.
+	AnnotationPredicateTime = "predicate-time"
+	// AnnotationHuaweiNPUCore represents the NPU/vNPU allocation result for the pod which is used by
+	// Huawei NPU device plugins to allocate NPU(s)/vNPU for pod.
+	AnnotationHuaweiNPUCore = "huawei.com/npu-core"
+)
+
+// DevicePluginAdapter adapt koord-scheduler's device allocation result to the format that third party vendor's
+// device plugin recognizes, so that user can directly use them as allocators with koord-scheduler without modification.
+// This is especially useful when third party device plugin natively supports fine-grained device allocation or virtualization.
+type DevicePluginAdapter interface {
+	Adapt(object metav1.Object, allocation []*apiext.DeviceAllocation) error
+}
+
+var (
+	defaultDevicePluginAdapter = &generalDevicePluginAdapter{
+		clock: clock.RealClock{},
+	}
+	gpuDevicePluginAdapterMap = map[string]DevicePluginAdapter{
+		apiext.GPUVendorHuawei: &huaweiGPUDevicePluginAdapter{
+			clock: clock.RealClock{},
+		},
+	}
+)
+
+func (p *Plugin) adaptForDevicePlugin(object metav1.Object, allocationResult apiext.DeviceAllocations, nodeName string) error {
+	if gpuAllocation, ok := allocationResult[schedulingv1alpha1.GPU]; ok {
+		extendedHandle, ok := p.handle.(frameworkext.ExtendedHandle)
+		if !ok {
+			return fmt.Errorf("expect handle to be type frameworkext.ExtendedHandle, got %T", p.handle)
+		}
+		deviceLister := extendedHandle.KoordinatorSharedInformerFactory().Scheduling().V1alpha1().Devices().Lister()
+		device, err := deviceLister.Get(nodeName)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get Device", "node", nodeName)
+			return err
+		}
+
+		vendor := device.Labels[apiext.LabelGPUVendor]
+		if adapter, ok := gpuDevicePluginAdapterMap[vendor]; ok {
+			if err := adapter.Adapt(object, gpuAllocation); err != nil {
+				return fmt.Errorf("failed to adapt for GPU device plugin of vendor %q: %w", vendor, err)
+			}
+		}
+	}
+	return defaultDevicePluginAdapter.Adapt(object, nil)
+}
+
+// generalDevicePluginAdapter annotates the bind timestamp to pod which enables users to write their own device plugins
+// that can be used with koord-scheduler.
+type generalDevicePluginAdapter struct {
+	clock clock.Clock
+}
+
+func (a *generalDevicePluginAdapter) Adapt(object metav1.Object, _ []*apiext.DeviceAllocation) error {
+	object.GetAnnotations()[AnnotationBindTimestamp] = strconv.FormatInt(a.clock.Now().UnixNano(), 10)
+	return nil
+}
+
+type huaweiGPUDevicePluginAdapter struct {
+	clock clock.Clock
+}
+
+func (a *huaweiGPUDevicePluginAdapter) Adapt(object metav1.Object, allocation []*apiext.DeviceAllocation) error {
+	object.GetAnnotations()[AnnotationPredicateTime] = strconv.FormatInt(a.clock.Now().UnixNano(), 10)
+	// TODO(zqzten): impl vNPU allocation adaption logic
+	minors := make([]string, 0, len(allocation))
+	for _, alloc := range allocation {
+		minors = append(minors, strconv.Itoa(int(alloc.Minor)))
+	}
+	object.GetAnnotations()[AnnotationHuaweiNPUCore] = strings.Join(minors, ",")
+	return nil
+}

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestGeneralDevicePluginAdapter_Adapt(t *testing.T) {
+	now := time.Now()
+
+	type args struct {
+		object metav1.Object
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErr    bool
+		wantObject metav1.Object
+	}{
+		{
+			name: "normal",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+					},
+				},
+			},
+		},
+	}
+
+	adapter := &generalDevicePluginAdapter{
+		clock: fakeclock.NewFakeClock(now),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := adapter.Adapt(tt.args.object, nil)
+			assert.Equal(t, tt.wantErr, err != nil, err)
+			assert.Equal(t, tt.wantObject, tt.args.object)
+		})
+	}
+}
+
+func TestHuaweiGPUDevicePluginAdapter_Adapt(t *testing.T) {
+	now := time.Now()
+
+	type args struct {
+		object     metav1.Object
+		allocation []*apiext.DeviceAllocation
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErr    bool
+		wantObject metav1.Object
+	}{
+		{
+			name: "single minor",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocation: []*apiext.DeviceAllocation{
+					{Minor: 0},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationPredicateTime: strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationHuaweiNPUCore: "0",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple minors",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocation: []*apiext.DeviceAllocation{
+					{Minor: 0},
+					{Minor: 1},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationPredicateTime: strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationHuaweiNPUCore: "0,1",
+					},
+				},
+			},
+		},
+	}
+
+	adapter := &huaweiGPUDevicePluginAdapter{
+		clock: fakeclock.NewFakeClock(now),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := adapter.Adapt(tt.args.object, tt.args.allocation)
+			assert.Equal(t, tt.wantErr, err != nil, err)
+			assert.Equal(t, tt.wantObject, tt.args.object)
+		})
+	}
+}
+
+func TestPlugin_adaptForDevicePlugin(t *testing.T) {
+	now := time.Now()
+	defaultDevicePluginAdapter = &generalDevicePluginAdapter{
+		clock: fakeclock.NewFakeClock(now),
+	}
+	gpuDevicePluginAdapterMap = map[string]DevicePluginAdapter{
+		apiext.GPUVendorHuawei: &huaweiGPUDevicePluginAdapter{
+			clock: fakeclock.NewFakeClock(now),
+		},
+	}
+
+	type args struct {
+		object           metav1.Object
+		allocationResult apiext.DeviceAllocations
+		nodeName         string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		device     *schedulingv1alpha1.Device
+		wantErr    bool
+		wantObject metav1.Object
+	}{
+		{
+			name: "nvidia",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "nvidia",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvidia",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: apiext.GPUVendorNVIDIA,
+					},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+					},
+				},
+			},
+		},
+		{
+			name: "huawei",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "huawei",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "huawei",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: apiext.GPUVendorHuawei,
+					},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationPredicateTime: strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationHuaweiNPUCore: "0",
+					},
+				},
+			},
+		},
+		{
+			name: "unknown vendor",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "test",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: "test",
+					},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+					},
+				},
+			},
+		},
+		{
+			name: "non-gpu device allocation",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.FPGA: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "nvidia",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvidia",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: apiext.GPUVendorNVIDIA,
+					},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+					},
+				},
+			},
+		},
+		{
+			name: "device not found",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "test",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvidia",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: apiext.GPUVendorNVIDIA,
+					},
+				},
+			},
+			wantErr: true,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			if tt.device != nil {
+				_, err := suit.koordClientSet.SchedulingV1alpha1().Devices().Create(context.TODO(), tt.device, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			pl, err := suit.proxyNew(getDefaultArgs(), suit.Framework)
+			assert.NoError(t, err)
+
+			suit.Framework.SharedInformerFactory().Start(nil)
+			suit.koordinatorSharedInformerFactory.Start(nil)
+			suit.Framework.SharedInformerFactory().WaitForCacheSync(nil)
+			suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)
+
+			err = pl.(*Plugin).adaptForDevicePlugin(tt.args.object, tt.args.allocationResult, tt.args.nodeName)
+			assert.Equal(t, tt.wantErr, err != nil, err)
+			assert.Equal(t, tt.wantObject, tt.args.object)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/devicehandler_gpu.go
+++ b/pkg/scheduler/plugins/deviceshare/devicehandler_gpu.go
@@ -56,6 +56,7 @@ func calcDesiredRequestsAndCountForGPU(podRequests corev1.ResourceList) (corev1.
 
 	gpuShare, ok := podRequests[apiext.ResourceGPUShared]
 	gpuCore, coreExists := podRequests[apiext.ResourceGPUCore]
+	huaweiNPUCore, huaweiNPUCoreExists := podRequests[apiext.ResourceHuaweiNPUCore]
 	gpuMemoryRatio, memoryRatioExists := podRequests[apiext.ResourceGPUMemoryRatio]
 	// gpu share mode
 	if ok && gpuShare.Value() > 0 {
@@ -69,6 +70,9 @@ func calcDesiredRequestsAndCountForGPU(podRequests corev1.ResourceList) (corev1.
 	requests := corev1.ResourceList{}
 	if coreExists {
 		requests[apiext.ResourceGPUCore] = *resource.NewQuantity(gpuCore.Value()/desiredCount, resource.DecimalSI)
+	}
+	if huaweiNPUCoreExists {
+		requests[apiext.ResourceHuaweiNPUCore] = *resource.NewQuantity(huaweiNPUCore.Value()/desiredCount, resource.DecimalSI)
 	}
 	if memoryRatioExists {
 		gpuMemoryRatioPerGPU := gpuMemoryRatio.Value() / desiredCount

--- a/pkg/scheduler/plugins/deviceshare/devicehandler_gpu_test.go
+++ b/pkg/scheduler/plugins/deviceshare/devicehandler_gpu_test.go
@@ -216,6 +216,19 @@ func Test_calcDesiredRequestsAndCountForGPU(t *testing.T) {
 			wantDesiredNumberOfGPUs: 1,
 			wantGPUShared:           true,
 		},
+		{
+			name: "huawei npu mode",
+			podRequests: corev1.ResourceList{
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(200, resource.DecimalSI),
+				apiext.ResourceHuaweiNPUCore:  *resource.NewQuantity(40, resource.DecimalSI),
+			},
+			wantRequestPerInstance: corev1.ResourceList{
+				apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				apiext.ResourceHuaweiNPUCore:  *resource.NewQuantity(20, resource.DecimalSI),
+			},
+			wantDesiredNumberOfGPUs: 2,
+			wantGPUShared:           false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -40,6 +40,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/schedulingphase"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
@@ -559,6 +560,12 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState *framework.CycleS
 
 	if err := apiext.SetDeviceAllocations(object, state.allocationResult); err != nil {
 		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.DevicePluginAdaption) {
+		if err := p.adaptForDevicePlugin(object, state.allocationResult, nodeName); err != nil {
+			return framework.AsStatus(err)
+		}
 	}
 	return nil
 }

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -43,6 +43,7 @@ const (
 	GPUCore
 	GPUMemory
 	GPUMemoryRatio
+	HuaweiNPUCore
 	FPGA
 	RDMA
 )
@@ -57,6 +58,7 @@ var DeviceResourceNames = map[schedulingv1alpha1.DeviceType][]corev1.ResourceNam
 		apiext.ResourceGPUCore,
 		apiext.ResourceGPUMemory,
 		apiext.ResourceGPUMemoryRatio,
+		apiext.ResourceHuaweiNPUCore,
 	},
 	schedulingv1alpha1.RDMA: {apiext.ResourceRDMA},
 	schedulingv1alpha1.FPGA: {apiext.ResourceFPGA},
@@ -71,6 +73,7 @@ var DeviceResourceFlags = map[corev1.ResourceName]uint{
 	apiext.ResourceGPUMemory:      GPUMemory,
 	apiext.ResourceGPUMemoryRatio: GPUMemoryRatio,
 	apiext.ResourceGPUShared:      GPUShared,
+	apiext.ResourceHuaweiNPUCore:  HuaweiNPUCore,
 	apiext.ResourceFPGA:           FPGA,
 	apiext.ResourceRDMA:           RDMA,
 }
@@ -84,6 +87,7 @@ var ValidDeviceResourceCombinations = map[uint]func(resources corev1.ResourceLis
 	GPUMemoryRatio:                       ValidDeviceResourceCombinationsGPUPercentage,
 	GPUCore | GPUMemory:                  ValidDeviceResourceCombinationsGPUPercentage,
 	GPUCore | GPUMemoryRatio:             ValidDeviceResourceCombinationsGPUPercentage,
+	HuaweiNPUCore | GPUMemoryRatio:       ValidDeviceResourceCombinationsGPUPercentage,
 	GPUShared | GPUMemory:                ValidDeviceResourceCombinationsGPUShared,
 	GPUShared | GPUMemoryRatio:           ValidDeviceResourceCombinationsGPUShared,
 	GPUShared | GPUCore | GPUMemory:      ValidDeviceResourceCombinationsGPUShared,
@@ -118,6 +122,12 @@ var ResourceCombinationsMapper = map[uint]func(podRequest corev1.ResourceList) c
 	GPUCore | GPUMemoryRatio: func(podRequest corev1.ResourceList) corev1.ResourceList {
 		return corev1.ResourceList{
 			apiext.ResourceGPUCore:        podRequest[apiext.ResourceGPUCore],
+			apiext.ResourceGPUMemoryRatio: podRequest[apiext.ResourceGPUMemoryRatio],
+		}
+	},
+	HuaweiNPUCore | GPUMemoryRatio: func(podRequest corev1.ResourceList) corev1.ResourceList {
+		return corev1.ResourceList{
+			apiext.ResourceHuaweiNPUCore:  podRequest[apiext.ResourceHuaweiNPUCore],
 			apiext.ResourceGPUMemoryRatio: podRequest[apiext.ResourceGPUMemoryRatio],
 		}
 	},

--- a/pkg/scheduler/plugins/deviceshare/utils_test.go
+++ b/pkg/scheduler/plugins/deviceshare/utils_test.go
@@ -214,6 +214,24 @@ func TestValidateDeviceRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid huawei npu request",
+			podRequest: corev1.ResourceList{
+				apiext.ResourceHuaweiNPUCore:  resource.MustParse("40"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+			},
+			want:    HuaweiNPUCore | GPUMemoryRatio,
+			wantErr: false,
+		},
+		{
+			name: "invalid huawei npu request",
+			podRequest: corev1.ResourceList{
+				apiext.ResourceHuaweiNPUCore: resource.MustParse("40"),
+				apiext.ResourceGPUMemory:     resource.MustParse("128Gi"),
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
 			name: "invalid fpga request",
 			podRequest: corev1.ResourceList{
 				apiext.ResourceFPGA: resource.MustParse("201"),
@@ -350,6 +368,20 @@ func TestConvertDeviceRequest(t *testing.T) {
 			want: corev1.ResourceList{
 				apiext.ResourceGPUCore:   resource.MustParse("50"),
 				apiext.ResourceGPUMemory: resource.MustParse("32Gi"),
+			},
+		},
+		{
+			name: "huaweiNPUCore | gpuMemoryRatio",
+			args: args{
+				podRequest: corev1.ResourceList{
+					apiext.ResourceHuaweiNPUCore:  resource.MustParse("20"),
+					apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+				},
+				combination: HuaweiNPUCore | GPUMemoryRatio,
+			},
+			want: corev1.ResourceList{
+				apiext.ResourceHuaweiNPUCore:  resource.MustParse("20"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
 			},
 		},
 		{

--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin_test.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin_test.go
@@ -92,6 +92,7 @@ func TestPluginNeedSync(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -120,6 +121,7 @@ func TestPluginNeedSync(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "486", // only driver version change
 			},
@@ -148,6 +150,7 @@ func TestPluginNeedSync(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -227,6 +230,7 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -255,6 +259,7 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "486", // only driver version change
 			},
@@ -283,6 +288,7 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -325,7 +331,7 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 		// add labels
 		got, got1 = p.NeedSyncMeta(nil, testNodeWithoutDevice, testNodeWithDevice)
 		assert.True(t, got)
-		assert.Equal(t, fmt.Sprintf(NeedSyncForGPUModelMsgFmt, extension.LabelGPUModel), got1)
+		assert.Equal(t, fmt.Sprintf(NeedSyncForGPUModelMsgFmt, extension.LabelGPUVendor), got1)
 		// driver version update
 		got, got1 = p.NeedSyncMeta(nil, testNodeWithDevice, testNodeWithDeviceDriverUpdate)
 		assert.True(t, got)
@@ -334,7 +340,7 @@ func TestPluginNeedSyncMeta(t *testing.T) {
 		// remove labels
 		got, got1 = p.NeedSyncMeta(nil, testNodeWithDevice, testNodeWithoutDevice)
 		assert.True(t, got)
-		assert.Equal(t, fmt.Sprintf(NeedSyncForGPUModelMsgFmt, extension.LabelGPUModel), got1)
+		assert.Equal(t, fmt.Sprintf(NeedSyncForGPUModelMsgFmt, extension.LabelGPUVendor), got1)
 	})
 }
 
@@ -357,11 +363,12 @@ func TestPluginPrepare(t *testing.T) {
 			},
 		},
 	}
-	testNodeWithDevice := &corev1.Node{
+	testNodeWithDeviceNVIDIA := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -385,13 +392,60 @@ func TestPluginPrepare(t *testing.T) {
 			},
 		},
 	}
-	testNodeWithoutDeviceResources := &corev1.Node{
+	testNodeWithDeviceHuawei := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				"test-label":             "test-value",
+				extension.LabelGPUVendor: extension.GPUVendorHuawei,
+				extension.LabelGPUModel:  "Ascend-910",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:               resource.MustParse("100"),
+				corev1.ResourceMemory:            resource.MustParse("400Gi"),
+				extension.ResourceHuaweiNPUCore:  *resource.NewQuantity(160, resource.DecimalSI),
+				extension.ResourceGPUMemory:      *resource.NewQuantity(18000, resource.DecimalSI),
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:               resource.MustParse("100"),
+				corev1.ResourceMemory:            resource.MustParse("400Gi"),
+				extension.ResourceHuaweiNPUCore:  *resource.NewQuantity(160, resource.DecimalSI),
+				extension.ResourceGPUMemory:      *resource.NewQuantity(18000, resource.DecimalSI),
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(200, resource.DecimalSI),
+			},
+		},
+	}
+	testNodeWithoutDeviceResourcesNVIDIA := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+			Capacity: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100"),
+				corev1.ResourceMemory: resource.MustParse("400Gi"),
+			},
+		},
+	}
+	testNodeWithoutDeviceResourcesHuawei := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				"test-label":             "test-value",
+				extension.LabelGPUVendor: extension.GPUVendorHuawei,
+				extension.LabelGPUModel:  "Ascend-910",
 			},
 		},
 		Status: corev1.NodeStatus{
@@ -425,9 +479,9 @@ func TestPluginPrepare(t *testing.T) {
 			wantField: testNodeWithoutDevice,
 		},
 		{
-			name: "update resources and labels correctly",
+			name: "nvidia: update resources and labels correctly",
 			args: args{
-				node: testNodeWithoutDevice,
+				node: testNodeWithoutDevice.DeepCopy(),
 				nr: &framework.NodeResource{
 					Resources: map[corev1.ResourceName]*resource.Quantity{
 						extension.ResourceGPU:            resource.NewQuantity(200, resource.DecimalSI),
@@ -437,6 +491,7 @@ func TestPluginPrepare(t *testing.T) {
 					},
 					ZoneResources: map[string]corev1.ResourceList{},
 					Labels: map[string]string{
+						extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 						extension.LabelGPUModel:         "A100",
 						extension.LabelGPUDriverVersion: "480",
 					},
@@ -448,12 +503,12 @@ func TestPluginPrepare(t *testing.T) {
 				},
 			},
 			wantErr:   false,
-			wantField: testNodeWithDevice,
+			wantField: testNodeWithDeviceNVIDIA,
 		},
 		{
-			name: "reset resources correctly",
+			name: "nvidia: reset resources correctly",
 			args: args{
-				node: testNodeWithDevice,
+				node: testNodeWithDeviceNVIDIA,
 				nr: &framework.NodeResource{
 					Resets: map[corev1.ResourceName]bool{
 						extension.ResourceGPU:            true,
@@ -464,7 +519,47 @@ func TestPluginPrepare(t *testing.T) {
 				},
 			},
 			wantErr:   false,
-			wantField: testNodeWithoutDeviceResources,
+			wantField: testNodeWithoutDeviceResourcesNVIDIA,
+		},
+		{
+			name: "huawei: update resources and labels correctly",
+			args: args{
+				node: testNodeWithoutDevice.DeepCopy(),
+				nr: &framework.NodeResource{
+					Resources: map[corev1.ResourceName]*resource.Quantity{
+						extension.ResourceHuaweiNPUCore:  resource.NewQuantity(160, resource.DecimalSI),
+						extension.ResourceGPUMemory:      resource.NewQuantity(18000, resource.DecimalSI),
+						extension.ResourceGPUMemoryRatio: resource.NewQuantity(200, resource.DecimalSI),
+					},
+					ZoneResources: map[string]corev1.ResourceList{},
+					Labels: map[string]string{
+						extension.LabelGPUVendor: extension.GPUVendorHuawei,
+						extension.LabelGPUModel:  "Ascend-910",
+					},
+					Annotations: map[string]string{
+						"ignored-annotation": "ignored-value",
+					},
+					Messages: map[corev1.ResourceName]string{},
+					Resets:   map[corev1.ResourceName]bool{},
+				},
+			},
+			wantErr:   false,
+			wantField: testNodeWithDeviceHuawei,
+		},
+		{
+			name: "huawei: reset resources correctly",
+			args: args{
+				node: testNodeWithDeviceHuawei,
+				nr: &framework.NodeResource{
+					Resets: map[corev1.ResourceName]bool{
+						extension.ResourceHuaweiNPUCore:  true,
+						extension.ResourceGPUMemory:      true,
+						extension.ResourceGPUMemoryRatio: true,
+					},
+				},
+			},
+			wantErr:   false,
+			wantField: testNodeWithoutDeviceResourcesHuawei,
 		},
 	}
 	for _, tt := range tests {
@@ -503,10 +598,11 @@ func TestPluginCalculate(t *testing.T) {
 			},
 		},
 	}
-	testDevice := &schedulingv1alpha1.Device{
+	testDeviceNVIDIA := &schedulingv1alpha1.Device{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNode.Name,
 			Labels: map[string]string{
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -531,6 +627,41 @@ func TestPluginCalculate(t *testing.T) {
 					Type:   schedulingv1alpha1.GPU,
 					Resources: map[corev1.ResourceName]resource.Quantity{
 						extension.ResourceGPUCore:        *resource.NewQuantity(100, resource.DecimalSI),
+						extension.ResourceGPUMemory:      *resource.NewQuantity(10000, resource.DecimalSI),
+						extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+					},
+				},
+			},
+		},
+	}
+	testDeviceHuawei := &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNode.Name,
+			Labels: map[string]string{
+				extension.LabelGPUVendor: extension.GPUVendorHuawei,
+				extension.LabelGPUModel:  "Ascend-910",
+			},
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{
+				{
+					UUID:   "1",
+					Minor:  pointer.Int32(0),
+					Health: true,
+					Type:   schedulingv1alpha1.GPU,
+					Resources: map[corev1.ResourceName]resource.Quantity{
+						extension.ResourceHuaweiNPUCore:  *resource.NewQuantity(20, resource.DecimalSI),
+						extension.ResourceGPUMemory:      *resource.NewQuantity(8000, resource.DecimalSI),
+						extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+					},
+				},
+				{
+					UUID:   "2",
+					Minor:  pointer.Int32(1),
+					Health: true,
+					Type:   schedulingv1alpha1.GPU,
+					Resources: map[corev1.ResourceName]resource.Quantity{
+						extension.ResourceHuaweiNPUCore:  *resource.NewQuantity(20, resource.DecimalSI),
 						extension.ResourceGPUMemory:      *resource.NewQuantity(10000, resource.DecimalSI),
 						extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
 					},
@@ -651,7 +782,7 @@ func TestPluginCalculate(t *testing.T) {
 		{
 			name: "calculate device resources correctly",
 			fields: fields{
-				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDeviceNVIDIA).Build(),
 			},
 			syncSharedResource: true,
 			args: args{
@@ -686,6 +817,7 @@ func TestPluginCalculate(t *testing.T) {
 				{
 					Name: PluginName,
 					Labels: map[string]string{
+						extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 						extension.LabelGPUModel:         "A100",
 						extension.LabelGPUDriverVersion: "480",
 					},
@@ -697,7 +829,7 @@ func TestPluginCalculate(t *testing.T) {
 		{
 			name: "calculate device resources correctly",
 			fields: fields{
-				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDeviceHuawei).Build(),
 			},
 			syncSharedResource: true,
 			args: args{
@@ -705,13 +837,8 @@ func TestPluginCalculate(t *testing.T) {
 			},
 			want: []framework.ResourceItem{
 				{
-					Name:     extension.ResourceGPU,
-					Quantity: resource.NewQuantity(200, resource.DecimalSI),
-					Message:  UpdateResourcesMsg,
-				},
-				{
-					Name:     extension.ResourceGPUCore,
-					Quantity: resource.NewQuantity(200, resource.DecimalSI),
+					Name:     extension.ResourceHuaweiNPUCore,
+					Quantity: resource.NewQuantity(40, resource.DecimalSI),
 					Message:  UpdateResourcesMsg,
 				},
 				{
@@ -732,8 +859,8 @@ func TestPluginCalculate(t *testing.T) {
 				{
 					Name: PluginName,
 					Labels: map[string]string{
-						extension.LabelGPUModel:         "A100",
-						extension.LabelGPUDriverVersion: "480",
+						extension.LabelGPUVendor: extension.GPUVendorHuawei,
+						extension.LabelGPUModel:  "Ascend-910",
 					},
 					Message: UpdateLabelsMsg,
 				},
@@ -819,7 +946,7 @@ func TestPluginCalculate(t *testing.T) {
 		{
 			name: "calculate device resources correctly",
 			fields: fields{
-				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDeviceNVIDIA).Build(),
 			},
 			args: args{
 				node: testNode,
@@ -848,6 +975,7 @@ func TestPluginCalculate(t *testing.T) {
 				{
 					Name: PluginName,
 					Labels: map[string]string{
+						extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 						extension.LabelGPUModel:         "A100",
 						extension.LabelGPUDriverVersion: "480",
 					},
@@ -859,20 +987,15 @@ func TestPluginCalculate(t *testing.T) {
 		{
 			name: "calculate device resources correctly",
 			fields: fields{
-				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDevice).Build(),
+				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(testNode, testDeviceHuawei).Build(),
 			},
 			args: args{
 				node: testNode,
 			},
 			want: []framework.ResourceItem{
 				{
-					Name:     extension.ResourceGPU,
-					Quantity: resource.NewQuantity(200, resource.DecimalSI),
-					Message:  UpdateResourcesMsg,
-				},
-				{
-					Name:     extension.ResourceGPUCore,
-					Quantity: resource.NewQuantity(200, resource.DecimalSI),
+					Name:     extension.ResourceHuaweiNPUCore,
+					Quantity: resource.NewQuantity(40, resource.DecimalSI),
 					Message:  UpdateResourcesMsg,
 				},
 				{
@@ -888,8 +1011,8 @@ func TestPluginCalculate(t *testing.T) {
 				{
 					Name: PluginName,
 					Labels: map[string]string{
-						extension.LabelGPUModel:         "A100",
-						extension.LabelGPUDriverVersion: "480",
+						extension.LabelGPUVendor: extension.GPUVendorHuawei,
+						extension.LabelGPUModel:  "Ascend-910",
 					},
 					Message: UpdateLabelsMsg,
 				},
@@ -980,6 +1103,11 @@ func TestPluginCalculate(t *testing.T) {
 					Message: ResetResourcesMsg,
 				},
 				{
+					Name:    extension.ResourceHuaweiNPUCore,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
 					Name:    extension.ResourceGPUMemory,
 					Reset:   true,
 					Message: ResetResourcesMsg,
@@ -1013,6 +1141,11 @@ func TestPluginCalculate(t *testing.T) {
 				},
 				{
 					Name:    extension.ResourceGPUCore,
+					Reset:   true,
+					Message: ResetResourcesMsg,
+				},
+				{
+					Name:    extension.ResourceHuaweiNPUCore,
 					Reset:   true,
 					Message: ResetResourcesMsg,
 				},
@@ -1080,6 +1213,7 @@ func Test_cleanupGPUNodeResource(t *testing.T) {
 			Name: "test-node",
 			Labels: map[string]string{
 				"test-label":                    "test-value",
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},
@@ -1137,6 +1271,7 @@ func Test_cleanupGPUNodeResource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNode.Name,
 			Labels: map[string]string{
+				extension.LabelGPUVendor:        extension.GPUVendorNVIDIA,
 				extension.LabelGPUModel:         "A100",
 				extension.LabelGPUDriverVersion: "480",
 			},

--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils.go
@@ -28,12 +28,14 @@ var (
 	ResourceNames = []corev1.ResourceName{
 		extension.ResourceGPU,
 		extension.ResourceGPUCore,
+		extension.ResourceHuaweiNPUCore,
 		extension.ResourceGPUMemory,
 		extension.ResourceGPUMemoryRatio,
 		extension.ResourceGPUShared,
 	}
 	// Labels are the known labels reconciled by the plugin from devices to nodes.
 	Labels = []string{
+		extension.LabelGPUVendor,
 		extension.LabelGPUModel,
 		extension.LabelGPUDriverVersion,
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This is the first time that we introduce a heterogeneous GPU (other than NVIDIA) to fine-grained device scheduling, so this PR also contains some fundamental works which would help us integrate other heterogeneous devices easier in the future.

Let's first explain the fundamental works:

As we all know, there're three major phases in the lifecycle of fine-grained device scheduling: **reporting, scheduling, allocating**.

**For reporting**, currently koordlet only supports reporting NVIDIA GPUs, but #2423 is working on heterogeneous GPU reporting including Huawei NPU, so **this PR only introduces the missing vendor label to device/node (which is necessary for the following works) and leaves the rest works to the implementation of #2423**.

**For scheduling**, current device share scheduling is rather vendor agnostic, so **this PR does not modify the core scheduling logic**.

**For allocating**, currently koordlet only supports allocate NVIDIA GPUs, if we want it to support other heterogeneous GPUs, we might consider integrate codes from device plugins provided by vendor of these GPUs which would soon make koordlet hard to maintain. So, can we just reuse these existing device plugins? The answer is YES.

**This PR introduces a device plugin adaption mechanism to device share scheduling**, which makes koord-scheduler able to write allocation results in some format that third party vendor's device plugins recognize, so that user can directly use them as allocators with koord-scheduler without modification. This is especially useful when third party device plugin natively supports fine-grained device allocation or virtualization.

---

Now let's focus on the adaption works for Huawei Ascend NPU. Note that this PR only covers full card scheduling, partial card (vNPU) scheduling would be covered in latter PRs.

Unlike NVIDIA GPUs, Huawei Ascend NPU uses the accurate number of AI cores of an NPU to represent the computing power resource instead of a ratio. So this PR introduces a new resource `huawei.com/npu-core` which represents the number of AI cores of Huawei NPU to device share scheduling, this resource is reported and recognized by the device plugin of Huawei NPU and would also be used in vNPU scheduling.

So from the user's perspective, requesting X full NPUs would be:

```yaml
huawei.com/npu-core: X*(the number of AI cores of the requested NPU model)
koordinator.sh/gpu-memory-ratio: X*100
```

Other combinations are not supported due to obvious reasons.

Another special point of Huawei NPU full card scheduling is that during multi card scheduling, it is required to allocate NPUs according to some hardware topology ([ref](https://www.hiascend.com/document/detail/zh/mindx-dl/600/clusterscheduling/ref/affinityschedulesd/dl_affinity_0005.html)). This can be achieved by the existing GPU partition feature of device share scheduling so this PR does not cover this.

### Ⅱ. Does this pull request fix one issue?

part of #2335

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
