### PR TITLE
koordlet: add mainline kernel support for IsCoreSchedSupported()

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/coresched/core_sched_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/core_sched_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
@@ -50,7 +51,8 @@ func TestPlugin(t *testing.T) {
 
 func TestPluginSystemSupported(t *testing.T) {
 	type fields struct {
-		prepareFn func(helper *sysutil.FileTestUtil)
+		prepareFn   func(helper *sysutil.FileTestUtil)
+		notAnolisOS bool
 	}
 	type wants struct {
 		systemSupported bool
@@ -134,6 +136,7 @@ func TestPluginSystemSupported(t *testing.T) {
 				Reader:   resourceexecutor.NewCgroupReader(),
 				Executor: resourceexecutor.NewTestResourceExecutor(),
 			})
+			system.HostSystemInfo.IsAnolisOS = !tt.fields.notAnolisOS
 			sysSupported := p.SystemSupported()
 			assert.Equal(t, tt.wants.systemSupported, sysSupported)
 			assert.Equal(t, tt.wants.supportMsg, p.supportedMsg)
@@ -145,6 +148,7 @@ func TestPlugin_initSystem(t *testing.T) {
 	type fields struct {
 		prepareFn   func(helper *sysutil.FileTestUtil)
 		giSupported *bool
+		notAnolisOS bool
 	}
 	tests := []struct {
 		name      string
@@ -281,6 +285,7 @@ func TestPlugin_initSystem(t *testing.T) {
 			if tt.fields.prepareFn != nil {
 				tt.fields.prepareFn(helper)
 			}
+			system.HostSystemInfo.IsAnolisOS = !tt.fields.notAnolisOS
 
 			p := newPlugin()
 			p.Setup(hooks.Options{})
@@ -302,6 +307,7 @@ func TestPlugin_SetContainerCookie(t *testing.T) {
 		preparePluginFn func(p *Plugin)
 		cse             sysutil.CoreSchedExtendedInterface
 		groupID         string
+		notAnolisOS     bool
 	}
 	type wantFields struct {
 		cookieToPIDs  map[uint64][]uint32
@@ -1245,6 +1251,7 @@ func TestPlugin_SetContainerCookie(t *testing.T) {
 			if tt.fields.prepareFn != nil {
 				tt.fields.prepareFn(helper)
 			}
+			system.HostSystemInfo.IsAnolisOS = !tt.fields.notAnolisOS
 			p := tt.fields.plugin
 			if tt.fields.cse != nil {
 				p.cse = tt.fields.cse

--- a/pkg/koordlet/runtimehooks/hooks/coresched/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/rule_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 	"github.com/koordinator-sh/koordinator/pkg/util/sloconfig"
 )
@@ -496,6 +497,7 @@ func Test_ruleUpdateCb(t *testing.T) {
 		plugin          *Plugin
 		preparePluginFn func(p *Plugin)
 		cse             sysutil.CoreSchedExtendedInterface
+		notAnolisOS     bool
 	}
 	type wantFields struct {
 		rule               *Rule
@@ -1663,7 +1665,7 @@ func Test_ruleUpdateCb(t *testing.T) {
 				defer close(stopCh)
 				p.executor.Run(stopCh)
 			}
-
+			system.HostSystemInfo.IsAnolisOS = !tt.fields.notAnolisOS
 			gotErr := p.ruleUpdateCb(tt.arg)
 			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
 			assert.Equal(t, tt.wantFields.rule, p.rule)

--- a/pkg/koordlet/util/system/core_sched.go
+++ b/pkg/koordlet/util/system/core_sched.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unsafe"
 
+	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 )
 
@@ -272,12 +274,37 @@ func IsCoreSchedSysctlSupported() bool {
 	return FileExists(GetProcSysFilePath(KernelSchedCore))
 }
 
+// ProbeCoreSchedIfEnabled checks if the MAINLINE kernel support the core scheduling.
+// Since there's no direct API, we probe by calling prctl and checking its return value.
+func ProbeCoreSchedIfEnabled() bool {
+	cookie := uint64(0)
+	cookiePtr := &cookie
+	ret, err := unix.PrctlRetInt(unix.PR_SCHED_CORE, unix.PR_SCHED_CORE_GET, uintptr(0), uintptr(CoreSchedScopeThread), uintptr(unsafe.Pointer(cookiePtr)))
+	if err != nil {
+		klog.V(4).Infof("failed to probe core sched status via prctl, err: %s", err)
+		return false
+	}
+	return ret == 0
+}
+
 // IsCoreSchedSupported checks if the kernel supports the core scheduling.
-// Currently, it relies on the interfaces provided by the Anolis OS.
+// Currently, it supports both Anolis OS and mainline kernel.
 func IsCoreSchedSupported() (bool, string) {
-	// kernel supports if:
+	// Anolis OS supports if:
 	// a) sysctl has sched_core,
 	// b) sched_features has SCHED_CORE/NO_SCHED_CORE
+	// Mainline kernel supports if(only 5.14 and later):
+	// a) CONFIG_SCHED_CORE config option enabled
+
+	if !HostSystemInfo.IsAnolisOS {
+		// For mainline kernel
+		if ProbeCoreSchedIfEnabled() {
+			return true, "prctl supported"
+		} else {
+			return false, "not unsupported by prctl"
+		}
+	}
+
 	if IsCoreSchedSysctlSupported() {
 		return true, "sysctl supported"
 	}
@@ -296,12 +323,22 @@ func IsCoreSchedSupported() (bool, string) {
 
 // EnableCoreSchedIfSupported checks if the core scheduling feature is enabled in the kernel sched_features.
 // If kernel supported (available in the latest Anolis OS), it tries to enable the core scheduling feature.
+// For Anolis OS
 // The core sched's kernel feature is known set in two places, if both of them are not found, the system is considered
 // unsupported for the core scheduling:
 //  1. In `/proc/sys/kernel/sched_core`, the value `1` means the feature is enabled while `0` means disabled.
 //  2. (Older kernel) In `/sys/kernel/debug/sched_features`, the field `CORE_SCHED` means the feature is enabled while `NO_CORE_SCHED`
 //     means it is disabled.
+//
+// For mainline kernel
+// Core scheduling support is enabled via the CONFIG_SCHED_CORE config option. And can not be turn on/off dynamically.
 func EnableCoreSchedIfSupported() (bool, string) {
+	if !HostSystemInfo.IsAnolisOS {
+		// For mainline kernel
+		if ProbeCoreSchedIfEnabled() {
+			return true, ""
+		}
+	}
 	// 1. try sysctl
 	isSysctlSupported, err := GetSchedCore()
 	if err == nil && isSysctlSupported {

--- a/pkg/koordlet/util/system/core_sched_test.go
+++ b/pkg/koordlet/util/system/core_sched_test.go
@@ -174,7 +174,8 @@ func TestFakeCoreSchedExtended(t *testing.T) {
 
 func TestEnableCoreSchedIfSupported(t *testing.T) {
 	type fields struct {
-		prepareFn func(helper *FileTestUtil)
+		prepareFn   func(helper *FileTestUtil)
+		notAnolisOS bool
 	}
 	tests := []struct {
 		name   string
@@ -283,6 +284,7 @@ func TestEnableCoreSchedIfSupported(t *testing.T) {
 			if tt.fields.prepareFn != nil {
 				tt.fields.prepareFn(helper)
 			}
+			HostSystemInfo.IsAnolisOS = !tt.fields.notAnolisOS
 			got, got1 := EnableCoreSchedIfSupported()
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want1, got1)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

koordlet: add mainline kernel support for IsCoreSchedSupported()

The Coresched plugin previously relied on Anolis OS kernel-specific interfaces to detect core scheduling support, which caused incorrect "unsupported" reports even when running on mainline kernels that natively support core scheduling.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2604 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
