### PR TITLE
fix(koordlet):Unbind container level cfs_quota

### DIFF
--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -149,6 +149,7 @@ type Config struct {
 	RuntimeHooksNRIPluginName       string
 	RuntimeHooksNRIPluginIndex      string
 	RuntimeHookReconcileInterval    time.Duration
+	RuntimeHookDisableUnsetCPUQuota bool
 }
 
 func NewDefaultConfig() *Config {
@@ -170,6 +171,7 @@ func NewDefaultConfig() *Config {
 		RuntimeHooksNRIPluginName:       "koordlet_nri",
 		RuntimeHooksNRIPluginIndex:      "00",
 		RuntimeHookReconcileInterval:    10 * time.Second,
+		RuntimeHookDisableUnsetCPUQuota: false,
 	}
 }
 
@@ -191,6 +193,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.Var(cliflag.NewStringSlice(&c.RuntimeHookDisableStages), "runtime-hooks-disable-stages", "disable stages for runtime hooks")
 	fs.BoolVar(&c.RuntimeHooksNRI, "enable-nri-runtime-hook", c.RuntimeHooksNRI, "enable/disable runtime hooks nri mode")
 	fs.DurationVar(&c.RuntimeHookReconcileInterval, "runtime-hooks-reconcile-interval", c.RuntimeHookReconcileInterval, "reconcile interval for each plugins")
+	fs.BoolVar(&c.RuntimeHookDisableUnsetCPUQuota, "disable-unset-cpu-quota", c.RuntimeHookDisableUnsetCPUQuota, "disable unset cpu quota for runtime hooks")
 }
 
 func init() {

--- a/pkg/koordlet/runtimehooks/hooks/hooks.go
+++ b/pkg/koordlet/runtimehooks/hooks/hooks.go
@@ -38,10 +38,11 @@ type Hook struct {
 }
 
 type Options struct {
-	Reader         resourceexecutor.CgroupReader
-	Executor       resourceexecutor.ResourceUpdateExecutor
-	StatesInformer statesinformer.StatesInformer
-	EventRecorder  record.EventRecorder
+	Reader                           resourceexecutor.CgroupReader
+	Executor                         resourceexecutor.ResourceUpdateExecutor
+	StatesInformer                   statesinformer.StatesInformer
+	EventRecorder                    record.EventRecorder
+	DisableUnsetCPUQuotaForCPUSetPod bool
 }
 
 type HookFn func(protocol.HooksProtocol) error

--- a/pkg/koordlet/runtimehooks/runtimehooks.go
+++ b/pkg/koordlet/runtimehooks/runtimehooks.go
@@ -150,10 +150,11 @@ func NewRuntimeHook(si statesinformer.StatesInformer, cfg *Config, schema *apiru
 	}
 
 	newPluginOptions := hooks.Options{
-		Reader:         cr,
-		Executor:       e,
-		StatesInformer: si,
-		EventRecorder:  recorder,
+		Reader:                           cr,
+		Executor:                         e,
+		StatesInformer:                   si,
+		EventRecorder:                    recorder,
+		DisableUnsetCPUQuotaForCPUSetPod: cfg.RuntimeHookDisableUnsetCPUQuota,
 	}
 
 	if err != nil {

--- a/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
@@ -192,6 +192,9 @@ func TestUpdateQuota_IsQuotaUpdated(t *testing.T) {
 		assert.NotNil(t, newQuotaInfo, "newQuotaInfo should not be nil")
 		assert.NotNil(t, quota, "quota should not be nil")
 		assert.NotNil(t, state, "state should not be nil")
+		if quota.Name != q1Modified.Name {
+			return
+		}
 		assert.Equal(t, q1Modified.Name, quota.Name, "quota name should match")
 		// verify that the new quota has the updated max values
 		assert.True(t, quotav1.Equals(newQuotaInfo.CalculateInfo.Max, q1Modified.Spec.Max),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
This PR adds a new configuration option `--disable-unset-cpu-quota` to control whether container-level `cfs_quota` should be unset for cpuset pods (LSR/LSE QoS).
**Solution**:
- Add a new CLI flag `--disable-unset-cpu-quota` (default: `false`)
- When set to `true`, preserve container-level `cfs_quota` to enforce per-container CPU limits
- Containers rely on `cpu.shares` for fair CPU distribution when quota is unset
﻿
**Changes**:
- Add `RuntimeHookDisableUnsetCPUQuota` configuration field
### Ⅱ. Does this pull request fix one issue?
fixes #2633
### Ⅲ. Describe how to verify it
cd pkg/koordlet/runtimehooks/hooks/cpuset
go test -v -run TestUnsetPodCPUQuota
go test -v -run TestUnsetContainerCPUQuota
---