### PR TITLE
scheduler: refactor dp adapter node lock workflow

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/eventhandler_node.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_node.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+func registerNodeEventHandler(sharedInformerFactory informers.SharedInformerFactory) {
+	sharedInformerFactory.Core().V1().Nodes().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				var node *corev1.Node
+				switch t := obj.(type) {
+				case *corev1.Node:
+					node = t
+				case cache.DeletedFinalStateUnknown:
+					var ok bool
+					node, ok = t.Obj.(*corev1.Node)
+					if !ok {
+						return
+					}
+				default:
+					return
+				}
+				deleteNodeLock(node.Name)
+			},
+		})
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -772,6 +772,8 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 		args.GPUSharedResourceTemplatesConfig.ConfigMapNamespace, args.GPUSharedResourceTemplatesConfig.ConfigMapName,
 		handle.SharedInformerFactory())
 
+	registerNodeEventHandler(handle.SharedInformerFactory())
+
 	return &Plugin{
 		handle:                          extendedHandle,
 		nodeDeviceCache:                 deviceCache,

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -4869,9 +4869,7 @@ func Test_Plugin_Unreserve(t *testing.T) {
 
 func Test_Plugin_PreBind(t *testing.T) {
 	now := time.Now()
-	defaultDevicePluginAdapter = &generalDevicePluginAdapter{
-		clock: fakeclock.NewFakeClock(now),
-	}
+	dpAdapterClock = fakeclock.NewFakeClock(now)
 
 	testPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

* extract node lock logic from specific adapters to general workflow
* introduce internal node level lock to avoid node lock conflicts during concurrent binding
* unlock node if original locker pod has been deleted
* use a global clock for testing

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
