### PR TITLE
koordlet: fix typo and add memory-ratio resource for buildXPUDevice()

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -324,6 +324,7 @@ func (s *statesInformer) buildXPUDevice(xpuDevices koordletuti.XPUDevices) []sch
 		}
 
 		resources := make(map[corev1.ResourceName]resource.Quantity)
+		resources[extension.ResourceGPUMemoryRatio] = *resource.NewQuantity(100, resource.DecimalSI)
 		for resourceName, resourceQuantity := range xpu.Resources {
 			quantity, err := resource.ParseQuantity(resourceQuantity)
 			if err != nil {
@@ -338,9 +339,9 @@ func (s *statesInformer) buildXPUDevice(xpuDevices koordletuti.XPUDevices) []sch
 			resources[corev1.ResourceName(resourceName)] = quantity
 		}
 
-		deviceHelathy := true
+		deviceHealthy := true
 		if xpu.Status != nil {
-			deviceHelathy = xpu.Status.Healthy
+			deviceHealthy = xpu.Status.Healthy
 		}
 
 		topo := getXPUDeviceTopology(&xpu)
@@ -350,7 +351,7 @@ func (s *statesInformer) buildXPUDevice(xpuDevices koordletuti.XPUDevices) []sch
 			UUID:       xpu.UUID,
 			Minor:      pointer.Int32(int32(minor)),
 			Type:       schedulingv1alpha1.GPU,
-			Health:     deviceHelathy,
+			Health:     deviceHealthy,
 			Resources:  resources,
 			Topology:   topo,
 			Conditions: conditions,

--- a/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux_test.go
@@ -187,10 +187,10 @@ func Test_reportXPUDevice(t *testing.T) {
 			UUID:   "185011D4-21104518-A0C4ED94-14CC040A-56102003",
 			Minor:  "0",
 			Resources: map[string]string{
-				"huawei.com/npu-core":       "32",
-				"hauwei.com/npu-cpu":        "14",
-				"koordinator.sh/gpu-memory": "32Gi",
-				"huawei.com/dvpp":           "100",
+				extension.ResourceHuaweiNPUCore:     "32",
+				extension.ResourceHuaweiNPUCPU:      "14",
+				string(extension.ResourceGPUMemory): "32Gi",
+				extension.ResourceHuaweiNPUDVPP:     "100",
 			},
 			Topology: &koordletutil.DeviceTopology{
 				P2PLinks: []koordletutil.DeviceP2PLink{
@@ -247,10 +247,11 @@ func Test_reportXPUDevice(t *testing.T) {
 			Type:   schedulingv1alpha1.GPU,
 			Health: true,
 			Resources: map[corev1.ResourceName]resource.Quantity{
-				"huawei.com/npu-core":       npuCoreQuantity,
-				"hauwei.com/npu-cpu":        npuCpuQuantity,
-				"koordinator.sh/gpu-memory": gpuMemQuantity,
-				"huawei.com/dvpp":           dvppQuantity,
+				extension.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI),
+				extension.ResourceHuaweiNPUCore:  npuCoreQuantity,
+				extension.ResourceHuaweiNPUCPU:   npuCpuQuantity,
+				extension.ResourceGPUMemory:      gpuMemQuantity,
+				extension.ResourceHuaweiNPUDVPP:  dvppQuantity,
 			},
 			Topology: &schedulingv1alpha1.DeviceTopology{
 				SocketID: -1,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- fix typo and add memory-ratio resource for buildXPUDevice()

### Ⅱ. Does this pull request fix one issue?
- NONE

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
