### PR TITLE
webhook: support skipping pod enhanced validation via label

### DIFF
--- a/apis/extension/constants.go
+++ b/apis/extension/constants.go
@@ -48,6 +48,9 @@ const (
 	// LabelPodEvictEnabled is a label key that pods with `koordinator.sh/eviction-disabled` will
 	// be able to evict.
 	LabelPodEvictEnabled = DomainPrefix + "eviction-enabled"
+
+	// LabelPodSkipEnhancedValidation is the pod label key used to opt out a pod from enhanced validation.
+	LabelPodSkipEnhancedValidation = PodDomainPrefix + "/skip-enhanced-validation"
 )
 
 type AggregationType string

--- a/pkg/webhook/pod/validating/pod_enhanced_validator.go
+++ b/pkg/webhook/pod/validating/pod_enhanced_validator.go
@@ -48,10 +48,6 @@ const (
 
 	// DefaultConfReconcileInterval is the default reconcile interval for config
 	DefaultConfReconcileInterval = 5 * time.Minute
-
-	// LabelKeySkipEnhancedValidation is the pod label key used to opt out a pod from enhanced validation.
-	// Set to "true" to skip all pod-enhanced-validator rules for that pod.
-	LabelKeySkipEnhancedValidation = extension.PodDomainPrefix + "/skip-enhanced-validation"
 )
 
 var (
@@ -279,7 +275,7 @@ func (m *PodEnhancedValidator) ValidatePod(pod *corev1.Pod) (string, error) {
 		return "", nil
 	}
 	// skip validation for pods with the skip-enhanced-validation label
-	if pod.Labels[LabelKeySkipEnhancedValidation] == "true" {
+	if pod.Labels[extension.LabelPodSkipEnhancedValidation] == "true" {
 		return "", nil
 	}
 	// validate pod against all rules

--- a/pkg/webhook/pod/validating/pod_enhanced_validator_test.go
+++ b/pkg/webhook/pod/validating/pod_enhanced_validator_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
@@ -180,7 +181,7 @@ func TestPodEnhancedValidate(t *testing.T) {
 			name:      "quota-label-required: pod with skip-enhanced-validation label",
 			operation: admissionv1.Create,
 			newPod: elasticquota.MakePod("ns1", "pod1").Label(
-				LabelKeySkipEnhancedValidation, "true").Obj(),
+				extension.LabelPodSkipEnhancedValidation, "true").Obj(),
 			configMap:   quotaLabelRequiredCM,
 			wantAllowed: true,
 			wantReason:  "",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
This PR introduces a skip-enhanced-validation label mechanism that allows specific pods to bypass all enhanced validation rules. This feature is particularly useful for system-critical pods or those managed by other controllers that should be exempt from certain validation constraints.

Changed logic:
1. Added a new constant [LabelKeySkipEnhancedValidation](file:///Users/yangtao/Desk/workspace_go/github.com/koordinator/pkg/webhook/pod/validating/pod_enhanced_validator.go#L53-L54) with the value `pod.koordinator.sh/skip-enhanced-validation`
2. Implemented a check in the [ValidatePod](file:///Users/yangtao/Desk/workspace_go/github.com/koordinator/pkg/webhook/elasticquota/plugin_check_quota_meta_validate.go#L96-L117) function to skip all validation rules when a pod has this label set to "true"
3. Added a comprehensive test case to verify that pods with the skip-enhanced-validation label correctly bypass validation

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
