### PR TITLE
scheduler: fix PreBind Patch for pods with same name but different uid

### DIFF
--- a/pkg/scheduler/plugins/defaultprebind/plugin_test.go
+++ b/pkg/scheduler/plugins/defaultprebind/plugin_test.go
@@ -37,7 +37,6 @@ func TestApplyPatch(t *testing.T) {
 		name        string
 		originalObj metav1.Object
 		modifiedObj metav1.Object
-		wantObj     metav1.Object
 		wantStatus  *framework.Status
 	}{
 		{
@@ -102,6 +101,66 @@ func TestApplyPatch(t *testing.T) {
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU: resource.MustParse("4"),
 									apiext.ResourceGPU: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: nil,
+		},
+		{
+			name: "skipped to patch pod",
+			originalObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "xxxxxx",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "test",
+									Value: "true",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			modifiedObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "xxxxxx",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "test",
+									Value: "true",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
 								},
 							},
 						},
@@ -176,6 +235,72 @@ func TestApplyPatch(t *testing.T) {
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU: resource.MustParse("4"),
 											apiext.ResourceGPU: resource.MustParse("100"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: nil,
+		},
+		{
+			name: "skipped to patch reservation",
+			originalObj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-reservation",
+					UID:  "yyyyyy",
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "test",
+											Value: "true",
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("4"),
+										},
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("4"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			modifiedObj: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-reservation",
+					UID:  "yyyyyy",
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "test",
+											Value: "true",
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("4"),
+										},
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("4"),
 										},
 									},
 								},

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -98,6 +98,9 @@ func RetryOnConflictOrTooManyRequests(fn func() error) error {
 }
 
 func GeneratePodPatch(oldPod, newPod *corev1.Pod) ([]byte, error) {
+	// For safely patch, generate with the object UID
+	oldPod = oldPod.DeepCopy()
+	oldPod.UID = ""
 	oldData, err := json.Marshal(oldPod)
 	if err != nil {
 		return nil, err
@@ -111,14 +114,15 @@ func GeneratePodPatch(oldPod, newPod *corev1.Pod) ([]byte, error) {
 }
 
 func PatchPod(ctx context.Context, clientset clientset.Interface, oldPod, newPod *corev1.Pod) (*corev1.Pod, error) {
+	if reflect.DeepEqual(oldPod, newPod) {
+		return oldPod, nil
+	}
+
 	// generate patch bytes for the update
 	patchBytes, err := GeneratePodPatch(oldPod, newPod)
 	if err != nil {
 		klog.V(5).InfoS("failed to generate pod patch", "pod", klog.KObj(oldPod), "err", err)
 		return nil, err
-	}
-	if string(patchBytes) == "{}" { // nothing to patch
-		return oldPod, nil
 	}
 
 	// patch with pod client
@@ -133,6 +137,9 @@ func PatchPod(ctx context.Context, clientset clientset.Interface, oldPod, newPod
 }
 
 func GenerateReservationPatch(oldReservation, newReservation *schedulingv1alpha1.Reservation) ([]byte, error) {
+	// For safely patch, generate with the object UID
+	oldReservation = oldReservation.DeepCopy()
+	oldReservation.UID = ""
 	oldData, err := json.Marshal(oldReservation)
 	if err != nil {
 		return nil, err
@@ -146,13 +153,14 @@ func GenerateReservationPatch(oldReservation, newReservation *schedulingv1alpha1
 }
 
 func PatchReservation(ctx context.Context, clientset koordinatorclientset.Interface, oldReservation, newReservation *schedulingv1alpha1.Reservation) (*schedulingv1alpha1.Reservation, error) {
+	if reflect.DeepEqual(oldReservation, newReservation) {
+		return oldReservation, nil
+	}
+
 	patchBytes, err := GenerateReservationPatch(oldReservation, newReservation)
 	if err != nil {
 		klog.V(5).InfoS("failed to generate reservation patch", "reservation", klog.KObj(oldReservation), "err", err)
 		return nil, err
-	}
-	if string(patchBytes) == "{}" { // nothing to patch
-		return oldReservation, nil
 	}
 
 	// NOTE: CRDs do not support strategy merge patch, so here falls back to merge patch.

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -229,6 +229,7 @@ func Test_GeneratePodPatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "test-pod-1",
+			UID:       "xxx",
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -252,6 +253,13 @@ func Test_GeneratePodPatch(t *testing.T) {
 	metadata, ok := patchMap["metadata"].(map[string]interface{})
 	if !ok {
 		t.Errorf("error converting metadata to version map")
+	}
+	uid, ok := metadata["uid"]
+	if !ok {
+		t.Errorf("expect metadata.uid to be not nil")
+	}
+	if fmt.Sprint(uid) != string(pod1.UID) {
+		t.Errorf("metadata.uid got %s, expect %s", uid, pod1.UID)
 	}
 	annotation, _ := metadata["annotations"].(map[string]interface{})
 	if fmt.Sprint(annotation) != fmt.Sprint(patchAnnotation) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Fix a bug where the async PreBind may Patch to an unexpected pod with the same name but a different UID.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

This problem occurs when two pods with the same namespace and name are scheduled in nearly the same interval. Due to the binding cycles being executed out of order, the first pod to PreBind may not exist so it may Patch another pod.

We use the approach that Patch objects with their UIDs, so the Patch request will ensure that the object UID is unchanged since this field is immutable.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
