### PR TITLE
fix: GetLocalStorageInfo maybe hang

### DIFF
--- a/pkg/koordlet/util/storageinfo.go
+++ b/pkg/koordlet/util/storageinfo.go
@@ -90,6 +90,7 @@ func (s *LocalStorageInfo) scanDevices() error {
 func (s *LocalStorageInfo) scanVolumeGroups() error {
 	vgsCommand := exec.Command(
 		"vgs",
+		"--readonly",
 		"--noheadings",
 		"--options", strings.Join(vgsColumns, ","),
 	)
@@ -103,6 +104,7 @@ func (s *LocalStorageInfo) scanVolumeGroups() error {
 func (s *LocalStorageInfo) scanLogicalVolumes() error {
 	lvsCommand := exec.Command(
 		"lvs",
+		"--readonly",
 		"--noheadings",
 		"--options", strings.Join(lvsColumns, ","),
 	)


### PR DESCRIPTION
… volumes use lvm command simultaneously.

### Ⅰ. Describe what this PR does

    fix: GetLocalStorageInfo maybe hang, such as other component creating volumes use lvm command simultaneously.

### Ⅱ. Does this pull request fix one issue?

   NONE

### Ⅲ. Describe how to verify it
If creating an lvm volume takes a lot of time and executing other lvm commands at the same time, the command may hang.