### PR TITLE
koordlet: Set HostToContainer propagation for kubelet dir

### DIFF
--- a/config/manager/koordlet.yaml
+++ b/config/manager/koordlet.yaml
@@ -84,6 +84,7 @@ spec:
             - mountPath: /var/lib/kubelet
               name: host-kubelet-rootdir
               readOnly: true
+              mountPropagation: HostToContainer
             - mountPath: /dev
               name: host-dev
               mountPropagation: HostToContainer


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The default mount propagation (None) creates an isolated mount namespace for the koordlet pod, which inherits existing mounts from the host at startup. 
When a new `koordlet` pod starts, the `hostPath` volume for `/var/lib/kubelet` causes any existing mounts on the host under that directory to be propagated into the new pod's namespace. This new pod then holds a reference to the device, preventing its removal on the host.
This PR fixes the issue by changing the mount propagation of the /var/lib/kubelet hostPath volume to HostToContainer. This ensures that both mount and unmount events on the host are propagated to the koordlet container.
#### Steps to Reproduce the Issue
1.  **Mount a device under `/var/lib/kubelet` on the host.**
    ```bash
    # Identify a device, e.g., /dev/dm-0
    ➜  ~ multipath -l
    36005853018caffad3220666f00000000 dm-0 

    # Mount it to a subdirectory of /var/lib/kubelet
    ➜  ~ mount -t xfs /dev/dm-0 /var/lib/kubelet/tmp_mount
    ```
2.  **Restart the `koordlet` pod.**
    ```bash
    # Delete the old pod
    ➜  ~ kubectl delete pod -n koordinator-system koordlet-nnbrw
    pod "koordlet-nnbrw" deleted

    # Check the mount info inside the NEW pod
    ➜  ~ kubectl exec -it -n koordinator-system koordlet-sg9dk -- cat /proc/self/mountinfo | grep tmp_mount
    9060 9016 253:0 / /var/lib/kubelet/tmp_mount rw,relatime - xfs /dev/mapper/36005853018caffad3220666f00000000 ...
    ```
3.  **Attempt to clean up the device on the host.**
    The cleanup fails because the new `koordlet` pod now holds the reference, even after `umount` is called on the host.
    ```bash
    # Unmounting on the host appears to work
    ➜  ~ umount /var/lib/kubelet/tmp_mount

    # But removing the underlying device fails
    ➜  ~ dmsetup remove /dev/dm-0
    device-mapper: remove ioctl on 36005853018caffad3220666f00000000 failed: Device or resource busy
    ```
4.  **The device can only be released after the mount is manually unmounted from *inside* the new `koordlet` container.**
    ```bash
    # Unmount from inside the container
    ➜  ~ kubectl exec -it -n koordinator-system koordlet-sg9dk -- umount /var/lib/kubelet/tmp_mount

    # Now cleanup on the host succeeds
    ➜  ~ dmsetup remove /dev/dm-0                                                      
    ➜  ~ echo $?
     0

    ```
<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Repeat the above reproduction steps, and the dm device can be correctly deleted.
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
