### PR TITLE
scheduler: Reservation skips fitsNode to deduplicate with NodeResourceFit

### DIFF
--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -70,6 +70,12 @@ const (
 	// OmitNodeLabelsForReservation is used to omit node labels while matching reservation affinity.
 	OmitNodeLabelsForReservation featuregate.Feature = "OmitNodeLabelsForReservation"
 
+	// owner: @saintube @ZiMengSheng
+	// alpha: v1.7
+	//
+	// SkipReservationFitsNode is used to skip reservation fits node when the logic is repeated by NodeResourceFits.
+	SkipReservationFitsNode featuregate.Feature = "SkipReservationFitsNode"
+
 	// owner: @zqzten
 	// alpha: v1.7
 	//
@@ -98,6 +104,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	SupportParentQuotaSubmitPod:               {Default: false, PreRelease: featuregate.Alpha},
 	LazyReservationRestore:                    {Default: false, PreRelease: featuregate.Alpha},
 	OmitNodeLabelsForReservation:              {Default: false, PreRelease: featuregate.Alpha},
+	SkipReservationFitsNode:                   {Default: false, PreRelease: featuregate.Alpha},
 	DevicePluginAdaption:                      {Default: false, PreRelease: featuregate.Alpha},
 	CSIStorageCapacity:                        {Default: true, PreRelease: featuregate.GA}, // remove in 1.26
 	GenericEphemeralVolume:                    {Default: true, PreRelease: featuregate.GA},

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -85,14 +85,15 @@ var (
 )
 
 type Plugin struct {
-	handle                       frameworkext.ExtendedHandle
-	args                         *config.ReservationArgs
-	rLister                      listerschedulingv1alpha1.ReservationLister
-	client                       clientschedulingv1alpha1.SchedulingV1alpha1Interface
-	reservationCache             *reservationCache
-	nominator                    *nominator
-	preemptionMgr                *PreemptionMgr
-	enableLazyReservationRestore bool
+	handle                        frameworkext.ExtendedHandle
+	args                          *config.ReservationArgs
+	rLister                       listerschedulingv1alpha1.ReservationLister
+	client                        clientschedulingv1alpha1.SchedulingV1alpha1Interface
+	reservationCache              *reservationCache
+	nominator                     *nominator
+	preemptionMgr                 *PreemptionMgr
+	enableLazyReservationRestore  bool
+	enableSkipReservationFitsNode bool
 }
 
 func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -123,13 +124,14 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	frameworkext.SetReservationCache(cache)
 
 	p := &Plugin{
-		handle:                       extendedHandle,
-		args:                         pluginArgs,
-		rLister:                      reservationLister,
-		client:                       extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
-		reservationCache:             cache,
-		nominator:                    nm,
-		enableLazyReservationRestore: k8sfeature.DefaultFeatureGate.Enabled(features.LazyReservationRestore),
+		handle:                        extendedHandle,
+		args:                          pluginArgs,
+		rLister:                       reservationLister,
+		client:                        extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
+		reservationCache:              cache,
+		nominator:                     nm,
+		enableLazyReservationRestore:  k8sfeature.DefaultFeatureGate.Enabled(features.LazyReservationRestore),
+		enableSkipReservationFitsNode: k8sfeature.DefaultFeatureGate.Enabled(features.SkipReservationFitsNode),
 	}
 
 	if pluginArgs.EnablePreemption {
@@ -363,6 +365,9 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 	nodeRState := state.nodeReservationStates[node.Name]
 	podRequestsResourceNames := quotav1.ResourceNames(state.podRequests)
 
+	// Contextualization: If a pod only have one reservation matched, the fitsNode should be equivalent to
+	// the NodeResourceFit's Filter, so we can skip the fitsNode to reduce overhead.
+	isFitsNodeSkipped := pl.enableSkipReservationFitsNode && len(matchedReservations) <= 1
 	allInsufficientResourcesByNode := sets.NewString()
 	var allInsufficientResourceReasonsByReservation []string
 	for _, rInfo := range matchedReservations {
@@ -383,23 +388,26 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 		preemptibleInRR := state.preemptibleInRRs[node.Name][rInfo.UID()]
 		preemptible := framework.NewResource(preemptibleInRR)
 		preemptible.Add(state.preemptible[node.Name])
-		insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo, nodeRState, rInfo, preemptible)
-		if len(insufficientResourcesByNode) > 0 && klog.V(5).Enabled() {
-			var podRequested framework.Resource
-			if nodeRState.podRequested != nil {
-				podRequested = *nodeRState.podRequested
-			}
-			var rAllocated framework.Resource
-			if nodeRState.rAllocated != nil {
-				rAllocated = *nodeRState.rAllocated
-			}
-			klog.V(5).Infof("node %s doesn't have sufficient resources: %+v for pod: %s/%s, nodeRState.PodRequested: %+v, rAllocated: %+v, rInfo.Allocatable: %+v, rInfo.Allocated: %+v, rInfo.Reserved: %+v, preemptible: %+v",
-				node.Name, insufficientResourcesByNode, pod.Namespace, pod.Name, podRequested, rAllocated, rInfo.Allocatable, rInfo.Allocated, rInfo.Reserved, preemptible)
-		}
 		state.preemptLock.RUnlock()
 
-		nodeFits := len(insufficientResourcesByNode) <= 0
-		allInsufficientResourcesByNode.Insert(insufficientResourcesByNode...)
+		nodeFits := true
+		if !isFitsNodeSkipped {
+			insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo, nodeRState, rInfo, preemptible)
+			if len(insufficientResourcesByNode) > 0 && klog.V(5).Enabled() {
+				var podRequested framework.Resource
+				if nodeRState.podRequested != nil {
+					podRequested = *nodeRState.podRequested
+				}
+				var rAllocated framework.Resource
+				if nodeRState.rAllocated != nil {
+					rAllocated = *nodeRState.rAllocated
+				}
+				klog.V(5).Infof("node %s doesn't have sufficient resources: %+v for pod: %s/%s, nodeRState.PodRequested: %+v, rAllocated: %+v, rInfo.Allocatable: %+v, rInfo.Allocated: %+v, rInfo.Reserved: %+v, preemptible: %+v",
+					node.Name, insufficientResourcesByNode, pod.Namespace, pod.Name, podRequested, rAllocated, rInfo.Allocatable, rInfo.Allocated, rInfo.Reserved, preemptible)
+			}
+			nodeFits = len(insufficientResourcesByNode) <= 0
+			allInsufficientResourcesByNode.Insert(insufficientResourcesByNode...)
+		}
 
 		reservationFits := false
 		allocatePolicy := rInfo.GetAllocatePolicy()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Add the feature-gate SkipReservationFitsNode to improve performance when the Reservation's fitsNode duplicates the Filter of the NodeResourceFit plugin.
  - Revise some minor issues.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
