### PR TITLE
scheduler: loadaware support dominantResourceWeight

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -43,6 +43,9 @@ type LoadAwareSchedulingArgs struct {
 	// ResourceWeights indicates the weights of resources.
 	// The weights of CPU and Memory are both 1 by default.
 	ResourceWeights map[corev1.ResourceName]int64
+	// DominantResourceWeight indicates the weight of the dominant resource.
+	// Dominant resource is the resource with the maximum utilization, which is based on the concept of Dominant Resource Fairness.
+	DominantResourceWeight int64
 	// UsageThresholds indicates the resource utilization threshold of the whole machine.
 	// The default for CPU is 65%, and the default for memory is 95%.
 	UsageThresholds map[corev1.ResourceName]int64

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -98,7 +98,7 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 	if obj.NodeMetricExpirationSeconds == nil {
 		obj.NodeMetricExpirationSeconds = pointer.Int64(defaultNodeMetricExpirationSeconds)
 	}
-	if len(obj.ResourceWeights) == 0 {
+	if len(obj.ResourceWeights) == 0 && obj.DominantResourceWeight == 0 {
 		obj.ResourceWeights = defaultResourceWeights
 	}
 	if len(obj.UsageThresholds) == 0 {

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -42,6 +42,9 @@ type LoadAwareSchedulingArgs struct {
 	// ResourceWeights indicates the weights of resources.
 	// The weights of CPU and Memory are both 1 by default.
 	ResourceWeights map[corev1.ResourceName]int64 `json:"resourceWeights,omitempty"`
+	// DominantResourceWeight indicates the weight of the dominant resource.
+	// Dominant resource is the resource with the maximum utilization, which is based on the concept of Dominant Resource Fairness.
+	DominantResourceWeight int64 `json:"dominantResourceWeight,omitempty"`
 	// UsageThresholds indicates the resource utilization threshold of the whole machine.
 	// The default for CPU is 65%, and the default for memory is 95%.
 	UsageThresholds map[corev1.ResourceName]int64 `json:"usageThresholds,omitempty"`

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -393,6 +393,7 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
+	out.DominantResourceWeight = in.DominantResourceWeight
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.ProdUsageIncludeSys = in.ProdUsageIncludeSys
@@ -427,6 +428,7 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
+	out.DominantResourceWeight = in.DominantResourceWeight
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.ProdUsageIncludeSys = in.ProdUsageIncludeSys

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -98,7 +98,7 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 	if obj.NodeMetricExpirationSeconds == nil {
 		obj.NodeMetricExpirationSeconds = pointer.Int64(defaultNodeMetricExpirationSeconds)
 	}
-	if len(obj.ResourceWeights) == 0 {
+	if len(obj.ResourceWeights) == 0 && obj.DominantResourceWeight == 0 {
 		obj.ResourceWeights = defaultResourceWeights
 	}
 	if len(obj.UsageThresholds) == 0 {

--- a/pkg/scheduler/apis/config/v1beta3/types.go
+++ b/pkg/scheduler/apis/config/v1beta3/types.go
@@ -43,6 +43,9 @@ type LoadAwareSchedulingArgs struct {
 	// ResourceWeights indicates the weights of resources.
 	// The weights of CPU and Memory are both 1 by default.
 	ResourceWeights map[corev1.ResourceName]int64 `json:"resourceWeights,omitempty"`
+	// DominantResourceWeight indicates the weight of the dominant resource.
+	// Dominant resource is the resource with the maximum utilization, which is based on the concept of Dominant Resource Fairness.
+	DominantResourceWeight int64 `json:"dominantResourceWeight,omitempty"`
 	// UsageThresholds indicates the resource utilization threshold of the whole machine.
 	// The default for CPU is 65%, and the default for memory is 95%.
 	UsageThresholds map[corev1.ResourceName]int64 `json:"usageThresholds,omitempty"`

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -393,6 +393,7 @@ func autoConvert_v1beta3_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingAr
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
+	out.DominantResourceWeight = in.DominantResourceWeight
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.ProdUsageIncludeSys = in.ProdUsageIncludeSys
@@ -422,6 +423,7 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1beta3_LoadAwareSchedulingAr
 	out.NodeMetricExpirationSeconds = (*int64)(unsafe.Pointer(in.NodeMetricExpirationSeconds))
 	out.EnableScheduleWhenNodeMetricsExpired = (*bool)(unsafe.Pointer(in.EnableScheduleWhenNodeMetricsExpired))
 	out.ResourceWeights = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ResourceWeights))
+	out.DominantResourceWeight = in.DominantResourceWeight
 	out.UsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.UsageThresholds))
 	out.ProdUsageThresholds = *(*map[corev1.ResourceName]int64)(unsafe.Pointer(&in.ProdUsageThresholds))
 	out.ProdUsageIncludeSys = in.ProdUsageIncludeSys

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -39,6 +39,12 @@ func ValidateLoadAwareSchedulingArgs(args *config.LoadAwareSchedulingArgs) error
 	if err := validateResourceWeights(args.ResourceWeights); err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("resourceWeights"), args.ResourceWeights, err.Error()))
 	}
+	if args.DominantResourceWeight < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("dominantResourceWeight"), args.DominantResourceWeight, "dominantResourceWeight should not be a negative value"))
+	}
+	if args.DominantResourceWeight > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("dominantResourceWeight"), args.DominantResourceWeight, "dominantResourceWeight should be less than 100"))
+	}
 	if err := validateResourceThresholds(args.UsageThresholds); err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("usageThresholds"), args.UsageThresholds, err.Error()))
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Add a new argument `dominantResourceWeight` in load aware scheduling plugin, which is a integer >= 0 and <= 100. When dominantResourceWeight is not zero, it is used as the weight for dominant resource's score on node.

The node's dominant resource is defined as the most used resource on node:

> dominant resource score = min(allocatable - usedOfExistingPods - estimatedOfIncomingPod) / allocatable)

When dominantResourceWeight is set non zero, plugin will not use default resource weight list.

### Ⅱ. Does this pull request fix one issue?

fixes #2596

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
