### PR TITLE
scheduler: nodenumaresource and deviceshare support unassigned event

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler.go
@@ -93,7 +93,11 @@ func (c *podEventHandler) OnDelete(obj interface{}) {
 }
 
 func (c *podEventHandler) updatePod(oldPod, pod *corev1.Pod) {
+	// For multi-scheduler scenarios: clean up old pod when new pod becomes unassigned
 	if pod.Spec.NodeName == "" {
+		if oldPod != nil && oldPod.Spec.NodeName != "" {
+			c.resourceManager.Release(oldPod.Spec.NodeName, oldPod.UID)
+		}
 		return
 	}
 	if util.IsPodTerminated(pod) {

--- a/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/pod_eventhandler_test.go
@@ -154,3 +154,164 @@ func TestPodEventHandler(t *testing.T) {
 	}
 
 }
+
+func TestPodEventHandler_UpdatePod_unassigned(t *testing.T) {
+	tests := []struct {
+		name                       string
+		oldPod                     *corev1.Pod
+		newPod                     *corev1.Pod
+		wantOldPodCleanedFromCache bool
+	}{
+		{
+			name: "newPod nodeName becomes empty, should clean up oldPod",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLSR),
+					},
+					Annotations: map[string]string{
+						extension.AnnotationResourceSpec:   `{"preferredCPUBindPolicy": "FullPCPUs"}`,
+						extension.AnnotationResourceStatus: `{"cpuset": "0-3"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLSR),
+					},
+					Annotations: map[string]string{
+						extension.AnnotationResourceSpec:   `{"preferredCPUBindPolicy": "FullPCPUs"}`,
+						extension.AnnotationResourceStatus: `{"cpuset": "0-3"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "", // nodeName becomes empty
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			wantOldPodCleanedFromCache: true,
+		},
+		{
+			name: "oldPod without nodeName, should not clean up",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "", // oldPod also has no nodeName
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "",
+				},
+			},
+			wantOldPodCleanedFromCache: false,
+		},
+		{
+			name:   "oldPod is nil, should not clean up",
+			oldPod: nil,
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "",
+				},
+			},
+			wantOldPodCleanedFromCache: false,
+		},
+		{
+			name: "normal update: newPod has nodeName, should process normally",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "",
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       uuid.NewUUID(),
+					Namespace: "default",
+					Name:      "test-pod",
+					Labels: map[string]string{
+						extension.LabelPodQoS: string(extension.QoSLSR),
+					},
+					Annotations: map[string]string{
+						extension.AnnotationResourceSpec:   `{"preferredCPUBindPolicy": "FullPCPUs"}`,
+						extension.AnnotationResourceStatus: `{"cpuset": "0-3"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			wantOldPodCleanedFromCache: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpuTopology := buildCPUTopologyForTest(2, 2, 4, 2)
+			topologyOptionsManager := NewTopologyOptionsManager()
+			topologyOptionsManager.UpdateTopologyOptions("node1", func(options *TopologyOptions) {
+				options.CPUTopology = cpuTopology
+			})
+			resourceManager := &resourceManager{
+				topologyOptionsManager: topologyOptionsManager,
+				nodeAllocations:        map[string]*NodeAllocation{},
+			}
+			handler := &podEventHandler{
+				resourceManager: resourceManager,
+			}
+
+			// Pre-populate cache if oldPod has nodeName and allocations
+			if tt.oldPod != nil && tt.oldPod.Spec.NodeName != "" {
+				if _, ok := tt.oldPod.Annotations[extension.AnnotationResourceStatus]; ok {
+					handler.updatePod(nil, tt.oldPod)
+				}
+			}
+
+			// Call updatePod
+			handler.updatePod(tt.oldPod, tt.newPod)
+
+			// Verify cache state
+			if tt.wantOldPodCleanedFromCache && tt.oldPod != nil && tt.oldPod.Spec.NodeName != "" {
+				nodeAllocation := resourceManager.getOrCreateNodeAllocation(tt.oldPod.Spec.NodeName)
+				_, exists := nodeAllocation.allocatedPods[tt.oldPod.UID]
+				assert.False(t, exists, "oldPod allocation should be cleaned from cache")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

In multi-scheduler scenarios, we allow pods to transition from the assigned state to an unassigned state for retry purposes. In this case, the event handlers of plugin caches should adapt the transition to release resources.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
