### PR TITLE
scheduler: introduce gpu minors annotation to device plugin adapter

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -4716,6 +4716,7 @@ func Test_Plugin_PreBind(t *testing.T) {
 					Annotations: map[string]string{
 						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":0,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-8c25ea37-2909-6e62-b7bf-e2fcadebea8d"},{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-befd76c3-8a36-7b8a-179c-eae75aa7d9f2"}],"rdma":[{"minor":1,"resources":{"koordinator.sh/rdma":"100"},"id":"0000:1f:00.0"}]}`,
 						AnnotationBindTimestamp:          strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationGPUMinors:              "0,1",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

We've met cases that the built-in `NVIDIA_VISIBLE_DEVICES=all` env of CUDA images invalidates the one injected by device plugin. Under this case users need to explicitly declare this env in pod template to override the one of pod image. Since the value of the env is decided by scheduler, this PR introduces a `scheduling.koordinator.sh/gpu-minors` annotation to device plugin adapter so that users can use this as a field ref of the env, like this:
```yaml
- name: NVIDIA_VISIBLE_DEVICES
   valueFrom:
      fieldRef:
        apiVersion: v1
        fieldPath: metadata.annotations['scheduling.koordinator.sh/gpu-minors']
```

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
