### PR TITLE
scheduler: add koordinator.sh/gpu-memory to default device share scoring strategy resources

### DIFF
--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -226,6 +226,10 @@ func SetDefaults_DeviceShareArgs(obj *DeviceShareArgs) {
 					Weight: 1,
 				},
 				{
+					Name:   string(extension.ResourceGPUMemory),
+					Weight: 1,
+				},
+				{
 					Name:   string(extension.ResourceRDMA),
 					Weight: 1,
 				},

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -226,6 +226,10 @@ func SetDefaults_DeviceShareArgs(obj *DeviceShareArgs) {
 					Weight: 1,
 				},
 				{
+					Name:   string(extension.ResourceGPUMemory),
+					Weight: 1,
+				},
+				{
 					Name:   string(extension.ResourceRDMA),
 					Weight: 1,
 				},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds the missing `koordinator.sh/gpu-memory` resource to the default scoring strategy of device share so that the Pods with request of it can be correctly scheduled with the default spread strategy without further configuration.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
