### PR TITLE
manager: reconcile colocation-profile if enabled

### DIFF
--- a/apis/extension/cluster_colocation_profile.go
+++ b/apis/extension/cluster_colocation_profile.go
@@ -22,6 +22,10 @@ import (
 
 const (
 	AnnotationSkipUpdateResource = "config.koordinator.sh/skip-update-resources"
+
+	// LabelControllerManaged indicates whether the colocation profile should be reconciled by the controller.
+	// If not specified, the controller only reconciles the profile if ReconcileByDefault is set to true.
+	LabelControllerManaged = "config.koordinator.sh/controller-managed"
 )
 
 func ShouldSkipUpdateResource(profile *configv1alpha1.ClusterColocationProfile) bool {
@@ -30,4 +34,8 @@ func ShouldSkipUpdateResource(profile *configv1alpha1.ClusterColocationProfile) 
 	}
 	_, ok := profile.Annotations[AnnotationSkipUpdateResource]
 	return ok
+}
+
+func ShouldReconcileProfile(profile *configv1alpha1.ClusterColocationProfile) bool {
+	return profile != nil && profile.Labels != nil && profile.Labels[LabelControllerManaged] == "true"
 }

--- a/pkg/controller/colocationprofile/colocationprofile_util_test.go
+++ b/pkg/controller/colocationprofile/colocationprofile_util_test.go
@@ -40,6 +40,9 @@ func Test_listPodsForProfile(t *testing.T) {
 	testProfileForNothing := &configv1alpha1.ClusterColocationProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-profile",
+			Labels: map[string]string{
+				extension.LabelControllerManaged: "true",
+			},
 		},
 		Spec: configv1alpha1.ClusterColocationProfileSpec{
 			Selector: nil,
@@ -59,6 +62,9 @@ func Test_listPodsForProfile(t *testing.T) {
 	testProfile := &configv1alpha1.ClusterColocationProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-profile",
+			Labels: map[string]string{
+				extension.LabelControllerManaged: "true",
+			},
 		},
 		Spec: configv1alpha1.ClusterColocationProfileSpec{
 			Selector: &metav1.LabelSelector{
@@ -207,6 +213,9 @@ func Test_updatePodByClusterColocationProfile(t *testing.T) {
 			profile: &configv1alpha1.ClusterColocationProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-profile",
+					Labels: map[string]string{
+						extension.LabelControllerManaged: "true",
+					},
 				},
 				Spec: configv1alpha1.ClusterColocationProfileSpec{
 					NamespaceSelector: &metav1.LabelSelector{
@@ -318,6 +327,9 @@ func Test_updatePodByClusterColocationProfile(t *testing.T) {
 			profile: &configv1alpha1.ClusterColocationProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-profile",
+					Labels: map[string]string{
+						extension.LabelControllerManaged: "true",
+					},
 				},
 				Spec: configv1alpha1.ClusterColocationProfileSpec{
 					NamespaceSelector: &metav1.LabelSelector{
@@ -436,6 +448,10 @@ func Test_updatePodByClusterColocationProfile(t *testing.T) {
 			profile: &configv1alpha1.ClusterColocationProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-profile",
+
+					Labels: map[string]string{
+						extension.LabelControllerManaged: "true",
+					},
 				},
 				Spec: configv1alpha1.ClusterColocationProfileSpec{
 					Selector: &metav1.LabelSelector{},
@@ -549,6 +565,10 @@ func Test_updatePodByClusterColocationProfile(t *testing.T) {
 			profile: &configv1alpha1.ClusterColocationProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-profile",
+
+					Labels: map[string]string{
+						extension.LabelControllerManaged: "true",
+					},
 				},
 				Spec: configv1alpha1.ClusterColocationProfileSpec{
 					NamespaceSelector: &metav1.LabelSelector{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-manager:
- Controller reconciles the ClusterColocationProfile only when it sets enabled.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
