### PR TITLE
scheduler: fix missing Unreserve when ResizePod=true

### DIFF
--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -199,7 +199,7 @@ type ReservationScoreExtensions interface {
 	NormalizeReservationScore(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, scores ReservationScoreList) *framework.Status
 }
 
-// ResizePodPlugin is an interface that resize the pod resource spec after reserve.
+// ResizePodPlugin is an interface that resize the pod resource spec before the Assume phase.
 // If you want to use the feature, must enable the feature gate ResizePod=true
 type ResizePodPlugin interface {
 	framework.Plugin


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix a bug when the feature ResizePod is enabled, the scheduler may miss the Unreserve when it fails to AssumePod.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
