### PR TITLE
scheduler: make network-topology aware existing pods

### DIFF
--- a/apis/extension/coscheduling.go
+++ b/apis/extension/coscheduling.go
@@ -17,15 +17,11 @@ limitations under the License.
 package extension
 
 import (
-	"encoding/json"
-	"sort"
 	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
 
 const (
@@ -68,14 +64,6 @@ const (
 	// AnnotationAliasGangMatchPolicy defines same match policy but different prefix.
 	// Duplicate definitions here are only for compatibility considerations
 	AnnotationAliasGangMatchPolicy = "pod-group.scheduling.sigs.k8s.io/match-policy"
-
-	// AnnotationGangPodNetworkTopologyIndex defines the index of a specific pod in the gang group which should typically
-	// match the underlying biz semantics (such as PyTorch rank).
-	// This would currently be considered in network topology aware scheduling.
-	AnnotationGangPodNetworkTopologyIndex = AnnotationGangPrefix + "/network-topology-index"
-
-	// AnnotationGangNetworkTopologySpec defines the network topology aware requirements of the gang group.
-	AnnotationGangNetworkTopologySpec = AnnotationGangPrefix + "/network-topology-spec"
 )
 
 const (
@@ -123,67 +111,6 @@ func GetGangWaitTime(pod *corev1.Pod) (time.Duration, error) {
 		return 0, nil
 	}
 	return time.ParseDuration(waitTimeStr)
-}
-
-type NetworkTopologySpec struct {
-	GatherStrategy []NetworkTopologyGatherRule `json:"gatherStrategy,omitempty"`
-}
-
-type NetworkTopologyGatherRule struct {
-	Layer    schedulingv1alpha1.TopologyLayer `json:"layer"`
-	Strategy NetworkTopologyGatherStrategy    `json:"strategy"`
-}
-
-type NetworkTopologyGatherStrategy string
-
-const (
-	NetworkTopologyGatherStrategyMustGather   NetworkTopologyGatherStrategy = "MustGather"
-	NetworkTopologyGatherStrategyPreferGather NetworkTopologyGatherStrategy = "PreferGather"
-)
-
-func GetNetworkTopologySpec(obj metav1.Object) (*NetworkTopologySpec, error) {
-	spec := obj.GetAnnotations()[AnnotationGangNetworkTopologySpec]
-	if spec == "" {
-		return nil, nil
-	}
-	var networkTopologySpec NetworkTopologySpec
-	if err := json.Unmarshal([]byte(spec), &networkTopologySpec); err != nil {
-		return nil, err
-	}
-	return &networkTopologySpec, nil
-}
-
-func GetPodIndex(pod *corev1.Pod) (int, error) {
-	if pod == nil {
-		return -1, nil
-	}
-	indexStr, ok := pod.Annotations[AnnotationGangPodNetworkTopologyIndex]
-	if !ok {
-		return -1, nil
-	}
-	index, err := strconv.Atoi(indexStr)
-	if err != nil {
-		return -1, err
-	}
-	return index, nil
-}
-
-// SortPodsByIndex sort pods by index than by name,
-// pods without valid index would be ordered after pods with index.
-func SortPodsByIndex(pods []*corev1.Pod) {
-	sort.Slice(pods, func(a, b int) bool {
-		podA, podB := pods[a], pods[b]
-		indexA, _ := GetPodIndex(podA)
-		indexB, _ := GetPodIndex(podB)
-		if indexA >= 0 && indexB >= 0 {
-			if indexA != indexB {
-				return indexA < indexB
-			}
-		} else if indexA >= 0 || indexB >= 0 {
-			return indexA >= 0
-		}
-		return podA.Name < podB.Name
-	})
 }
 
 const (

--- a/apis/extension/network_topology.go
+++ b/apis/extension/network_topology.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+const (
+
+	// AnnotationGangPodNetworkTopologyIndex defines the index of a specific pod in the gang group which should typically
+	// match the underlying biz semantics (such as PyTorch rank).
+	// This would currently be considered in network topology aware scheduling.
+	AnnotationGangPodNetworkTopologyIndex = AnnotationGangPrefix + "/network-topology-index"
+
+	// AnnotationGangNetworkTopologySpec defines the network topology aware requirements of the gang group.
+	AnnotationGangNetworkTopologySpec = AnnotationGangPrefix + "/network-topology-spec"
+
+	AnnotationPodNetworkTopologySelector = SchedulingDomainPrefix + "/network-topology-selector"
+)
+
+type NetworkTopologySpec struct {
+	GatherStrategy []NetworkTopologyGatherRule `json:"gatherStrategy,omitempty"`
+}
+
+type NetworkTopologyGatherRule struct {
+	Layer    schedulingv1alpha1.TopologyLayer `json:"layer"`
+	Strategy NetworkTopologyGatherStrategy    `json:"strategy"`
+}
+
+type NetworkTopologyGatherStrategy string
+
+const (
+	NetworkTopologyGatherStrategyMustGather   NetworkTopologyGatherStrategy = "MustGather"
+	NetworkTopologyGatherStrategyPreferGather NetworkTopologyGatherStrategy = "PreferGather"
+)
+
+func GetNetworkTopologySpec(obj metav1.Object) (*NetworkTopologySpec, error) {
+	spec := obj.GetAnnotations()[AnnotationGangNetworkTopologySpec]
+	if spec == "" {
+		return nil, nil
+	}
+	var networkTopologySpec NetworkTopologySpec
+	if err := json.Unmarshal([]byte(spec), &networkTopologySpec); err != nil {
+		return nil, err
+	}
+	return &networkTopologySpec, nil
+}
+
+func GetPodNetworkTopologyIndex(pod *corev1.Pod) (int, error) {
+	if pod == nil {
+		return -1, nil
+	}
+	indexStr, ok := pod.Annotations[AnnotationGangPodNetworkTopologyIndex]
+	if !ok {
+		return -1, nil
+	}
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return -1, err
+	}
+	return index, nil
+}
+
+// SortPodsByIndex sort pods by index than by name,
+// pods without valid index would be ordered after pods with index.
+func SortPodsByIndex(pods []*corev1.Pod) {
+	sort.Slice(pods, func(a, b int) bool {
+		podA, podB := pods[a], pods[b]
+		indexA, _ := GetPodNetworkTopologyIndex(podA)
+		indexB, _ := GetPodNetworkTopologyIndex(podB)
+		if indexA >= 0 && indexB >= 0 {
+			if indexA != indexB {
+				return indexA < indexB
+			}
+		} else if indexA >= 0 || indexB >= 0 {
+			return indexA >= 0
+		}
+		return podA.Name < podB.Name
+	})
+}
+
+func GetPodNetworkTopologySelector(obj metav1.Object) string {
+	return obj.GetAnnotations()[AnnotationPodNetworkTopologySelector]
+}

--- a/apis/extension/network_topology_test.go
+++ b/apis/extension/network_topology_test.go
@@ -169,11 +169,11 @@ func TestGetPodIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetPodIndex(tt.args.pod)
-			if !tt.wantErr(t, err, fmt.Sprintf("GetPodIndex(%v)", tt.args.pod)) {
+			got, err := GetPodNetworkTopologyIndex(tt.args.pod)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetPodNetworkTopologyIndex(%v)", tt.args.pod)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "GetPodIndex(%v)", tt.args.pod)
+			assert.Equalf(t, tt.want, got, "GetPodNetworkTopologyIndex(%v)", tt.args.pod)
 		})
 	}
 }

--- a/config/manager/scheduler-config.yaml
+++ b/config/manager/scheduler-config.yaml
@@ -83,6 +83,7 @@ data:
           preScore:
             enabled:
               - name: Reservation
+              - name: Coscheduling
           score:
             enabled:
               - name: LoadAwareScheduling
@@ -93,6 +94,8 @@ data:
                 weight: 1
               - name: Reservation
                 weight: 5000
+              - name: Coscheduling
+                weight: 1
           reserve:
             enabled:
               - name: LoadAwareScheduling

--- a/pkg/scheduler/frameworkext/networktopology/tree.go
+++ b/pkg/scheduler/frameworkext/networktopology/tree.go
@@ -95,8 +95,9 @@ type TreeNode struct {
 	Parent   *TreeNode
 	Children map[string]*TreeNode
 
-	OfferSlot int
-	Score     int
+	OfferSlot      int
+	Score          int
+	ExistingPodNum int
 }
 
 type TreeNodeMeta struct {

--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -66,6 +66,8 @@ type Manager interface {
 	PreEnqueue(context.Context, *corev1.Pod) (err error)
 	BeforePreFilter(context.Context, *framework.CycleState, *corev1.Pod) (err error)
 	PreFilter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod) (*framework.PreFilterResult, *framework.Status)
+	PreScore(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodes []*corev1.Node) *framework.Status
+	Score(ctx context.Context, state *framework.CycleState, p *corev1.Pod, nodeName string) (int64, *framework.Status)
 	Permit(context.Context, *corev1.Pod) (time.Duration, Status)
 	PostBind(context.Context, *corev1.Pod, string)
 	PostFilter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, m framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Sometimes, in addition to placing a job or Pod in a network topology with the best possible performance within the current batch, it's also desirable to group the job or Pod with other Pods belonging to its application or even the user. 

This PR addresses this need by introducing `scheduling.koordinator.sh/network-topology-selector` to identify these relationships and to recognize these ExistingPods in the Job network topology scheduling (FindOneNode) and preemption (PostFilter) processes, as well as the Pod scheduling process (Score).

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
