### PR TITLE
scheduler: support reservation scale changed by spec

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -460,7 +460,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	frameworkExtenderFactory.InitScheduler(&frameworkext.SchedulerAdapter{Scheduler: sched})
 	schedAdapter := frameworkExtenderFactory.Scheduler()
 
-	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
+	eventhandlers.AddScheduleEventHandler(cc.KoordinatorClient, sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
 	reservationErrorHandler := eventhandlers.MakeReservationErrorHandler(
 		sched,
 		schedAdapter,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -96,6 +96,9 @@ const (
 
 	// ValidatePodDeviceResource enables validate pod device resource
 	ValidatePodDeviceResource featuregate.Feature = "ValidatePodDeviceResource"
+
+	// ReservationEnableUpdateSpec enables update reservation status by reservation spec changed
+	ReservationEnableUpdateSpec featuregate.Feature = "ReservationEnableUpdateSpec"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -123,6 +123,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	CSIStorageCapacity:                        {Default: true, PreRelease: featuregate.GA},    // remove in 1.26
 	GenericEphemeralVolume:                    {Default: true, PreRelease: featuregate.GA},
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},
+	ReservationEnableUpdateSpec:               {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/scheduler/frameworkext/eventhandlers/event_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/event_handler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 
+	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
@@ -34,7 +35,7 @@ import (
 // - Reservation event handlers for the scheduler just like pods'. One special case is that reservations have expiration, which the scheduler should clean up expired ones from the
 // cache and queue.
 // - Pod and reservation event handlers for multi-scheduler clean up.
-func AddScheduleEventHandler(sched *scheduler.Scheduler, schedAdapter frameworkext.Scheduler, informerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
+func AddScheduleEventHandler(client koordinatorclientset.Interface, sched *scheduler.Scheduler, schedAdapter frameworkext.Scheduler, informerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	if k8sfeature.DefaultFeatureGate.Enabled(features.DynamicSchedulerCheck) {
 		// Clean up irresponsible pods for scheduling queue
@@ -46,7 +47,7 @@ func AddScheduleEventHandler(sched *scheduler.Scheduler, schedAdapter frameworke
 
 	reservationInformer := koordSharedInformerFactory.Scheduling().V1alpha1().Reservations().Informer()
 	// unified reservation event handler for both cache and queue
-	_, err := reservationInformer.AddEventHandler(reservationEventHandlers(sched, schedAdapter))
+	_, err := reservationInformer.AddEventHandler(reservationEventHandlers(client, sched, schedAdapter))
 	if err != nil {
 		klog.Fatalf("failed to add reservation handler, err: %s", err)
 	}

--- a/pkg/scheduler/frameworkext/eventhandlers/event_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/event_handler_test.go
@@ -41,7 +41,7 @@ func TestAddScheduleEventHandler(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
 		koordClientSet := koordfake.NewSimpleClientset()
 		koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-		AddScheduleEventHandler(sched, internalHandler, informerFactory, koordSharedInformerFactory)
+		AddScheduleEventHandler(nil, sched, internalHandler, informerFactory, koordSharedInformerFactory)
 	})
 }
 

--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/klog/v2"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
@@ -129,7 +131,8 @@ func NewReservePod(r *schedulingv1alpha1.Reservation) *corev1.Pod {
 	} else if IsReservationExpired(r) || IsReservationFailed(r) {
 		reservePod.Status.Phase = corev1.PodFailed
 	}
-	if IsReservationAvailable(r) {
+	if !k8sfeature.DefaultMutableFeatureGate.Enabled(features.ReservationEnableUpdateSpec) &&
+		IsReservationAvailable(r) {
 		podRequests := resource.PodRequests(reservePod, resource.PodResourcesOptions{})
 		if !quotav1.Equals(podRequests, r.Status.Allocatable) {
 			//


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

It is necessary to provide changes to the requested resources for reservations that are currently available. Since the source of resource requests is templates, it is hoped that changes can also be made through the same fields. However, currently only the status field can be provided to reverse correct the scheduling ledger, which results in template resource request changes being forcibly corrected even if they are modified.

### Ⅱ. Does this pull request fix one issue?

Add features ReservationEnableUpdateSpec to enable reservation scale changed by spec template, and ignore status allocatable changes when ReservationEnabling Update Spec is set

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
