### PR TITLE
webhook: fix pod validating error that can't forbid illegal comibinations of QoS and priorityClass

### DIFF
--- a/pkg/webhook/pod/validating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/validating/cluster_colocation_profile.go
@@ -65,7 +65,7 @@ func (h *PodValidatingHandler) clusterColocationProfileValidatingPod(ctx context
 		allowed = false
 		reason = err.Error()
 	}
-	return allowed, reason, nil
+	return allowed, reason, err
 }
 
 func validateRequiredQoSClass(pod *corev1.Pod) field.ErrorList {

--- a/pkg/webhook/pod/validating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/validating/cluster_colocation_profile_test.go
@@ -87,6 +87,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `labels.koordinator.sh/qosClass: Invalid value: "LS": field is immutable`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate remove QoS",
@@ -103,6 +104,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `labels.koordinator.sh/qosClass: Invalid value: "": field is immutable`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate defined QoS",
@@ -159,6 +161,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `labels.koordinator.sh/qosClass: Required value: must specify koordinator QoS BE with koordinator colocation resources`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate immutable priorityClass",
@@ -175,6 +178,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `spec.priority: Invalid value: "koord-prod": field is immutable`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate remove priorityClass",
@@ -187,6 +191,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  fmt.Sprintf(`spec.priority: Invalid value: %q: field is immutable`, extension.GetPodPriorityClassRaw(&corev1.Pod{})),
+			wantErr:     true,
 		},
 		{
 			name:      "validate koordinator priority",
@@ -207,6 +212,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `labels.koordinator.sh/priority: Invalid value: "8888": field is immutable`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate remove koordinator priority",
@@ -223,6 +229,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `labels.koordinator.sh/priority: Invalid value: "": field is immutable`,
+			wantErr:     true,
 		},
 		{
 			name:      "allowed QoS and priorityClass combination: BE And NonProd",
@@ -278,6 +285,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `Pod: Forbidden: koordinator.sh/qosClass=BE and priorityClass=koord-prod cannot be used in combination`,
+			wantErr:     true,
 		},
 		{
 			name:      "forbidden QoS and priorityClass combination: LSR And Batch",
@@ -303,6 +311,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `Pod: Forbidden: koordinator.sh/qosClass=LSR and priorityClass=koord-batch cannot be used in combination`,
+			wantErr:     true,
 		},
 		{
 			name:      "forbidden QoS and priorityClass combination: LSR And Mid",
@@ -328,6 +337,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `Pod: Forbidden: koordinator.sh/qosClass=LSR and priorityClass=koord-mid cannot be used in combination`,
+			wantErr:     true,
 		},
 		{
 			name:      "forbidden QoS and priorityClass combination: LSR And Free",
@@ -353,6 +363,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `Pod: Forbidden: koordinator.sh/qosClass=LSR and priorityClass=koord-free cannot be used in combination`,
+			wantErr:     true,
 		},
 		{
 			name:      "validate resources - LSR And Prod",
@@ -411,6 +422,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `pod.spec.containers[*].resources.requests: Required value: LSR Pod must declare the requested CPUs`,
+			wantErr:     true,
 		},
 		{
 			name:      "forbidden resources - LSR And Prod: non-integer CPUs",
@@ -442,6 +454,7 @@ func TestClusterColocationProfileValidatingPod(t *testing.T) {
 			},
 			wantAllowed: false,
 			wantReason:  `pod.spec.containers[*].resources.requests: Invalid value: "100m": the requested CPUs of LSR Pod must be integer`,
+			wantErr:     true,
 		},
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Fix the pod validating webhook error that couldn't correctly forbid illegal combinations of QoS and priorityClass.



<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None
### Ⅲ. Describe how to verify it
For example, the pod validating webhook should forbid the combination of **`BE`** QoS and **`koord-prod`**,
and return reason message that _`Error from server: error when creating "STDIN": admission webhook "vpod.koordinator.sh" denied the request: Pod: Forbidden: koordinator.sh/qosClass=BE and priorityClass=koord-prod cannot be used in combination`_
```shell
#!/bin/bash
priority=("koord-prod" "koord-mid" "koord-batch" "koord-free" "system-cluster-critical")
qos=("SYSTEM" "LSE" "LSR" "LS" "BE" "NONE")

for p in "${priority[@]}"; do
  for q in "${qos[@]}"; do
  q_lower=$([ -n "$q" ] && echo "$q" | tr A-Z a-z || echo "")
  cat <<EOF | kubectl create -f -
apiVersion: v1
kind: Pod
metadata:
  name: t1-${p}-${q_lower}
  namespace: test-koordinator
  labels:
    koordinator.sh/qosClass: ${q}
spec:
  schedulerName: koord-scheduler
  priorityClassName: ${p}
  tolerations:
  - operator: Exists
  containers:
  - name: nginx
    image: nginx:latest
    imagePullPolicy: IfNotPresent
    resources:
        limits:
          cpu: "1000m"
          memory: "500Mi"
        requests:
          cpu: "1000m"
          memory: "500Mi"
EOF
done
done
```

However, the pod validating webhook didn't effective and I successfully created these illegal pods.
<img width="500" alt="pod-webhook-error" src="https://github.com/user-attachments/assets/a12b9718-30b5-48a7-915c-1578aaaa454d" />

In the original wrong logic, the `clusterColocationProfileValidatingPod` function will only return `nil` err, even if errors do occur.
By this PR modify, it could return non-nil err and correctly forbid illegal combinations.
<img width="900" alt="image" src="https://github.com/user-attachments/assets/557db5f3-68c0-49db-aaf7-7279976e4f53" />

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
