### PR TITLE
scheduler: fix after deleting an ElasticQuota, its associated metrics can still be queried

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/controller.go
+++ b/pkg/scheduler/plugins/elasticquota/controller.go
@@ -265,11 +265,11 @@ func (ctrl *Controller) syncElasticQuotaStatusMetricsWorker() {
 		if summary == nil {
 			continue
 		}
-		syncElasticQuotaMetrics(eq, summary)
+		syncElasticQuotaMetrics(eq, summary, false)
 	}
 }
 
-func syncElasticQuotaMetrics(eq *v1alpha1.ElasticQuota, summary *core.QuotaInfoSummary) {
+func syncElasticQuotaMetrics(eq *v1alpha1.ElasticQuota, summary *core.QuotaInfoSummary, isDelete bool) {
 	quotaLabels := map[string]string{
 		"name":      summary.Name,
 		"tree":      summary.Tree,
@@ -299,15 +299,15 @@ func syncElasticQuotaMetrics(eq *v1alpha1.ElasticQuota, summary *core.QuotaInfoS
 		decorateResource(eq, v)
 
 		k = strings.TrimPrefix(k, extension.QuotaKoordinatorPrefix+"/")
-		RecordElasticQuotaMetric(ElasticQuotaStatusMetric, v, k, quotaLabels)
+		RecordElasticQuotaMetric(ElasticQuotaStatusMetric, v, k, quotaLabels, isDelete)
 	}
 	decorateResource(eq, summary.Used)
-	RecordElasticQuotaMetric(ElasticQuotaStatusMetric, summary.Used, "used", quotaLabels)
+	RecordElasticQuotaMetric(ElasticQuotaStatusMetric, summary.Used, "used", quotaLabels, isDelete)
 
 	decorateResource(eq, summary.Min)
 	decorateResource(eq, summary.Max)
 	decorateResource(eq, summary.SharedWeight)
-	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.Min, "min", quotaLabels)
-	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.Max, "max", quotaLabels)
-	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.SharedWeight, "sharedWeight", quotaLabels)
+	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.Min, "min", quotaLabels, isDelete)
+	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.Max, "max", quotaLabels, isDelete)
+	RecordElasticQuotaMetric(ElasticQuotaSpecMetric, summary.SharedWeight, "sharedWeight", quotaLabels, isDelete)
 }

--- a/pkg/scheduler/plugins/elasticquota/controller_test.go
+++ b/pkg/scheduler/plugins/elasticquota/controller_test.go
@@ -396,34 +396,8 @@ func Test_syncElasticQuotaMetrics(t *testing.T) {
 		Allocated:             MakeResourceList().CPU(7).Mem(50).Obj(),
 		Guaranteed:            MakeResourceList().CPU(8).Mem(50).Obj(),
 	}
-	syncElasticQuotaMetrics(eq, summary)
-	metricsCh := make(chan prometheus.Metric, 10)
-	go func() {
-		ElasticQuotaSpecMetric.Collect(metricsCh)
-		ElasticQuotaStatusMetric.Collect(metricsCh)
-		close(metricsCh)
-	}()
-	var ms []prometheus.Metric
-loopChan:
-	for {
-		select {
-		case metric, ok := <-metricsCh:
-			if !ok {
-				break loopChan
-			}
-			ms = append(ms, metric)
-		}
-	}
-
-	var dtoMetrics []*dto.Metric
-	for _, v := range ms {
-		m := dto.Metric{}
-		assert.NoError(t, v.Write(&m))
-		dtoMetrics = append(dtoMetrics, &m)
-	}
-	sort.Slice(dtoMetrics, func(i, j int) bool {
-		return dtoMetrics[i].String() < dtoMetrics[j].String()
-	})
+	syncElasticQuotaMetrics(eq, summary, false)
+	dtoMetrics := getMetrics(t)
 	expect := []string{
 		`{"label":[{"name":"field","value":"allocated"},{"name":"is_parent","value":"true"},{"name":"name","value":"test-eq"},{"name":"parent","value":"root"},{"name":"resource","value":"cpu"},{"name":"tree","value":"tree-1"}],"gauge":{"value":7000}}`,
 		`{"label":[{"name":"field","value":"allocated"},{"name":"is_parent","value":"true"},{"name":"name","value":"test-eq"},{"name":"parent","value":"root"},{"name":"resource","value":"memory"},{"name":"tree","value":"tree-1"}],"gauge":{"value":50}}`,
@@ -454,6 +428,40 @@ loopChan:
 		jsonStrBytes, _ := json.Marshal(v)
 		assert.Equal(t, expect[i], string(jsonStrBytes))
 	}
+	syncElasticQuotaMetrics(eq, summary, true)
+	dtoMetricsD := getMetrics(t)
+	assert.Equal(t, 0, len(dtoMetricsD))
+}
+
+func getMetrics(t *testing.T) []*dto.Metric {
+	metricsCh := make(chan prometheus.Metric, 10)
+	go func() {
+		ElasticQuotaSpecMetric.Collect(metricsCh)
+		ElasticQuotaStatusMetric.Collect(metricsCh)
+		close(metricsCh)
+	}()
+	var ms []prometheus.Metric
+loopChan:
+	for {
+		select {
+		case metric, ok := <-metricsCh:
+			if !ok {
+				break loopChan
+			}
+			ms = append(ms, metric)
+		}
+	}
+
+	var dtoMetrics []*dto.Metric
+	for _, v := range ms {
+		m := dto.Metric{}
+		assert.NoError(t, v.Write(&m))
+		dtoMetrics = append(dtoMetrics, &m)
+	}
+	sort.Slice(dtoMetrics, func(i, j int) bool {
+		return dtoMetrics[i].String() < dtoMetrics[j].String()
+	})
+	return dtoMetrics
 }
 
 type eqWrapper struct{ *v1alpha1.ElasticQuota }

--- a/pkg/scheduler/plugins/elasticquota/metrics.go
+++ b/pkg/scheduler/plugins/elasticquota/metrics.go
@@ -61,20 +61,24 @@ func init() {
 	)
 }
 
-func RecordElasticQuotaMetric(gaugeVec *metrics.GaugeVec, resources corev1.ResourceList, field string, labels map[string]string) {
+func RecordElasticQuotaMetric(gaugeVec *metrics.GaugeVec, resources corev1.ResourceList, field string, labels map[string]string, isDelete bool) {
 	for resourceName, quantity := range resources {
 		switch resourceName {
 		case corev1.ResourceCPU:
-			recordResourceMetric(gaugeVec, quantity.MilliValue(), string(resourceName), field, labels)
+			recordResourceMetric(gaugeVec, quantity.MilliValue(), string(resourceName), field, labels, isDelete)
 		default:
-			recordResourceMetric(gaugeVec, quantity.Value(), string(resourceName), field, labels)
+			recordResourceMetric(gaugeVec, quantity.Value(), string(resourceName), field, labels, isDelete)
 		}
 	}
 }
 
-func recordResourceMetric(gaugeVec *metrics.GaugeVec, value int64, resourceName, field string, labels map[string]string) {
+func recordResourceMetric(gaugeVec *metrics.GaugeVec, value int64, resourceName, field string, labels map[string]string, isDelete bool) {
 	labels["resource"] = resourceName
 	labels["field"] = field
 
-	gaugeVec.With(labels).Set(float64(value))
+	if isDelete {
+		gaugeVec.Delete(labels)
+	} else {
+		gaugeVec.With(labels).Set(float64(value))
+	}
 }

--- a/pkg/scheduler/plugins/elasticquota/quota_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_handler.go
@@ -104,7 +104,10 @@ func (g *Plugin) OnQuotaDelete(obj interface{}) {
 		klog.Errorf("quota is nil")
 		return
 	}
-
+	summary, _ := g.GetQuotaSummary(quota.Name, false)
+	if summary == nil {
+		syncElasticQuotaMetrics(quota, summary, true)
+	}
 	klog.V(5).Infof("OnQuotaDeleteFunc delete quota: %v", quota.Name)
 	g.deleteQuotaToTreeMap(quota.Name)
 	mgr := g.GetGroupQuotaManagerForTree(quota.Labels[extension.LabelQuotaTreeID])


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

After deleting an ElasticQuota, its associated metrics can still be queried

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

Fix https://github.com/koordinator-sh/koordinator/issues/2491

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
