### PR TITLE
koordlet: fix koordlet panic randomly,caused by node info not ready

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_node.go
+++ b/pkg/koordlet/statesinformer/impl/states_node.go
@@ -100,12 +100,13 @@ func (s *nodeInformer) HasSynced() bool {
 	if s.nodeInformer == nil {
 		return false
 	}
-	synced := s.nodeInformer.HasSynced()
+	// maybe the cache has synced ,but the event handlers haven't beed called yet
+	synced := s.nodeInformer.HasSynced() && s.GetNode() != nil
 	klog.V(5).Infof("node informer has synced %v", synced)
 	return synced
 }
 
-func newNodeInformer(client clientset.Interface, nodeName string) cache.SharedIndexInformer {
+var newNodeInformer = func(client clientset.Interface, nodeName string) cache.SharedIndexInformer {
 	tweakListOptionsFunc := func(opt *metav1.ListOptions) {
 		opt.FieldSelector = "metadata.name=" + nodeName
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

在携程的使用过程中,发现 koordlet 会随机启动失败，发现原因是 koordlet  corev1.Node 数据在 cache 中状态维护方式有缺陷造成的，此 PR 修复了这个问题。

### Ⅱ. Does this pull request fix one issue?

无

### Ⅲ. Describe how to verify it

单元测试构造了对应场景，让 event handler 执行慢一些就会稳定复现

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
