### PR TITLE
koordlet: fix partition in buildXPUDeviceAnnotations()

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -568,7 +568,7 @@ func (s *statesInformer) buildXPUDeviceLabels(xpuDevices koordletuti.XPUDevices)
 
 func (s *statesInformer) buildXPUDeviceAnnotations(xpuDevices koordletuti.XPUDevices) map[string]string {
 	partitionTable := getPartitionTableFromXPUDevices(xpuDevices)
-	if partitionTable == nil {
+	if len(partitionTable) == 0 {
 		return map[string]string{}
 	}
 	rawBytes, err := json.Marshal(partitionTable)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Partition annotations should only exist if the device information includes p2p links.

### Ⅱ. Does this pull request fix one issue?

None

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
