### PR TITLE
scheduler: fix reservation unreserve when binding leak

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -200,7 +200,8 @@ func (f *FrameworkExtenderFactory) InitScheduler(sched Scheduler) {
 				RecordPodQueueInfoToPod(podInfo)
 			}
 			f.monitor.RecordNextPod(podInfo)
-			if k8sfeature.DefaultFeatureGate.Enabled(features.ResizePod) {
+			if podInfo != nil && k8sfeature.DefaultFeatureGate.Enabled(features.ResizePod) {
+				// The podInfo can be nil when the queue is closing.
 				// Deep copy podInfo to allow pod modification during scheduling
 				podInfo = podInfo.DeepCopy()
 			}
@@ -250,6 +251,9 @@ func CopyQueueInfoToPod(podHasQueueInfo, podNeedQueueInfo *corev1.Pod) *corev1.P
 }
 
 func RecordPodQueueInfoToPod(podInfo *framework.QueuedPodInfo) {
+	if podInfo == nil || podInfo.Pod == nil { // the podInfo can be nil when the queue is closing
+		return
+	}
 	var initialTimestamp *metav1.Time
 	if podInfo.InitialAttemptTimestamp != nil {
 		initialTimestamp = &metav1.Time{Time: *podInfo.InitialAttemptTimestamp}

--- a/pkg/scheduler/frameworkext/framework_extender_factory_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory_test.go
@@ -153,6 +153,13 @@ func TestRecordPodQueueInfoToPod(t *testing.T) {
 		wantOriginalPod *corev1.Pod
 	}{
 		{
+			name:            "podInfo is nil",
+			originalPod:     nil,
+			podInfo:         nil,
+			wantPod:         nil,
+			wantOriginalPod: nil,
+		},
+		{
 			name:        "normal flow",
 			originalPod: &corev1.Pod{},
 			podInfo: &framework.QueuedPodInfo{
@@ -173,10 +180,16 @@ func TestRecordPodQueueInfoToPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.podInfo.Pod = tt.originalPod
+			if tt.originalPod != nil {
+				tt.podInfo.Pod = tt.originalPod
+			}
 			RecordPodQueueInfoToPod(tt.podInfo)
 			assert.Equal(t, tt.wantOriginalPod, tt.originalPod)
-			assert.Equal(t, tt.wantPod, tt.podInfo.PodInfo.Pod)
+			if tt.wantPod != nil {
+				assert.Equal(t, tt.wantPod, tt.podInfo.PodInfo.Pod)
+			} else {
+				assert.Nil(t, tt.podInfo)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/frameworkext/helper/forcesync_factory.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_factory.go
@@ -60,6 +60,7 @@ func (f *forceSyncSharedInformerFactory) InformerFor(obj runtime.Object, newFunc
 func (f *forceSyncSharedInformerFactory) Core() core.Interface {
 	return core.New(f, f.namespace, f.tweakListOptions)
 }
+
 func (f *forceSyncSharedInformerFactory) Storage() storage.Interface {
 	return storage.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -56,6 +56,7 @@ func (f *FakeFitPlugin) Filter(ctx context.Context, state *framework.CycleState,
 	}
 	return nil
 }
+
 func (f *FakeFitPlugin) Name() string {
 	return "FakeFitPlugin"
 }

--- a/pkg/scheduler/frameworkext/scheduler_adapter.go
+++ b/pkg/scheduler/frameworkext/scheduler_adapter.go
@@ -112,10 +112,12 @@ func (c *cacheAdapter) AddPod(logger klog.Logger, pod *corev1.Pod) error {
 func (c *cacheAdapter) UpdatePod(logger klog.Logger, oldPod, newPod *corev1.Pod) error {
 	return c.scheduler.Cache.UpdatePod(logger, oldPod, newPod)
 }
+
 func (c *cacheAdapter) RemovePod(logger klog.Logger, pod *corev1.Pod) error {
 	return c.scheduler.Cache.RemovePod(logger, pod)
 
 }
+
 func (c *cacheAdapter) AssumePod(logger klog.Logger, pod *corev1.Pod) error {
 	return c.scheduler.Cache.AssumePod(logger, pod)
 }

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -136,6 +136,7 @@ func makePg(name, namespace string, min int32, creationTime *time.Time, minResou
 	}
 	return pg
 }
+
 func (f *testSharedLister) NodeInfos() framework.NodeInfoLister {
 	return f
 }

--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager_test.go
@@ -292,6 +292,7 @@ func TestGroupQuotaManager_UpdateResourceKeyNoLock(t *testing.T) {
 		map[v1.ResourceName]struct{}{v1.ResourceMemory: {}},
 	)
 }
+
 func TestGroupQuotaManager_DeleteOneGroup(t *testing.T) {
 	gqm := NewGroupQuotaManagerForTest()
 	gqm.UpdateClusterTotalResource(createResourceList(1000, 1000*GigaByte))

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
@@ -198,6 +198,7 @@ func (p *podAssignCache) GetNodeMetricAndEstimatedOfExisting(name string, prodPo
 	}
 	return
 }
+
 func (n *nodeInfo) getTargetAggregatedUsage(aggregatedDuration metav1.Duration, aggregationType extension.AggregationType) ResourceVector {
 	// If no specific period is set, the non-empty maximum period recorded by NodeMetrics will be used by default.
 	// This is a default policy.
@@ -209,6 +210,7 @@ func (n *nodeInfo) getTargetAggregatedUsage(aggregatedDuration metav1.Duration, 
 	}
 	return vec
 }
+
 func (p *podAssignCache) getPodAssignInfo(nodeName string, pod *corev1.Pod) *podAssignInfo {
 	if nodeName == "" {
 		return nil


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

scheduler: fix a reservation cache leak bug when a bind request fails but eventually succeeds to assign pod.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
