### PR TITLE
koord-descheduler: fix log verbosity

### DIFF
--- a/cmd/koord-descheduler/app/server.go
+++ b/cmd/koord-descheduler/app/server.go
@@ -97,7 +97,7 @@ func NewDeschedulerCommand(registryOptions ...Option) *cobra.Command {
 
 	nfs := opts.Flags
 	verflag.AddFlags(nfs.FlagSet("global"))
-	globalflag.AddGlobalFlags(nfs.FlagSet("global"), cmd.Name())
+	globalflag.AddGlobalFlags(nfs.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	fs := cmd.Flags()
 	for _, f := range nfs.FlagSets {
 		fs.AddFlagSet(f)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When we adapt to api 1.28, the log verbosity of descheduler was broke. This PR fix it. 

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
fixes #2793 

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

Deploy it and check logs. Correct logs should start with flags: 
<img width="1582" height="230" alt="image" src="https://github.com/user-attachments/assets/5af2f80d-4761-40b3-9ab0-c2dac73c130e" />


### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
