### PR TITLE
koordlet: add metric for cpuset sharepool cpus.

### DIFF
--- a/pkg/koordlet/metrics/cpu_cpuset.go
+++ b/pkg/koordlet/metrics/cpu_cpuset.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	CPUSetSharePoolCPUS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "cpuset_share_pool_cpu_cores",
+		Help:      "Number of share pool cores",
+	}, []string{NodeKey})
+
+	CPUSetBESharePoolCPUS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "cpuset_be_share_pool_cpu_cores",
+		Help:      "Number of be share pool cores",
+	}, []string{NodeKey})
+
+	CPUSetCollector = []prometheus.Collector{
+		CPUSetSharePoolCPUS,
+		CPUSetBESharePoolCPUS,
+	}
+)
+
+func RecordCPUSetSharePoolCores(value float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	CPUSetSharePoolCPUS.With(labels).Set(value)
+}
+
+func RecordCPUSetBESharePoolCores(value float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	CPUSetBESharePoolCPUS.With(labels).Set(value)
+}

--- a/pkg/koordlet/metrics/internal_metrics.go
+++ b/pkg/koordlet/metrics/internal_metrics.go
@@ -39,6 +39,7 @@ func init() {
 	internalMustRegister(CommonCollectors...)
 	internalMustRegister(CPUSuppressCollector...)
 	internalMustRegister(CPUBurstCollector...)
+	internalMustRegister(CPUSetCollector...)
 	internalMustRegister(PredictionCollectors...)
 	internalMustRegister(CoreSchedCollector...)
 	internalMustRegister(ResourceExecutorCollector...)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does


- We expect to be able to monitor and observe the CPUSet share pool information, similar to `koordlet_be_suppress_cpu_cores`. 
- The observability of cpuset is insufficient currently. In some cases, we need to know the number of share pool CPU on the node, so as to guide us whether the node has allocated too many LSR/LSE Pods and how many cores the normal pods can actually use (in scenarios with resource oversale). Currently, this can only be achieved by adjusting the log level.


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
