### PR TITLE
scheduler: add DisableFilterWhenHighLoad to LoadAwareScheduling plugin

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -31,6 +31,9 @@ import (
 type LoadAwareSchedulingArgs struct {
 	metav1.TypeMeta
 
+	// DisableFilterWhenHighLoad controls whether to skip filtering based on node load.
+	// If true, the filter will not consider node usage thresholds.
+	DisableFilterWhenHighLoad *bool
 	// FilterExpiredNodeMetrics indicates whether to filter nodes where koordlet fails to update NodeMetric.
 	// Deprecated: NodeMetric should always be checked for expiration.
 	FilterExpiredNodeMetrics *bool

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -88,6 +88,9 @@ var (
 
 // SetDefaults_LoadAwareSchedulingArgs sets the default parameters for LoadAwareScheduling plugin.
 func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
+	if obj.DisableFilterWhenHighLoad == nil {
+		obj.DisableFilterWhenHighLoad = pointer.Bool(false)
+	}
 	if obj.FilterExpiredNodeMetrics == nil {
 		obj.FilterExpiredNodeMetrics = pointer.Bool(true)
 	}

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -31,6 +31,9 @@ import (
 type LoadAwareSchedulingArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// DisableFilterWhenHighLoad controls whether to skip filtering based on node load.
+	// If true, the filter will not consider node usage thresholds.
+	DisableFilterWhenHighLoad *bool
 	// FilterExpiredNodeMetrics indicates whether to filter nodes where koordlet fails to update NodeMetric.
 	FilterExpiredNodeMetrics *bool `json:"filterExpiredNodeMetrics,omitempty"`
 	// NodeMetricExpirationSeconds indicates the NodeMetric expiration in seconds.

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -383,6 +383,7 @@ func Convert_config_LoadAwareSchedulingAggregatedArgs_To_v1_LoadAwareSchedulingA
 }
 
 func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in *LoadAwareSchedulingArgs, out *config.LoadAwareSchedulingArgs, s conversion.Scope) error {
+	out.DisableFilterWhenHighLoad = (*bool)(unsafe.Pointer(in.DisableFilterWhenHighLoad))
 	out.FilterExpiredNodeMetrics = (*bool)(unsafe.Pointer(in.FilterExpiredNodeMetrics))
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
@@ -415,6 +416,7 @@ func Convert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in *Lo
 }
 
 func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in *config.LoadAwareSchedulingArgs, out *LoadAwareSchedulingArgs, s conversion.Scope) error {
+	out.DisableFilterWhenHighLoad = (*bool)(unsafe.Pointer(in.DisableFilterWhenHighLoad))
 	out.FilterExpiredNodeMetrics = (*bool)(unsafe.Pointer(in.FilterExpiredNodeMetrics))
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -251,6 +251,11 @@ func (in *LoadAwareSchedulingAggregatedArgs) DeepCopy() *LoadAwareSchedulingAggr
 func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DisableFilterWhenHighLoad != nil {
+		in, out := &in.DisableFilterWhenHighLoad, &out.DisableFilterWhenHighLoad
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FilterExpiredNodeMetrics != nil {
 		in, out := &in.FilterExpiredNodeMetrics, &out.FilterExpiredNodeMetrics
 		*out = new(bool)

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -88,6 +88,9 @@ var (
 
 // SetDefaults_LoadAwareSchedulingArgs sets the default parameters for LoadAwareScheduling plugin.
 func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
+	if obj.DisableFilterWhenHighLoad == nil {
+		obj.DisableFilterWhenHighLoad = pointer.Bool(false)
+	}
 	if obj.FilterExpiredNodeMetrics == nil {
 		obj.FilterExpiredNodeMetrics = pointer.Bool(true)
 	}

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -32,6 +32,9 @@ import (
 type LoadAwareSchedulingArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// DisableFilterWhenHighLoad controls whether to skip filtering based on node load.
+	// If true, the filter will not consider node usage thresholds.
+	DisableFilterWhenHighLoad *bool
 	// FilterExpiredNodeMetrics indicates whether to filter nodes where koordlet fails to update NodeMetric.
 	FilterExpiredNodeMetrics *bool `json:"filterExpiredNodeMetrics,omitempty"`
 	// NodeMetricExpirationSeconds indicates the NodeMetric expiration in seconds.

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -383,6 +383,7 @@ func Convert_config_LoadAwareSchedulingAggregatedArgs_To_v1beta3_LoadAwareSchedu
 }
 
 func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in *LoadAwareSchedulingArgs, out *config.LoadAwareSchedulingArgs, s conversion.Scope) error {
+	out.DisableFilterWhenHighLoad = (*bool)(unsafe.Pointer(in.DisableFilterWhenHighLoad))
 	out.FilterExpiredNodeMetrics = (*bool)(unsafe.Pointer(in.FilterExpiredNodeMetrics))
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
@@ -410,6 +411,7 @@ func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 }
 
 func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta3_LoadAwareSchedulingArgs(in *config.LoadAwareSchedulingArgs, out *LoadAwareSchedulingArgs, s conversion.Scope) error {
+	out.DisableFilterWhenHighLoad = (*bool)(unsafe.Pointer(in.DisableFilterWhenHighLoad))
 	out.FilterExpiredNodeMetrics = (*bool)(unsafe.Pointer(in.FilterExpiredNodeMetrics))
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -251,6 +251,11 @@ func (in *LoadAwareSchedulingAggregatedArgs) DeepCopy() *LoadAwareSchedulingAggr
 func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DisableFilterWhenHighLoad != nil {
+		in, out := &in.DisableFilterWhenHighLoad, &out.DisableFilterWhenHighLoad
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FilterExpiredNodeMetrics != nil {
 		in, out := &in.FilterExpiredNodeMetrics, &out.FilterExpiredNodeMetrics
 		*out = new(bool)

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -200,6 +200,11 @@ func (in *LoadAwareSchedulingAggregatedArgs) DeepCopy() *LoadAwareSchedulingAggr
 func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DisableFilterWhenHighLoad != nil {
+		in, out := &in.DisableFilterWhenHighLoad, &out.DisableFilterWhenHighLoad
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FilterExpiredNodeMetrics != nil {
 		in, out := &in.FilterExpiredNodeMetrics, &out.FilterExpiredNodeMetrics
 		*out = new(bool)

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -129,6 +129,11 @@ func (p *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *c
 		return nil
 	}
 
+	if p.args.DisableFilterWhenHighLoad != nil && *p.args.DisableFilterWhenHighLoad {
+		klog.V(4).Infof("LoadAwareScheduling filter is disabled for node %s", node.Name)
+		return nil
+	}
+
 	nodeMetric, err := p.nodeMetricLister.Get(node.Name)
 	if err != nil {
 		// For nodes that lack load information, fall back to the situation where there is no load-aware scheduling.


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->


- Add new config field `DisableFilterWhenHighLoad` to `LoadAwareSchedulingArgs`
When enabled, the plugin skips node resource usage filtering during scheduling
This is useful in high-load scenarios where strict filtering may block scheduling




### Ⅱ. Does this pull request fix one issue?

fixes: https://github.com/koordinator-sh/koordinator/issues/2538

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
