### PR TITLE
manager: colocationprofile support appending label suffix

### DIFF
--- a/apis/config/v1alpha1/cluster_colocation_profile_types.go
+++ b/apis/config/v1alpha1/cluster_colocation_profile_types.go
@@ -76,14 +76,19 @@ type ClusterColocationProfileSpec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// LabelKeysMapping describes the labels that needs to inject into Pod.Labels with the same values.
-	// It sets the Pod.Labels[LabelsToLabels[k]] = Pod.Labels[k] for each key k.
+	// It sets the Pod.Labels[LabelKeysMapping[k]] = Pod.Labels[k] for each key k.
 	// +optional
 	LabelKeysMapping map[string]string `json:"labelKeysMapping,omitempty"`
 
 	// AnnotationKeysMapping describes the annotations that needs to inject into Pod.Annotations with the same values.
-	// It sets the Pod.Annotations[AnnotationsToAnnotations[k]] = Pod.Annotations[k] for each key k.
+	// It sets the Pod.Annotations[AnnotationKeysMapping[k]] = Pod.Annotations[k] for each key k.
 	// +optional
 	AnnotationKeysMapping map[string]string `json:"annotationKeysMapping,omitempty"`
+
+	// LabelSuffixes describes the labels that needs to inject into Pod.Labels with the same values.
+	// It appends the suffix to the Pod.Labels[k] as Pod.Labels[k]+LabelSuffixes[k].
+	// +optional
+	LabelSuffixes map[string]string `json:"labelSuffix,omitempty"`
 
 	// If specified, the pod will be dispatched by specified scheduler.
 	// +optional

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -136,6 +136,13 @@ func (in *ClusterColocationProfileSpec) DeepCopyInto(out *ClusterColocationProfi
 			(*out)[key] = val
 		}
 	}
+	if in.LabelSuffixes != nil {
+		in, out := &in.LabelSuffixes, &out.LabelSuffixes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Patch.DeepCopyInto(&out.Patch)
 }
 

--- a/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
+++ b/config/crd/bases/config.koordinator.sh_clustercolocationprofiles.yaml
@@ -45,7 +45,7 @@ spec:
                   type: string
                 description: |-
                   AnnotationKeysMapping describes the annotations that needs to inject into Pod.Annotations with the same values.
-                  It sets the Pod.Annotations[AnnotationsToAnnotations[k]] = Pod.Annotations[k] for each key k.
+                  It sets the Pod.Annotations[AnnotationKeysMapping[k]] = Pod.Annotations[k] for each key k.
                 type: object
               annotations:
                 additionalProperties:
@@ -68,7 +68,14 @@ spec:
                   type: string
                 description: |-
                   LabelKeysMapping describes the labels that needs to inject into Pod.Labels with the same values.
-                  It sets the Pod.Labels[LabelsToLabels[k]] = Pod.Labels[k] for each key k.
+                  It sets the Pod.Labels[LabelKeysMapping[k]] = Pod.Labels[k] for each key k.
+                type: object
+              labelSuffix:
+                additionalProperties:
+                  type: string
+                description: |-
+                  LabelSuffixes describes the labels that needs to inject into Pod.Labels with the same values.
+                  It appends the suffix to the Pod.Labels[k] as Pod.Labels[k]+LabelSuffixes[k].
                 type: object
               labels:
                 additionalProperties:

--- a/pkg/controller/colocationprofile/colocationprofile_util.go
+++ b/pkg/controller/colocationprofile/colocationprofile_util.go
@@ -132,6 +132,17 @@ func (r *Reconciler) doMutateByColocationProfile(pod *corev1.Pod, profile *confi
 		}
 	}
 
+	if len(profile.Spec.LabelSuffixes) > 0 {
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		for key, suffix := range profile.Spec.LabelSuffixes {
+			if _, ok := pod.Labels[key]; ok {
+				pod.Labels[key] = pod.Labels[key] + suffix
+			}
+		}
+	}
+
 	if profile.Spec.QoSClass != "" {
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile.go
@@ -197,6 +197,17 @@ func (h *PodMutatingHandler) doMutateByColocationProfile(ctx context.Context, po
 		}
 	}
 
+	if len(profile.Spec.LabelSuffixes) > 0 {
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		for key, suffix := range profile.Spec.LabelSuffixes {
+			if _, ok := pod.Labels[key]; ok {
+				pod.Labels[key] = pod.Labels[key] + suffix
+			}
+		}
+	}
+
 	if profile.Spec.SchedulerName != "" {
 		pod.Spec.SchedulerName = profile.Spec.SchedulerName
 	}

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
@@ -1653,6 +1653,159 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "mutate pod labels with labels and suffixes",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod": "true",
+						"label-key-to-load":          "test-label-value",
+						"label-key-1":                "label-value-1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName: "nonExistSchedulerName",
+					Priority:      pointer.Int32(extension.PriorityBatchValueMax),
+				},
+			},
+			profile: &configv1alpha1.ClusterColocationProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-profile",
+				},
+				Spec: configv1alpha1.ClusterColocationProfileSpec{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"enable-koordinator-colocation": "true",
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"koordinator-colocation-pod": "true",
+						},
+					},
+					Labels: map[string]string{
+						"testLabelA":                 "valueA",
+						extension.LabelSchedulerName: "koordinator-scheduler",
+					},
+					LabelKeysMapping: map[string]string{
+						"label-key-to-load":           "label-key-to-store",
+						"label-key-to-load-not-exist": "label-key-to-store-not-exist",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA": "valueA",
+					},
+					LabelSuffixes: map[string]string{
+						"label-key-1":        "suffix",
+						"label-key-to-store": "suffix-0",
+						"suffix-label-key-1": "suffix-1",
+					},
+					QoSClass:            string(extension.QoSBE),
+					PriorityClassName:   "koordinator-batch",
+					KoordinatorPriority: pointer.Int32(1111),
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"labels":{"test-patch-label":"patch-a"},"annotations":{"test-patch-annotation":"patch-b"}}}`),
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pod-1",
+					Labels: map[string]string{
+						"koordinator-colocation-pod":   "true",
+						"label-key-1":                  "label-value-1suffix",
+						"testLabelA":                   "valueA",
+						"test-patch-label":             "patch-a",
+						"label-key-to-load":            "test-label-value",
+						"label-key-to-store":           "test-label-valuesuffix-0",
+						"label-key-to-store-not-exist": "",
+						extension.LabelPodQoS:          string(extension.QoSBE),
+						extension.LabelPodPriority:     "1111",
+						extension.LabelSchedulerName:   "koordinator-scheduler",
+					},
+					Annotations: map[string]string{
+						"testAnnotationA":       "valueA",
+						"test-patch-annotation": "patch-b",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "test-init-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									extension.BatchCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+									extension.BatchMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									extension.BatchCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+									extension.BatchMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-a",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									extension.BatchCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+									extension.BatchMemory: resource.MustParse("4Gi"),
+								},
+								Requests: corev1.ResourceList{
+									extension.BatchCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+									extension.BatchMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+					Overhead: map[corev1.ResourceName]resource.Quantity{
+						extension.BatchCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						extension.BatchMemory: resource.MustParse("2Gi"),
+					},
+					SchedulerName:     "nonExistSchedulerName",
+					Priority:          pointer.Int32(extension.PriorityBatchValueMax),
+					PriorityClassName: "koordinator-batch",
+					PreemptionPolicy:  &preemptionPolicy,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/webhook/reservation/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/reservation/mutating/cluster_colocation_profile.go
@@ -166,6 +166,17 @@ func (h *ReservationMutatingHandler) doMutateByColocationProfile(ctx context.Con
 		}
 	}
 
+	if len(profile.Spec.LabelSuffixes) > 0 {
+		if reservation.Labels == nil {
+			reservation.Labels = make(map[string]string)
+		}
+		for key, suffix := range profile.Spec.LabelSuffixes {
+			if _, ok := reservation.Labels[key]; ok {
+				reservation.Labels[key] = reservation.Labels[key] + suffix
+			}
+		}
+	}
+
 	if profile.Spec.SchedulerName != "" && reservation.Spec.Template != nil {
 		reservation.Spec.Template.Spec.SchedulerName = profile.Spec.SchedulerName
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

ClusterColocationProfile supports appending label suffixes.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

It helps when to inject different label values with their labels and some suffixes. 

For example, we want to label the pod with its quota name and priority class.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
