### PR TITLE
scheduler: fix frameworkExtender for multi-profile

### DIFF
--- a/pkg/scheduler/frameworkext/controllers.go
+++ b/pkg/scheduler/frameworkext/controllers.go
@@ -68,14 +68,14 @@ func NewControllersMap() *ControllersMap {
 	}
 }
 
-func (cm *ControllersMap) RegisterControllers(plugin framework.Plugin) {
+func (cm *ControllersMap) RegisterControllers(plugin framework.Plugin, profileName string) {
 	controllerProvider, ok := plugin.(ControllerProvider)
 	if !ok {
 		return
 	}
 	pluginControllers := cm.controllers[plugin.Name()]
 	if len(pluginControllers) > 0 {
-		klog.Warningf("Plugin %s already build controllers, skip it", plugin.Name())
+		klog.InfoS("Plugin already build controllers, skip it", "plugin", plugin.Name(), "profile", profileName, "controllers", len(pluginControllers))
 		return
 	}
 
@@ -91,6 +91,7 @@ func (cm *ControllersMap) RegisterControllers(plugin framework.Plugin) {
 		}
 		cm.controllers[plugin.Name()] = pluginControllers
 	}
+	klog.V(4).InfoS("Plugin successfully build controllers", "plugin", plugin.Name(), "profile", profileName, "controllers", len(pluginControllers))
 }
 
 func (cm *ControllersMap) Start() {

--- a/pkg/scheduler/frameworkext/controllers_test.go
+++ b/pkg/scheduler/frameworkext/controllers_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakePlugin implements framework.Plugin interface for testing
+type fakePlugin struct {
+	name string
+}
+
+func (f *fakePlugin) Name() string {
+	return f.name
+}
+
+// fakeControllerPlugin implements both framework.Plugin and ControllerProvider for testing
+type fakeControllerPlugin struct {
+	name        string
+	controllers []Controller
+	err         error
+}
+
+func (f *fakeControllerPlugin) Name() string {
+	return f.name
+}
+
+func (f *fakeControllerPlugin) NewControllers() ([]Controller, error) {
+	return f.controllers, f.err
+}
+
+// fakeController implements Controller interface for testing
+type fakeController struct {
+	name    string
+	started bool
+}
+
+func (f *fakeController) Name() string {
+	return f.name
+}
+
+func (f *fakeController) Start() {
+	f.started = true
+}
+
+func TestControllersMap_RegisterControllers(t *testing.T) {
+	tests := []struct {
+		name                       string
+		plugins                    []*fakeControllerPlugin
+		profileNames               []string
+		expectedControllerCounts   []int // expected number of controllers for each plugin
+		expectedTotalRegistrations int   // total number of unique plugins registered
+	}{
+		{
+			name: "register single plugin with controllers",
+			plugins: []*fakeControllerPlugin{
+				{
+					name: "plugin1",
+					controllers: []Controller{
+						&fakeController{name: "controller1"},
+						&fakeController{name: "controller2"},
+					},
+				},
+			},
+			profileNames:               []string{"profile1"},
+			expectedControllerCounts:   []int{2},
+			expectedTotalRegistrations: 1,
+		},
+		{
+			name: "register duplicate plugin should skip second registration",
+			plugins: []*fakeControllerPlugin{
+				{
+					name: "plugin1",
+					controllers: []Controller{
+						&fakeController{name: "controller1"},
+					},
+				},
+				{
+					name: "plugin1", // duplicate
+					controllers: []Controller{
+						&fakeController{name: "controller2"},
+					},
+				},
+			},
+			profileNames:               []string{"profile1", "profile2"},
+			expectedControllerCounts:   []int{1, 1}, // second registration should be skipped
+			expectedTotalRegistrations: 1,
+		},
+		{
+			name: "register different plugins should both succeed",
+			plugins: []*fakeControllerPlugin{
+				{
+					name: "plugin1",
+					controllers: []Controller{
+						&fakeController{name: "controller1"},
+					},
+				},
+				{
+					name: "plugin2",
+					controllers: []Controller{
+						&fakeController{name: "controller2"},
+					},
+				},
+			},
+			profileNames:               []string{"profile1", "profile2"},
+			expectedControllerCounts:   []int{1, 1},
+			expectedTotalRegistrations: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := NewControllersMap()
+
+			for i, plugin := range tt.plugins {
+				cm.RegisterControllers(plugin, tt.profileNames[i])
+
+				// Verify the controller count for this plugin
+				pluginControllers := cm.controllers[plugin.Name()]
+				assert.Equal(t, tt.expectedControllerCounts[i], len(pluginControllers),
+					"plugin %s should have %d controllers", plugin.Name(), tt.expectedControllerCounts[i])
+			}
+
+			// Verify total number of unique plugins registered
+			assert.Equal(t, tt.expectedTotalRegistrations, len(cm.controllers),
+				"should have %d unique plugins registered", tt.expectedTotalRegistrations)
+		})
+	}
+}
+
+func TestControllersMap_RegisterControllers_NonControllerProvider(t *testing.T) {
+	// Test that plugins not implementing ControllerProvider are ignored
+	cm := NewControllersMap()
+
+	plugin := &fakePlugin{name: "non-controller-plugin"}
+	cm.RegisterControllers(plugin, "profile1")
+
+	assert.Equal(t, 0, len(cm.controllers),
+		"non-ControllerProvider plugin should not be registered")
+}

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -103,6 +103,8 @@ func WithNetworkTopologyManager(manager networktopology.TreeManager) Option {
 	}
 }
 
+// FrameworkExtenderFactory is a factory for creating a FrameworkExtender.
+// NOTE: DO NOT put framework-level data here.
 type FrameworkExtenderFactory struct {
 	controllerMaps                   *ControllersMap
 	servicesEngine                   *services.Engine
@@ -365,12 +367,21 @@ func (f *FrameworkExtenderFactory) Run(ctx context.Context) {
 	}
 }
 
-func (f *FrameworkExtenderFactory) updatePlugins(pl framework.Plugin) {
+func (f *FrameworkExtenderFactory) updatePlugins(pl framework.Plugin, profileName string) {
+	if nextPodPlugin, ok := pl.(NextPodPlugin); ok {
+		pluginName := pl.Name()
+		if f.nextPodPlugin != nil && f.nextPodPlugin.Name() != pluginName {
+			klog.InfoS("NextPodPlugin already registered, skipped", "plugin", pluginName, "profile", profileName, "existing", f.nextPodPlugin.Name())
+		} else {
+			f.nextPodPlugin = nextPodPlugin
+			klog.V(4).InfoS("NextPodPlugin successfully registered", "plugin", pluginName, "profile", profileName)
+		}
+	}
 	if f.servicesEngine != nil {
-		f.servicesEngine.RegisterPluginService(pl)
+		f.servicesEngine.RegisterPluginService(pl, profileName)
 	}
 	if f.controllerMaps != nil {
-		f.controllerMaps.RegisterControllers(pl)
+		f.controllerMaps.RegisterControllers(pl, profileName)
 	}
 }
 
@@ -383,13 +394,7 @@ func PluginFactoryProxy(extenderFactory *FrameworkExtenderFactory, factoryFn fra
 		if err != nil {
 			return nil, err
 		}
-		if nextPodPlugin, ok := plugin.(NextPodPlugin); ok {
-			if extenderFactory.nextPodPlugin != nil && extenderFactory.nextPodPlugin.Name() != nextPodPlugin.Name() {
-				return nil, fmt.Errorf("duplicate NextPodPlugin: %s, %s", nextPodPlugin.Name(), extenderFactory.nextPodPlugin.Name())
-			}
-			extenderFactory.nextPodPlugin = nextPodPlugin
-		}
-		extenderFactory.updatePlugins(plugin)
+		extenderFactory.updatePlugins(plugin, fw.ProfileName())
 		frameworkExtender.(*frameworkExtenderImpl).updatePlugins(plugin)
 		return plugin, nil
 	}

--- a/pkg/scheduler/frameworkext/services/services.go
+++ b/pkg/scheduler/frameworkext/services/services.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 
 	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler"
 
 	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"
@@ -71,19 +72,32 @@ func handle(isLeader func() bool) http.HandlerFunc {
 
 type Engine struct {
 	*gin.Engine
+
+	registeredProviders map[string]struct{}
+	mu                  sync.Mutex
 }
 
 func NewEngine(e *gin.Engine) *Engine {
 	return &Engine{
-		Engine: e,
+		Engine:              e,
+		registeredProviders: make(map[string]struct{}),
 	}
 }
 
-func (e *Engine) RegisterPluginService(plugin framework.Plugin) {
+func (e *Engine) RegisterPluginService(plugin framework.Plugin, profileName string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	if serviceProvider, ok := plugin.(APIServiceProvider); ok {
+		providerName := plugin.Name()
 		baseGroup := e.Engine.Group(pluginServicesBaseRelativePath)
-		pluginServiceGroup := baseGroup.Group(plugin.Name())
+		pluginServiceGroup := baseGroup.Group(providerName)
+		if _, exists := e.registeredProviders[providerName]; exists {
+			klog.InfoS("service provider already registered, skipping duplicate registration", "provider", providerName, "profile", profileName)
+			return
+		}
 		serviceProvider.RegisterEndpoints(pluginServiceGroup)
+		e.registeredProviders[providerName] = struct{}{}
+		klog.V(4).InfoS("service provider successfully registered", "provider", providerName, "profile", profileName)
 	}
 }
 

--- a/pkg/scheduler/frameworkext/services/services_test.go
+++ b/pkg/scheduler/frameworkext/services/services_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakePlugin implements framework.Plugin interface for testing
+type fakePlugin struct {
+	name string
+}
+
+func (f *fakePlugin) Name() string {
+	return f.name
+}
+
+// fakeServiceProvider implements both framework.Plugin and APIServiceProvider
+type fakeServiceProvider struct {
+	fakePlugin
+	endpointsRegistered bool
+}
+
+func (f *fakeServiceProvider) RegisterEndpoints(group *gin.RouterGroup) {
+	f.endpointsRegistered = true
+	group.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"test": "ok"})
+	})
+}
+
+func TestEngine_RegisterPluginService(t *testing.T) {
+	tests := []struct {
+		name                       string
+		plugins                    []*fakeServiceProvider
+		profileNames               []string
+		expectedRegistrationCounts []bool // whether each registration should succeed
+	}{
+		{
+			name: "register single plugin service",
+			plugins: []*fakeServiceProvider{
+				{fakePlugin: fakePlugin{name: "test-plugin-1"}},
+			},
+			profileNames:               []string{"default-scheduler"},
+			expectedRegistrationCounts: []bool{true},
+		},
+		{
+			name: "register duplicate plugin service should skip",
+			plugins: []*fakeServiceProvider{
+				{fakePlugin: fakePlugin{name: "test-plugin-1"}},
+				{fakePlugin: fakePlugin{name: "test-plugin-1"}}, // duplicate
+			},
+			profileNames:               []string{"default-scheduler", "secondary-scheduler"},
+			expectedRegistrationCounts: []bool{true, false}, // second should be skipped
+		},
+		{
+			name: "register different plugins should both succeed",
+			plugins: []*fakeServiceProvider{
+				{fakePlugin: fakePlugin{name: "test-plugin-1"}},
+				{fakePlugin: fakePlugin{name: "test-plugin-2"}},
+			},
+			profileNames:               []string{"default-scheduler", "default-scheduler"},
+			expectedRegistrationCounts: []bool{true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ginEngine := gin.New()
+			engine := NewEngine(ginEngine)
+
+			for i, plugin := range tt.plugins {
+				engine.RegisterPluginService(plugin, tt.profileNames[i])
+
+				if tt.expectedRegistrationCounts[i] {
+					// Should be registered
+					assert.True(t, plugin.endpointsRegistered, "plugin %s should have endpoints registered", plugin.Name())
+					_, exists := engine.registeredProviders[plugin.Name()]
+					assert.True(t, exists, "plugin %s should be in registeredProviders", plugin.Name())
+				}
+			}
+
+			// Verify final state: each unique plugin name should be registered exactly once
+			uniquePlugins := make(map[string]bool)
+			for _, plugin := range tt.plugins {
+				uniquePlugins[plugin.Name()] = true
+			}
+			assert.Equal(t, len(uniquePlugins), len(engine.registeredProviders),
+				"registeredProviders should contain exactly %d unique plugins", len(uniquePlugins))
+		})
+	}
+}
+
+func TestEngine_RegisterPluginService_NonServiceProvider(t *testing.T) {
+	// Test that plugins not implementing APIServiceProvider are ignored
+	ginEngine := gin.New()
+	engine := NewEngine(ginEngine)
+
+	plugin := &fakePlugin{name: "non-service-plugin"}
+	engine.RegisterPluginService(plugin, "default-scheduler")
+
+	assert.Equal(t, 0, len(engine.registeredProviders),
+		"non-APIServiceProvider plugin should not be registered")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: fix the duplicate registration of service plugins and controller plugins in the FrameworkExtender when we set multiple scheduler profiles.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #2616

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
