### PR TITLE
all: provides vGPU allocation and utilization metrics

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -66,6 +66,7 @@ const (
 	LabelSecondaryDeviceWellPlanned string = NodeDomainPrefix + "/secondary-device-well-planned"
 
 	LabelGPUIsolationProvider = DomainPrefix + "gpu-isolation-provider"
+	LabelHAMIVGPUNodeName     = "hami.io/vgpu-node"
 )
 
 const (

--- a/config/manager/koordlet.yaml
+++ b/config/manager/koordlet.yaml
@@ -95,6 +95,8 @@ spec:
             - mountPath: /var/run/koordlet/xpu-device-infos/
               mountPropagation: Bidirectional
               name: xpu-device-infos
+            - mountPath: /usr/local/vgpu/containers
+              name: host-vgpu-containers
       hostNetwork: true
       hostPID: true
       restartPolicy: Always
@@ -162,3 +164,7 @@ spec:
             path: /var/run/koordlet/xpu-device-infos/
             type: DirectoryOrCreate
           name: xpu-device-infos
+        - hostPath:
+            path: /usr/local/vgpu/containers
+            type: DirectoryOrCreate
+          name: host-vgpu-containers

--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -160,6 +160,12 @@ const (
 	// PodResourcesProxy enabled hooked podResources of kubelet provided by koordlet.
 	// It provides a grpc service to enable discovery of pod resources allocated by koordinator system.
 	PodResourcesProxy featuregate.Feature = "PodResourcesProxy"
+
+	// owner: @qinfustu
+	// alpha v1.7
+	//
+	// HamiCoreVGPUMonitor enables the vGPU monitoring for HAMi-core.
+	HamiCoreVGPUMonitor featuregate.Feature = "HamiCoreVGPUMonitor"
 )
 
 func init() {
@@ -192,6 +198,7 @@ var (
 		ColdPageCollector:      {Default: false, PreRelease: featuregate.Alpha},
 		HugePageReport:         {Default: false, PreRelease: featuregate.Alpha},
 		PodResourcesProxy:      {Default: false, PreRelease: featuregate.Alpha},
+		HamiCoreVGPUMonitor:    {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/scheduler/frameworkext/schedule_diagnosis.go
+++ b/pkg/scheduler/frameworkext/schedule_diagnosis.go
@@ -87,20 +87,6 @@ func DumpDiagnosis(state *framework.CycleState) string {
 			sort.Slice(scheduleFailedDetails, func(i, j int) bool { return scheduleFailedDetails[i].NodeName < scheduleFailedDetails[j].NodeName })
 			diagnosis.ScheduleDiagnosis.NodeFailedDetails = scheduleFailedDetails
 		}
-		if len(diagnosis.PreemptionDiagnosis.NodeFailedDetails) == 0 {
-			var preemptFailedDetails []v1alpha1.NodeFailedDetail
-			for s, status := range diagnosis.PreemptionDiagnosis.NodeToStatusMap {
-				preemptFailedDetails = append(preemptFailedDetails, v1alpha1.NodeFailedDetail{
-					NodeName:         s,
-					FailedPlugin:     status.FailedPlugin(),
-					Reason:           status.Message(),
-					NominatedPods:    nil,
-					PreemptMightHelp: status.Code() != framework.UnschedulableAndUnresolvable,
-				})
-			}
-			sort.Slice(preemptFailedDetails, func(i, j int) bool { return preemptFailedDetails[i].NodeName < preemptFailedDetails[j].NodeName })
-			diagnosis.PreemptionDiagnosis.NodeFailedDetails = preemptFailedDetails
-		}
 		dumpMessage = util.DumpJSON(diagnosis)
 		klog.Infof("dump diagnosis for %s/%s/%s: %s", diagnosis.TargetPod.Namespace, diagnosis.TargetPod.Name, diagnosis.TargetPod.UID, dumpMessage)
 		// TODO export it to APIServer asynchronously
@@ -151,12 +137,8 @@ type Diagnosis struct {
 	PreFilterMessage     string      `json:"preFilterMessage,omitempty"`
 	TopologyKeyToExplain string      `json:"topologyKeyToExplain,omitempty"`
 	// maybe modify framework.Status to cover addedNominatedPods, corresponding resourceView(such as requested and total) when failed
-	ScheduleDiagnosis ScheduleDiagnosis `json:"scheduleDiagnosis"`
-	// NodePossibleVictims indicates the possible victims for members that can't be scheduled.
-	NodePossibleVictims []v1alpha1.NodePossibleVictim `json:"nodePossibleVictims,omitempty"`
-	PreemptionDiagnosis ScheduleDiagnosis             `json:"preemptionDiagnosis"`
-	NominatedPodToNodes map[string]string             `json:"nominatedPodToNodes,omitempty"`
-	ToRemoveVictims     []v1alpha1.PossibleVictim     `json:"toRemoveVictims,omitempty"`
+	ScheduleDiagnosis   ScheduleDiagnosis `json:"scheduleDiagnosis"`
+	PreemptionDiagnosis interface{}       `json:"preemptionDiagnosis"`
 }
 
 type ScheduleDiagnosis struct {

--- a/pkg/scheduler/frameworkext/schedule_diagnosis_test.go
+++ b/pkg/scheduler/frameworkext/schedule_diagnosis_test.go
@@ -66,8 +66,15 @@ func TestDumpDiagnosis(t *testing.T) {
 				}
 				diagnosis.ScheduleDiagnosis.AlreadyWaitForBound = 1
 				diagnosis.ScheduleDiagnosis.SchedulingMode = PodSchedulingMode
+				diagnosis.PreemptionDiagnosis = struct {
+					TriggerPodKey string `json:"TriggerPodKey,omitempty"`
+					PreemptorKey  string `json:"preemptorKey,omitempty"`
+				}{
+					TriggerPodKey: "default/test-pod",
+					PreemptorKey:  "default/test-pod",
+				}
 			},
-			wantDumpMessage: `{"timestamp":null,"questionedKey":"default/test-pod","nominatedNode":"nominatedNode","preFilterMessage":"preFilterMessage","topologyKeyToExplain":"topologyKeyToExplain","scheduleDiagnosis":{"schedulingMode":"Pod","alreadyWaitForBound":1,"nodeOfferSlot":{"node1":1,"node2":2},"nodeFailedDetails":[{"nodeName":"node1","preemptMightHelp":true},{"nodeName":"node2","reason":"node2-reason","preemptMightHelp":true}]},"preemptionDiagnosis":{}}`,
+			wantDumpMessage: `{"timestamp":null,"questionedKey":"default/test-pod","nominatedNode":"nominatedNode","preFilterMessage":"preFilterMessage","topologyKeyToExplain":"topologyKeyToExplain","scheduleDiagnosis":{"schedulingMode":"Pod","alreadyWaitForBound":1,"nodeOfferSlot":{"node1":1,"node2":2},"nodeFailedDetails":[{"nodeName":"node1","preemptMightHelp":true},{"nodeName":"node2","reason":"node2-reason","preemptMightHelp":true}]},"preemptionDiagnosis":{"TriggerPodKey":"default/test-pod","preemptorKey":"default/test-pod"}}`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
@@ -803,13 +803,62 @@ func TestPlugin_adaptForDevicePlugin(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
-						AnnotationGPUMinors:     "0",
 					},
 				},
 			},
 			wantNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+				},
+			},
+		},
+		{
+			name: "hami-core",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+						},
+						Annotations: map[string]string{},
+					},
+				},
+				allocationResult: apiext.DeviceAllocations{
+					schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+						{Minor: 0},
+					},
+				},
+				nodeName: "hami-core",
+			},
+			device: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hami-core",
+					Labels: map[string]string{
+						apiext.LabelGPUVendor: apiext.GPUVendorNVIDIA,
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hami-core",
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+						apiext.LabelHAMIVGPUNodeName:     "hami-core",
+					},
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationGPUMinors:     "0",
+					},
+				},
+			},
+			wantNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hami-core",
 				},
 			},
 		},

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -4765,6 +4765,42 @@ func Test_Plugin_PreBind(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "has the LabelGPUIsolationProvider label",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+						},
+					},
+				},
+
+				state: &preFilterState{
+					skip: false,
+					allocationResult: apiext.DeviceAllocations{
+						schedulingv1alpha1.GPU: {
+							{Minor: 0},
+						},
+					},
+				},
+			},
+			deviceCR:                           fakeDeviceCR,
+			devicePluginAdaptionFeatureEnabled: true,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apiext.LabelHAMIVGPUNodeName:     "test-node-1",
+						apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+					},
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":0,"resources":null,"id":"GPU-8c25ea37-2909-6e62-b7bf-e2fcadebea8d"}]}`,
+						AnnotationBindTimestamp:          strconv.FormatInt(now.UnixNano(), 10),
+						AnnotationGPUMinors:              "0",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Provides vGPU allocation and utilization metrics.

This only enables the configuration for hami-core to correctly export vGPU allocation and utilization to the node's /usr/local/vgpu directory. The vGPUMonitor component from hami-device-plugin needs to be integrated into the hami-core pod. vGPUMonitor will convert vGPU allocation and utilization into metrics. Detailed configuration will be documented.

doc：[Integrate the vGPUMonitor provided by HAMi into hami-core-distribute](https://github.com/koordinator-sh/website/pull/228)
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fix: https://github.com/koordinator-sh/koordinator/issues/2560
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
