### PR TITLE
koordlet: Fix invalid argument error in cfs_quota_us and cfs_burst_us validation

### DIFF
--- a/pkg/koordlet/resourceexecutor/reader.go
+++ b/pkg/koordlet/resourceexecutor/reader.go
@@ -42,6 +42,7 @@ type CgroupReader interface {
 	ReadPSI(parentDir string) (*sysutil.PSIByResource, error)
 	ReadMemoryColdPageUsage(parentDir string) (uint64, error)
 	ReadNetClsId(parentDir string) (uint32, error)
+	ReadCPUBurst(parentDir string) (int64, error)
 }
 
 var _ CgroupReader = &CgroupV1Reader{}
@@ -246,6 +247,14 @@ func (r *CgroupV1Reader) ReadNetClsId(parentDir string) (uint32, error) {
 		return 0, ErrResourceNotRegistered
 	}
 	return readCgroupAndParseUint32(parentDir, resource)
+}
+
+func (r *CgroupV1Reader) ReadCPUBurst(parentDir string) (int64, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV1, sysutil.CPUBurstName)
+	if !ok {
+		return -1, ErrResourceNotRegistered
+	}
+	return readCgroupAndParseInt64(parentDir, resource)
 }
 
 var _ CgroupReader = &CgroupV2Reader{}
@@ -468,6 +477,16 @@ func (r *CgroupV2Reader) ReadNetClsId(parentDir string) (uint32, error) {
 		return 0, ErrResourceNotRegistered
 	}
 	return readCgroupAndParseUint32(parentDir, resource)
+}
+
+func (r *CgroupV2Reader) ReadCPUBurst(parentDir string) (int64, error) {
+	resource, ok := sysutil.DefaultRegistry.Get(sysutil.CgroupVersionV2, sysutil.CPUBurstName)
+	if !ok {
+		return -1, ErrResourceNotRegistered
+	}
+
+	// since cpu.max.burst is a simgle value in cgroupV2 file, just convert the value to int64 and return
+	return readCgroupAndParseInt64(parentDir, resource)
 }
 
 func NewCgroupReader() CgroupReader {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
1. **Apply CPU Burst Limit**: Added a logic to cap `cfs_burst_us` based on `cfs_quota_us` in `applyCPUBurst` to avoid `invalid argument` errors during updates.
2. **Synchronous Quota Adjustment**: Ensured `cfs_burst_us` is adjusted alongside `cfs_quota_us` in `applyCFSQuota`.
3. **Refactoring**: Extracted common logic into `applyContainerCPUBurst` and `applyPodCPUBurst` for better maintainability.
4. **CgroupReader Enhancement**: Added support for reading current `cfs_burst_us` values.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
https://github.com/koordinator-sh/koordinator/issues/2778
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews
After the fix, cfs_burst_us is now more closely coupled with cfs_quota_us and will be adjusted synchronously with changes to the quota. While this resolves the invalid argument error, I would like to bring up a concern: does this coupling deviate from the original design intent of CPU Burst at the Linux kernel level? I would appreciate the community's insight and evaluation on this approach.
### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
