### PR TITLE
issue-2515 add page cache limit

### DIFF
--- a/apis/slo/v1alpha1/nodeslo_types.go
+++ b/apis/slo/v1alpha1/nodeslo_types.go
@@ -116,6 +116,16 @@ type MemoryQOS struct {
 	// +kubebuilder:validation:Minimum=-25
 	WmarkMinAdj *int64 `json:"wmarkMinAdj,omitempty" validate:"omitempty,min=-25,max=50"`
 
+	// memory.pagecache_limit.enable (Anolis OS required)
+	// The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+	PageCacheLimitEnable *int64 `json:"pageCacheLimitEnable,omitempty" validate:"omitempty,min=0,max=1"`
+	// memory.pagecache_limit.sync (Anolis OS required)
+	// This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
+	PageCacheLimitSync *int64 `json:"pageCacheLimitSync,omitempty" validate:"omitempty,min=0,max=1"`
+	// memory.pagecache_limit.size (Anolis OS required)
+	// This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+	PageCacheLimitSize *int64 `json:"pageCacheLimitSize,omitempty" validate:"omitempty,min=0,max=1"`
+
 	// TODO: enhance the usages of oom priority and oom kill group
 	PriorityEnable *int64 `json:"priorityEnable,omitempty" validate:"omitempty,min=0,max=1"`
 	Priority       *int64 `json:"priority,omitempty" validate:"omitempty,min=0,max=12"`
@@ -421,7 +431,8 @@ type SystemStrategy struct {
 	WatermarkScaleFactor *int64 `json:"watermarkScaleFactor,omitempty" validate:"omitempty,gt=0,max=400"`
 	// /sys/kernel/mm/memcg_reaper/reap_background
 	MemcgReapBackGround *int64 `json:"memcgReapBackGround,omitempty" validate:"omitempty,min=0,max=1"`
-
+	// /sys/kernel/mm/pagecache_limit/enabled (Anolis OS required)
+	MemcgPageCacheLimitEnabled *int64 `json:"memcgPageCacheLimitEnabled,omitempty" validate:"omitempty,min=0,max=1"`
 	// TotalNetworkBandwidth indicates the overall network bandwidth, cluster manager can set this field, and default value taken from /sys/class/net/${NIC_NAME}/speed, unit: Mbps
 	TotalNetworkBandwidth resource.Quantity `json:"totalNetworkBandwidth,omitempty"`
 }

--- a/apis/slo/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/slo/v1alpha1/zz_generated.deepcopy.go
@@ -436,6 +436,21 @@ func (in *MemoryQOS) DeepCopyInto(out *MemoryQOS) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PageCacheLimitEnable != nil {
+		in, out := &in.PageCacheLimitEnable, &out.PageCacheLimitEnable
+		*out = new(int64)
+		**out = **in
+	}
+	if in.PageCacheLimitSync != nil {
+		in, out := &in.PageCacheLimitSync, &out.PageCacheLimitSync
+		*out = new(int64)
+		**out = **in
+	}
+	if in.PageCacheLimitSize != nil {
+		in, out := &in.PageCacheLimitSize, &out.PageCacheLimitSize
+		*out = new(int64)
+		**out = **in
+	}
 	if in.PriorityEnable != nil {
 		in, out := &in.PriorityEnable, &out.PriorityEnable
 		*out = new(int64)
@@ -1195,6 +1210,11 @@ func (in *SystemStrategy) DeepCopyInto(out *SystemStrategy) {
 	}
 	if in.MemcgReapBackGround != nil {
 		in, out := &in.MemcgReapBackGround, &out.MemcgReapBackGround
+		*out = new(int64)
+		**out = **in
+	}
+	if in.MemcgPageCacheLimitEnabled != nil {
+		in, out := &in.MemcgPageCacheLimitEnabled, &out.MemcgPageCacheLimitEnabled
 		*out = new(int64)
 		**out = **in
 	}

--- a/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
+++ b/config/crd/bases/slo.koordinator.sh_nodeslos.yaml
@@ -285,6 +285,24 @@ spec:
                           oomKillGroup:
                             format: int64
                             type: integer
+                          pageCacheLimitEnable:
+                            description: |-
+                              memory.pagecache_limit.enable (Anolis OS required)
+                              The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+                            format: int64
+                            type: integer
+                          pageCacheLimitSize:
+                            description: |-
+                              memory.pagecache_limit.size (Anolis OS required)
+                              This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+                            format: int64
+                            type: integer
+                          pageCacheLimitSync:
+                            description: |-
+                              memory.pagecache_limit.sync (Anolis OS required)
+                              This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
+                            format: int64
+                            type: integer
                           priority:
                             format: int64
                             type: integer
@@ -591,6 +609,24 @@ spec:
                             minimum: 0
                             type: integer
                           oomKillGroup:
+                            format: int64
+                            type: integer
+                          pageCacheLimitEnable:
+                            description: |-
+                              memory.pagecache_limit.enable (Anolis OS required)
+                              The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+                            format: int64
+                            type: integer
+                          pageCacheLimitSize:
+                            description: |-
+                              memory.pagecache_limit.size (Anolis OS required)
+                              This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+                            format: int64
+                            type: integer
+                          pageCacheLimitSync:
+                            description: |-
+                              memory.pagecache_limit.sync (Anolis OS required)
+                              This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
                             format: int64
                             type: integer
                           priority:
@@ -901,6 +937,24 @@ spec:
                           oomKillGroup:
                             format: int64
                             type: integer
+                          pageCacheLimitEnable:
+                            description: |-
+                              memory.pagecache_limit.enable (Anolis OS required)
+                              The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+                            format: int64
+                            type: integer
+                          pageCacheLimitSize:
+                            description: |-
+                              memory.pagecache_limit.size (Anolis OS required)
+                              This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+                            format: int64
+                            type: integer
+                          pageCacheLimitSync:
+                            description: |-
+                              memory.pagecache_limit.sync (Anolis OS required)
+                              This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
+                            format: int64
+                            type: integer
                           priority:
                             format: int64
                             type: integer
@@ -1207,6 +1261,24 @@ spec:
                             minimum: 0
                             type: integer
                           oomKillGroup:
+                            format: int64
+                            type: integer
+                          pageCacheLimitEnable:
+                            description: |-
+                              memory.pagecache_limit.enable (Anolis OS required)
+                              The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+                            format: int64
+                            type: integer
+                          pageCacheLimitSize:
+                            description: |-
+                              memory.pagecache_limit.size (Anolis OS required)
+                              This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+                            format: int64
+                            type: integer
+                          pageCacheLimitSync:
+                            description: |-
+                              memory.pagecache_limit.sync (Anolis OS required)
+                              This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
                             format: int64
                             type: integer
                           priority:
@@ -1527,6 +1599,24 @@ spec:
                           oomKillGroup:
                             format: int64
                             type: integer
+                          pageCacheLimitEnable:
+                            description: |-
+                              memory.pagecache_limit.enable (Anolis OS required)
+                              The interface is memcg Switches for setting the memcg Is it enabled? Page Cache Limit function. Value range: 0~1
+                            format: int64
+                            type: integer
+                          pageCacheLimitSize:
+                            description: |-
+                              memory.pagecache_limit.size (Anolis OS required)
+                              This interface limits the current memcg of Page Cache Usage (unit: bytes). Value range: 0~current memcg The memory.limit_in_bytes value is set by you.
+                            format: int64
+                            type: integer
+                          pageCacheLimitSync:
+                            description: |-
+                              memory.pagecache_limit.sync (Anolis OS required)
+                              This interface controls the current memcg of Page Cache When the usage exceeds the limit, use asynchronous or synchronous recycling. Value range: 0~1
+                            format: int64
+                            type: integer
                           priority:
                             format: int64
                             type: integer
@@ -1728,6 +1818,11 @@ spec:
               systemStrategy:
                 description: node global system config
                 properties:
+                  memcgPageCacheLimitEnabled:
+                    description: /sys/kernel/mm/pagecache_limit/enabled (Anolis OS
+                      required)
+                    format: int64
+                    type: integer
                   memcgReapBackGround:
                     description: /sys/kernel/mm/memcg_reaper/reap_background
                     format: int64

--- a/pkg/koordlet/qosmanager/plugins/sysreconcile/system_config.go
+++ b/pkg/koordlet/qosmanager/plugins/sysreconcile/system_config.go
@@ -136,5 +136,17 @@ func caculateMemoryConfig(strategy *slov1alpha1.SystemStrategy, nodeMemory int64
 		}
 		resources = append(resources, resource)
 	}
+
+	if sysutil.ValidateResourceValue(strategy.MemcgPageCacheLimitEnabled, "", sysutil.MemcgPageCacheLimitEnable) && sysutil.HostSystemInfo.IsAnolisOS {
+		valueStr := strconv.FormatInt(*strategy.MemcgPageCacheLimitEnabled, 10)
+		file := sysutil.MemcgPageCacheLimitEnable.Path("")
+		eventHelper := audit.V(3).Node().Reason("systemConfig reconcile").Message("update calculated mem config page cache limit enabled to : %v", valueStr)
+		resource, err := resourceexecutor.NewCommonDefaultUpdater(file, file, valueStr, eventHelper)
+		if err != nil {
+			return resources
+		}
+		resources = append(resources, resource)
+	}
+
 	return resources
 }

--- a/pkg/koordlet/resourceexecutor/updater.go
+++ b/pkg/koordlet/resourceexecutor/updater.go
@@ -55,7 +55,9 @@ func init() {
 		sysutil.MemoryPriorityName,
 		sysutil.MemoryUsePriorityOomName,
 		sysutil.MemoryOomGroupName,
-		sysutil.NetClsClassIdName,
+		sysutil.MemoryPageCacheEnableName,
+		sysutil.MemoryPageCacheSyncName,
+		sysutil.MemoryPageCacheSizeName,
 	)
 	// special cases
 	DefaultCgroupUpdaterFactory.Register(NewCgroupUpdaterWithUpdateFunc(CgroupUpdateCPUSharesFunc), sysutil.CPUSharesName)

--- a/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodeslo_test.go
@@ -56,7 +56,8 @@ func Test_mergeNodeSLOSpec(t *testing.T) {
 			SharePoolThresholdPercent: nil,
 		},
 		SystemStrategy: &slov1alpha1.SystemStrategy{
-			WatermarkScaleFactor: pointer.Int64(200),
+			WatermarkScaleFactor:       pointer.Int64(200),
+			MemcgPageCacheLimitEnabled: pointer.Int64(1),
 		},
 	}
 	testingMergedNodeSLOSpec := sloconfig.DefaultNodeSLOSpecConfig()

--- a/pkg/koordlet/util/system/cgroup_resource.go
+++ b/pkg/koordlet/util/system/cgroup_resource.go
@@ -163,6 +163,9 @@ const (
 	MemoryUsePriorityOomName   = "memory.use_priority_oom"
 	MemoryOomGroupName         = "memory.oom.group"
 	MemoryIdlePageStatsName    = "memory.idle_page_stats"
+	MemoryPageCacheSizeName    = "memory.pagecache_limit.size"   // anolis os
+	MemoryPageCacheSyncName    = "memory.pagecache_limit.sync"   // anolis os
+	MemoryPageCacheEnableName  = "memory.pagecache_limit.enable" // anolis os
 
 	BlkioTRIopsName   = "blkio.throttle.read_iops_device"
 	BlkioTRBpsName    = "blkio.throttle.read_bps_device"
@@ -190,6 +193,9 @@ var (
 	MemoryUsePriorityOomValidator           = &RangeValidator{min: 0, max: 1}
 	MemoryWmarkMinAdjValidator              = &RangeValidator{min: -25, max: 50}
 	MemoryWmarkScaleFactorFileNameValidator = &RangeValidator{min: 1, max: 1000}
+	MemoryPageCacheLimitEnableValidator     = &RangeValidator{min: 0, max: 1}
+	MemoryPageCacheLimitSyncValidator       = &RangeValidator{min: 0, max: 1}
+	MemoryPageCacheLimitSizeValidator       = &RangeValidator{min: 0, max: math.MaxInt64}
 	BlkioTRIopsValidator                    = &BlkIORangeValidator{min: 0, max: math.MaxInt64, resource: BlkioTRIopsName}
 	BlkioTRBpsValidator                     = &BlkIORangeValidator{min: 0, max: math.MaxInt64, resource: BlkioTRBpsName}
 	BlkioTWIopsValidator                    = &BlkIORangeValidator{min: 0, max: math.MaxInt64, resource: BlkioTWIopsName}
@@ -239,6 +245,9 @@ var (
 	MemoryUsePriorityOom   = DefaultFactory.New(MemoryUsePriorityOomName, CgroupMemDir).WithValidator(MemoryUsePriorityOomValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 	MemoryOomGroup         = DefaultFactory.New(MemoryOomGroupName, CgroupMemDir).WithValidator(MemoryOomGroupValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 	MemoryIdlePageStats    = DefaultFactory.New(MemoryIdlePageStatsName, CgroupMemDir).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryPageCacheEnable  = DefaultFactory.New(MemoryPageCacheEnableName, CgroupMemDir).WithValidator(MemoryPageCacheLimitEnableValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryPageCacheSync    = DefaultFactory.New(MemoryPageCacheSyncName, CgroupMemDir).WithValidator(MemoryPageCacheLimitSyncValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
+	MemoryPageCacheSize    = DefaultFactory.New(MemoryPageCacheSizeName, CgroupMemDir).WithValidator(MemoryPageCacheLimitSizeValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 
 	BlkioReadIops  = DefaultFactory.New(BlkioTRIopsName, CgroupBlkioDir).WithValidator(BlkioTRIopsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
 	BlkioReadBps   = DefaultFactory.New(BlkioTRBpsName, CgroupBlkioDir).WithValidator(BlkioTRBpsValidator).WithCheckSupported(SupportedIfFileExistsInKubepods).WithCheckOnce(true)
@@ -280,6 +289,9 @@ var (
 		MemoryUsePriorityOom,
 		MemoryOomGroup,
 		MemoryIdlePageStats,
+		MemoryPageCacheEnable,
+		MemoryPageCacheSync,
+		MemoryPageCacheSize,
 		BlkioReadIops,
 		BlkioReadBps,
 		BlkioWriteIops,
@@ -321,6 +333,9 @@ var (
 	MemoryPriorityV2         = DefaultFactory.NewV2(MemoryPriorityName, MemoryPriorityName).WithValidator(MemoryPriorityValidator).WithCheckSupported(SupportedIfFileExists)
 	MemoryUsePriorityOomV2   = DefaultFactory.NewV2(MemoryUsePriorityOomName, MemoryUsePriorityOomName).WithValidator(MemoryUsePriorityOomValidator).WithCheckSupported(SupportedIfFileExists)
 	MemoryOomGroupV2         = DefaultFactory.NewV2(MemoryOomGroupName, MemoryOomGroupName).WithValidator(MemoryOomGroupValidator).WithCheckSupported(SupportedIfFileExists)
+	MemoryPageCacheEnableV2  = DefaultFactory.NewV2(MemoryPageCacheEnableName, MemoryPageCacheEnableName).WithValidator(MemoryPageCacheLimitEnableValidator).WithCheckSupported(SupportedIfFileExists)
+	MemoryPageCacheSyncV2    = DefaultFactory.NewV2(MemoryPageCacheSyncName, MemoryPageCacheSyncName).WithValidator(MemoryPageCacheLimitSyncValidator).WithCheckSupported(SupportedIfFileExists)
+	MemoryPageCacheSizeV2    = DefaultFactory.NewV2(MemoryPageCacheSizeName, MemoryPageCacheSizeName).WithValidator(MemoryPageCacheLimitSizeValidator).WithCheckSupported(SupportedIfFileExists)
 
 	knownCgroupV2Resources = []Resource{
 		CPUCFSQuotaV2,
@@ -352,6 +367,9 @@ var (
 		MemoryPriorityV2,
 		MemoryUsePriorityOomV2,
 		MemoryOomGroupV2,
+		MemoryPageCacheEnableV2,
+		MemoryPageCacheSyncV2,
+		MemoryPageCacheSizeV2,
 		// TODO: register BlkioIOWeight, BlkioIOQoS and BlkioIOModel
 
 		NetClsClassId,

--- a/pkg/koordlet/util/system/system_resource.go
+++ b/pkg/koordlet/util/system/system_resource.go
@@ -27,6 +27,7 @@ const (
 	ProcSysVmRelativePath     = "sys/vm/"
 	MemcgReaperRelativePath   = "kernel/mm/memcg_reaper/"
 	KidledRelativePath        = "kernel/mm/kidled/"
+	MemcgPageCacheLimitPath   = "kernel/mm/pagecache_limit/"
 	SchedFeaturesRelativePath = "kernel/debug/"
 
 	MinFreeKbytesFileName             = "min_free_kbytes"
@@ -34,6 +35,7 @@ const (
 	MemcgReapBackGroundFileName       = "reap_background"
 	KidledScanPeriodInSecondsFileName = "scan_period_in_seconds"
 	KidledUseHierarchyFileFileName    = "use_hierarchy"
+	MemcgPageCacheLimitFileName       = "enabled"
 	SchedFeaturesFileName             = "sched_features"
 )
 
@@ -43,6 +45,7 @@ var (
 	MemcgReapBackGroundValidator       = &RangeValidator{min: 0, max: 1}
 	KidledScanPeriodInSecondsValidator = &RangeValidator{min: 0, max: math.MaxInt64}
 	KidledUseHierarchyValidator        = &RangeValidator{min: 0, max: 1}
+	MemcgPageCacheLimitValidator       = &RangeValidator{min: 0, max: 1}
 )
 
 var (
@@ -51,6 +54,7 @@ var (
 	MemcgReapBackGround       = NewCommonSystemResource(MemcgReaperRelativePath, MemcgReapBackGroundFileName, GetSysRootDir).WithValidator(MemcgReapBackGroundValidator).WithCheckSupported(SupportedIfFileExists)
 	KidledScanPeriodInSeconds = NewCommonSystemResource(KidledRelativePath, KidledScanPeriodInSecondsFileName, GetSysRootDir).WithValidator(KidledScanPeriodInSecondsValidator).WithCheckSupported(SupportedIfFileExists)
 	KidledUseHierarchy        = NewCommonSystemResource(KidledRelativePath, KidledUseHierarchyFileFileName, GetSysRootDir).WithValidator(KidledUseHierarchyValidator).WithCheckSupported(SupportedIfFileExists)
+	MemcgPageCacheLimitEnable = NewCommonSystemResource(MemcgPageCacheLimitPath, MemcgPageCacheLimitFileName, GetSysRootDir).WithValidator(MemcgPageCacheLimitValidator).WithCheckSupported(SupportedIfFileExists)
 	// SchedFeatures is the system file which shows the enabled features of the kernel scheduling.
 	SchedFeatures = NewCommonSystemResource(SchedFeaturesRelativePath, SchedFeaturesFileName, GetSysRootDir).WithCheckSupported(SupportedIfFileExists)
 )

--- a/pkg/slo-controller/nodeslo/resource_strategy_test.go
+++ b/pkg/slo-controller/nodeslo/resource_strategy_test.go
@@ -1013,10 +1013,11 @@ func Test_calculateSystemConfigMerged(t *testing.T) {
 	testingSystemConfig1Str, _ := json.Marshal(testingSystemConfig1)
 	expectTestingSystemConfig1 := &configuration.SystemCfg{
 		ClusterStrategy: &slov1alpha1.SystemStrategy{
-			MinFreeKbytesFactor:   oldSLOCfg.SystemCfgMerged.ClusterStrategy.MinFreeKbytesFactor,
-			WatermarkScaleFactor:  pointer.Int64(151),
-			MemcgReapBackGround:   oldSLOCfg.SystemCfgMerged.ClusterStrategy.MemcgReapBackGround,
-			TotalNetworkBandwidth: resource.MustParse("0"),
+			MinFreeKbytesFactor:        oldSLOCfg.SystemCfgMerged.ClusterStrategy.MinFreeKbytesFactor,
+			WatermarkScaleFactor:       pointer.Int64(151),
+			MemcgReapBackGround:        oldSLOCfg.SystemCfgMerged.ClusterStrategy.MemcgReapBackGround,
+			MemcgPageCacheLimitEnabled: pointer.Int64(1),
+			TotalNetworkBandwidth:      resource.MustParse("0"),
 		},
 		NodeStrategies: []configuration.NodeSystemStrategy{
 			{
@@ -1028,10 +1029,11 @@ func Test_calculateSystemConfigMerged(t *testing.T) {
 					},
 				},
 				SystemStrategy: &slov1alpha1.SystemStrategy{
-					MinFreeKbytesFactor:   pointer.Int64(130),
-					WatermarkScaleFactor:  pointer.Int64(151),
-					MemcgReapBackGround:   pointer.Int64(1),
-					TotalNetworkBandwidth: resource.MustParse("0"),
+					MinFreeKbytesFactor:        pointer.Int64(130),
+					WatermarkScaleFactor:       pointer.Int64(151),
+					MemcgReapBackGround:        pointer.Int64(1),
+					MemcgPageCacheLimitEnabled: pointer.Int64(1),
+					TotalNetworkBandwidth:      resource.MustParse("0"),
 				},
 			},
 			{NodeCfgProfile: configuration.NodeCfgProfile{
@@ -1042,10 +1044,11 @@ func Test_calculateSystemConfigMerged(t *testing.T) {
 				},
 			},
 				SystemStrategy: &slov1alpha1.SystemStrategy{
-					MinFreeKbytesFactor:   pointer.Int64(140),
-					WatermarkScaleFactor:  pointer.Int64(151),
-					MemcgReapBackGround:   pointer.Int64(0),
-					TotalNetworkBandwidth: resource.MustParse("0"),
+					MinFreeKbytesFactor:        pointer.Int64(140),
+					WatermarkScaleFactor:       pointer.Int64(151),
+					MemcgReapBackGround:        pointer.Int64(0),
+					MemcgPageCacheLimitEnabled: pointer.Int64(1),
+					TotalNetworkBandwidth:      resource.MustParse("0"),
 				},
 			},
 		},

--- a/pkg/util/sloconfig/nodeslo_config.go
+++ b/pkg/util/sloconfig/nodeslo_config.go
@@ -425,10 +425,11 @@ func DefaultCPUBurstConfig() slov1alpha1.CPUBurstConfig {
 
 func DefaultSystemStrategy() *slov1alpha1.SystemStrategy {
 	return &slov1alpha1.SystemStrategy{
-		MinFreeKbytesFactor:   pointer.Int64(100), // 1 means 1/10000
-		WatermarkScaleFactor:  pointer.Int64(150), // 1 means 1/10000
-		MemcgReapBackGround:   pointer.Int64(0),
-		TotalNetworkBandwidth: resource.MustParse("0"),
+		MinFreeKbytesFactor:        pointer.Int64(100), // 1 means 1/10000
+		WatermarkScaleFactor:       pointer.Int64(150), // 1 means 1/10000
+		MemcgReapBackGround:        pointer.Int64(0),
+		MemcgPageCacheLimitEnabled: pointer.Int64(1),
+		TotalNetworkBandwidth:      resource.MustParse("0"),
 	}
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

## 概要设计 
 1. 在 koordlet 启动时，设置 pagecache limit 全局开关 /sys/kernel/mm/pagecache_limit/enabled。
 2. 在 koordlet 中，只针对 龙蜥 系统有这个配置接口。
 3. 通过在 pod 中的 Annotation 上，配置 key = "koordinator.sh/memoryQOS" 实现动态配置 page cache limit.

### 全局配置

```
1. configmap 配置中 SLOCtrlConfigMap = "slo-controller-config"
   kubectl  -n koordinator-system get cm slo-controller-config
2. 其中有个data yaml 文件 SystemConfigKey = "system-config"
   文件对应下面的 struct SystemCfg 。
type SystemCfg struct {
	ClusterStrategy *slov1alpha1.SystemStrategy `json:"clusterStrategy,omitempty"`
	NodeStrategies  []NodeSystemStrategy        `json:"nodeStrategies,omitempty" validate:"dive"`
}

type SystemStrategy struct {
   // for /proc/sys/vm/min_free_kbytes, min_free_kbytes = minFreeKbytesFactor * nodeTotalMemory /10000
   MinFreeKbytesFactor *int64 `json:"minFreeKbytesFactor,omitempty" validate:"omitempty,gt=0"`
   // /proc/sys/vm/watermark_scale_factor
   WatermarkScaleFactor *int64 `json:"watermarkScaleFactor,omitempty" validate:"omitempty,gt=0,max=400"`
   // /sys/kernel/mm/memcg_reaper/reap_background
   MemcgReapBackGround *int64 `json:"memcgReapBackGround,omitempty" validate:"omitempty,min=0,max=1"`

   // 新增全局配置接口
   // /sys/kernel/mm/pagecache_limit/enabled (Anolis OS required)
   MemcgPageCacheLimitEnabled *int64 `json:"memcgPageCacheLimitEnabled,omitempty" validate:"omitempty,min=0,max=1"`
}
```

### pod 配置

```
type PodMemoryQOSConfig struct {
   // Policy indicates the qos plan; use "default" if empty
   Policy    PodMemoryQOSPolicy `json:"policy,omitempty"`
   MemoryQOS `json:",inline"`
}

type MemoryQOS struct {
  MinLimitPercent      *int64 `json:"minLimitPercent,omitempty" validate:"omitempty,min=0,max=100"`
  LowLimitPercent      *int64 `json:"lowLimitPercent,omitempty" validate:"omitempty,min=0,max=100"`

  // 新增 page cache limit
  PageCacheLimitEnable *int64 `json:"pageCacheLimitEnable,omitempty" validate:"omitempty,min=0,max=1"`
  PageCacheLimitSync   *int64 `json:"pageCacheLimitSync,omitempty" validate:"omitempty,min=0,max=1"`
  PageCacheLimitSize   *int64 `json:"pageCacheLimitSize,omitempty" validate:"omitempty,min=0,max=1"`
}

PodMemoryQOSPolicyDefault PodMemoryQOSPolicy = "default"
PodMemoryQOSPolicyNone PodMemoryQOSPolicy = "none"
PodMemoryQOSPolicyAuto PodMemoryQOSPolicy = "auto"
```
