### PR TITLE
scheduler: during scheduling, it must consider whether hami-core is installed on the nodes

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -321,6 +321,11 @@ func (p *Plugin) Filter(ctx context.Context, cycleState *framework.CycleState, p
 		return framework.NewStatus(framework.Error, "node not found")
 	}
 
+	if state.gpuRequirements != nil && state.gpuRequirements.gpuShared &&
+		pod.Labels != nil && pod.Labels[apiext.LabelGPUIsolationProvider] != "" &&
+		pod.Labels[apiext.LabelGPUIsolationProvider] != node.Labels[apiext.LabelGPUIsolationProvider] {
+		return framework.NewStatus(framework.Error, "GPUIsolationProviderHAMICore not found on the node")
+	}
 	store := topologymanager.GetStore(cycleState)
 	_, ok := store.GetAffinity(node.Name)
 	if ok {


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
During scheduling, it must consider whether hami-core is installed on the nodes.

Note: When installing hami-core, you must set the node affinity label to koordinator.sh/gpu-isolation-provider=HAMi-core.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fix: https://github.com/koordinator-sh/koordinator/issues/2548

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
