### PR TITLE
scheduler: add scheduling hint

### DIFF
--- a/apis/extension/multi_scheduler_test.go
+++ b/apis/extension/multi_scheduler_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetSchedulerName(t *testing.T) {
+	// Test case 1: Pod with LabelSchedulerName label
+	podWithLabel := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				LabelSchedulerName: "custom-scheduler",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: "default-scheduler",
+		},
+	}
+
+	result := GetSchedulerName(podWithLabel)
+	assert.Equal(t, "custom-scheduler", result, "Should return scheduler name from label when present")
+
+	// Test case 2: Pod without LabelSchedulerName label
+	podWithoutLabel := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"other-label": "value",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: "default-scheduler",
+		},
+	}
+
+	result = GetSchedulerName(podWithoutLabel)
+	assert.Equal(t, "default-scheduler", result, "Should return spec.SchedulerName when label is not present")
+}
+
+func TestGetSchedulingHint(t *testing.T) {
+	// Test case 1: Nil pod
+	result, err := GetSchedulingHint(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, result, "Should return nil for nil pod")
+
+	// Test case 2: Pod without AnnotationSchedulingHint annotation
+	podWithoutAnnotation := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"other-annotation": "value",
+			},
+		},
+	}
+
+	result, err = GetSchedulingHint(podWithoutAnnotation)
+	assert.NoError(t, err)
+	assert.Nil(t, result, "Should return nil when annotation is not present")
+
+	// Test case 3: Pod with valid scheduling hint
+	schedulingHint := &SchedulingHint{
+		NodeNames: []string{"test-node"},
+		Extensions: map[string]interface{}{
+			"key1": "value1",
+			"key2": "123",
+		},
+	}
+
+	hintBytes, err := json.Marshal(schedulingHint)
+	assert.NoError(t, err)
+
+	podWithValidHint := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				AnnotationSchedulingHint: string(hintBytes),
+			},
+		},
+	}
+
+	result, err = GetSchedulingHint(podWithValidHint)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, []string{"test-node"}, result.NodeNames)
+	assert.Equal(t, schedulingHint.Extensions, result.Extensions)
+
+	// Test case 4: Pod with invalid scheduling hint JSON
+	podWithInvalidHint := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				AnnotationSchedulingHint: "invalid-json",
+			},
+		},
+	}
+
+	result, err = GetSchedulingHint(podWithInvalidHint)
+	assert.Error(t, err)
+	assert.Nil(t, result, "Should return error for invalid JSON")
+}

--- a/pkg/scheduler/frameworkext/hinter/scheduling_hint.go
+++ b/pkg/scheduler/frameworkext/hinter/scheduling_hint.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hinter
+
+import "k8s.io/kubernetes/pkg/scheduler/framework"
+
+const SchedulingHintStateKey = "SchedulingHintState"
+
+var _ framework.StateData = &SchedulingHintStateData{}
+
+type SchedulingHintStateData struct {
+	PreFilterNodes []string // hint to preFilter node
+	Extensions     map[string]interface{}
+}
+
+func (a *SchedulingHintStateData) Clone() framework.StateData {
+	return &SchedulingHintStateData{
+		PreFilterNodes: a.PreFilterNodes,
+		Extensions:     a.Extensions,
+	}
+}
+
+func GetSchedulingHintState(cycleState *framework.CycleState) *SchedulingHintStateData {
+	stateData, err := cycleState.Read(SchedulingHintStateKey)
+	if err != nil {
+		return nil
+	}
+	return stateData.(*SchedulingHintStateData)
+}
+
+func SetSchedulingHintState(cycleState *framework.CycleState, data *SchedulingHintStateData) {
+	cycleState.Write(SchedulingHintStateKey, data)
+}

--- a/pkg/scheduler/frameworkext/hinter/scheduling_hint_test.go
+++ b/pkg/scheduler/frameworkext/hinter/scheduling_hint_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hinter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestSchedulingHintStateData_Clone(t *testing.T) {
+	originalNodeInfo := ""
+	extensions := map[string]interface{}{
+		"key1": "value1",
+		"key2": 123,
+	}
+
+	original := &SchedulingHintStateData{
+		PreFilterNodes: []string{originalNodeInfo},
+		Extensions:     extensions,
+	}
+
+	cloned := original.Clone().(*SchedulingHintStateData)
+
+	assert.NotNil(t, cloned)
+	assert.Equal(t, original.PreFilterNodes, cloned.PreFilterNodes)
+	assert.Equal(t, original.Extensions, cloned.Extensions)
+
+	assert.NotSame(t, original.Extensions, cloned.Extensions)
+}
+
+func TestGetSchedulingHintState(t *testing.T) {
+	cycleState := framework.NewCycleState()
+
+	result := GetSchedulingHintState(cycleState)
+	assert.Nil(t, result)
+
+	stateData := &SchedulingHintStateData{
+		PreFilterNodes: []string{},
+		Extensions:     make(map[string]interface{}),
+	}
+
+	SetSchedulingHintState(cycleState, stateData)
+
+	result = GetSchedulingHintState(cycleState)
+	assert.NotNil(t, result)
+	assert.Equal(t, stateData, result)
+}
+
+func TestSetSchedulingHintStateData(t *testing.T) {
+	cycleState := framework.NewCycleState()
+
+	stateData := &SchedulingHintStateData{
+		PreFilterNodes: []string{},
+		Extensions:     make(map[string]interface{}),
+	}
+
+	SetSchedulingHintState(cycleState, stateData)
+
+	retrievedData, err := cycleState.Read(SchedulingHintStateKey)
+	assert.NoError(t, err)
+	assert.Equal(t, stateData, retrievedData)
+}
+
+func TestSchedulingHintStateData_Integration(t *testing.T) {
+	cycleState := framework.NewCycleState()
+
+	nodeInfo := "test-node"
+	extensions := map[string]interface{}{
+		"testKey": "testValue",
+	}
+
+	stateData := &SchedulingHintStateData{
+		PreFilterNodes: []string{nodeInfo},
+		Extensions:     extensions,
+	}
+
+	SetSchedulingHintState(cycleState, stateData)
+
+	retrieved := GetSchedulingHintState(cycleState)
+	assert.NotNil(t, retrieved)
+	assert.Equal(t, []string{nodeInfo}, retrieved.PreFilterNodes)
+	assert.Equal(t, extensions, retrieved.Extensions)
+
+	cloned := retrieved.Clone().(*SchedulingHintStateData)
+	assert.Equal(t, retrieved, cloned)
+}

--- a/pkg/scheduler/plugins/reservation/scheduling_hint.go
+++ b/pkg/scheduler/plugins/reservation/scheduling_hint.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
+)
+
+type HintState struct {
+	// Selected nodes to pre-filter.
+	PreFilterNodeInfos []string
+	HintExtensions
+}
+
+type HintExtensions struct {
+	// Whether to skip the nodeInfo restoration in this cycle.
+	// e.g. the ownership for reservations does not change.
+	SkipRestoreNodeInfo bool
+}
+
+func getSchedulingHint(cycleState *framework.CycleState) (*HintState, bool) {
+	schedulingHint := hinter.GetSchedulingHintState(cycleState)
+	if schedulingHint == nil || schedulingHint.Extensions == nil {
+		return nil, false
+	}
+	if schedulingHint.Extensions[Name] == nil {
+		return nil, false
+	}
+	extensions, ok := schedulingHint.Extensions[Name].(HintExtensions)
+	if !ok {
+		return nil, false
+	}
+	return &HintState{
+		PreFilterNodeInfos: schedulingHint.PreFilterNodes,
+		HintExtensions:     extensions,
+	}, true
+}

--- a/pkg/scheduler/plugins/reservation/scheduling_hint_test.go
+++ b/pkg/scheduler/plugins/reservation/scheduling_hint_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
+)
+
+func Test_getSchedulingHint(t *testing.T) {
+	// Create a mock cycle state
+	cycleState := framework.NewCycleState()
+
+	tests := []struct {
+		name           string
+		setupState     func(*framework.CycleState)
+		expectedResult *HintState
+		expectedOK     bool
+	}{
+		{
+			name:           "no scheduling hint state",
+			setupState:     func(state *framework.CycleState) {},
+			expectedResult: nil,
+			expectedOK:     false,
+		},
+		{
+			name: "scheduling hint state without extensions",
+			setupState: func(state *framework.CycleState) {
+				hintState := &hinter.SchedulingHintStateData{}
+				state.Write(hinter.SchedulingHintStateKey, hintState)
+			},
+			expectedResult: nil,
+			expectedOK:     false,
+		},
+		{
+			name: "scheduling hint state with extensions but not for reservation plugin",
+			setupState: func(state *framework.CycleState) {
+				hintState := &hinter.SchedulingHintStateData{
+					Extensions: map[string]interface{}{
+						"other-plugin": HintExtensions{SkipRestoreNodeInfo: true},
+					},
+				}
+				state.Write(hinter.SchedulingHintStateKey, hintState)
+			},
+			expectedResult: nil,
+			expectedOK:     false,
+		},
+		{
+			name: "scheduling hint state with reservation plugin extensions - wrong type",
+			setupState: func(state *framework.CycleState) {
+				hintState := &hinter.SchedulingHintStateData{
+					PreFilterNodes: []string{"node1", "node2"},
+					Extensions: map[string]interface{}{
+						Name: "wrong-type",
+					},
+				}
+				state.Write(hinter.SchedulingHintStateKey, hintState)
+			},
+			expectedResult: nil,
+			expectedOK:     false,
+		},
+		{
+			name: "scheduling hint state with reservation plugin extensions - correct type",
+			setupState: func(state *framework.CycleState) {
+				hintState := &hinter.SchedulingHintStateData{
+					PreFilterNodes: []string{"node1", "node2"},
+					Extensions: map[string]interface{}{
+						Name: HintExtensions{SkipRestoreNodeInfo: true},
+					},
+				}
+				state.Write(hinter.SchedulingHintStateKey, hintState)
+			},
+			expectedResult: &HintState{
+				PreFilterNodeInfos: []string{"node1", "node2"},
+				HintExtensions:     HintExtensions{SkipRestoreNodeInfo: true},
+			},
+			expectedOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the cycle state
+			tt.setupState(cycleState)
+
+			// Call the function
+			result, ok := getSchedulingHint(cycleState)
+
+			// Verify results
+			assert.Equal(t, tt.expectedOK, ok, "Expected ok to be %v, but got %v", tt.expectedOK, ok)
+
+			if tt.expectedOK {
+				assert.NotNil(t, result, "Expected result to be non-nil")
+				assert.Equal(t, tt.expectedResult.PreFilterNodeInfos, result.PreFilterNodeInfos,
+					"Expected PreFilterNodeInfos %v, but got %v",
+					tt.expectedResult.PreFilterNodeInfos, result.PreFilterNodeInfos)
+				assert.Equal(t, tt.expectedResult.SkipRestoreNodeInfo, result.SkipRestoreNodeInfo,
+					"Expected SkipRestoreNodeInfo %v, but got %v",
+					tt.expectedResult.SkipRestoreNodeInfo, result.SkipRestoreNodeInfo)
+			} else {
+				assert.Nil(t, result, "Expected result to be nil, but got %v", result)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"testing"
 
-	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing"
-
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -31,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/pointer"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- koord-scheduler: Add a mechanism to hint at the scheduler plugins.

For example, we can talk to the reservation plugin that you should pre-filter on the given nodes, and no need to visit all nodes with reserved resources to reduce overhead. And, for a continuous scheduling cycle inside a job, the ownership for reserved resources should not change, so we do not need to repeatedly restore reserved resources for the sibling pods.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
