### PR TITLE
fix: podGroup not add to queue when pg not fount in PodGroupController's syncHandler

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup.go
@@ -204,7 +204,7 @@ func (ctrl *PodGroupController) syncHandler(key string) error {
 		return nil
 	}
 	defer func() {
-		if err != nil {
+		if err != nil && !apierrs.IsNotFound(err) {
 			ctrl.pgQueue.AddRateLimited(key)
 			return
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

fix: podGroup not add to queue when pg not fount in PodGroupController's syncHandler

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes https://github.com/koordinator-sh/koordinator/issues/2563

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
