### PR TITLE
koord-descheduler: support skip eviction gates

### DIFF
--- a/config/manager/descheduler-config.yaml
+++ b/config/manager/descheduler-config.yaml
@@ -34,6 +34,15 @@ data:
           apiVersion: descheduler/v1alpha2
           kind: MigrationControllerArgs
           evictionPolicy: Eviction
+          # skipEvictionGates provides a unified bypass mechanism for gates/filters/throttlers
+          # evaluated before eviction/migration.
+          # skipEvictionGates:
+          #   - MaxMigratingGlobally
+          #   - MaxMigratingPerNode
+          #   - MaxMigratingPerNamespace
+          #   - MaxMigratingPerWorkload
+          #   - MaxUnavailablePerWorkload
+          #   - ExpectedReplicas
           namespaces:
             exclude:
               - kube-system

--- a/docs/proposals/scheduling/20220701-pod-migration-job.md
+++ b/docs/proposals/scheduling/20220701-pod-migration-job.md
@@ -410,6 +410,10 @@ type MigrationControllerArgs struct {
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	MaxMigratingPerWorkload *intstr.IntOrString `json:"maxMigratingPerWorkload,omitempty"`
 
+    // SkipEvictionGates allows bypassing specific gates/filters/throttlers during the eviction phase.
+    // Default is an empty list (no gates are bypassed).
+    SkipEvictionGates []string `json:"skipEvictionGates,omitempty"`
+
 	// MaxUnavailablePerWorkload represents he maximum number of pods that can be unavailable during migrate per workload.
 	// The unavailable state includes NotRunning/NotReady/Migrating/Evicting
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).

--- a/pkg/descheduler/apis/config/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/types_pluginargs.go
@@ -21,6 +21,30 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// EvictionGate identifies a gate/filter/throttler that can be bypassed before evicting pods.
+// It is intentionally a string enum so it can be configured via YAML/JSON.
+type EvictionGate string
+
+const (
+	// Retryable throttlers (limits)
+	EvictionGateMaxUnavailablePerWorkload EvictionGate = "MaxUnavailablePerWorkload"
+	EvictionGateMaxMigratingPerWorkload   EvictionGate = "MaxMigratingPerWorkload"
+	EvictionGateMaxMigratingPerNode       EvictionGate = "MaxMigratingPerNode"
+	EvictionGateMaxMigratingPerNamespace  EvictionGate = "MaxMigratingPerNamespace"
+	EvictionGateMaxMigratingGlobally      EvictionGate = "MaxMigratingGlobally"
+
+	// Policy gates (evictability / scope / safety)
+	EvictionGateExpectedReplicas  EvictionGate = "ExpectedReplicas"
+	EvictionGatePVC               EvictionGate = "PVC"
+	EvictionGateBarePods          EvictionGate = "BarePods"
+	EvictionGateLocalStorage      EvictionGate = "LocalStorage"
+	EvictionGateSystemCritical    EvictionGate = "SystemCritical"
+	EvictionGatePriorityThreshold EvictionGate = "PriorityThreshold"
+	EvictionGateLabelSelector     EvictionGate = "LabelSelector"
+	EvictionGateNamespaces        EvictionGate = "Namespaces"
+	EvictionGateNodeFit           EvictionGate = "NodeFit"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MigrationControllerArgs holds arguments used to configure the MigrationController
@@ -65,6 +89,25 @@ type MigrationControllerArgs struct {
 
 	// NodeSelector for a set of nodes to operate over
 	NodeSelector string
+
+	// SkipEvictionGates allows bypassing specific gates/filters/throttlers during the eviction phase.
+	// Valid values include (case-sensitive):
+	//   - MaxUnavailablePerWorkload
+	//   - MaxMigratingPerWorkload
+	//   - MaxMigratingPerNode
+	//   - MaxMigratingPerNamespace
+	//   - MaxMigratingGlobally
+	//   - ExpectedReplicas
+	//   - PVC
+	//   - BarePods
+	//   - LocalStorage
+	//   - SystemCritical
+	//   - PriorityThreshold
+	//   - LabelSelector
+	//   - Namespaces
+	//   - NodeFit
+	// Default is an empty list (no gates are bypassed).
+	SkipEvictionGates []EvictionGate
 
 	// MaxMigratingGlobally represents the maximum number of pods that can be migrating during migrate globally.
 	MaxMigratingGlobally *int32

--- a/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
+++ b/pkg/descheduler/apis/config/v1alpha2/types_pluginargs.go
@@ -68,6 +68,10 @@ type MigrationControllerArgs struct {
 	// NodeSelector for a set of nodes to operate over
 	NodeSelector string `json:"nodeSelector,omitempty"`
 
+	// SkipEvictionGates allows bypassing specific gates/filters/throttlers during the eviction phase.
+	// Default is an empty list (no gates are bypassed).
+	SkipEvictionGates []config.EvictionGate `json:"skipEvictionGates,omitempty"`
+
 	// MaxMigratingGlobally represents the maximum number of pods that can be migrating during migrate globally.
 	MaxMigratingGlobally *int32 `json:"maxMigratingGlobally,omitempty"`
 

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.conversion.go
@@ -553,6 +553,7 @@ func autoConvert_v1alpha2_MigrationControllerArgs_To_config_MigrationControllerA
 	out.Namespaces = (*config.Namespaces)(unsafe.Pointer(in.Namespaces))
 	out.NodeFit = in.NodeFit
 	out.NodeSelector = in.NodeSelector
+	out.SkipEvictionGates = *(*[]config.EvictionGate)(unsafe.Pointer(&in.SkipEvictionGates))
 	out.MaxMigratingGlobally = (*int32)(unsafe.Pointer(in.MaxMigratingGlobally))
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))
@@ -595,6 +596,7 @@ func autoConvert_config_MigrationControllerArgs_To_v1alpha2_MigrationControllerA
 	out.Namespaces = (*Namespaces)(unsafe.Pointer(in.Namespaces))
 	out.NodeFit = in.NodeFit
 	out.NodeSelector = in.NodeSelector
+	out.SkipEvictionGates = *(*[]config.EvictionGate)(unsafe.Pointer(&in.SkipEvictionGates))
 	out.MaxMigratingGlobally = (*int32)(unsafe.Pointer(in.MaxMigratingGlobally))
 	out.MaxMigratingPerNode = (*int32)(unsafe.Pointer(in.MaxMigratingPerNode))
 	out.MaxMigratingPerNamespace = (*int32)(unsafe.Pointer(in.MaxMigratingPerNamespace))

--- a/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -400,6 +400,11 @@ func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 		*out = new(Namespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SkipEvictionGates != nil {
+		in, out := &in.SkipEvictionGates, &out.SkipEvictionGates
+		*out = make([]config.EvictionGate, len(*in))
+		copy(*out, *in)
+	}
 	if in.MaxMigratingGlobally != nil {
 		in, out := &in.MaxMigratingGlobally, &out.MaxMigratingGlobally
 		*out = new(int32)

--- a/pkg/descheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/descheduler/apis/config/validation/validation_pluginargs.go
@@ -30,6 +30,28 @@ import (
 func ValidateMigrationControllerArgs(path *field.Path, args *deschedulerconfig.MigrationControllerArgs) error {
 	var allErrs field.ErrorList
 
+	validSkipEvictionGates := map[deschedulerconfig.EvictionGate]struct{}{
+		deschedulerconfig.EvictionGateMaxUnavailablePerWorkload: {},
+		deschedulerconfig.EvictionGateMaxMigratingPerWorkload:   {},
+		deschedulerconfig.EvictionGateMaxMigratingPerNode:       {},
+		deschedulerconfig.EvictionGateMaxMigratingPerNamespace:  {},
+		deschedulerconfig.EvictionGateMaxMigratingGlobally:      {},
+		deschedulerconfig.EvictionGateExpectedReplicas:          {},
+		deschedulerconfig.EvictionGatePVC:                       {},
+		deschedulerconfig.EvictionGateBarePods:                  {},
+		deschedulerconfig.EvictionGateLocalStorage:              {},
+		deschedulerconfig.EvictionGateSystemCritical:            {},
+		deschedulerconfig.EvictionGatePriorityThreshold:         {},
+		deschedulerconfig.EvictionGateLabelSelector:             {},
+		deschedulerconfig.EvictionGateNamespaces:                {},
+		deschedulerconfig.EvictionGateNodeFit:                   {},
+	}
+	for i, g := range args.SkipEvictionGates {
+		if _, ok := validSkipEvictionGates[g]; !ok {
+			allErrs = append(allErrs, field.Invalid(path.Child("skipEvictionGates").Index(i), g, "unknown eviction gate"))
+		}
+	}
+
 	if args.MaxMigratingGlobally != nil && *args.MaxMigratingGlobally < 0 {
 		allErrs = append(allErrs, field.Invalid(path.Child("maxMigratingGlobally"), *args.MaxMigratingGlobally, "maxMigratingGlobally should be greater or equal 0"))
 	}

--- a/pkg/descheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/descheduler/apis/config/validation/validation_pluginargs_test.go
@@ -93,6 +93,13 @@ func TestValidateMigrationControllerArgs(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid skipEvictionGates",
+			args: &v1alpha2.MigrationControllerArgs{
+				SkipEvictionGates: []deschedulerconfig.EvictionGate{"NoSuchGate"},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/descheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/descheduler/apis/config/zz_generated.deepcopy.go
@@ -371,6 +371,11 @@ func (in *MigrationControllerArgs) DeepCopyInto(out *MigrationControllerArgs) {
 		*out = new(Namespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SkipEvictionGates != nil {
+		in, out := &in.SkipEvictionGates, &out.SkipEvictionGates
+		*out = make([]EvictionGate, len(*in))
+		copy(*out, *in)
+	}
 	if in.MaxMigratingGlobally != nil {
 		in, out := &in.MaxMigratingGlobally, &out.MaxMigratingGlobally
 		*out = new(int32)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR introduces a unified **_Skip Set_** for `MigrationController` by adding `SkipEvictionGates` (a string-enum EvictionGate) to `MigrationControllerArgs`, allowing users to explicitly bypass selected gates/filters/throttlers before evicting/migrating pods.
I centralize the skip behavior in the filter wiring: parse `SkipEvictionGates` into a set in `pkg/descheduler/controllers/migration/arbitrator/filter.go` and conditionally skip checks when building the non-retryable / retryable filter chains and `EvictorFilter` constraints. `MaxMigratingPerWorkload` and `MaxUnavailablePerWorkload` can be skipped independently.

The main concept is that if a gate is listed in SkipEvictionGates, that gate is bypassed (i.e., it must not block eviction). `SkipEvictionGates` is designed to have the highest priority to avoid “configured skip but still blocked” surprises.

**NOTE**: Gate categories: Max* gates are retryable **throttlers** (capacity/limit-based), while Namespaces/LabelSelector/NodeFit/... are **policy gates**; this PR unifies the configuration entrypoint but does not change their retryable/non-retryable nature.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes #2709 
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
