### PR TITLE
scheduler: fix deviceshare leak for unassigned pods

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
@@ -119,7 +119,7 @@ func (n *nodeDeviceCache) updatePod(oldPod *corev1.Pod, pod *corev1.Pod) {
 	info := n.getNodeDevice(pod.Spec.NodeName, true)
 	info.lock.Lock()
 	defer info.lock.Unlock()
-	if oldPod != nil && len(oldAllocations) > 0 {
+	if oldPod != nil && oldPod.Spec.NodeName != "" && len(oldAllocations) > 0 { // avoid leaking for an unassigned pod
 		info.updateCacheUsed(oldAllocations, oldPod, false)
 		klog.V(5).InfoS("remove old pod from nodeDevice cache on node", "pod", klog.KObj(pod), "node", oldPod.Spec.NodeName)
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: fix a cache leak bug when an unassigned pod has device-allocated annotation and then binding to a new node.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
