### PR TITLE
scheduler: ReservationCache adapt multi profile

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -894,7 +894,7 @@ func Test_updateReservation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{})
+			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{}, corev1.DefaultSchedulerName)
 			registeredPlugins := []schedulertesting.RegisterPluginFunc{
 				schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 				schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
@@ -1157,7 +1157,7 @@ func Test_updateReservationInCache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{})
+			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{}, corev1.DefaultSchedulerName)
 			sched := frameworkext.NewFakeScheduler()
 			updateReservationInSchedulerCache(sched, tt.oldObj, tt.newObj)
 			pod, err := sched.GetPod(&corev1.Pod{
@@ -1277,7 +1277,7 @@ func Test_deleteReservationFromCache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{})
+			frameworkext.SetReservationCache(&frameworkext.FakeReservationCache{}, corev1.DefaultSchedulerName)
 			sched := frameworkext.NewFakeScheduler()
 			if reservationutil.ValidateReservation(tt.obj) == nil {
 				sched.AddPod(klog.Background(), reservationutil.NewReservePod(tt.obj))

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -67,6 +67,7 @@ type extendedHandleOptions struct {
 	servicesEngine                   *services.Engine
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
+	reservationCache                 ReservationCache
 	reservationNominator             ReservationNominator
 	networkTopologyManager           networktopology.TreeManager
 }
@@ -91,6 +92,12 @@ func WithKoordinatorSharedInformerFactory(informerFactory koordinatorinformers.S
 	}
 }
 
+func WithReservationCache(cache ReservationCache) Option {
+	return func(options *extendedHandleOptions) {
+		options.reservationCache = cache
+	}
+}
+
 func WithReservationNominator(nominator ReservationNominator) Option {
 	return func(options *extendedHandleOptions) {
 		options.reservationNominator = nominator
@@ -110,7 +117,8 @@ type FrameworkExtenderFactory struct {
 	servicesEngine                   *services.Engine
 	koordinatorClientSet             koordinatorclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
-	reservationNominator             ReservationNominator
+	reservationCache                 ReservationCache     // for testing
+	reservationNominator             ReservationNominator // for testing
 	nextPodPlugin                    NextPodPlugin
 	profiles                         map[string]FrameworkExtender
 	monitor                          *SchedulerMonitor
@@ -138,6 +146,7 @@ func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, 
 		servicesEngine:                   handleOptions.servicesEngine,
 		koordinatorClientSet:             handleOptions.koordinatorClientSet,
 		koordinatorSharedInformerFactory: handleOptions.koordinatorSharedInformerFactory,
+		reservationCache:                 handleOptions.reservationCache,
 		reservationNominator:             handleOptions.reservationNominator,
 		profiles:                         map[string]FrameworkExtender{},
 		monitor:                          NewSchedulerMonitor(schedulerMonitorPeriod, schedulingTimeout),

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -49,6 +49,8 @@ type ExtendedHandle interface {
 	RegisterErrorHandlerFilters(preFilter PreErrorHandlerFilter, afterFilter PostErrorHandlerFilter)
 	RegisterForgetPodHandler(handler ForgetPodHandler)
 	ForgetPod(logger klog.Logger, pod *corev1.Pod) error
+	// GetReservationCache returns the ReservationCache object to support cache operations for reservation infos.
+	GetReservationCache() ReservationCache
 	// GetReservationNominator returns the ReservationNominator object to support nominating reservation.
 	// It returns nil when the framework does not support the resource reservation.
 	GetReservationNominator() ReservationNominator

--- a/pkg/scheduler/frameworkext/reservation_cache_test.go
+++ b/pkg/scheduler/frameworkext/reservation_cache_test.go
@@ -28,10 +28,10 @@ import (
 
 func TestReservationCache(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
-		oldRCache := GetReservationCache()
+		oldRCaches := GetAllReservationCaches()
 		defer func() {
-			if oldRCache != nil {
-				SetReservationCache(oldRCache)
+			if len(oldRCaches) > 0 {
+				ClearReservationCache()
 			}
 		}()
 		testR := &schedulingv1alpha1.Reservation{
@@ -43,9 +43,9 @@ func TestReservationCache(t *testing.T) {
 		rc := &FakeReservationCache{
 			RInfo: NewReservationInfo(testR),
 		}
-		SetReservationCache(rc)
-		got := GetReservationCache()
-		assert.Equal(t, rc, got)
+		SetReservationCache(rc, corev1.DefaultSchedulerName)
+		got := GetAllReservationCaches()
+		assert.Equal(t, map[string]ReservationCache{corev1.DefaultSchedulerName: rc}, got)
 		got1 := rc.GetReservationInfo(testR.UID)
 		assert.Equal(t, NewReservationInfo(testR), got1)
 		got2 := rc.GetReservationInfoByPod(&corev1.Pod{}, "test-node")

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -229,7 +229,7 @@ func (p *Plugin) AddPod(ctx context.Context, cycleState *framework.CycleState, p
 	}
 
 	var rInfo *frameworkext.ReservationInfo
-	if rCache := frameworkext.GetReservationCache(); rCache != nil {
+	if rCache := p.handle.GetReservationCache(); rCache != nil {
 		rInfo = rCache.GetReservationInfoByPod(podInfoToAdd.Pod, node.Name)
 	}
 	if rInfo == nil {
@@ -288,7 +288,7 @@ func (p *Plugin) RemovePod(ctx context.Context, cycleState *framework.CycleState
 	}
 
 	var rInfo *frameworkext.ReservationInfo
-	if rCache := frameworkext.GetReservationCache(); rCache != nil {
+	if rCache := p.handle.GetReservationCache(); rCache != nil {
 		rInfo = rCache.GetReservationInfoByPod(podInfoToRemove.Pod, node.Name)
 	}
 	if rInfo == nil {

--- a/pkg/scheduler/plugins/nodenumaresource/reservation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation.go
@@ -610,7 +610,7 @@ func (p *Plugin) allocateWithNominated(
 }
 
 func (p *Plugin) getPodNominatedReservationInfo(pod *corev1.Pod, nodeName string) *frameworkext.ReservationInfo {
-	rCache := frameworkext.GetReservationCache()
+	rCache := p.handle.GetReservationCache()
 	if rCache == nil {
 		return nil
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: safely clean up ReservationCache in multiple scheduler profile scenarios.

Without this fix, when we register the Reservation in multiple plugin configs, the reservation cache can leak ReservationInfos since the deleteReservationFromSchedulerCache only cleans the last registered plugin's reservation cache.

In this PR, we make the ReservationCache private to the FrameworkExtender, and the deleteReservationFromSchedulerCache is responsible for cleaning the ReservationInfo for each profile.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #2616.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
