### PR TITLE
chore: fix typo for RegisterTypeNodeMetadata

### DIFF
--- a/pkg/koordlet/statesinformer/api.go
+++ b/pkg/koordlet/statesinformer/api.go
@@ -94,7 +94,7 @@ func (r RegisterType) String() string {
 	case RegisterTypeNodeTopology:
 		return "RegisterTypeNodeTopology"
 	case RegisterTypeNodeMetadata:
-		return "RegisterNodeMetadata"
+		return "RegisterTypeNodeMetadata"
 	default:
 		return "RegisterTypeUnknown"
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Unified prefix for registertype enumeration values, fix RegisterNodeMetadata to RegisterTypeNodeMetadata

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
