### PR TITLE
webhook: support skip validating priority when feature ColocationProf…

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -51,6 +51,9 @@ const (
 	// ColocationProfileSkipMutatingResources config whether to update resourceName according to priority by default
 	ColocationProfileSkipMutatingResources featuregate.Feature = "ColocationProfileSkipMutatingResources"
 
+	// ColocationProfileSkipValidatingPriority config whether to validate label priority
+	ColocationProfileSkipValidatingPriority featuregate.Feature = "ColocationProfileSkipValidatingPriority"
+
 	// WebhookFramework enables webhook framework, global feature-gate for webhook
 	WebhookFramework featuregate.Feature = "WebhookFramework"
 
@@ -102,28 +105,29 @@ const (
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PodMutatingWebhook:                     {Default: true, PreRelease: featuregate.Beta},
-	PodValidatingWebhook:                   {Default: true, PreRelease: featuregate.Beta},
-	ElasticQuotaMutatingWebhook:            {Default: true, PreRelease: featuregate.Beta},
-	ElasticQuotaValidatingWebhook:          {Default: true, PreRelease: featuregate.Beta},
-	NodeMutatingWebhook:                    {Default: false, PreRelease: featuregate.Alpha},
-	NodeValidatingWebhook:                  {Default: false, PreRelease: featuregate.Alpha},
-	ConfigMapValidatingWebhook:             {Default: false, PreRelease: featuregate.Alpha},
-	ReservationMutatingWebhook:             {Default: false, PreRelease: featuregate.Alpha},
-	WebhookFramework:                       {Default: true, PreRelease: featuregate.Beta},
-	ColocationProfileSkipMutatingResources: {Default: false, PreRelease: featuregate.Alpha},
-	MultiQuotaTree:                         {Default: false, PreRelease: featuregate.Alpha},
-	ElasticQuotaIgnorePodOverhead:          {Default: false, PreRelease: featuregate.Alpha},
-	ElasticQuotaGuaranteeUsage:             {Default: false, PreRelease: featuregate.Alpha},
-	ElasticQuotaEnableUpdateResourceKey:    {Default: false, PreRelease: featuregate.Alpha},
-	ElasticQuotaEvaluationTransformPod:     {Default: false, PreRelease: featuregate.Alpha},
-	DisableDefaultQuota:                    {Default: false, PreRelease: featuregate.Alpha},
-	SupportParentQuotaSubmitPod:            {Default: false, PreRelease: featuregate.Alpha},
-	EnableQuotaAdmission:                   {Default: false, PreRelease: featuregate.Alpha},
-	EnableSyncGPUSharedResource:            {Default: false, PreRelease: featuregate.Alpha},
-	ColocationProfileController:            {Default: false, PreRelease: featuregate.Alpha},
-	ValidatePodDeviceResource:              {Default: false, PreRelease: featuregate.Alpha},
-	EnablePodEnhancedValidator:             {Default: false, PreRelease: featuregate.Alpha},
+	PodMutatingWebhook:                      {Default: true, PreRelease: featuregate.Beta},
+	PodValidatingWebhook:                    {Default: true, PreRelease: featuregate.Beta},
+	ElasticQuotaMutatingWebhook:             {Default: true, PreRelease: featuregate.Beta},
+	ElasticQuotaValidatingWebhook:           {Default: true, PreRelease: featuregate.Beta},
+	NodeMutatingWebhook:                     {Default: false, PreRelease: featuregate.Alpha},
+	NodeValidatingWebhook:                   {Default: false, PreRelease: featuregate.Alpha},
+	ConfigMapValidatingWebhook:              {Default: false, PreRelease: featuregate.Alpha},
+	ReservationMutatingWebhook:              {Default: false, PreRelease: featuregate.Alpha},
+	WebhookFramework:                        {Default: true, PreRelease: featuregate.Beta},
+	ColocationProfileSkipMutatingResources:  {Default: false, PreRelease: featuregate.Alpha},
+	ColocationProfileSkipValidatingPriority: {Default: false, PreRelease: featuregate.Alpha},
+	MultiQuotaTree:                          {Default: false, PreRelease: featuregate.Alpha},
+	ElasticQuotaIgnorePodOverhead:           {Default: false, PreRelease: featuregate.Alpha},
+	ElasticQuotaGuaranteeUsage:              {Default: false, PreRelease: featuregate.Alpha},
+	ElasticQuotaEnableUpdateResourceKey:     {Default: false, PreRelease: featuregate.Alpha},
+	ElasticQuotaEvaluationTransformPod:      {Default: false, PreRelease: featuregate.Alpha},
+	DisableDefaultQuota:                     {Default: false, PreRelease: featuregate.Alpha},
+	SupportParentQuotaSubmitPod:             {Default: false, PreRelease: featuregate.Alpha},
+	EnableQuotaAdmission:                    {Default: false, PreRelease: featuregate.Alpha},
+	EnableSyncGPUSharedResource:             {Default: false, PreRelease: featuregate.Alpha},
+	ColocationProfileController:             {Default: false, PreRelease: featuregate.Alpha},
+	ValidatePodDeviceResource:               {Default: false, PreRelease: featuregate.Alpha},
+	EnablePodEnhancedValidator:              {Default: false, PreRelease: featuregate.Alpha},
 }
 
 const (

--- a/pkg/webhook/pod/validating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/validating/cluster_colocation_profile.go
@@ -27,7 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/util"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
@@ -51,7 +53,9 @@ func (h *PodValidatingHandler) clusterColocationProfileValidatingPod(ctx context
 
 		allErrs = append(allErrs, validateImmutableQoSClass(oldPod, newPod)...)
 		allErrs = append(allErrs, validateImmutablePriorityClass(oldPod, newPod)...)
-		allErrs = append(allErrs, validateImmutablePriority(oldPod, newPod)...)
+		if !utilfeature.DefaultFeatureGate.Enabled(features.ColocationProfileSkipValidatingPriority) {
+			allErrs = append(allErrs, validateImmutablePriority(oldPod, newPod)...)
+		}
 	}
 
 	allErrs = append(allErrs, validateRequiredQoSClass(newPod)...)


### PR DESCRIPTION
…ileSkipValidatingPriority  enabled

### Ⅰ. Describe what this PR does

The current eviction requires the use of a priority label to sort pods, but colocation profile validation does not allow modification of this label.

### Ⅱ. Does this pull request fix one issue?

Add feature ColocationProfileSkipValidatingPriority to skip when it is enabled.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
