### PR TITLE
scheduler: preprocess unmatch reservation's allocated

### DIFF
--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -17,6 +17,8 @@ limitations under the License.
 package frameworkext
 
 import (
+	"sort"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +30,7 @@ import (
 	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -37,18 +40,21 @@ import (
 )
 
 type ReservationInfo struct {
-	Reservation      *schedulingv1alpha1.Reservation
-	Pod              *corev1.Pod
-	ResourceNames    []corev1.ResourceName
-	Allocatable      corev1.ResourceList // RO
-	Allocated        corev1.ResourceList // RO
-	Reserved         corev1.ResourceList // reserved inside the reservation
-	Available        *framework.Resource // Allocatable - Reserved - Allocated
-	AllocatablePorts framework.HostPortInfo
-	AllocatedPorts   framework.HostPortInfo
-	AssignedPods     map[types.UID]*PodRequirement
-	OwnerMatchers    []reservationutil.ReservationOwnerMatcher
-	ParseError       error
+	Reservation           *schedulingv1alpha1.Reservation
+	Pod                   *corev1.Pod
+	ResourceNames         []corev1.ResourceName
+	Allocatable           corev1.ResourceList // RO
+	Allocated             corev1.ResourceList // RO
+	Reserved              corev1.ResourceList // reserved inside the reservation
+	Available             *framework.Resource // pre-calculated info: Allocatable - Reserved - Allocated
+	AllocatedResource     *framework.Resource // pre-calculated info: Allocated
+	Non0AllocatedMilliCPU int64               // pre-calculated info: non-zero milli-CPU of Allocated
+	Non0AllocatedMem      int64               // pre-calculated info: non-zero Memory of Allocated
+	AllocatablePorts      framework.HostPortInfo
+	AllocatedPorts        framework.HostPortInfo
+	AssignedPods          map[types.UID]*PodRequirement
+	OwnerMatchers         []reservationutil.ReservationOwnerMatcher
+	ParseError            error
 }
 
 type PodRequirement struct {
@@ -86,6 +92,9 @@ func NewReservationInfo(r *schedulingv1alpha1.Reservation) *ReservationInfo {
 	allocatable := reservationutil.ReservationRequests(r)
 	reserved := util.GetNodeReservationFromAnnotation(r.Annotations)
 	resourceNames := quotav1.ResourceNames(allocatable)
+	sort.Slice(resourceNames, func(i, j int) bool {
+		return resourceNames[i] < resourceNames[j]
+	})
 	if r.Spec.AllocatePolicy == schedulingv1alpha1.ReservationAllocatePolicyRestricted {
 		options, err := apiext.GetReservationRestrictedOptions(r.Annotations)
 		if err == nil {
@@ -126,6 +135,9 @@ func NewReservationInfoFromPod(pod *corev1.Pod) *ReservationInfo {
 	allocatable := resource.PodRequests(pod, resource.PodResourcesOptions{})
 	reserved := util.GetNodeReservationFromAnnotation(pod.Annotations)
 	resourceNames := quotav1.ResourceNames(allocatable)
+	sort.Slice(resourceNames, func(i, j int) bool {
+		return resourceNames[i] < resourceNames[j]
+	})
 	options, err := apiext.GetReservationRestrictedOptions(pod.Annotations)
 	if err == nil {
 		resourceNames = reservationutil.GetReservationRestrictedResources(resourceNames, options)
@@ -355,18 +367,21 @@ func (ri *ReservationInfo) Clone() *ReservationInfo {
 
 	// use a shallow copy to reduce overhead
 	return &ReservationInfo{
-		Reservation:      ri.Reservation,
-		Pod:              ri.Pod,
-		ResourceNames:    resourceNames,
-		Allocatable:      ri.Allocatable,
-		Allocated:        ri.Allocated,
-		Reserved:         ri.Reserved,
-		Available:        ri.Available,
-		AllocatablePorts: util.CloneHostPorts(ri.AllocatablePorts),
-		AllocatedPorts:   util.CloneHostPorts(ri.AllocatedPorts),
-		AssignedPods:     assignedPods,
-		OwnerMatchers:    ri.OwnerMatchers,
-		ParseError:       ri.ParseError,
+		Reservation:           ri.Reservation,
+		Pod:                   ri.Pod,
+		ResourceNames:         resourceNames,
+		Allocatable:           ri.Allocatable,
+		Allocated:             ri.Allocated,
+		Reserved:              ri.Reserved,
+		Available:             ri.Available,
+		AllocatedResource:     ri.AllocatedResource,
+		Non0AllocatedMilliCPU: ri.Non0AllocatedMilliCPU,
+		Non0AllocatedMem:      ri.Non0AllocatedMem,
+		AllocatablePorts:      util.CloneHostPorts(ri.AllocatablePorts),
+		AllocatedPorts:        util.CloneHostPorts(ri.AllocatedPorts),
+		AssignedPods:          assignedPods,
+		OwnerMatchers:         ri.OwnerMatchers,
+		ParseError:            ri.ParseError,
 	}
 }
 
@@ -382,6 +397,9 @@ func (ri *ReservationInfo) UpdateReservation(r *schedulingv1alpha1.Reservation) 
 			parseErrors = append(parseErrors, err)
 		}
 	}
+	sort.Slice(resourceNames, func(i, j int) bool {
+		return resourceNames[i] < resourceNames[j]
+	})
 	ri.ResourceNames = resourceNames
 
 	ri.Reservation = r
@@ -395,7 +413,7 @@ func (ri *ReservationInfo) UpdateReservation(r *schedulingv1alpha1.Reservation) 
 		reserved = quotav1.Mask(reserved, ri.ResourceNames)
 	}
 	ri.Reserved = reserved
-	ri.RefreshAvailable()
+	ri.RefreshPreCalculated()
 
 	ownerMatchers, err := reservationutil.ParseReservationOwnerMatchers(r.Spec.Owners)
 	if err != nil {
@@ -421,6 +439,9 @@ func (ri *ReservationInfo) UpdatePod(pod *corev1.Pod) {
 	} else {
 		parseErrors = append(parseErrors, err)
 	}
+	sort.Slice(resourceNames, func(i, j int) bool {
+		return resourceNames[i] < resourceNames[j]
+	})
 	ri.ResourceNames = resourceNames
 
 	ri.Pod = pod
@@ -431,7 +452,7 @@ func (ri *ReservationInfo) UpdatePod(pod *corev1.Pod) {
 		reserved = quotav1.Mask(reserved, ri.ResourceNames)
 	}
 	ri.Reserved = reserved
-	ri.RefreshAvailable()
+	ri.RefreshPreCalculated()
 
 	owners, err := apiext.GetReservationOwners(pod.Annotations)
 	if err != nil {
@@ -463,14 +484,14 @@ func (ri *ReservationInfo) AddAssignedPod(pod *corev1.Pod) {
 	ri.Allocated = quotav1.Add(ri.Allocated, quotav1.Mask(requirement.Requests, ri.ResourceNames))
 	ri.AllocatedPorts = util.AppendHostPorts(ri.AllocatedPorts, requirement.Ports)
 	ri.AssignedPods[pod.UID] = requirement
-	ri.RefreshAvailable()
+	ri.RefreshPreCalculated()
 }
 
 func (ri *ReservationInfo) RemoveAssignedPod(pod *corev1.Pod) {
 	if requirement, ok := ri.AssignedPods[pod.UID]; ok {
 		if len(requirement.Requests) > 0 {
 			ri.Allocated = quotav1.SubtractWithNonNegativeResult(ri.Allocated, quotav1.Mask(requirement.Requests, ri.ResourceNames))
-			ri.RefreshAvailable()
+			ri.RefreshPreCalculated()
 		}
 		if len(requirement.Ports) > 0 {
 			util.RemoveHostPorts(ri.AllocatedPorts, requirement.Ports)
@@ -480,15 +501,30 @@ func (ri *ReservationInfo) RemoveAssignedPod(pod *corev1.Pod) {
 	}
 }
 
-func (ri *ReservationInfo) RefreshAvailable() {
+func (ri *ReservationInfo) RefreshPreCalculated() {
 	// Reservation available = Allocatable - Allocated - InnerReserved
 	resources := quotav1.SubtractWithNonNegativeResult(quotav1.Subtract(ri.Allocatable, ri.Allocated), ri.Reserved)
 	ri.Available = framework.NewResource(resources)
+	allocatedResource := framework.NewResource(ri.Allocated)
+	ri.AllocatedResource = allocatedResource
+	if ri.Allocated != nil {
+		non0MilliCPU, non0Mem := schedutil.GetNonzeroRequests(&ri.Allocated)
+		ri.Non0AllocatedMilliCPU, ri.Non0AllocatedMem = non0MilliCPU, non0Mem
+	} else {
+		ri.Non0AllocatedMilliCPU, ri.Non0AllocatedMem = 0, 0
+	}
 }
 
 func (ri *ReservationInfo) GetAvailable() *framework.Resource {
 	if ri.Available == nil {
-		ri.RefreshAvailable()
+		ri.RefreshPreCalculated()
 	}
 	return ri.Available
+}
+
+func (ri *ReservationInfo) GetAllocatedResource() (*framework.Resource, int64, int64) {
+	if ri.AllocatedResource == nil {
+		ri.RefreshPreCalculated()
+	}
+	return ri.AllocatedResource, ri.Non0AllocatedMilliCPU, ri.Non0AllocatedMem
 }

--- a/pkg/scheduler/frameworkext/reservation_info_test.go
+++ b/pkg/scheduler/frameworkext/reservation_info_test.go
@@ -18,7 +18,6 @@ package frameworkext
 
 import (
 	"encoding/json"
-	"sort"
 	"testing"
 	"time"
 
@@ -29,11 +28,139 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/utils/pointer"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
+
+func TestReservationInfo(t *testing.T) {
+	testRestrictedReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-r",
+			UID:  "123456",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			AllocateOnce:   pointer.Bool(false),
+		},
+	}
+	testOwnerMatcher, err := reservationutil.ParseReservationOwnerMatchers(testRestrictedReservation.Spec.Owners)
+	assert.NoError(t, err)
+	testInvalidReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-r",
+			UID:  "123456",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "foo",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   nil,
+							},
+						},
+					},
+				},
+			},
+			AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			AllocateOnce:   pointer.Bool(false),
+		},
+	}
+	_, testParseInvalidOwnerErr := reservationutil.ParseReservationOwnerMatchers(testInvalidReservation.Spec.Owners)
+	tests := []struct {
+		name string
+		r    *schedulingv1alpha1.Reservation
+		want *ReservationInfo
+	}{
+		{
+			name: "normal restricted reservation",
+			r:    testRestrictedReservation,
+			want: &ReservationInfo{
+				Reservation: testRestrictedReservation,
+				Pod:         reservationutil.NewReservePod(testRestrictedReservation),
+				ResourceNames: []corev1.ResourceName{
+					corev1.ResourceCPU,
+					corev1.ResourceMemory,
+				},
+				Allocatable:      reservationutil.ReservationRequests(testRestrictedReservation),
+				AllocatablePorts: util.RequestedHostPorts(reservationutil.NewReservePod(testRestrictedReservation)),
+				AssignedPods:     map[types.UID]*PodRequirement{},
+				OwnerMatchers:    testOwnerMatcher,
+			},
+		},
+		{
+			name: "parse error for invalid reservation",
+			r:    testInvalidReservation,
+			want: &ReservationInfo{
+				Reservation: testInvalidReservation,
+				Pod:         reservationutil.NewReservePod(testInvalidReservation),
+				ResourceNames: []corev1.ResourceName{
+					corev1.ResourceCPU,
+					corev1.ResourceMemory,
+				},
+				Allocatable:      reservationutil.ReservationRequests(testInvalidReservation),
+				AllocatablePorts: util.RequestedHostPorts(reservationutil.NewReservePod(testInvalidReservation)),
+				AssignedPods:     map[types.UID]*PodRequirement{},
+				OwnerMatchers:    nil,
+				ParseError:       utilerrors.NewAggregate([]error{testParseInvalidOwnerErr}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewReservationInfo(tt.r)
+			assert.Equal(t, tt.want, got)
+			got1 := got.Clone()
+			assert.Equal(t, tt.want, got1)
+		})
+	}
+}
 
 func TestIsAvailable(t *testing.T) {
 	tests := []struct {
@@ -384,12 +511,13 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 			reservation:    reservation,
 			newReservation: reservation,
 			want: &ReservationInfo{
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: ownerMatchers,
-				ParseError:    parseError,
+				ResourceNames:     []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:       allocatable.DeepCopy(),
+				Available:         framework.NewResource(allocatable),
+				AllocatedResource: &framework.Resource{},
+				AssignedPods:      map[types.UID]*PodRequirement{},
+				OwnerMatchers:     ownerMatchers,
+				ParseError:        parseError,
 			},
 		},
 		{
@@ -407,10 +535,11 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 				return r
 			}(),
 			want: &ReservationInfo{
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
+				ResourceNames:     []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:       allocatable.DeepCopy(),
+				Available:         framework.NewResource(allocatable),
+				AllocatedResource: &framework.Resource{},
+				AssignedPods:      map[types.UID]*PodRequirement{},
 				OwnerMatchers: func() []reservationutil.ReservationOwnerMatcher {
 					m, _ := reservationutil.ParseReservationOwnerMatchers([]schedulingv1alpha1.ReservationOwner{
 						{
@@ -444,11 +573,12 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 				return r
 			}(),
 			want: &ReservationInfo{
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: nil,
+				ResourceNames:     []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:       allocatable.DeepCopy(),
+				Available:         framework.NewResource(allocatable),
+				AllocatedResource: &framework.Resource{},
+				AssignedPods:      map[types.UID]*PodRequirement{},
+				OwnerMatchers:     nil,
 				ParseError: func() error {
 					_, err := reservationutil.ParseReservationOwnerMatchers([]schedulingv1alpha1.ReservationOwner{
 						{
@@ -487,9 +617,10 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 					MilliCPU: 8000,
 					Memory:   16 * 1024 * 1024 * 1024,
 				},
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: ownerMatchers,
-				ParseError:    nil,
+				AllocatedResource: &framework.Resource{},
+				AssignedPods:      map[types.UID]*PodRequirement{},
+				OwnerMatchers:     ownerMatchers,
+				ParseError:        nil,
 			},
 		},
 		{
@@ -513,9 +644,10 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 					MilliCPU: 3000,
 					Memory:   8 * 1024 * 1024 * 1024,
 				},
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: ownerMatchers,
-				ParseError:    nil,
+				AllocatedResource: &framework.Resource{},
+				AssignedPods:      map[types.UID]*PodRequirement{},
+				OwnerMatchers:     ownerMatchers,
+				ParseError:        nil,
 			},
 		},
 	}
@@ -523,12 +655,6 @@ func TestReservationInfoUpdateReservation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reservationInfo := NewReservationInfo(tt.reservation)
 			reservationInfo.UpdateReservation(tt.newReservation)
-			sort.Slice(reservationInfo.ResourceNames, func(i, j int) bool {
-				return reservationInfo.ResourceNames[i] < reservationInfo.ResourceNames[j]
-			})
-			sort.Slice(tt.want.ResourceNames, func(i, j int) bool {
-				return tt.want.ResourceNames[i] < tt.want.ResourceNames[j]
-			})
 			tt.want.Reservation = tt.newReservation
 			tt.want.Pod = reservationutil.NewReservePod(tt.newReservation)
 			assert.Equal(t, tt.want, reservationInfo)
@@ -581,14 +707,17 @@ func TestReservationInfoUpdatePod(t *testing.T) {
 			pod:    pod,
 			newPod: pod,
 			want: &ReservationInfo{
-				Pod:           pod,
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: ownerMatchers,
-				ParseError:    parseError,
+				Pod:                   pod,
+				ResourceNames:         []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:           allocatable.DeepCopy(),
+				Allocated:             corev1.ResourceList{},
+				Available:             framework.NewResource(allocatable),
+				AllocatedResource:     &framework.Resource{},
+				Non0AllocatedMilliCPU: schedutil.DefaultMilliCPURequest,
+				Non0AllocatedMem:      schedutil.DefaultMemoryRequest,
+				AssignedPods:          map[types.UID]*PodRequirement{},
+				OwnerMatchers:         ownerMatchers,
+				ParseError:            parseError,
 			},
 		},
 		{
@@ -606,11 +735,14 @@ func TestReservationInfoUpdatePod(t *testing.T) {
 				return p
 			}(),
 			want: &ReservationInfo{
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
+				ResourceNames:         []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:           allocatable.DeepCopy(),
+				Allocated:             corev1.ResourceList{},
+				Available:             framework.NewResource(allocatable),
+				AllocatedResource:     &framework.Resource{},
+				Non0AllocatedMilliCPU: schedutil.DefaultMilliCPURequest,
+				Non0AllocatedMem:      schedutil.DefaultMemoryRequest,
+				AssignedPods:          map[types.UID]*PodRequirement{},
 				OwnerMatchers: func() []reservationutil.ReservationOwnerMatcher {
 					m, _ := reservationutil.ParseReservationOwnerMatchers([]schedulingv1alpha1.ReservationOwner{
 						{
@@ -644,12 +776,15 @@ func TestReservationInfoUpdatePod(t *testing.T) {
 				return p
 			}(),
 			want: &ReservationInfo{
-				ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-				Allocatable:   allocatable.DeepCopy(),
-				Allocated:     corev1.ResourceList{},
-				Available:     framework.NewResource(allocatable),
-				AssignedPods:  map[types.UID]*PodRequirement{},
-				OwnerMatchers: nil,
+				ResourceNames:         []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Allocatable:           allocatable.DeepCopy(),
+				Allocated:             corev1.ResourceList{},
+				Available:             framework.NewResource(allocatable),
+				AllocatedResource:     &framework.Resource{},
+				Non0AllocatedMilliCPU: schedutil.DefaultMilliCPURequest,
+				Non0AllocatedMem:      schedutil.DefaultMemoryRequest,
+				AssignedPods:          map[types.UID]*PodRequirement{},
+				OwnerMatchers:         nil,
 				ParseError: func() error {
 					_, err := reservationutil.ParseReservationOwnerMatchers([]schedulingv1alpha1.ReservationOwner{
 						{
@@ -672,12 +807,6 @@ func TestReservationInfoUpdatePod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reservationInfo := NewReservationInfoFromPod(tt.pod)
 			reservationInfo.UpdatePod(tt.newPod)
-			sort.Slice(reservationInfo.ResourceNames, func(i, j int) bool {
-				return reservationInfo.ResourceNames[i] < reservationInfo.ResourceNames[j]
-			})
-			sort.Slice(tt.want.ResourceNames, func(i, j int) bool {
-				return tt.want.ResourceNames[i] < tt.want.ResourceNames[j]
-			})
 			tt.want.Pod = tt.newPod
 			assert.Equal(t, tt.want, reservationInfo)
 		})
@@ -775,6 +904,12 @@ func TestReservationInfoRefreshAvailable(t *testing.T) {
 					apiext.ResourceNvidiaGPU: 1,
 				},
 			},
+			AllocatedResource: &framework.Resource{
+				MilliCPU: 1000,
+				Memory:   4 * 1024 * 1024 * 1024,
+			},
+			Non0AllocatedMilliCPU: 1000,
+			Non0AllocatedMem:      4 * 1024 * 1024 * 1024,
 			AssignedPods: map[types.UID]*PodRequirement{
 				testPod.UID: {
 					Namespace: testPod.Namespace,
@@ -786,13 +921,52 @@ func TestReservationInfoRefreshAvailable(t *testing.T) {
 			OwnerMatchers: ownerMatchers,
 			ParseError:    nil,
 		}
+		expectedRInfo1 := &ReservationInfo{
+			Reservation:   testReservation,
+			Pod:           reservationutil.NewReservePod(testReservation),
+			ResourceNames: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory, apiext.ResourceNvidiaGPU},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:       resource.MustParse("4"),
+				corev1.ResourceMemory:    resource.MustParse("8Gi"),
+				apiext.ResourceNvidiaGPU: resource.MustParse("1"),
+			},
+			Allocated: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("0"),
+			},
+			Available: &framework.Resource{
+				MilliCPU: 4000,
+				Memory:   8 * 1024 * 1024 * 1024,
+				ScalarResources: map[corev1.ResourceName]int64{
+					apiext.ResourceNvidiaGPU: 1,
+				},
+			},
+			AllocatedResource:     &framework.Resource{},
+			Non0AllocatedMilliCPU: 0,
+			Non0AllocatedMem:      0,
+			AssignedPods:          map[types.UID]*PodRequirement{},
+			OwnerMatchers:         ownerMatchers,
+			ParseError:            nil,
+		}
+
 		rInfo := NewReservationInfo(testReservation)
 		rInfo.AddAssignedPod(testPod)
-		rInfo.RefreshAvailable()
-		sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
-			return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
-		})
+		rInfo.RefreshPreCalculated()
 		assert.Equal(t, expectedRInfo, rInfo)
+		gotAvailable := rInfo.GetAvailable()
+		assert.Equal(t, expectedRInfo.Available, gotAvailable)
+		gotAllocatedResource, gotNon0MilliCPU, gotNon0Mem := rInfo.GetAllocatedResource()
+		assert.Equal(t, expectedRInfo.AllocatedResource, gotAllocatedResource)
+		assert.Equal(t, expectedRInfo.Non0AllocatedMilliCPU, gotNon0MilliCPU)
+		assert.Equal(t, expectedRInfo.Non0AllocatedMem, gotNon0Mem)
+		rInfo.RemoveAssignedPod(testPod)
+		assert.Equal(t, expectedRInfo1, rInfo)
+		gotAvailable = rInfo.GetAvailable()
+		assert.Equal(t, expectedRInfo1.Available, gotAvailable)
+		gotAllocatedResource, gotNon0MilliCPU, gotNon0Mem = rInfo.GetAllocatedResource()
+		assert.Equal(t, expectedRInfo1.AllocatedResource, gotAllocatedResource)
+		assert.Equal(t, expectedRInfo1.Non0AllocatedMilliCPU, gotNon0MilliCPU)
+		assert.Equal(t, expectedRInfo1.Non0AllocatedMem, gotNon0Mem)
 	})
 }
 

--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -73,7 +73,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 	reservationInfos := cache.listAvailableReservationInfosOnNode(reservation.Status.NodeName)
 	assert.Len(t, reservationInfos, 1)
 	rInfo := reservationInfos[0]
-	rInfo.RefreshAvailable()
+	rInfo.RefreshPreCalculated()
 	expectReservationInfo := &frameworkext.ReservationInfo{
 		Reservation: reservation,
 		Pod:         reservationutil.NewReservePod(reservation),
@@ -88,7 +88,7 @@ func TestCacheUpdateReservation(t *testing.T) {
 		Allocated:    nil,
 		AssignedPods: map[types.UID]*frameworkext.PodRequirement{},
 	}
-	expectReservationInfo.RefreshAvailable()
+	expectReservationInfo.RefreshPreCalculated()
 	sort.Slice(rInfo.ResourceNames, func(i, j int) bool {
 		return rInfo.ResourceNames[i] < rInfo.ResourceNames[j]
 	})
@@ -261,7 +261,7 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 			},
 		},
 	}
-	expectReservationInfo.RefreshAvailable()
+	expectReservationInfo.RefreshPreCalculated()
 	assert.Equal(t, expectReservationInfo, rInfo)
 
 	cache.updatePod(reservation.UID, pod, pod)
@@ -285,6 +285,6 @@ func TestCacheAddOrUpdateOrDeletePod(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("0"),
 	}
 	expectReservationInfo.AssignedPods = map[types.UID]*frameworkext.PodRequirement{}
-	expectReservationInfo.RefreshAvailable()
+	expectReservationInfo.RefreshPreCalculated()
 	assert.Equal(t, expectReservationInfo, rInfo)
 }

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -865,7 +865,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 				sort.Slice(wantReservationInfo.ResourceNames, func(i, j int) bool {
 					return wantReservationInfo.ResourceNames[i] < wantReservationInfo.ResourceNames[j]
 				})
-				wantReservationInfo.RefreshAvailable()
+				wantReservationInfo.RefreshPreCalculated()
 				rInfo := pl.handle.GetReservationNominator().GetNominatedReservation(tt.pod, nodeName)
 				if rInfo != nil {
 					sort.Slice(rInfo.ResourceNames, func(i, j int) bool {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler
  - Reservation: Pre-calculate the unmatched allocated resources in ReservationInfo to improve performance.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
