### PR TITLE
scheduler: revise preEnqueue RepresentativePod

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang_context.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_context.go
@@ -78,8 +78,11 @@ func (h *GangSchedulingContextHolder) setGangSchedulingContext(gangSchedulingCon
 }
 
 type GangSchedulingContext struct {
-	gangGroup            sets.Set[string]
-	firstPod             *corev1.Pod
-	failedMessage        string
+	gangGroup     sets.Set[string]
+	firstPod      *corev1.Pod
+	failedMessage string
+
+	// secure alreadyAttemptedPods to avoid concurrent map read and write
+	sync.RWMutex
 	alreadyAttemptedPods sets.Set[string]
 }

--- a/pkg/scheduler/plugins/coscheduling/core/ganggroup.go
+++ b/pkg/scheduler/plugins/coscheduling/core/ganggroup.go
@@ -15,7 +15,7 @@ const (
 	ReasonPodDeleted = "PodDeleted"
 	ReasonPodBound   = "PodBound"
 
-	ReasonGangGroupFailureCauseThisPod = "GangGroupFailureCauseThisPod"
+	ReasonGangGroupEnterIntoScheduling = "GangGroupEnterIntoScheduling"
 )
 
 type GangGroupInfo struct {
@@ -141,17 +141,6 @@ func (gg *GangGroupInfo) RecordIfNoRepresentatives(pod *corev1.Pod) string {
 	return gg.RepresentativePodKey
 }
 
-func (gg *GangGroupInfo) ReplaceRepresentative(pod *corev1.Pod, reason string) {
-	gg.lock.Lock()
-	defer gg.lock.Unlock()
-
-	podKey := util.GetId(pod.Namespace, pod.Name)
-	if podKey != gg.RepresentativePodKey {
-		klog.Infof("gangGroupInfo: ReplaceRepresentative, original: %v, now: %s, gangGroup: %v, reason: %s", gg.RepresentativePodKey, podKey, gg.GangGroupId, reason)
-	}
-	gg.RepresentativePodKey = podKey
-}
-
 func (gg *GangGroupInfo) DeleteIfRepresentative(pod *corev1.Pod, reason string) {
 	gg.lock.Lock()
 	defer gg.lock.Unlock()
@@ -160,4 +149,11 @@ func (gg *GangGroupInfo) DeleteIfRepresentative(pod *corev1.Pod, reason string) 
 		gg.RepresentativePodKey = ""
 		klog.Infof("gangGroupInfo: DeleteIfRepresentative, pod: %v, gangGroup: %v, reason: %s", podKey, gg.GangGroupId, reason)
 	}
+}
+
+func (gg *GangGroupInfo) ClearCurrentRepresentative(reason string) {
+	klog.Infof("gangGroupInfo: ClearCurrentRepresentative, pod: %v, gangGroup: %v, reason: %s", gg.RepresentativePodKey, gg.GangGroupId, reason)
+	gg.lock.Lock()
+	defer gg.lock.Unlock()
+	gg.RepresentativePodKey = ""
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. 一个 GangGroup 还未经过调度时，让 GangGroup 可调度的事件由所有 Member Pod 接收，我们会在所有可调度的 Member Pod 中选一个代表 Pod 进入 ActiveQ 或者 BackoffQ
2. 一个 GangGroup 调度周期开始后，我们应该将代表 Pod 删除，因为没有人在 ActiveQ 或者 BackoffQ 中排队了，但是
  a. 应该避免后续 Pod 进入 ActiveQ 或者 BackoffQ，以避免删除它时间开销很大
  b. 如果有已经尝试或者正在尝试的 Pod 的 PreEnqueue 事件，应该放行，因为这种 Enqueue 可能会让 Gang 重新调度成功

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
