### PR TITLE
scheduler: fix incorrect resource check for pre-allocation reservation when no pre-allocatable pods exist on node

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -479,7 +479,9 @@ func (pl *Plugin) filterWithPreAllocatablePods(ctx context.Context, cycleState *
 	state := getStateData(cycleState)
 	nodeRState := state.nodeReservationStates[node.Name]
 	if nodeRState == nil {
-		nodeRState = &nodeReservationState{}
+		nodeRState = &nodeReservationState{
+			podRequested: nodeInfo.Requested.Clone(),
+		}
 	}
 
 	state.preemptLock.RLock()


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

When there are no pre-allocatable pods on a node, nodeReservationStates doesn't contain an entry for that node. The code creates an empty nodeReservationState with nil podRequested, causing incorrect resource availability calculation in filterWithPreAllocatablePods.

This PR fixes the issue by initializing podRequested from nodeInfo.Requested.Clone() when no pre-allocatable pods exist on the target node.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
UT

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
