### PR TITLE
koordlet: fix avg not being collected in AggregatedUsage

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric.go
@@ -574,6 +574,7 @@ func (r *nodeMetricInformer) collectNodeAggregateMetric(endTime time.Time, aggre
 		start := endTime.Add(-d.Duration)
 		aggregateUsage := slov1alpha1.AggregatedUsage{
 			Usage: map[apiext.AggregationType]slov1alpha1.ResourceMap{
+				apiext.AVG: r.queryNodeMetric(start, endTime, metriccache.AggregationTypeAVG, true),
 				apiext.P50: r.queryNodeMetric(start, endTime, metriccache.AggregationTypeP50, true),
 				apiext.P90: r.queryNodeMetric(start, endTime, metriccache.AggregationTypeP90, true),
 				apiext.P95: r.queryNodeMetric(start, endTime, metriccache.AggregationTypeP95, true),
@@ -654,6 +655,7 @@ func (r *nodeMetricInformer) collectSystemAggregateMetric(endTime time.Time, agg
 		start := endTime.Add(-d.Duration)
 		aggregateUsage := slov1alpha1.AggregatedUsage{
 			Usage: map[apiext.AggregationType]slov1alpha1.ResourceMap{
+				apiext.AVG: r.querySystemMetric(start, endTime, metriccache.AggregationTypeAVG, true),
 				apiext.P50: r.querySystemMetric(start, endTime, metriccache.AggregationTypeP50, true),
 				apiext.P90: r.querySystemMetric(start, endTime, metriccache.AggregationTypeP90, true),
 				apiext.P95: r.querySystemMetric(start, endTime, metriccache.AggregationTypeP95, true),

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
@@ -603,6 +603,7 @@ func Test_nodeMetricInformer_collectNodeAggregateMetric(t *testing.T) {
 				AggregatedNodeUsages: []slov1alpha1.AggregatedUsage{
 					{
 						Usage: map[apiext.AggregationType]slov1alpha1.ResourceMap{
+							apiext.AVG: tt.fields.nodeResultAVG,
 							apiext.P50: tt.fields.nodeResultP50,
 							apiext.P90: tt.fields.nodeResultP90,
 							apiext.P95: tt.fields.nodeResultP95,
@@ -1251,6 +1252,7 @@ func Test_nodeMetricInformer_collectSystemAggregateMetric(t *testing.T) {
 				AggregatedNodeUsages: []slov1alpha1.AggregatedUsage{
 					{
 						Usage: map[apiext.AggregationType]slov1alpha1.ResourceMap{
+							apiext.AVG: tt.fields.sysResultAVG,
 							apiext.P50: tt.fields.sysResultP50,
 							apiext.P90: tt.fields.sysResultP90,
 							apiext.P95: tt.fields.sysResultP95,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In the documentation, AggregationType has "avg" as an optional value.

https://github.com/koordinator-sh/website/blob/f4a33b7ecc776ed74e7deeffdfd9fefc9fd9b88a/docs/user-manuals/load-aware-scheduling.md?plain=1#L120-L128

But koordlet does not collect avg data. This PR adds the collection of avg aggregation type.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
