### PR TITLE
scheduler: deviceshare adapt pre-allocation

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -153,10 +153,12 @@ func (ext *frameworkExtenderImpl) updatePlugins(pl framework.Plugin) {
 	// TODO(joseph): In the future, use only the default ReservationNominator
 	if r, ok := pl.(ReservationNominator); ok {
 		ext.reservationNominator = r
+		klog.V(4).InfoS("framework extender got ReservationNominator registered", "profile", ext.ProfileName(), "plugin", pl.Name())
 	}
 	if r, ok := pl.(ReservationCache); ok {
 		ext.reservationCache = r
 		SetReservationCache(r, ext.Framework.ProfileName())
+		klog.V(4).InfoS("framework extender got ReservationCache registered", "profile", ext.ProfileName(), "plugin", pl.Name())
 	}
 	if r, ok := pl.(ReservationFilterPlugin); ok {
 		ext.reservationFilterPlugins = append(ext.reservationFilterPlugins, r)

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -3002,7 +3002,7 @@ func Test_Plugin_Filter(t *testing.T) {
 					nodeToState: frameworkext.NodeReservationRestoreStates{
 						"test-node": &nodeReservationRestoreStateData{
 							mergedMatchedAllocatable: allocatable,
-							matched: []reservationAlloc{
+							matched: []reusableAlloc{
 								{
 									rInfo:       frameworkext.NewReservationInfo(reservation),
 									allocatable: allocatable,
@@ -4494,7 +4494,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 					nodeToState: frameworkext.NodeReservationRestoreStates{
 						tt.args.node.Name: &nodeReservationRestoreStateData{
 							mergedMatchedAllocatable: allocatable,
-							matched: []reservationAlloc{
+							matched: []reusableAlloc{
 								{
 									rInfo:       frameworkext.NewReservationInfo(reservation),
 									allocatable: allocatable,

--- a/pkg/scheduler/plugins/deviceshare/scoring_test.go
+++ b/pkg/scheduler/plugins/deviceshare/scoring_test.go
@@ -577,7 +577,7 @@ func TestScore(t *testing.T) {
 					nodeToState: frameworkext.NodeReservationRestoreStates{
 						"test-node": &nodeReservationRestoreStateData{
 							mergedMatchedAllocatable: allocatable,
-							matched: []reservationAlloc{
+							matched: []reusableAlloc{
 								{
 									rInfo:       frameworkext.NewReservationInfo(reservation),
 									allocatable: allocatable,

--- a/pkg/scheduler/plugins/deviceshare/topology_hint.go
+++ b/pkg/scheduler/plugins/deviceshare/topology_hint.go
@@ -153,7 +153,7 @@ func (p *Plugin) Allocate(ctx context.Context, cycleState *framework.CycleState,
 
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
-	allocateResult, status := p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.hasReservationAffinity)
+	allocateResult, status := p.tryAllocateFromReusable(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.isReservationRequired)
 	if !status.IsSuccess() {
 		return status
 	}
@@ -228,7 +228,7 @@ func (p *Plugin) generateTopologyHints(cycleState *framework.CycleState, state *
 			}
 		}
 
-		allocateResult, status = p.tryAllocateFromReservation(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.hasReservationAffinity)
+		allocateResult, status = p.tryAllocateFromReusable(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.isReservationRequired)
 		if !status.IsSuccess() {
 			return
 		}

--- a/pkg/scheduler/plugins/deviceshare/utils.go
+++ b/pkg/scheduler/plugins/deviceshare/utils.go
@@ -389,7 +389,7 @@ func preparePod(pod *corev1.Pod, gpuSharedResourceTemplatesCache *gpuSharedResou
 		if err != nil {
 			return nil, framework.NewStatus(framework.UnschedulableAndUnresolvable, err.Error())
 		}
-		state.hasReservationAffinity = reservationAffinity != nil
+		state.isReservationRequired = reservationAffinity != nil || apiext.IsPreAllocationRequired(pod.Labels)
 	}
 
 	return

--- a/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
+++ b/pkg/scheduler/plugins/nodenumaresource/resource_manager.go
@@ -204,11 +204,11 @@ func (c *resourceManager) Allocate(node *corev1.Node, pod *corev1.Pod, options *
 	if options.hint.NUMANodeAffinity != nil {
 		resources, err := c.allocateResourcesByHint(node, pod, options)
 		if err != nil {
-			klog.Errorf("allocateResourcesByHint for pod %s on node %s, failed: %v", klog.KObj(pod), node.Name, err)
+			klog.V(4).Infof("allocateResourcesByHint for pod %s on node %s, hint %s, failed: %v", klog.KObj(pod), node.Name, options.hint.NUMANodeAffinity, err)
 			return nil, err
 		}
 		if len(resources) == 0 {
-			klog.Warningf("succeed allocateResourcesByHint but allocatedNUMAResources nil, options: %+v", options)
+			klog.Warningf("succeed allocateResourcesByHint for pod %s on node %s, hint %s, but allocatedNUMAResources nil, options: %+v", klog.KObj(pod), node.Name, options.hint.NUMANodeAffinity, options)
 		}
 		allocation.NUMANodeResources = resources
 
@@ -216,6 +216,7 @@ func (c *resourceManager) Allocate(node *corev1.Node, pod *corev1.Pod, options *
 	if options.requestCPUBind {
 		cpus, err := c.allocateCPUSet(node, pod, allocation.NUMANodeResources, options)
 		if err != nil {
+			klog.V(4).Infof("allocateCPUSet for pod %s on node %s, allocation.NUMANodeResources %+v, failed: %v", klog.KObj(pod), node.Name, allocation.NUMANodeResources, err)
 			return nil, framework.NewStatus(framework.Unschedulable, err.Error())
 		}
 		if cpus.IsEmpty() {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: DeviceShare adapts the reservation pre-allocation.

Basically, a plugin implementing the ReservationRestorePlugin interface needs the following adaptations:

1. Implementing RestoreReservationPreAllocation to support restoring resources of pre-allocatable pods for the reservation.
2. tryAllocateFromReusable supports filter with pre-allocatable pods. e.g. Filter a 2-card reserve pod (reservation) with a 1-card pre-allocatable pod.
3. FilterNominateReservation supports allocating from the pre-allocatable pods.
4. allocateWithNominated supports allocating with the nominated pre-allocatable pod.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Part of #2150.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
