### PR TITLE
scheduler: add scheduling hint plugin

### DIFF
--- a/apis/extension/multi_scheduler.go
+++ b/apis/extension/multi_scheduler.go
@@ -35,7 +35,7 @@ func GetSchedulerName(pod *corev1.Pod) string {
 }
 
 type SchedulingHint struct {
-	NodeNames  []string               `json:"nodeName,omitempty"`
+	NodeNames  []string               `json:"nodeNames,omitempty"`
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 

--- a/cmd/koord-scheduler/main.go
+++ b/cmd/koord-scheduler/main.go
@@ -34,6 +34,7 @@ import (
 	noderesourcesfitplus "github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/noderesourcefitplus"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/scarceresourceavoidance"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/schedulinghint"
 
 	// Ensure metric package is initialized
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
@@ -51,6 +52,7 @@ var koordinatorPlugins = map[string]frameworkruntime.PluginFactory{
 	defaultprebind.Name:          defaultprebind.New,
 	noderesourcesfitplus.Name:    noderesourcesfitplus.New,
 	scarceresourceavoidance.Name: scarceresourceavoidance.New,
+	schedulinghint.Name:          schedulinghint.New,
 }
 
 func flatten(plugins map[string]frameworkruntime.PluginFactory) []app.Option {

--- a/config/manager/scheduler-config.yaml
+++ b/config/manager/scheduler-config.yaml
@@ -60,6 +60,7 @@ data:
               - name: PrioritySort
           preFilter:
             enabled:
+              - name: SchedulingHint
               - name: Reservation
               - name: NodeNUMAResource
               - name: DeviceShare

--- a/pkg/scheduler/plugins/schedulinghint/scheduling_hint.go
+++ b/pkg/scheduler/plugins/schedulinghint/scheduling_hint.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulinghint
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
+)
+
+const Name = "SchedulingHint"
+
+var (
+	_ framework.PreFilterPlugin         = &Plugin{}
+	_ frameworkext.PreFilterTransformer = &Plugin{}
+)
+
+type Plugin struct {
+	handle frameworkext.ExtendedHandle
+}
+
+func New(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	extendedHandle, ok := handle.(frameworkext.ExtendedHandle)
+	if !ok {
+		return nil, fmt.Errorf("handle is not a frameworkext.ExtendedHandle")
+	}
+	return &Plugin{
+		handle: extendedHandle,
+	}, nil
+}
+
+func (p *Plugin) Name() string {
+	return Name
+}
+
+func (p *Plugin) PreFilter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod) (*framework.PreFilterResult, *framework.Status) {
+	hintState := hinter.GetSchedulingHintState(state)
+	if hintState == nil || len(hintState.PreFilterNodes) <= 0 {
+		return nil, nil
+	}
+	return &framework.PreFilterResult{
+		NodeNames: sets.New(hintState.PreFilterNodes...),
+	}, nil
+}
+
+func (p *Plugin) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
+}
+
+func (p *Plugin) BeforePreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod) (*corev1.Pod, bool, *framework.Status) {
+	hint, err := extension.GetSchedulingHint(pod)
+	if err != nil {
+		return nil, false, framework.NewStatus(framework.Error, err.Error())
+	}
+	if hint == nil {
+		return nil, false, nil
+	}
+	hinter.SetSchedulingHintState(cycleState, &hinter.SchedulingHintStateData{
+		PreFilterNodes: hint.NodeNames,
+		Extensions:     hint.Extensions,
+	})
+	klog.V(4).InfoS("Use scheduling hint", "pod", klog.KObj(pod), "PreFilterNodes", hint.NodeNames, "extensions", hint.Extensions)
+	return nil, false, nil
+}
+
+func (p *Plugin) AfterPreFilter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, preRes *framework.PreFilterResult) *framework.Status {
+	return nil
+}

--- a/pkg/scheduler/plugins/schedulinghint/scheduling_hint_test.go
+++ b/pkg/scheduler/plugins/schedulinghint/scheduling_hint_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulinghint
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
+)
+
+func TestPlugin_Name(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, Name, p.Name())
+}
+
+func TestPlugin_PreFilter(t *testing.T) {
+	p := &Plugin{}
+	state := framework.NewCycleState()
+	pod := &corev1.Pod{}
+	res, status := p.PreFilter(context.TODO(), state, pod)
+	assert.Nil(t, res)
+	assert.Nil(t, status)
+
+	hintPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				extension.AnnotationSchedulingHint: "{\"nodeNames\":[\"node-1\",\"node-2\"]}",
+			},
+		},
+	}
+	state = framework.NewCycleState()
+	_, _, _ = p.BeforePreFilter(context.TODO(), state, hintPod)
+	res, status = p.PreFilter(context.TODO(), state, hintPod)
+	assert.Nil(t, status)
+	assert.Equal(t, &framework.PreFilterResult{NodeNames: sets.New("node-1", "node-2")}, res)
+	_ = p.AfterPreFilter(context.TODO(), state, hintPod, res)
+}
+
+func TestPlugin_PreFilterExtensions(t *testing.T) {
+	p := &Plugin{}
+	assert.Nil(t, p.PreFilterExtensions())
+}
+
+func TestPlugin_AfterPreFilter(t *testing.T) {
+	p := &Plugin{}
+	state := framework.NewCycleState()
+	pod := &corev1.Pod{}
+	status := p.AfterPreFilter(context.TODO(), state, pod, nil)
+	assert.Nil(t, status)
+}
+
+func TestPlugin_BeforePreFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		wantModified   bool
+		wantStatusNil  bool
+		wantStatusCode framework.Code
+		wantHintState  *hinter.SchedulingHintStateData
+	}{
+		{
+			name:           "nil pod",
+			pod:            nil,
+			wantModified:   false,
+			wantStatusNil:  true,
+			wantHintState:  nil,
+			wantStatusCode: framework.Success,
+		},
+		{
+			name: "no scheduling hint annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other-annotation": "value",
+					},
+				},
+			},
+			wantModified:   false,
+			wantStatusNil:  true,
+			wantHintState:  nil,
+			wantStatusCode: framework.Success,
+		},
+		{
+			name: "valid scheduling hint with node names and extensions",
+			pod: func() *corev1.Pod {
+				h := &extension.SchedulingHint{
+					NodeNames: []string{"node-1", "node-2"},
+					Extensions: map[string]interface{}{
+						"key": "value",
+					},
+				}
+				b, _ := json.Marshal(h)
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							extension.AnnotationSchedulingHint: string(b),
+						},
+					},
+				}
+			}(),
+			wantModified:  false,
+			wantStatusNil: true,
+			wantHintState: &hinter.SchedulingHintStateData{
+				PreFilterNodes: []string{"node-1", "node-2"},
+				Extensions:     map[string]interface{}{"key": "value"},
+			},
+			wantStatusCode: framework.Success,
+		},
+		{
+			name: "invalid scheduling hint json",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						extension.AnnotationSchedulingHint: "invalid-json",
+					},
+				},
+			},
+			wantModified:   false,
+			wantStatusNil:  false,
+			wantHintState:  nil,
+			wantStatusCode: framework.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			state := framework.NewCycleState()
+
+			retPod, modified, status := p.BeforePreFilter(context.TODO(), state, tt.pod)
+
+			assert.Nil(t, retPod)
+			assert.Equal(t, tt.wantModified, modified)
+
+			if tt.wantStatusNil {
+				assert.Nil(t, status)
+			} else {
+				assert.NotNil(t, status)
+				assert.Equal(t, tt.wantStatusCode, status.Code())
+			}
+
+			hintState := hinter.GetSchedulingHintState(state)
+			if tt.wantHintState == nil {
+				assert.Nil(t, hintState)
+			} else {
+				assert.NotNil(t, hintState)
+				assert.Equal(t, tt.wantHintState.PreFilterNodes, hintState.PreFilterNodes)
+				assert.Equal(t, tt.wantHintState.Extensions, hintState.Extensions)
+			}
+		})
+	}
+}
+
+func TestNew_HandleIsNotExtendedHandle(t *testing.T) {
+	var handle framework.Handle = nil
+	p, err := New(nil, handle)
+	assert.Nil(t, p)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Add the plugin SchedulingHint to apply the hint state according to pod annotations.
Fix the typo for the scheduling hint API.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
