### PR TITLE
scheduler: fix panic for reservation handler

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -73,7 +73,7 @@ func MakeReservationErrorHandler(
 			if reservationNominator := extendedHandle.GetReservationNominator(); reservationNominator != nil {
 				// If the pod preempting successfully, we should keep the nomination of the pod to reservation, and other pods can not allocate
 				// the preempted reserved resources in the next cycle.
-				if nominatingInfo.NominatingMode == framework.ModeOverride && nominatingInfo.NominatedNodeName == "" || nominatingInfo.NominatingMode == framework.ModeNoop && pod.Status.NominatedNodeName == "" {
+				if nominatingInfo == nil || nominatingInfo.NominatingMode == framework.ModeOverride && nominatingInfo.NominatedNodeName == "" || nominatingInfo.NominatingMode == framework.ModeNoop && pod.Status.NominatedNodeName == "" {
 					reservationNominator.DeleteNominatedReservePodOrReservation(pod)
 				} else {
 					klog.V(5).Infof("Keep the NominatedReservation of the Pod %s, nominatingInfo %+v, nominatedNodeName %s", klog.KObj(pod), nominatingInfo, pod.Status.NominatedNodeName)

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -243,6 +243,7 @@ func TestMakeReservationErrorHandler_NominationHandling(t *testing.T) {
 		name                             string
 		isReservePod                     bool
 		hasReservationAffinity           bool
+		nilNominatingInfo                bool
 		nominatingMode                   framework.NominatingMode
 		nominatedNodeName                string
 		podNominatedNodeName             string
@@ -293,6 +294,12 @@ func TestMakeReservationErrorHandler_NominationHandling(t *testing.T) {
 			hasReservationAffinity: true,
 			nominatingMode:         framework.ModeNoop,
 			nominatedNodeName:      "",
+		},
+		{
+			name:                             "normal pod with nil nominatingInfo should delete nomination",
+			isReservePod:                     false,
+			nilNominatingInfo:                true,
+			expectDeleteNominatedReservation: true,
 		},
 	}
 
@@ -369,9 +376,12 @@ func TestMakeReservationErrorHandler_NominationHandling(t *testing.T) {
 				PodInfo: podInfo,
 			}
 
-			nominatingInfo := &framework.NominatingInfo{
-				NominatingMode:    tt.nominatingMode,
-				NominatedNodeName: tt.nominatedNodeName,
+			var nominatingInfo *framework.NominatingInfo
+			if !tt.nilNominatingInfo {
+				nominatingInfo = &framework.NominatingInfo{
+					NominatingMode:    tt.nominatingMode,
+					NominatedNodeName: tt.nominatedNodeName,
+				}
 			}
 
 			handler(context.TODO(), extendedHandle, queuedPodInfo, framework.NewStatus(framework.Unschedulable, "test error"), nominatingInfo, time.Now())


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix panic when the `schedulePod` returns a nil nominatingInfo.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
