### PR TITLE
scheduler: revise reservation's event handler for multi-scheduler

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -60,6 +60,20 @@ type ReservationAllocated struct {
 	UID  types.UID `json:"uid,omitempty"`
 }
 
+func (r *ReservationAllocated) GetName() string {
+	if r == nil {
+		return ""
+	}
+	return r.Name
+}
+
+func (r *ReservationAllocated) GetUID() types.UID {
+	if r == nil {
+		return ""
+	}
+	return r.UID
+}
+
 // ReservationAffinity represents the constraints of Pod selection Reservation
 type ReservationAffinity struct {
 	// Specifies the reservation name directly, other reservation affinity fields will be ignored.

--- a/apis/extension/reservation_test.go
+++ b/apis/extension/reservation_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -132,6 +133,48 @@ func TestRemoveReservationAllocated(t *testing.T) {
 	changed, err = RemoveReservationAllocated(pod, reservation)
 	assert.Error(t, err)
 	assert.False(t, changed)
+}
+
+func TestReservationAllocatedGetters(t *testing.T) {
+	tests := []struct {
+		name       string
+		allocated  *ReservationAllocated
+		expectName string
+		expectUID  types.UID
+	}{
+		{
+			name:       "nil reservation allocated",
+			allocated:  nil,
+			expectName: "",
+			expectUID:  "",
+		},
+		{
+			name: "valid reservation allocated",
+			allocated: &ReservationAllocated{
+				Name: "test-reservation",
+				UID:  "test-uid-123",
+			},
+			expectName: "test-reservation",
+			expectUID:  "test-uid-123",
+		},
+		{
+			name: "empty name and uid",
+			allocated: &ReservationAllocated{
+				Name: "",
+				UID:  "",
+			},
+			expectName: "",
+			expectUID:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName := tt.allocated.GetName()
+			gotUID := tt.allocated.GetUID()
+			assert.Equal(t, tt.expectName, gotName)
+			assert.Equal(t, tt.expectUID, gotUID)
+		})
+	}
 }
 
 func TestExactMatchReservation(t *testing.T) {

--- a/pkg/scheduler/plugins/reservation/cache.go
+++ b/pkg/scheduler/plugins/reservation/cache.go
@@ -168,18 +168,17 @@ func (cache *reservationCache) addPod(reservationUID types.UID, pod *corev1.Pod)
 	return nil
 }
 
-func (cache *reservationCache) updatePod(reservationUID types.UID, oldPod, newPod *corev1.Pod) {
+func (cache *reservationCache) updatePod(oldReservationUID, newReservationUID types.UID, oldPod, newPod *corev1.Pod) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 
-	rInfo := cache.reservationInfos[reservationUID]
-	if rInfo != nil {
-		if oldPod != nil {
-			rInfo.RemoveAssignedPod(oldPod)
-		}
-		if newPod != nil {
-			rInfo.AddAssignedPod(newPod)
-		}
+	oldRInfo := cache.reservationInfos[oldReservationUID]
+	if oldRInfo != nil && oldPod != nil {
+		oldRInfo.RemoveAssignedPod(oldPod)
+	}
+	newRInfo := cache.reservationInfos[newReservationUID]
+	if newRInfo != nil && newPod != nil {
+		newRInfo.AddAssignedPod(newPod)
 	}
 }
 

--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -51,7 +51,7 @@ func (h *reservationEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 	if reservationutil.IsReservationActive(r) {
 		h.cache.updateReservation(r)
 		klog.V(4).InfoS("add reservation into reservationCache",
-			"reservation", klog.KObj(r), "node", reservationutil.GetReservationNodeName(r))
+			"reservation", klog.KObj(r), "uid", r.UID, "node", reservationutil.GetReservationNodeName(r))
 	}
 }
 
@@ -69,7 +69,7 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		h.cache.updateReservation(newR)
 		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(newR))
 		klog.V(4).InfoS("update reservation into reservationCache",
-			"reservation", klog.KObj(newR), "node", reservationutil.GetReservationNodeName(newR))
+			"reservation", klog.KObj(newR), "uid", newR.UID, "node", reservationutil.GetReservationNodeName(newR))
 	} else if reservationutil.IsReservationFailed(newR) || reservationutil.IsReservationSucceeded(newR) {
 		// Here it is only marked that ReservationInfo is unavailable,
 		// and the real deletion operation is executed in deleteReservationFromCache(pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go).
@@ -110,5 +110,5 @@ func (h *reservationEventHandler) OnDelete(obj interface{}) {
 	}
 	h.cache.updateReservationIfExists(r)
 	klog.V(4).InfoS("got delete reservation event but just update it if exists",
-		"reservation", klog.KObj(r), "node", reservationutil.GetReservationNodeName(r))
+		"reservation", klog.KObj(r), "uid", r.UID, "node", reservationutil.GetReservationNodeName(r))
 }

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -97,22 +96,31 @@ func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 	}
 
 	h.nominator.DeleteNominatedReservePodOrReservation(newPod)
-	var reservationUID types.UID
+	var oldRAllocated, newRAllocated *apiext.ReservationAllocated
 	if oldPod != nil {
 		reservationAllocated, err := apiext.GetReservationAllocated(oldPod)
 		if err == nil && reservationAllocated != nil && reservationAllocated.UID != "" {
-			reservationUID = reservationAllocated.UID
+			oldRAllocated = reservationAllocated
 		}
 	}
-	if newPod != nil && reservationUID == "" {
+	if newPod != nil {
 		reservationAllocated, err := apiext.GetReservationAllocated(newPod)
 		if err == nil && reservationAllocated != nil && reservationAllocated.UID != "" {
-			reservationUID = reservationAllocated.UID
+			newRAllocated = reservationAllocated
 		}
 	}
 
-	if reservationUID != "" {
-		h.cache.updatePod(reservationUID, oldPod, newPod)
+	if oldRAllocated != nil || newRAllocated != nil {
+		h.cache.updatePod(oldRAllocated.GetUID(), newRAllocated.GetUID(), oldPod, newPod)
+		if oldRAllocated == nil {
+			klog.V(4).InfoS("add pod for reservation", "pod", klog.KObj(newPod), "reservation", newRAllocated.GetName(), "uid", newRAllocated.GetUID())
+		} else if newRAllocated == nil {
+			klog.V(4).InfoS("delete pod for reservation", "pod", klog.KObj(oldPod), "reservation", oldRAllocated.GetName(), "uid", oldRAllocated.GetUID())
+		} else if oldRAllocated.GetUID() != newRAllocated.GetUID() {
+			klog.V(4).InfoS("update pod for different reservation", "pod", klog.KObj(newPod), "oldReservation", oldRAllocated.GetName(), "oldUID", oldRAllocated.GetUID(), "newReservation", newRAllocated.GetName(), "newUID", newRAllocated.GetUID())
+		} else {
+			klog.V(5).InfoS("update pod for same reservation", "pod", klog.KObj(newPod), "reservation", newRAllocated.GetName(), "uid", newRAllocated.GetUID())
+		}
 	}
 
 	if newPod != nil && apiext.IsReservationOperatingMode(newPod) {
@@ -133,6 +141,7 @@ func (h *podEventHandler) deletePod(pod *corev1.Pod) {
 	reservationAllocated, err := apiext.GetReservationAllocated(pod)
 	if err == nil && reservationAllocated != nil && reservationAllocated.UID != "" {
 		h.cache.deletePod(reservationAllocated.UID, pod)
+		klog.V(4).InfoS("delete pod for reservation", "pod", klog.KObj(pod), "reservation", reservationAllocated.GetName(), "uid", reservationAllocated.GetUID())
 	}
 
 	if apiext.IsReservationOperatingMode(pod) {

--- a/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_benchmark_test.go
@@ -372,7 +372,7 @@ func BenchmarkBeforePrefilterWithUnmatchedPod(b *testing.B) {
 					},
 				},
 			}
-			pl.reservationCache.updatePod(reservation.UID, nil, pod)
+			pl.reservationCache.updatePod(reservation.UID, reservation.UID, nil, pod)
 			nodeInfo.AddPod(pod)
 			assert.NoError(b, pl.handle.Scheduler().GetCache().AddPod(klog.Background(), pod))
 		}
@@ -783,7 +783,7 @@ func BenchmarkBeforePrefilterWithUnmatchedPodEnableLazyReservationRestore(b *tes
 					},
 				},
 			}
-			pl.reservationCache.updatePod(reservation.UID, nil, pod)
+			pl.reservationCache.updatePod(reservation.UID, reservation.UID, nil, pod)
 			nodeInfo.AddPod(pod)
 			assert.NoError(b, pl.handle.Scheduler().GetCache().AddPod(klog.Background(), pod))
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: revise the reservation's event handler for mult-scheduler scenarios where:

1. The allocated reservation of the pod can change.
2. A reservation can transform from assigned to unassigned due to arbitration failure.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
