### PR TITLE
scheduler: fix coscheduling prebind with illegal labels

### DIFF
--- a/apis/extension/coscheduling.go
+++ b/apis/extension/coscheduling.go
@@ -187,8 +187,8 @@ func SortPodsByIndex(pods []*corev1.Pod) {
 }
 
 const (
-	// LabelBindGangGroupId is the label of the pod's gang group id to bind.
-	LabelBindGangGroupId = SchedulingDomainPrefix + "/bind-gang-group-id"
-	// LabelBindGangMemberCount is the count of the pod's gang group member pods to bind.
-	LabelBindGangMemberCount = SchedulingDomainPrefix + "/bind-gang-member-count"
+	// AnnotationBindGangGroupId is the annotation key for the pod's gang group id to bind.
+	AnnotationBindGangGroupId = SchedulingDomainPrefix + "/bind-gang-group-id"
+	// AnnotationBindGangMemberCount is the annotation key for the count of the pod's gang group member pods to bind.
+	AnnotationBindGangMemberCount = SchedulingDomainPrefix + "/bind-gang-member-count"
 )

--- a/config/manager/scheduler-config.yaml
+++ b/config/manager/scheduler-config.yaml
@@ -108,6 +108,7 @@ data:
               - name: NodeNUMAResource
               - name: DeviceShare
               - name: Reservation
+              - name: Coscheduling
               - name: DefaultPreBind
           bind:
             disabled:

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -216,11 +216,11 @@ func (cs *Coscheduling) PreBind(ctx context.Context, cycleState *framework.Cycle
 	if gangInfo == nil {
 		return nil
 	}
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
 	}
-	pod.Labels[extension.LabelBindGangGroupId] = gangInfo.GangGroupId
-	pod.Labels[extension.LabelBindGangMemberCount] = strconv.FormatInt(int64(gangInfo.MemberCount), 10)
+	pod.Annotations[extension.AnnotationBindGangGroupId] = gangInfo.GangGroupId
+	pod.Annotations[extension.AnnotationBindGangMemberCount] = strconv.FormatInt(int64(gangInfo.MemberCount), 10)
 	return nil
 }
 
@@ -230,11 +230,11 @@ func (cs *Coscheduling) PreBindReservation(ctx context.Context, cycleState *fram
 	if gangInfo == nil {
 		return nil
 	}
-	if r.Labels == nil {
-		r.Labels = make(map[string]string)
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
 	}
-	r.Labels[extension.LabelBindGangGroupId] = gangInfo.GangGroupId
-	r.Labels[extension.LabelBindGangMemberCount] = strconv.FormatInt(int64(gangInfo.MemberCount), 10)
+	r.Annotations[extension.AnnotationBindGangGroupId] = gangInfo.GangGroupId
+	r.Annotations[extension.AnnotationBindGangMemberCount] = strconv.FormatInt(int64(gangInfo.MemberCount), 10)
 	return nil
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -716,20 +716,20 @@ func TestPreBind(t *testing.T) {
 				}
 			}
 
-			// Act: PreBind should set gang binding labels
+			// Act: PreBind should set gang binding annotations
 			preBindStatus := gp.PreBind(ctx, cycleState, tt.pod, "node-1")
 			assert.True(t, preBindStatus.IsSuccess())
 
-			// Assert: check gang labels
+			// Assert: check gang annotations
 			if tt.expectLabelsSet {
-				assert.Equal(t, tt.expectGangGroupID, tt.pod.Labels[extension.LabelBindGangGroupId])
-				assert.Equal(t, tt.expectMemberCount, tt.pod.Labels[extension.LabelBindGangMemberCount])
+				assert.Equal(t, tt.expectGangGroupID, tt.pod.Annotations[extension.AnnotationBindGangGroupId])
+				assert.Equal(t, tt.expectMemberCount, tt.pod.Annotations[extension.AnnotationBindGangMemberCount])
 				if tt.podHasExistingLabel {
 					assert.Equal(t, "custom-value", tt.pod.Labels["custom-label"])
 				}
 			} else {
-				assert.NotContains(t, tt.pod.Labels, extension.LabelBindGangGroupId)
-				assert.NotContains(t, tt.pod.Labels, extension.LabelBindGangMemberCount)
+				assert.NotContains(t, tt.pod.Annotations, extension.AnnotationBindGangGroupId)
+				assert.NotContains(t, tt.pod.Annotations, extension.AnnotationBindGangMemberCount)
 			}
 		})
 	}
@@ -865,22 +865,22 @@ func TestPreBindReservation(t *testing.T) {
 				}
 			}
 
-			// Act: PreBindReservation should set gang binding labels
+			// Act: PreBindReservation should set gang binding annotations
 			preBindRStatus := gp.PreBindReservation(ctx, cycleState, tt.reservation, "node-1")
 			assert.True(t, preBindRStatus.IsSuccess())
 
-			// Assert: check gang labels on the Reservation
+			// Assert: check gang annotations on the Reservation
 			if tt.expectLabelsSet {
-				assert.NotNil(t, tt.reservation.Labels)
-				assert.Equal(t, tt.expectGangGroupID, tt.reservation.Labels[extension.LabelBindGangGroupId])
-				assert.Equal(t, tt.expectMemberCount, tt.reservation.Labels[extension.LabelBindGangMemberCount])
+				assert.NotNil(t, tt.reservation.Annotations)
+				assert.Equal(t, tt.expectGangGroupID, tt.reservation.Annotations[extension.AnnotationBindGangGroupId])
+				assert.Equal(t, tt.expectMemberCount, tt.reservation.Annotations[extension.AnnotationBindGangMemberCount])
 				if tt.reservationHasLabel {
 					assert.Equal(t, "custom-value", tt.reservation.Labels["custom-label"])
 				}
 			} else {
-				if tt.reservation.Labels != nil {
-					assert.NotContains(t, tt.reservation.Labels, extension.LabelBindGangGroupId)
-					assert.NotContains(t, tt.reservation.Labels, extension.LabelBindGangMemberCount)
+				if tt.reservation.Annotations != nil {
+					assert.NotContains(t, tt.reservation.Annotations, extension.AnnotationBindGangGroupId)
+					assert.NotContains(t, tt.reservation.Annotations, extension.AnnotationBindGangMemberCount)
 				}
 			}
 		})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: Fix the issue that pods with gang scheduling may fail the pre-bind due to the Coscheduling plugin patches the pod with invalid labels.

It is introduced in #2655. The value `GangGroupId` may be "ns-xxx/job-yyy" or "job-a,job-b,job-c" which are not the legal format of the label values. In this patch, we use annotations instead of labels to denote the gang binding info.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
