### PR TITLE
scheduler: fix nominated reservation during preemption

### DIFF
--- a/pkg/scheduler/frameworkext/fake.go
+++ b/pkg/scheduler/frameworkext/fake.go
@@ -300,3 +300,11 @@ func (nm *FakeNominator) GetNominatedPreAllocation(rInfo *ReservationInfo, nodeN
 func (nm *FakeNominator) deletePreAllocation(pod *corev1.Pod) {
 	delete(nm.preAllocatable, pod.UID)
 }
+
+// GetNominatedNodeForReservePod returns the node name that the reserve pod is nominated to.
+// This is only for testing purposes.
+func (nm *FakeNominator) GetNominatedNodeForReservePod(pod *corev1.Pod) string {
+	nm.lock.RLock()
+	defer nm.lock.RUnlock()
+	return nm.nominatedReservePodToNode[pod.UID]
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: fix the nominated reservation is deleted even when preempting success.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
