### PR TITLE
koordlet: add cpuset sharepool cpu info to metrics.

### DIFF
--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -182,13 +182,13 @@ const (
 	// owner: @tan90github
 	// alpha: v1.8
 	//
-	// CPUSetMetricEnhance enables recording per-cpu info metrics of share pool and BE share pool.
+	// PerCPUMetric enables recording per-cpu info metrics of share pool and BE share pool.
 	// NOTE: Enabling this feature will generate high-cardinality time series at node × share pool cpu numbers level:
 	// - koordlet_cpuset_share_pool_info{node, cpu}
 	// - koordlet_cpuset_be_share_pool_info{node, cpu}
 	// which may significantly increase the pressure on Prometheus/TSDB/remote-write.
 	// It is recommended to enable it only during small clusters or troubleshooting/capacity assessment.
-	CPUSetMetricEnhance featuregate.Feature = "CPUSetMetricEnhance"
+	PerCPUMetric featuregate.Feature = "PerCPUMetric"
 )
 
 func init() {
@@ -224,7 +224,7 @@ var (
 		HugePageReport:         {Default: false, PreRelease: featuregate.Alpha},
 		PodResourcesProxy:      {Default: false, PreRelease: featuregate.Alpha},
 		HamiCoreVGPUMonitor:    {Default: false, PreRelease: featuregate.Alpha},
-		CPUSetMetricEnhance:    {Default: false, PreRelease: featuregate.Alpha},
+		PerCPUMetric:           {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/features/koordlet_features.go
+++ b/pkg/features/koordlet_features.go
@@ -178,6 +178,17 @@ const (
 	//
 	// HamiCoreVGPUMonitor enables the vGPU monitoring for HAMi-core.
 	HamiCoreVGPUMonitor featuregate.Feature = "HamiCoreVGPUMonitor"
+
+	// owner: @tan90github
+	// alpha: v1.8
+	//
+	// CPUSetMetricEnhance enables recording per-cpu info metrics of share pool and BE share pool.
+	// NOTE: Enabling this feature will generate high-cardinality time series at node × share pool cpu numbers level:
+	// - koordlet_cpuset_share_pool_info{node, cpu}
+	// - koordlet_cpuset_be_share_pool_info{node, cpu}
+	// which may significantly increase the pressure on Prometheus/TSDB/remote-write.
+	// It is recommended to enable it only during small clusters or troubleshooting/capacity assessment.
+	CPUSetMetricEnhance featuregate.Feature = "CPUSetMetricEnhance"
 )
 
 func init() {
@@ -213,6 +224,7 @@ var (
 		HugePageReport:         {Default: false, PreRelease: featuregate.Alpha},
 		PodResourcesProxy:      {Default: false, PreRelease: featuregate.Alpha},
 		HamiCoreVGPUMonitor:    {Default: false, PreRelease: featuregate.Alpha},
+		CPUSetMetricEnhance:    {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/koordlet/metrics/cpu_cpuset.go
+++ b/pkg/koordlet/metrics/cpu_cpuset.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
 	CPUSetSharePoolCPUS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -31,9 +35,23 @@ var (
 		Help:      "Number of be share pool cores",
 	}, []string{NodeKey})
 
+	CPUSetSharePoolInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "cpuset_share_pool_info",
+		Help:      "CPUSet share pool info, means this cpu id is in cpuset share pool",
+	}, []string{NodeKey, CPUIDKey})
+
+	CPUSetBESharePoolInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "cpuset_be_share_pool_info",
+		Help:      "CPUSet be share pool info, means this cpu id is in cpuset be share pool",
+	}, []string{NodeKey, CPUIDKey})
+
 	CPUSetCollector = []prometheus.Collector{
 		CPUSetSharePoolCPUS,
 		CPUSetBESharePoolCPUS,
+		CPUSetSharePoolInfo,
+		CPUSetBESharePoolInfo,
 	}
 )
 
@@ -51,4 +69,22 @@ func RecordCPUSetBESharePoolCores(value float64) {
 		return
 	}
 	CPUSetBESharePoolCPUS.With(labels).Set(value)
+}
+
+func RecordCPUSetSharePoolInfo(cpu int) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[CPUIDKey] = strconv.Itoa(cpu)
+	CPUSetSharePoolInfo.With(labels).Set(1)
+}
+
+func RecordCPUSetBESharePoolInfo(cpu int) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[CPUIDKey] = strconv.Itoa(cpu)
+	CPUSetBESharePoolInfo.With(labels).Set(1)
 }

--- a/pkg/koordlet/metrics/cpu_cpuset.go
+++ b/pkg/koordlet/metrics/cpu_cpuset.go
@@ -80,6 +80,10 @@ func RecordCPUSetSharePoolInfo(cpu int) {
 	CPUSetSharePoolInfo.With(labels).Set(1)
 }
 
+func ResetCPUSetSharePoolInfo() {
+	CPUSetSharePoolInfo.Reset()
+}
+
 func RecordCPUSetBESharePoolInfo(cpu int) {
 	labels := genNodeLabels()
 	if labels == nil {
@@ -87,4 +91,8 @@ func RecordCPUSetBESharePoolInfo(cpu int) {
 	}
 	labels[CPUIDKey] = strconv.Itoa(cpu)
 	CPUSetBESharePoolInfo.With(labels).Set(1)
+}
+
+func ResetCPUSetBESharePoolInfo() {
+	CPUSetBESharePoolInfo.Reset()
 }

--- a/pkg/koordlet/metrics/cpu_cpuset.go
+++ b/pkg/koordlet/metrics/cpu_cpuset.go
@@ -38,13 +38,13 @@ var (
 	CPUSetSharePoolInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KoordletSubsystem,
 		Name:      "cpuset_share_pool_info",
-		Help:      "CPUSet share pool info, means this cpu id is in cpuset share pool",
+		Help:      "Indicates whether the CPU ID is currently part of the share pool (1 = in pool)",
 	}, []string{NodeKey, CPUIDKey})
 
 	CPUSetBESharePoolInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KoordletSubsystem,
 		Name:      "cpuset_be_share_pool_info",
-		Help:      "CPUSet be share pool info, means this cpu id is in cpuset be share pool",
+		Help:      "Indicates whether the CPU ID is currently part of the BE share pool (1 = in pool)",
 	}, []string{NodeKey, CPUIDKey})
 
 	CPUSetCollector = []prometheus.Collector{

--- a/pkg/koordlet/metrics/metrics.go
+++ b/pkg/koordlet/metrics/metrics.go
@@ -52,6 +52,8 @@ const (
 	UnitCore    = "core"
 	UnitByte    = "byte"
 	UnitInteger = "integer"
+
+	CPUIDKey = "cpu"
 )
 
 var (

--- a/pkg/koordlet/metrics/metrics_test.go
+++ b/pkg/koordlet/metrics/metrics_test.go
@@ -446,3 +446,59 @@ func TestHostApplicationCollectors(t *testing.T) {
 		ResetHostApplicationResourceUsage()
 	})
 }
+
+func TestCPUSetCollectors(t *testing.T) {
+	testingNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-node",
+			Labels: map[string]string{},
+		},
+	}
+
+	t.Run("test not panic", func(t *testing.T) {
+		Register(testingNode)
+		defer Register(nil)
+
+		RecordCPUSetSharePoolCores(8)
+		RecordCPUSetBESharePoolCores(4)
+		RecordCPUSetSharePoolInfo(0)
+		RecordCPUSetSharePoolInfo(1)
+		RecordCPUSetBESharePoolInfo(2)
+		RecordCPUSetBESharePoolInfo(3)
+		ResetCPUSetSharePoolInfo()
+		ResetCPUSetBESharePoolInfo()
+	})
+
+	t.Run("test value collection", func(t *testing.T) {
+		Register(testingNode)
+		defer Register(nil)
+
+		// Record share pool cores and verify value
+		RecordCPUSetSharePoolCores(8)
+		gauge, err := CPUSetSharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.NotNil(t, gauge)
+
+		// Record BE share pool cores and verify value
+		RecordCPUSetBESharePoolCores(4)
+		gauge, err = CPUSetBESharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.NotNil(t, gauge)
+
+		// Record per-CPU info
+		RecordCPUSetSharePoolInfo(0)
+		RecordCPUSetSharePoolInfo(1)
+		gauge, err = CPUSetSharePoolInfo.GetMetricWithLabelValues("test-node", "0")
+		assert.NoError(t, err)
+		assert.NotNil(t, gauge)
+
+		RecordCPUSetBESharePoolInfo(2)
+		gauge, err = CPUSetBESharePoolInfo.GetMetricWithLabelValues("test-node", "2")
+		assert.NoError(t, err)
+		assert.NotNil(t, gauge)
+
+		// Reset and verify cleared
+		ResetCPUSetSharePoolInfo()
+		ResetCPUSetBESharePoolInfo()
+	})
+}

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/cpuset.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
@@ -45,6 +46,8 @@ type cpusetPlugin struct {
 	ruleRWMutex          sync.RWMutex
 	executor             resourceexecutor.ResourceUpdateExecutor
 	disableUnsetCPUQuota bool
+	// record sharePool, beSharePool cpu ID info.
+	recordPerSharePoolCPUInfo bool
 }
 
 var (
@@ -82,6 +85,7 @@ func (p *cpusetPlugin) Register(op hooks.Options) {
 	reconciler.RegisterHostAppReconciler(sysutil.CPUSet, "set host application cpuset",
 		p.SetHostAppCPUSet, &reconciler.ReconcilerOption{})
 	p.executor = op.Executor
+	p.recordPerSharePoolCPUInfo = features.DefaultKoordletFeatureGate.Enabled(features.PerCPUMetric)
 }
 
 var singleton *cpusetPlugin

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -192,6 +192,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 	}
 
+	// record sharePool, beSharePool cpu numbers and cpu ID info.
 	var shareCPUSetCount, beShareCPUSetCount int
 	for _, nodeSharePool := range cpuSharePools {
 		nodeSharePoolCPUSet, err := cpuset.Parse(nodeSharePool.CPUSet)
@@ -200,6 +201,10 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 			continue
 		}
 		shareCPUSetCount += nodeSharePoolCPUSet.Size()
+
+		for _, e := range nodeSharePoolCPUSet.ToSlice() {
+			metrics.RecordCPUSetSharePoolInfo(e)
+		}
 	}
 
 	for _, nodeBESharePool := range beCPUSharePools {
@@ -209,6 +214,10 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 			continue
 		}
 		beShareCPUSetCount += nodeBESharePoolCPUSet.Size()
+
+		for _, e := range nodeBESharePoolCPUSet.ToSlice() {
+			metrics.RecordCPUSetBESharePoolInfo(e)
+		}
 	}
 
 	metrics.RecordCPUSetSharePoolCores(float64(shareCPUSetCount))

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -207,7 +207,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		shareCPUSetCount += nodeSharePoolCPUSet.Size()
 
 		if p.recordPerSharePoolCPUInfo {
-			for _, e := range nodeSharePoolCPUSet.ToSlice() {
+			for _, e := range nodeSharePoolCPUSet.ToSliceNoSort() {
 				metrics.RecordCPUSetSharePoolInfo(e)
 			}
 		}
@@ -222,7 +222,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		beShareCPUSetCount += nodeBESharePoolCPUSet.Size()
 
 		if p.recordPerSharePoolCPUInfo {
-			for _, e := range nodeBESharePoolCPUSet.ToSlice() {
+			for _, e := range nodeBESharePoolCPUSet.ToSliceNoSort() {
 				metrics.RecordCPUSetBESharePoolInfo(e)
 			}
 		}

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -193,6 +193,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 	}
 
 	// record sharePool, beSharePool cpu numbers and cpu ID info.
+	recordPerCPUInfo := features.DefaultKoordletFeatureGate.Enabled(features.CPUSetMetricEnhance)
 	var shareCPUSetCount, beShareCPUSetCount int
 	for _, nodeSharePool := range cpuSharePools {
 		nodeSharePoolCPUSet, err := cpuset.Parse(nodeSharePool.CPUSet)
@@ -202,8 +203,10 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 		shareCPUSetCount += nodeSharePoolCPUSet.Size()
 
-		for _, e := range nodeSharePoolCPUSet.ToSlice() {
-			metrics.RecordCPUSetSharePoolInfo(e)
+		if recordPerCPUInfo {
+			for _, e := range nodeSharePoolCPUSet.ToSlice() {
+				metrics.RecordCPUSetSharePoolInfo(e)
+			}
 		}
 	}
 
@@ -215,8 +218,10 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 		beShareCPUSetCount += nodeBESharePoolCPUSet.Size()
 
-		for _, e := range nodeBESharePoolCPUSet.ToSlice() {
-			metrics.RecordCPUSetBESharePoolInfo(e)
+		if recordPerCPUInfo {
+			for _, e := range nodeBESharePoolCPUSet.ToSlice() {
+				metrics.RecordCPUSetBESharePoolInfo(e)
+			}
 		}
 	}
 

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule.go
@@ -192,9 +192,12 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 	}
 
-	// record sharePool, beSharePool cpu numbers and cpu ID info.
-	recordPerCPUInfo := features.DefaultKoordletFeatureGate.Enabled(features.CPUSetMetricEnhance)
 	var shareCPUSetCount, beShareCPUSetCount int
+	if p.recordPerSharePoolCPUInfo {
+		// sharePool CPUSet ID info may be expired and needs to be reset before record new metrics.
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+	}
 	for _, nodeSharePool := range cpuSharePools {
 		nodeSharePoolCPUSet, err := cpuset.Parse(nodeSharePool.CPUSet)
 		if err != nil {
@@ -203,7 +206,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 		shareCPUSetCount += nodeSharePoolCPUSet.Size()
 
-		if recordPerCPUInfo {
+		if p.recordPerSharePoolCPUInfo {
 			for _, e := range nodeSharePoolCPUSet.ToSlice() {
 				metrics.RecordCPUSetSharePoolInfo(e)
 			}
@@ -218,7 +221,7 @@ func (p *cpusetPlugin) parseRule(nodeTopoIf interface{}) (bool, error) {
 		}
 		beShareCPUSetCount += nodeBESharePoolCPUSet.Size()
 
-		if recordPerCPUInfo {
+		if p.recordPerSharePoolCPUInfo {
 			for _, e := range nodeBESharePoolCPUSet.ToSlice() {
 				metrics.RecordCPUSetBESharePoolInfo(e)
 			}

--- a/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpuset/rule_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -31,6 +33,7 @@ import (
 	ext "github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/features"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
@@ -1224,4 +1227,209 @@ func Test_cpusetPlugin_ruleUpdateCbForHostApp(t *testing.T) {
 			assert.Equal(t, tt.wantCPUSet, gotCPUSet)
 		})
 	}
+}
+
+func Test_cpusetPlugin_parseRule_withPerCPUMetric(t *testing.T) {
+	// Register a test node for metrics
+	testingNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	metrics.Register(testingNode)
+	defer metrics.Register(nil)
+
+	sharePools := []ext.CPUSharedPool{
+		{
+			Socket: 0,
+			Node:   0,
+			CPUSet: "0-3",
+		},
+	}
+	beSharePools := []ext.CPUSharedPool{
+		{
+			Socket: 0,
+			Node:   0,
+			CPUSet: "4-7",
+		},
+	}
+	cpuPolicy := &ext.KubeletCPUManagerPolicy{
+		Policy: ext.KubeletCPUManagerPolicyNone,
+	}
+
+	nodeTopo := &topov1alpha1.NodeResourceTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node",
+			Annotations: map[string]string{},
+		},
+	}
+	nodeTopo.Annotations[ext.AnnotationNodeCPUSharedPools] = util.DumpJSON(sharePools)
+	nodeTopo.Annotations[ext.AnnotationNodeBECPUSharedPools] = util.DumpJSON(beSharePools)
+	nodeTopo.Annotations[ext.AnnotationKubeletCPUManagerPolicy] = util.DumpJSON(cpuPolicy)
+
+	// helper to read the actual value of a prometheus Gauge
+	gaugeValue := func(t *testing.T, gauge interface{ Write(*dto.Metric) error }) float64 {
+		t.Helper()
+		m := &dto.Metric{}
+		assert.NoError(t, gauge.Write(m))
+		return m.GetGauge().GetValue()
+	}
+
+	t.Run("per-cpu metrics emitted when feature enabled", func(t *testing.T) {
+		// Reset metrics to ensure a clean state
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+
+		p := &cpusetPlugin{
+			recordPerSharePoolCPUInfo: true,
+		}
+
+		updated, err := p.parseRule(nodeTopo)
+		assert.NoError(t, err)
+		assert.True(t, updated)
+
+		// Verify per-CPU share pool info metrics: cpu 0-3 should all be 1
+		for _, cpu := range []string{"0", "1", "2", "3"} {
+			gauge, err := metrics.CPUSetSharePoolInfo.GetMetricWithLabelValues("test-node", cpu)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(1), gaugeValue(t, gauge), "share pool info value for cpu %s", cpu)
+		}
+
+		// Verify per-CPU BE share pool info metrics: cpu 4-7 should all be 1
+		for _, cpu := range []string{"4", "5", "6", "7"} {
+			gauge, err := metrics.CPUSetBESharePoolInfo.GetMetricWithLabelValues("test-node", cpu)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(1), gaugeValue(t, gauge), "BE share pool info value for cpu %s", cpu)
+		}
+
+		// Verify share pool cores count: "0-3" = 4 cores
+		gauge, err := metrics.CPUSetSharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(4), gaugeValue(t, gauge))
+
+		// Verify BE share pool cores count: "4-7" = 4 cores
+		gauge, err = metrics.CPUSetBESharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(4), gaugeValue(t, gauge))
+
+		// Clean up
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+	})
+
+	t.Run("per-cpu metrics not emitted when feature disabled", func(t *testing.T) {
+		// Reset metrics to ensure a clean state
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+
+		p := &cpusetPlugin{
+			recordPerSharePoolCPUInfo: false,
+		}
+
+		updated, err := p.parseRule(nodeTopo)
+		assert.NoError(t, err)
+		assert.True(t, updated)
+
+		// Share pool cores metric should still be recorded (not gated): "0-3" = 4 cores
+		gauge, err := metrics.CPUSetSharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(4), gaugeValue(t, gauge))
+
+		// BE share pool cores metric should still be recorded: "4-7" = 4 cores
+		gauge, err = metrics.CPUSetBESharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(4), gaugeValue(t, gauge))
+	})
+
+	t.Run("expired per-cpu metrics cleaned on share pool shrink", func(t *testing.T) {
+		// Reset metrics to ensure a clean state
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+
+		p := &cpusetPlugin{
+			recordPerSharePoolCPUInfo: true,
+		}
+
+		// t0: sharepool = {0,1,2,3}, beSharepool = {4,5,6,7}
+		updated, err := p.parseRule(nodeTopo)
+		assert.NoError(t, err)
+		assert.True(t, updated)
+
+		// Verify t0 state: cpu 0-3 in share pool
+		for _, cpu := range []string{"0", "1", "2", "3"} {
+			gauge, err := metrics.CPUSetSharePoolInfo.GetMetricWithLabelValues("test-node", cpu)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(1), gaugeValue(t, gauge))
+		}
+		// Verify t0 state: cpu 4-7 in BE share pool
+		for _, cpu := range []string{"4", "5", "6", "7"} {
+			gauge, err := metrics.CPUSetBESharePoolInfo.GetMetricWithLabelValues("test-node", cpu)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(1), gaugeValue(t, gauge))
+		}
+
+		// t1: sharepool shrinks to {2,3}, beSharepool shrinks to {6,7}
+		shrunkSharePools := []ext.CPUSharedPool{
+			{Socket: 0, Node: 0, CPUSet: "2-3"},
+		}
+		shrunkBESharePools := []ext.CPUSharedPool{
+			{Socket: 0, Node: 0, CPUSet: "6-7"},
+		}
+		shrunkNodeTopo := &topov1alpha1.NodeResourceTopology{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-node",
+				Annotations: map[string]string{},
+			},
+		}
+		shrunkNodeTopo.Annotations[ext.AnnotationNodeCPUSharedPools] = util.DumpJSON(shrunkSharePools)
+		shrunkNodeTopo.Annotations[ext.AnnotationNodeBECPUSharedPools] = util.DumpJSON(shrunkBESharePools)
+		shrunkNodeTopo.Annotations[ext.AnnotationKubeletCPUManagerPolicy] = util.DumpJSON(cpuPolicy)
+
+		updated, err = p.parseRule(shrunkNodeTopo)
+		assert.NoError(t, err)
+		assert.True(t, updated)
+
+		// Verify t1: share pool cores count should be 2
+		gauge, err := metrics.CPUSetSharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(2), gaugeValue(t, gauge))
+
+		// Verify t1: BE share pool cores count should be 2
+		gauge, err = metrics.CPUSetBESharePoolCPUS.GetMetricWithLabelValues("test-node")
+		assert.NoError(t, err)
+		assert.Equal(t, float64(2), gaugeValue(t, gauge))
+
+		// Verify t1: only cpu 2,3 remain in share pool info
+		// Collect all metric series from CPUSetSharePoolInfo to check
+		collectCPUIDs := func(gaugeVec *prometheus.GaugeVec) map[string]float64 {
+			ch := make(chan prometheus.Metric, 100)
+			go func() {
+				gaugeVec.Collect(ch)
+				close(ch)
+			}()
+			result := map[string]float64{}
+			for m := range ch {
+				d := &dto.Metric{}
+				assert.NoError(t, m.Write(d))
+				for _, lp := range d.GetLabel() {
+					if lp.GetName() == "cpu" {
+						result[lp.GetValue()] = d.GetGauge().GetValue()
+					}
+				}
+			}
+			return result
+		}
+
+		sharePoolCPUs := collectCPUIDs(metrics.CPUSetSharePoolInfo)
+		assert.Equal(t, map[string]float64{"2": 1, "3": 1}, sharePoolCPUs,
+			"only cpu 2,3 should remain in share pool info after shrink; cpu 0,1 should be cleaned")
+
+		beSharePoolCPUs := collectCPUIDs(metrics.CPUSetBESharePoolInfo)
+		assert.Equal(t, map[string]float64{"6": 1, "7": 1}, beSharePoolCPUs,
+			"only cpu 6,7 should remain in BE share pool info after shrink; cpu 4,5 should be cleaned")
+
+		// Clean up
+		metrics.ResetCPUSetSharePoolInfo()
+		metrics.ResetCPUSetBESharePoolInfo()
+	})
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
This PR adds the `koordlet_cpuset_share_pool_info` metric, which exports the specific CPU IDs currently assigned to the Share Pool. The same applies to the BE Share Pool.

For CPU pinning scenarios (e.g., LSE/LSR pods), we should monitor the Share Pool's usage. If too many exclusive cpus are allocated, non-pinned pods may be crowded into a small Share Pool, causing severe CPU contention and node hotspots.

With the `koordlet_cpuset_share_pool_info` metric, we can easily monitor the CPU utilization of the sharepool through the following PromQL metric, and prevent hot spot issues in advance.

```
avg(
  irate(node_cpu_seconds_total{instance=~"kind-worker1", mode=~"user"}[5m])
  and on(node, cpu)
  koordlet_cpuset_share_pool_info
)
```

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
no
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Go to prometheus, and query follow promql
- koordlet_cpuset_share_pool_info{}
- koordlet_cpuset_be_share_pool_info{}
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
