### PR TITLE
scheduler: fine-grained device scheduling support Cambricon dynamic sMLU

### DIFF
--- a/apis/extension/device_share.go
+++ b/apis/extension/device_share.go
@@ -69,8 +69,9 @@ const (
 )
 
 const (
-	GPUVendorNVIDIA = "nvidia"
-	GPUVendorHuawei = "huawei"
+	GPUVendorNVIDIA    = "nvidia"
+	GPUVendorHuawei    = "huawei"
+	GPUVendorCambricon = "cambricon"
 )
 
 // DeviceAllocations would be injected into Pod as form of annotation during Pre-bind stage.

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -623,7 +623,7 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState *framework.CycleS
 	}
 
 	if k8sfeature.DefaultMutableFeatureGate.Enabled(features.DevicePluginAdaption) {
-		if err := p.adaptForDevicePlugin(object, state.allocationResult, nodeName); err != nil {
+		if err := p.adaptForDevicePlugin(ctx, object, state.allocationResult, nodeName); err != nil {
 			return framework.AsStatus(err)
 		}
 	}

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -128,7 +128,11 @@ func (f *testSharedLister) HavePodsWithRequiredAntiAffinityList() ([]*framework.
 }
 
 func (f *testSharedLister) Get(nodeName string) (*framework.NodeInfo, error) {
-	return f.nodeInfoMap[nodeName], nil
+	nodeInfo, ok := f.nodeInfoMap[nodeName]
+	if !ok {
+		return nil, fmt.Errorf("unable to find node: %s", nodeName)
+	}
+	return nodeInfo, nil
 }
 
 type pluginTestSuit struct {
@@ -4766,7 +4770,7 @@ func Test_Plugin_PreBind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.DevicePluginAdaption, tt.devicePluginAdaptionFeatureEnabled)()
 
-			suit := newPluginTestSuit(t, nil)
+			suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}}})
 			_, err := suit.ClientSet().CoreV1().Pods(testPod.Namespace).Create(context.TODO(), testPod, metav1.CreateOptions{})
 			assert.NoError(t, err)
 			if tt.deviceCR != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR makes fine-grained device scheduling support Cambricon dynamic sMLU. The core scheduling logic is the same as NVIDIA so that this work only covers DP adaption.

Note that Cambricon DP does not support external MLU (full card) scheduling so we can only support dynamic sMLU (GPU share) for now.

How to use:
```yaml
koordinator.sh/gpu.shared: "1"
koordinator.sh/gpu-core: "5"
koordinator.sh/gpu-memory: 1Gi
# below are only used to trigger Cambricon DP
cambricon.com/mlu.smlu.vcore: "1"
cambricon.com/mlu.smlu.vmemory: "1"
```

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
