### PR TITLE
scheduler: loadaware support force estimated duration and other improvements

### DIFF
--- a/apis/extension/load_aware.go
+++ b/apis/extension/load_aware.go
@@ -30,12 +30,12 @@ const (
 	AnnotationCustomUsageThresholds = SchedulingDomainPrefix + "/usage-thresholds"
 	// AnnotationCustomEstimatedScalingFactors represents the user-defined factor when estimating resource usage.
 	AnnotationCustomEstimatedScalingFactors = SchedulingDomainPrefix + "/load-estimated-scaling-factors"
-	// AnnotationCustomForceEstimationSecondsAfterPodScheduled represents the user-defined
+	// AnnotationCustomEstimatedSecondsAfterPodScheduled represents the user-defined
 	// force estimation seconds after pod scheduled.
-	AnnotationCustomForceEstimationSecondsAfterPodScheduled = SchedulingDomainPrefix + "/force-load-estimation-seconds-after-pod-scheduled"
-	// AnnotationCustomForceEstimationSecondsAfterInitialized represents the user-defined
+	AnnotationCustomEstimatedSecondsAfterPodScheduled = SchedulingDomainPrefix + "/load-estimated-seconds-after-pod-scheduled"
+	// AnnotationCustomEstimatedSecondsAfterInitialized represents the user-defined
 	// force estimation seconds after initialized.
-	AnnotationCustomForceEstimationSecondsAfterInitialized = SchedulingDomainPrefix + "/force-load-estimation-seconds-after-initialized"
+	AnnotationCustomEstimatedSecondsAfterInitialized = SchedulingDomainPrefix + "/load-estimated-seconds-after-initialized"
 )
 
 // CustomUsageThresholds supports user-defined node resource utilization thresholds.
@@ -81,8 +81,8 @@ func GetCustomEstimatedScalingFactors(pod *corev1.Pod) map[corev1.ResourceName]i
 	return nil
 }
 
-func GetCustomForceEstimationSecondsAfterPodScheduled(pod *corev1.Pod) int64 {
-	if s := pod.Annotations[AnnotationCustomForceEstimationSecondsAfterPodScheduled]; s != "" {
+func GetCustomEstimatedSecondsAfterPodScheduled(pod *corev1.Pod) int64 {
+	if s := pod.Annotations[AnnotationCustomEstimatedSecondsAfterPodScheduled]; s != "" {
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 			return i
 		}
@@ -90,8 +90,8 @@ func GetCustomForceEstimationSecondsAfterPodScheduled(pod *corev1.Pod) int64 {
 	return -1
 }
 
-func GetCustomForceEstimationSecondsAfterInitialized(pod *corev1.Pod) int64 {
-	if s := pod.Annotations[AnnotationCustomForceEstimationSecondsAfterInitialized]; s != "" {
+func GetCustomEstimatedSecondsAfterInitialized(pod *corev1.Pod) int64 {
+	if s := pod.Annotations[AnnotationCustomEstimatedSecondsAfterInitialized]; s != "" {
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 			return i
 		}

--- a/apis/extension/load_aware.go
+++ b/apis/extension/load_aware.go
@@ -28,6 +28,8 @@ const (
 	// AnnotationCustomUsageThresholds represents the user-defined resource utilization threshold.
 	// For specific value definitions, see CustomUsageThresholds
 	AnnotationCustomUsageThresholds = SchedulingDomainPrefix + "/usage-thresholds"
+	// AnnotationCustomEstimatedScalingFactors represents the user-defined factor when estimating resource usage.
+	AnnotationCustomEstimatedScalingFactors = SchedulingDomainPrefix + "/load-estimated-scaling-factors"
 	// AnnotationCustomForceEstimationSecondsAfterPodScheduled represents the user-defined
 	// force estimation seconds after pod scheduled.
 	AnnotationCustomForceEstimationSecondsAfterPodScheduled = SchedulingDomainPrefix + "/force-load-estimation-seconds-after-pod-scheduled"
@@ -66,6 +68,17 @@ func GetCustomUsageThresholds(node *corev1.Node) (*CustomUsageThresholds, error)
 		return nil, err
 	}
 	return usageThresholds, nil
+}
+
+// also returns nil if unmarshal error
+func GetCustomEstimatedScalingFactors(pod *corev1.Pod) map[corev1.ResourceName]int64 {
+	if s := pod.Annotations[AnnotationCustomEstimatedScalingFactors]; s != "" {
+		factors := make(map[corev1.ResourceName]int64)
+		if err := json.Unmarshal([]byte(s), &factors); err == nil {
+			return factors
+		}
+	}
+	return nil
 }
 
 func GetCustomForceEstimationSecondsAfterPodScheduled(pod *corev1.Pod) int64 {

--- a/apis/extension/load_aware.go
+++ b/apis/extension/load_aware.go
@@ -18,6 +18,7 @@ package extension
 
 import (
 	"encoding/json"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,12 @@ const (
 	// AnnotationCustomUsageThresholds represents the user-defined resource utilization threshold.
 	// For specific value definitions, see CustomUsageThresholds
 	AnnotationCustomUsageThresholds = SchedulingDomainPrefix + "/usage-thresholds"
+	// AnnotationCustomForceEstimationSecondsAfterPodScheduled represents the user-defined
+	// force estimation seconds after pod scheduled.
+	AnnotationCustomForceEstimationSecondsAfterPodScheduled = SchedulingDomainPrefix + "/force-load-estimation-seconds-after-pod-scheduled"
+	// AnnotationCustomForceEstimationSecondsAfterInitialized represents the user-defined
+	// force estimation seconds after initialized.
+	AnnotationCustomForceEstimationSecondsAfterInitialized = SchedulingDomainPrefix + "/force-load-estimation-seconds-after-initialized"
 )
 
 // CustomUsageThresholds supports user-defined node resource utilization thresholds.
@@ -59,4 +66,22 @@ func GetCustomUsageThresholds(node *corev1.Node) (*CustomUsageThresholds, error)
 		return nil, err
 	}
 	return usageThresholds, nil
+}
+
+func GetCustomForceEstimationSecondsAfterPodScheduled(pod *corev1.Pod) int64 {
+	if s := pod.Annotations[AnnotationCustomForceEstimationSecondsAfterPodScheduled]; s != "" {
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	}
+	return -1
+}
+
+func GetCustomForceEstimationSecondsAfterInitialized(pod *corev1.Pod) int64 {
+	if s := pod.Annotations[AnnotationCustomForceEstimationSecondsAfterInitialized]; s != "" {
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -56,14 +56,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64
-	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// EstimatedSecondsAfterPodScheduled indicates the force estimation duration
 	// after pod condition PodScheduled transition to True in seconds.
-	ForceEstimationSecondsAfterPodScheduled *int64
-	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	EstimatedSecondsAfterPodScheduled *int64
+	// EstimatedSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
-	ForceEstimationSecondsAfterInitialized *int64
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
-	AllowCustomizeEstimationFromMetadata bool
+	EstimatedSecondsAfterInitialized *int64
+	// AllowCustomizeEstimation indicates whether to allow reading estimation args from pod's metadata.
+	AllowCustomizeEstimation bool
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs
 }

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -56,6 +56,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64
+	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// after pod condition PodScheduled transition to True in seconds.
+	ForceEstimationSecondsAfterPodScheduled *int64
+	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	// after pod condition Initialized transition to True in seconds.
+	ForceEstimationSecondsAfterInitialized *int64
+	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowForceEstimationFromMetadata bool
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs
 }

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -62,8 +62,8 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64
-	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
-	AllowForceEstimationFromMetadata bool
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowCustomizeEstimationFromMetadata bool
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs
 }

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -62,7 +62,7 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
 	AllowCustomizeEstimationFromMetadata bool
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -61,7 +61,7 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
 	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -55,14 +55,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
-	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// EstimatedSecondsAfterPodScheduled indicates the force estimation duration
 	// after pod condition PodScheduled transition to True in seconds.
-	ForceEstimationSecondsAfterPodScheduled *int64 `json:"forceEstimationSecondsAfterPodScheduled,omitempty"`
-	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	EstimatedSecondsAfterPodScheduled *int64 `json:"estimatedSecondsAfterPodScheduled,omitempty"`
+	// EstimatedSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
-	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
-	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
+	EstimatedSecondsAfterInitialized *int64 `json:"estimatedSecondsAfterInitialized,omitempty"`
+	// AllowCustomizeEstimation indicates whether to allow reading estimation args from pod's metadata.
+	AllowCustomizeEstimation bool `json:"allowCustomizeEstimation,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -55,6 +55,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
+	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// after pod condition PodScheduled transition to True in seconds.
+	ForceEstimationSecondsAfterPodScheduled *int64 `json:"forceEstimationSecondsAfterPodScheduled,omitempty"`
+	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	// after pod condition Initialized transition to True in seconds.
+	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
+	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowForceEstimationFromMetadata bool `json:"allowForceEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -61,8 +61,8 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
-	AllowForceEstimationFromMetadata bool `json:"allowForceEstimationFromMetadata,omitempty"`
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -396,7 +396,7 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
 	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
+	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -428,7 +428,7 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
 	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
+	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -394,9 +394,9 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
-	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
-	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
+	out.EstimatedSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterPodScheduled))
+	out.EstimatedSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterInitialized))
+	out.AllowCustomizeEstimation = in.AllowCustomizeEstimation
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -426,9 +426,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
-	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
-	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
+	out.EstimatedSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterPodScheduled))
+	out.EstimatedSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterInitialized))
+	out.AllowCustomizeEstimation = in.AllowCustomizeEstimation
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -394,6 +394,9 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
+	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
+	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -423,6 +426,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
+	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
+	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -299,13 +299,13 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
-	if in.ForceEstimationSecondsAfterPodScheduled != nil {
-		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+	if in.EstimatedSecondsAfterPodScheduled != nil {
+		in, out := &in.EstimatedSecondsAfterPodScheduled, &out.EstimatedSecondsAfterPodScheduled
 		*out = new(int64)
 		**out = **in
 	}
-	if in.ForceEstimationSecondsAfterInitialized != nil {
-		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+	if in.EstimatedSecondsAfterInitialized != nil {
+		in, out := &in.EstimatedSecondsAfterInitialized, &out.EstimatedSecondsAfterInitialized
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -299,6 +299,16 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ForceEstimationSecondsAfterPodScheduled != nil {
+		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ForceEstimationSecondsAfterInitialized != nil {
+		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -56,14 +56,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
-	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// EstimatedSecondsAfterPodScheduled indicates the force estimation duration
 	// after pod condition PodScheduled transition to True in seconds.
-	ForceEstimationSecondsAfterPodScheduled *int64 `json:"forceEstimationSecondsAfterPodScheduled,omitempty"`
-	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	EstimatedSecondsAfterPodScheduled *int64 `json:"estimatedSecondsAfterPodScheduled,omitempty"`
+	// EstimatedSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
-	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
-	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
+	EstimatedSecondsAfterInitialized *int64 `json:"estimatedSecondsAfterInitialized,omitempty"`
+	// AllowCustomizeEstimation indicates whether to allow reading estimation args from pod's metadata.
+	AllowCustomizeEstimation bool `json:"allowCustomizeEstimation,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -62,8 +62,8 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
-	AllowForceEstimationFromMetadata bool `json:"allowForceEstimationFromMetadata,omitempty"`
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -56,6 +56,14 @@ type LoadAwareSchedulingArgs struct {
 	// EstimatedScalingFactors indicates the factor when estimating resource usage.
 	// The default value of CPU is 85%, and the default value of Memory is 70%.
 	EstimatedScalingFactors map[corev1.ResourceName]int64 `json:"estimatedScalingFactors,omitempty"`
+	// ForceEstimationSecondsAfterPodScheduled indicates the force estimation duration
+	// after pod condition PodScheduled transition to True in seconds.
+	ForceEstimationSecondsAfterPodScheduled *int64 `json:"forceEstimationSecondsAfterPodScheduled,omitempty"`
+	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
+	// after pod condition Initialized transition to True in seconds.
+	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
+	// AllowForceEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	AllowForceEstimationFromMetadata bool `json:"allowForceEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`
 }

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -62,7 +62,7 @@ type LoadAwareSchedulingArgs struct {
 	// ForceEstimationSecondsAfterInitialized indicates the force estimation duration
 	// after pod condition Initialized transition to True in seconds.
 	ForceEstimationSecondsAfterInitialized *int64 `json:"forceEstimationSecondsAfterInitialized,omitempty"`
-	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading force estimation args from pod's metadata.
+	// AllowCustomizeEstimationFromMetadata indicates whether to allow reading estimation args from pod's metadata.
 	AllowCustomizeEstimationFromMetadata bool `json:"allowCustomizeEstimationFromMetadata,omitempty"`
 	// Aggregated supports resource utilization filtering and scoring based on percentile statistics
 	Aggregated *LoadAwareSchedulingAggregatedArgs `json:"aggregated,omitempty"`

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -396,7 +396,7 @@ func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
 	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
+	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -423,7 +423,7 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta3_LoadAwareSchedulingAr
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
 	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
 	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
+	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -394,6 +394,9 @@ func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
+	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
+	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -418,6 +421,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta3_LoadAwareSchedulingAr
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
+	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
+	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
+	out.AllowForceEstimationFromMetadata = in.AllowForceEstimationFromMetadata
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -394,9 +394,9 @@ func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
-	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
-	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
+	out.EstimatedSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterPodScheduled))
+	out.EstimatedSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterInitialized))
+	out.AllowCustomizeEstimation = in.AllowCustomizeEstimation
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(config.LoadAwareSchedulingAggregatedArgs)
@@ -421,9 +421,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta3_LoadAwareSchedulingAr
 	}
 	out.Estimator = in.Estimator
 	out.EstimatedScalingFactors = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.EstimatedScalingFactors))
-	out.ForceEstimationSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterPodScheduled))
-	out.ForceEstimationSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.ForceEstimationSecondsAfterInitialized))
-	out.AllowCustomizeEstimationFromMetadata = in.AllowCustomizeEstimationFromMetadata
+	out.EstimatedSecondsAfterPodScheduled = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterPodScheduled))
+	out.EstimatedSecondsAfterInitialized = (*int64)(unsafe.Pointer(in.EstimatedSecondsAfterInitialized))
+	out.AllowCustomizeEstimation = in.AllowCustomizeEstimation
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -299,13 +299,13 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
-	if in.ForceEstimationSecondsAfterPodScheduled != nil {
-		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+	if in.EstimatedSecondsAfterPodScheduled != nil {
+		in, out := &in.EstimatedSecondsAfterPodScheduled, &out.EstimatedSecondsAfterPodScheduled
 		*out = new(int64)
 		**out = **in
 	}
-	if in.ForceEstimationSecondsAfterInitialized != nil {
-		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+	if in.EstimatedSecondsAfterInitialized != nil {
+		in, out := &in.EstimatedSecondsAfterInitialized, &out.EstimatedSecondsAfterInitialized
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -299,6 +299,16 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ForceEstimationSecondsAfterPodScheduled != nil {
+		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ForceEstimationSecondsAfterInitialized != nil {
+		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -243,13 +243,13 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
-	if in.ForceEstimationSecondsAfterPodScheduled != nil {
-		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+	if in.EstimatedSecondsAfterPodScheduled != nil {
+		in, out := &in.EstimatedSecondsAfterPodScheduled, &out.EstimatedSecondsAfterPodScheduled
 		*out = new(int64)
 		**out = **in
 	}
-	if in.ForceEstimationSecondsAfterInitialized != nil {
-		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+	if in.EstimatedSecondsAfterInitialized != nil {
+		in, out := &in.EstimatedSecondsAfterInitialized, &out.EstimatedSecondsAfterInitialized
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -243,6 +243,16 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.ForceEstimationSecondsAfterPodScheduled != nil {
+		in, out := &in.ForceEstimationSecondsAfterPodScheduled, &out.ForceEstimationSecondsAfterPodScheduled
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ForceEstimationSecondsAfterInitialized != nil {
+		in, out := &in.ForceEstimationSecondsAfterInitialized, &out.ForceEstimationSecondsAfterInitialized
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Aggregated != nil {
 		in, out := &in.Aggregated, &out.Aggregated
 		*out = new(LoadAwareSchedulingAggregatedArgs)

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -48,7 +48,7 @@ func NewDefaultEstimator(args *config.LoadAwareSchedulingArgs, handle framework.
 	return &DefaultEstimator{
 		resourceWeights: args.ResourceWeights,
 		scalingFactors:  args.EstimatedScalingFactors,
-		allowCustomize:  args.AllowCustomizeEstimationFromMetadata,
+		allowCustomize:  args.AllowCustomizeEstimation,
 	}, nil
 }
 

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator.go
@@ -41,12 +41,14 @@ const (
 type DefaultEstimator struct {
 	resourceWeights map[corev1.ResourceName]int64
 	scalingFactors  map[corev1.ResourceName]int64
+	allowCustomize  bool
 }
 
 func NewDefaultEstimator(args *config.LoadAwareSchedulingArgs, handle framework.Handle) (Estimator, error) {
 	return &DefaultEstimator{
 		resourceWeights: args.ResourceWeights,
 		scalingFactors:  args.EstimatedScalingFactors,
+		allowCustomize:  args.AllowCustomizeEstimationFromMetadata,
 	}, nil
 }
 
@@ -55,7 +57,20 @@ func (e *DefaultEstimator) Name() string {
 }
 
 func (e *DefaultEstimator) EstimatePod(pod *corev1.Pod) (map[corev1.ResourceName]int64, error) {
-	return estimatedPodUsed(pod, e.resourceWeights, e.scalingFactors), nil
+	var factors map[corev1.ResourceName]int64
+	if e.allowCustomize {
+		factors = extension.GetCustomEstimatedScalingFactors(pod)
+	}
+	if len(factors) == 0 {
+		factors = e.scalingFactors
+	} else {
+		for k, v := range e.scalingFactors {
+			if _, ok := factors[k]; !ok {
+				factors[k] = v
+			}
+		}
+	}
+	return estimatedPodUsed(pod, e.resourceWeights, factors), nil
 }
 
 func estimatedPodUsed(pod *corev1.Pod, resourceWeights map[corev1.ResourceName]int64, scalingFactors map[corev1.ResourceName]int64) map[corev1.ResourceName]int64 {

--- a/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
+++ b/pkg/scheduler/plugins/loadaware/estimator/default_estimator_test.go
@@ -271,7 +271,7 @@ func TestDefaultEstimatorEstimatePod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var v1beta3args v1beta3.LoadAwareSchedulingArgs
 			v1beta3args.EstimatedScalingFactors = tt.scalarFactors
-			v1beta3args.AllowCustomizeEstimationFromMetadata = tt.allowCustomize
+			v1beta3args.AllowCustomizeEstimation = tt.allowCustomize
 			v1beta3.SetDefaults_LoadAwareSchedulingArgs(&v1beta3args)
 			var loadAwareSchedulingArgs config.LoadAwareSchedulingArgs
 			err := v1beta3.Convert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(&v1beta3args, &loadAwareSchedulingArgs, nil)

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
@@ -388,7 +388,7 @@ func (p *Plugin) shouldForceEstimatePod(info *podAssignInfo, now time.Time) bool
 		if _, c := podutil.GetPodCondition(&info.pod.Status, corev1.PodInitialized); c != nil && c.Status == corev1.ConditionTrue {
 			it = c.LastTransitionTime.Time
 		}
-		if !it.IsZero() && it.Add(time.Duration(forceAfterInitialized) * time.Second).After(now) {
+		if !it.IsZero() && it.Add(time.Duration(forceAfterInitialized)*time.Second).After(now) {
 			return true
 		}
 	}

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -370,9 +370,6 @@ func (p *Plugin) shouldForceEstimatePod(info *podAssignInfo, now time.Time) bool
 	if s := p.args.ForceEstimationSecondsAfterInitialized; s != nil && forceAfterInitialized < 0 {
 		forceAfterInitialized = *s
 	}
-	if forceAfterPodScheduled <= 0 && forceAfterInitialized <= 0 {
-		return false
-	}
 	if forceAfterPodScheduled > 0 {
 		// try to use pod conditions
 		var st time.Time

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
@@ -24,7 +24,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -38,16 +40,19 @@ type podAssignCache struct {
 	// podInfoItems stores podAssignInfo according to each node.
 	// podAssignInfo is indexed using the Pod's types.UID
 	podInfoItems map[string]map[types.UID]*podAssignInfo
+	estimator    estimator.Estimator
 }
 
 type podAssignInfo struct {
 	timestamp time.Time
 	pod       *corev1.Pod
+	estimated map[corev1.ResourceName]int64
 }
 
-func newPodAssignCache() *podAssignCache {
+func newPodAssignCache(estimator estimator.Estimator) *podAssignCache {
 	return &podAssignCache{
 		podInfoItems: map[string]map[types.UID]*podAssignInfo{},
+		estimator:    estimator,
 	}
 }
 
@@ -92,13 +97,27 @@ func (p *podAssignCache) assign(nodeName string, pod *corev1.Pod) {
 		m = make(map[types.UID]*podAssignInfo)
 		p.podInfoItems[nodeName] = m
 	}
-
+	estimated, err := p.estimator.EstimatePod(pod)
+	if err != nil || len(estimated) == 0 {
+		estimated = nil
+	}
 	if _, ok := m[pod.UID]; ok {
 		m[pod.UID].pod = pod
+		m[pod.UID].estimated = estimated
 	} else {
+		// try to use time from PodScheduled condition first
+		var timestamp time.Time
+		if _, c := podutil.GetPodCondition(&pod.Status, corev1.PodScheduled); c != nil && c.Status == corev1.ConditionTrue {
+			timestamp = c.LastTransitionTime.Time
+		}
+		// if PodScheduled condition not found, fallback to use assign timestamp from scheduler internal, which cannot be zero.
+		if timestamp.IsZero() {
+			timestamp = timeNowFn()
+		}
 		m[pod.UID] = &podAssignInfo{
-			timestamp: timeNowFn(),
+			timestamp: timestamp,
 			pod:       pod,
+			estimated: estimated,
 		}
 	}
 }

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 )
 
 var fakeTimeNowFn = func() time.Time {

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,7 +101,8 @@ func TestPodAssignCache_OnAdd(t *testing.T) {
 				timeNowFn = preTimeNowFn
 			}()
 			timeNowFn = fakeTimeNowFn
-			assignCache := newPodAssignCache()
+			e, _ := estimator.NewDefaultEstimator(&config.LoadAwareSchedulingArgs{}, nil)
+			assignCache := newPodAssignCache(e)
 			assignCache.OnAdd(tt.pod, true)
 			assert.Equal(t, tt.wantCache, assignCache.podInfoItems)
 		})
@@ -261,7 +264,8 @@ func TestPodAssignCache_OnUpdate(t *testing.T) {
 			timeNowFn = fakeTimeNowFn
 			assignCache := tt.assignCache
 			if assignCache == nil {
-				assignCache = newPodAssignCache()
+				e, _ := estimator.NewDefaultEstimator(&config.LoadAwareSchedulingArgs{}, nil)
+				assignCache = newPodAssignCache(e)
 			}
 			assignCache.OnUpdate(nil, tt.pod)
 			assert.Equal(t, tt.wantCache, assignCache.podInfoItems)

--- a/pkg/scheduler/plugins/loadaware/service_test.go
+++ b/pkg/scheduler/plugins/loadaware/service_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,9 +40,9 @@ func TestQueryNode(t *testing.T) {
 			timeNowFn = preTimeNowFn
 		}()
 		timeNowFn = fakeTimeNowFn
-
+		e, _ := estimator.NewDefaultEstimator(&config.LoadAwareSchedulingArgs{}, nil)
 		pl := &Plugin{
-			podAssignCache: newPodAssignCache(),
+			podAssignCache: newPodAssignCache(e),
 		}
 		testNodeName := "test-node"
 		pendingPod := &corev1.Pod{

--- a/pkg/scheduler/plugins/loadaware/service_test.go
+++ b/pkg/scheduler/plugins/loadaware/service_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
-	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 )
 
 func TestQueryNode(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

#### New Features

For some workload, the process has to loading configuration and data in bootstraping for a while before it executes operators that consume a lot of cpu and memory.

The solution is to add args and pod annotations that can force loadaware to use estimated usage in the duration after the pod is scheduled or initialized (all init containers are executed successfully)

LoadAwareSchedulingArgs
- `forceEstimationSecondsAfterPodScheduled` default force estimated duration after scheduled, < 0 means disabled by default
- `forceEstimationSecondsAfterInitialized` default force estimated duration after initialized,  < 0 means disabled by default
- `allowCustomizeEstimationFromMetadata` whether plugin allow to customize pod estimation with its annotations

pod metadata.annotations
- `scheduling.koordinator.sh/force-load-estimation-seconds-after-pod-scheduled` customization will be skipped if value < 0 or invalid (not base 10 integer format)
- `scheduling.koordinator.sh/force-load-estimation-seconds-after-initialized` customization will be skipped if value < 0 or invalid (not base 10 integer format)
- `scheduling.koordinator.sh/load-estimated-scaling-factors` represents pod customized estimated scaling factors, factors from plugin args will only be used when resource name does not exist in annotation value, customization will be skipped if json format invalid

#### Improvements

1. Try to use pod scheduled condition time as timestamp when pod is added to cache to avoid estimate all pods when scheduler starts in several minutes (base on NodeMetric's `spec.metricCollectPolicy.reportIntervalSeconds` and force estimation settings)
2. Store estimated usage in cache to avoid redundant calculation when estimate assigned pod used for node.
3. Fix plugin ut and avoid manipulating assigned pod cache data directly in test code which duplicate the cache maintaining code.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
