### PR TITLE
scheduler: set PodGroup's OccupiedBy field  correctly

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
@@ -315,14 +315,14 @@ func (ctrl *PodGroupController) patchPodGroup(old, new *schedv1alpha1.PodGroup) 
 }
 
 func fillOccupiedObj(pg *schedv1alpha1.PodGroup, pod *v1.Pod) {
+	if len(pod.OwnerReferences) == 0 {
+		return
+	}
 	var refs []string
 	for _, ownerRef := range pod.OwnerReferences {
 		refs = append(refs, fmt.Sprintf("%s/%s", pod.Namespace, ownerRef.Name))
 	}
-	if len(pg.Status.OccupiedBy) == 0 {
-		return
-	}
-	if len(refs) != 0 {
+	if len(refs) > 0 {
 		sort.Strings(refs)
 		pg.Status.OccupiedBy = strings.Join(refs, ",")
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
Currently, PodGroup OccupiedBy field is not set correctly.

- set PodGroup's OccupiedBy field  correctly
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
