### PR TITLE
kubeclients: use protobuf for native resources #2812

### DIFF
--- a/cmd/koord-descheduler/app/options/options.go
+++ b/cmd/koord-descheduler/app/options/options.go
@@ -265,10 +265,10 @@ func (o *Options) Config() (*deschedulerappconfig.Config, error) {
 		}
 	}
 
-	mgrKubeConfig := *kubeConfig
+	mgrKubeConfig := restclient.CopyConfig(kubeConfig)
 	mgrKubeConfig.ContentType = ""
 	mgrKubeConfig.AcceptContentTypes = ""
-	mgr, err := ctrl.NewManager(&mgrKubeConfig, ctrl.Options{
+	mgr, err := ctrl.NewManager(mgrKubeConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: "0"},
 		HealthProbeBindAddress: "0",
@@ -284,7 +284,7 @@ func (o *Options) Config() (*deschedulerappconfig.Config, error) {
 	c.Client = client
 	c.KubeConfig = kubeConfig
 	c.InformerFactory = informers.NewSharedInformerFactory(mgr, 0)
-	dynClient := dynamic.NewForConfigOrDie(kubeConfig)
+	dynClient := dynamic.NewForConfigOrDie(mgrKubeConfig)
 	c.DynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, corev1.NamespaceAll, nil)
 	c.LeaderElection = leaderElectionConfig
 

--- a/cmd/koord-scheduler/app/options/options.go
+++ b/cmd/koord-scheduler/app/options/options.go
@@ -24,6 +24,7 @@ import (
 	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/rest"
 	scheduleroptions "k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 
 	schedulerappconfig "github.com/koordinator-sh/koordinator/cmd/koord-scheduler/app/config"
@@ -74,17 +75,20 @@ func (o *Options) Config(ctx context.Context) (*schedulerappconfig.Config, error
 	// So we need to fix it ourselves.
 	config.InformerFactory = frameworkexthelper.NewForceSyncSharedInformerFactory(config.InformerFactory)
 
+	config.KubeConfig.ContentType = runtime.ContentTypeProtobuf
+	config.KubeConfig.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
+
 	// use json for CRD clients
-	kubeConfig := *config.KubeConfig
+	kubeConfig := rest.CopyConfig(config.KubeConfig)
 	kubeConfig.ContentType = runtime.ContentTypeJSON
 	kubeConfig.AcceptContentTypes = runtime.ContentTypeJSON
-	koordinatorClient, err := koordinatorclientset.NewForConfig(&kubeConfig)
+	koordinatorClient, err := koordinatorclientset.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
 	koordinatorSharedInformerFactory := koordinatorinformers.NewSharedInformerFactoryWithOptions(koordinatorClient, 0)
 
-	nrtClient, err := nrtclientset.NewForConfig(&kubeConfig)
+	nrtClient, err := nrtclientset.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/generic_client.go
+++ b/pkg/client/generic_client.go
@@ -36,6 +36,7 @@ type GenericClientset struct {
 func newForConfig(c *rest.Config) (*GenericClientset, error) {
 	cWithProtobuf := rest.CopyConfig(c)
 	cWithProtobuf.ContentType = runtime.ContentTypeProtobuf
+	cWithProtobuf.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cWithProtobuf)
 	if err != nil {
 		return nil, err

--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -156,7 +156,8 @@ func SetDefaults_DeschedulerConfiguration(obj *DeschedulerConfiguration) {
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElection)
 
 	if len(obj.ClientConnection.ContentType) == 0 {
-		obj.ClientConnection.ContentType = "application/vnd.kubernetes.protobuf"
+		obj.ClientConnection.ContentType = runtime.ContentTypeProtobuf
+		obj.ClientConnection.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
 	}
 	// Scheduler has an opinion about QPS/Burst, setting specific defaults for itself, instead of generic settings.
 	if obj.ClientConnection.QPS == 0.0 {

--- a/pkg/koordlet/config/config.go
+++ b/pkg/koordlet/config/config.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -96,6 +97,8 @@ func (c *Configuration) InitKubeConfigForKoordlet(kubeAPIQPS float64, kubeAPIBur
 	cfg.UserAgent = "koordlet"
 	cfg.QPS = float32(kubeAPIQPS)
 	cfg.Burst = kubeAPIBurst
+	cfg.ContentType = runtime.ContentTypeProtobuf
+	cfg.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
 	c.KubeRestConf = cfg
 	return nil
 }

--- a/pkg/koordlet/koordlet.go
+++ b/pkg/koordlet/koordlet.go
@@ -26,6 +26,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -86,9 +87,15 @@ func NewDaemon(config *config.Configuration) (Daemon, error) {
 	klog.Infof("kernel version INFO: %+v", system.HostSystemInfo)
 
 	kubeClient := clientset.NewForConfigOrDie(config.KubeRestConf)
-	crdClient := clientsetbeta1.NewForConfigOrDie(config.KubeRestConf)
-	topologyClient := topologyclientset.NewForConfigOrDie(config.KubeRestConf)
-	schedulingClient := v1alpha1.NewForConfigOrDie(config.KubeRestConf)
+
+	// use json for CRD clients
+	crdRestConf := rest.CopyConfig(config.KubeRestConf)
+	crdRestConf.ContentType = apiruntime.ContentTypeJSON
+	crdRestConf.AcceptContentTypes = apiruntime.ContentTypeJSON
+
+	crdClient := clientsetbeta1.NewForConfigOrDie(crdRestConf)
+	topologyClient := topologyclientset.NewForConfigOrDie(crdRestConf)
+	schedulingClient := v1alpha1.NewForConfigOrDie(crdRestConf)
 
 	metricCache, err := metriccache.NewMetricCache(config.MetricCacheConf)
 	if err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

**Summary**
This PR updates the Kubernetes API client configurations across Koordinator components to prefer **Protobuf** serialization over JSON by default, while maintaining JSON as a fallback.

**How does this PR work?**
Currently, `koordlet`, `koord-manager`, `koord-scheduler`, and `koord-descheduler` hardcode `ContentTypeJSON` and `AcceptContentTypes` to JSON when communicating with the Kubernetes API server for native resources (Pods, Nodes, ConfigMaps, etc.).

This PR modifies the underlying `rest.Config` setup for these four components to use:
* `ContentType = "application/vnd.kubernetes.protobuf"`
* `AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"`

This ensures that the clients use the significantly faster Protobuf format for native K8s resources, which reduces the API server CPU load for serialization/deserialization and drastically lowers network bandwidth usage in large clusters, while gracefully falling back to JSON for custom resources (CRDs).

### Ⅱ. Does this pull request fix one issue?

fixes #2812

### Ⅲ. Describe how to verify it

1. Compile all the components using `make build` and ensure compilation is successful.
2. Run standard unit tests using `make test`.
3. In a deployed cluster, the outbound network bandwidth and API Server CPU overhead of these components should demonstrably drop when executing large-scale workloads over time.

### Ⅳ. Special notes for reviews

NONE

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`