### PR TITLE
koord-descheduler: fix AnomalyCondition check bugs and make nodePools inherit top-level default configs.

### DIFF
--- a/pkg/descheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults.go
@@ -264,7 +264,10 @@ func SetDefaults_LowNodeLoadArgs(obj *LowNodeLoadArgs) {
 		obj.AnomalyCondition = defaultLoadAnomalyCondition
 	} else if obj.AnomalyCondition.ConsecutiveAbnormalities == 0 {
 		obj.AnomalyCondition.ConsecutiveAbnormalities = defaultLoadAnomalyCondition.ConsecutiveAbnormalities
+	} else if obj.AnomalyCondition.ConsecutiveNormalities == 0 {
+		obj.AnomalyCondition.ConsecutiveNormalities = defaultLoadAnomalyCondition.ConsecutiveNormalities
 	}
+
 	if obj.DetectorCacheTimeout == nil {
 		obj.DetectorCacheTimeout = &metav1.Duration{Duration: defaultDetectorCacheTimeout}
 	}
@@ -289,6 +292,40 @@ func SetDefaults_LowNodeLoadArgs(obj *LowNodeLoadArgs) {
 		for resourceName, weight := range defaultResourceWeights {
 			if v := obj.ResourceWeights[resourceName]; v <= 0 {
 				obj.ResourceWeights[resourceName] = weight
+			}
+		}
+	}
+
+	SetDefaults_LowNodeLoadNodePools(obj)
+}
+
+func SetDefaults_LowNodeLoadNodePools(args *LowNodeLoadArgs) {
+	for i := range args.NodePools {
+		pool := &args.NodePools[i]
+		if pool.HighThresholds == nil {
+			pool.HighThresholds = args.HighThresholds
+		}
+		if pool.LowThresholds == nil {
+			pool.LowThresholds = args.LowThresholds
+		}
+		if pool.ProdHighThresholds == nil {
+			pool.ProdHighThresholds = args.ProdHighThresholds
+		}
+		if pool.ProdLowThresholds == nil {
+			pool.ProdLowThresholds = args.ProdLowThresholds
+		}
+		if pool.ResourceWeights == nil {
+			pool.ResourceWeights = args.ResourceWeights
+		}
+
+		if pool.AnomalyCondition == nil {
+			pool.AnomalyCondition = args.AnomalyCondition
+		} else {
+			if pool.AnomalyCondition.ConsecutiveAbnormalities == 0 {
+				pool.AnomalyCondition.ConsecutiveAbnormalities = args.AnomalyCondition.ConsecutiveAbnormalities
+			}
+			if pool.AnomalyCondition.ConsecutiveNormalities == 0 {
+				pool.AnomalyCondition.ConsecutiveNormalities = args.AnomalyCondition.ConsecutiveNormalities
 			}
 		}
 	}

--- a/pkg/descheduler/apis/config/v1alpha2/defaults_test.go
+++ b/pkg/descheduler/apis/config/v1alpha2/defaults_test.go
@@ -126,3 +126,285 @@ func TestSetDefaults_LowNodeLoadArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDefaults_NodePoolsUseDefaultArgsFromLowNodeLoadArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     *LowNodeLoadArgs
+		expected *LowNodeLoadArgs
+	}{
+		{
+			name: "nodePools inherit all fields from top-level config",
+			args: &LowNodeLoadArgs{
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU:    80,
+					corev1.ResourceMemory: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU:    20,
+					corev1.ResourceMemory: 20,
+				},
+				ProdHighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 90,
+				},
+				ProdLowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 10,
+				},
+				ResourceWeights: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 2,
+				},
+				AnomalyCondition: &LoadAnomalyCondition{
+					Timeout:                  &metav1.Duration{Duration: 2 * time.Minute},
+					ConsecutiveAbnormalities: 10,
+					ConsecutiveNormalities:   5,
+				},
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "test-pool",
+					},
+				},
+			},
+			expected: &LowNodeLoadArgs{
+				NodeFit:                     ptr.To[bool](true),
+				NodeMetricExpirationSeconds: ptr.To[int64](defaultNodeMetricExpirationSeconds),
+				DetectorCacheTimeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ResourceWeights: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    2,
+					corev1.ResourceMemory: 1,
+				},
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU:    80,
+					corev1.ResourceMemory: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU:    20,
+					corev1.ResourceMemory: 20,
+				},
+				ProdHighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 90,
+				},
+				ProdLowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 10,
+				},
+				AnomalyCondition: &LoadAnomalyCondition{
+					Timeout:                  &metav1.Duration{Duration: 2 * time.Minute},
+					ConsecutiveAbnormalities: 10,
+					ConsecutiveNormalities:   5,
+				},
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "test-pool",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU:    80,
+							corev1.ResourceMemory: 80,
+						},
+						LowThresholds: ResourceThresholds{
+							corev1.ResourceCPU:    20,
+							corev1.ResourceMemory: 20,
+						},
+						ProdHighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 90,
+						},
+						ProdLowThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 10,
+						},
+						ResourceWeights: map[corev1.ResourceName]int64{
+							corev1.ResourceCPU:    2,
+							corev1.ResourceMemory: 1,
+						},
+						AnomalyCondition: &LoadAnomalyCondition{
+							Timeout:                  &metav1.Duration{Duration: 2 * time.Minute},
+							ConsecutiveAbnormalities: 10,
+							ConsecutiveNormalities:   5,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple nodePools inherit from top-level config",
+			args: &LowNodeLoadArgs{
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 20,
+				},
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "pool-1",
+					},
+					{
+						Name: "pool-2",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 70,
+						},
+					},
+				},
+			},
+			expected: &LowNodeLoadArgs{
+				NodeFit:                     ptr.To[bool](true),
+				NodeMetricExpirationSeconds: ptr.To[int64](defaultNodeMetricExpirationSeconds),
+				DetectorCacheTimeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ResourceWeights: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    1,
+					corev1.ResourceMemory: 1,
+				},
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 20,
+				},
+				AnomalyCondition: defaultLoadAnomalyCondition,
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "pool-1",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 80,
+						},
+						LowThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 20,
+						},
+						ResourceWeights: map[corev1.ResourceName]int64{
+							corev1.ResourceCPU:    1,
+							corev1.ResourceMemory: 1,
+						},
+						AnomalyCondition: defaultLoadAnomalyCondition,
+					},
+					{
+						Name: "pool-2",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 70,
+						},
+						LowThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 20,
+						},
+						ResourceWeights: map[corev1.ResourceName]int64{
+							corev1.ResourceCPU:    1,
+							corev1.ResourceMemory: 1,
+						},
+						AnomalyCondition: defaultLoadAnomalyCondition,
+					},
+				},
+			},
+		},
+		{
+			name: "nodePools with partial zero values inherit from top-level",
+			args: &LowNodeLoadArgs{
+				AnomalyCondition: &LoadAnomalyCondition{
+					Timeout:                  &metav1.Duration{Duration: 2 * time.Minute},
+					ConsecutiveAbnormalities: 10,
+					ConsecutiveNormalities:   5,
+				},
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "test-pool",
+						AnomalyCondition: &LoadAnomalyCondition{
+							Timeout:                  &metav1.Duration{Duration: 1 * time.Minute},
+							ConsecutiveAbnormalities: 0,
+							ConsecutiveNormalities:   0,
+						},
+					},
+				},
+			},
+			expected: &LowNodeLoadArgs{
+				NodeFit:                     ptr.To[bool](true),
+				NodeMetricExpirationSeconds: ptr.To[int64](defaultNodeMetricExpirationSeconds),
+				DetectorCacheTimeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ResourceWeights: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    1,
+					corev1.ResourceMemory: 1,
+				},
+				AnomalyCondition: &LoadAnomalyCondition{
+					Timeout:                  &metav1.Duration{Duration: 2 * time.Minute},
+					ConsecutiveAbnormalities: 10,
+					ConsecutiveNormalities:   5,
+				},
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "test-pool",
+						AnomalyCondition: &LoadAnomalyCondition{
+							Timeout:                  &metav1.Duration{Duration: 1 * time.Minute},
+							ConsecutiveAbnormalities: 10,
+							ConsecutiveNormalities:   5,
+						},
+						ResourceWeights: map[corev1.ResourceName]int64{
+							corev1.ResourceCPU:    1,
+							corev1.ResourceMemory: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nodePools keep own config when specified",
+			args: &LowNodeLoadArgs{
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 20,
+				},
+				AnomalyCondition: defaultLoadAnomalyCondition,
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "custom-pool",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 70,
+						},
+						LowThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 30,
+						},
+						AnomalyCondition: &LoadAnomalyCondition{
+							ConsecutiveAbnormalities: 3,
+							ConsecutiveNormalities:   2,
+						},
+					},
+				},
+			},
+			expected: &LowNodeLoadArgs{
+				NodeFit:                     ptr.To[bool](true),
+				NodeMetricExpirationSeconds: ptr.To[int64](defaultNodeMetricExpirationSeconds),
+				DetectorCacheTimeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ResourceWeights: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    1,
+					corev1.ResourceMemory: 1,
+				},
+				HighThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 80,
+				},
+				LowThresholds: ResourceThresholds{
+					corev1.ResourceCPU: 20,
+				},
+				AnomalyCondition: defaultLoadAnomalyCondition,
+				NodePools: []LowNodeLoadNodePool{
+					{
+						Name: "custom-pool",
+						HighThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 70,
+						},
+						LowThresholds: ResourceThresholds{
+							corev1.ResourceCPU: 30,
+						},
+						AnomalyCondition: &LoadAnomalyCondition{
+							ConsecutiveAbnormalities: 3,
+							ConsecutiveNormalities:   2,
+						},
+						ResourceWeights: map[corev1.ResourceName]int64{
+							corev1.ResourceCPU:    1,
+							corev1.ResourceMemory: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetDefaults_LowNodeLoadArgs(tt.args)
+			assert.Equal(t, tt.expected, tt.args)
+		})
+	}
+}

--- a/pkg/descheduler/apis/config/validation/validation_loadaware.go
+++ b/pkg/descheduler/apis/config/validation/validation_loadaware.go
@@ -85,9 +85,13 @@ func ValidateLowLoadUtilizationArgs(path *field.Path, args *deschedulerconfig.Lo
 			}
 		}
 
-		if nodePool.AnomalyCondition.ConsecutiveAbnormalities <= 0 {
+		if nodePool.AnomalyCondition != nil && nodePool.AnomalyCondition.ConsecutiveAbnormalities <= 0 {
 			fieldPath := nodePoolPath.Child("anomalyDetectionThresholds").Child("consecutiveAbnormalities")
 			allErrs = append(allErrs, field.Invalid(fieldPath, nodePool.AnomalyCondition.ConsecutiveAbnormalities, "consecutiveAbnormalities must be greater than 0"))
+		}
+		if nodePool.AnomalyCondition != nil && nodePool.AnomalyCondition.ConsecutiveNormalities <= 0 {
+			fieldPath := nodePoolPath.Child("anomalyDetectionThresholds").Child("consecutiveNormalities")
+			allErrs = append(allErrs, field.Invalid(fieldPath, nodePool.AnomalyCondition.ConsecutiveNormalities, "consecutiveNormalities must be greater than 0"))
 		}
 	}
 

--- a/pkg/descheduler/apis/config/validation/validation_loadaware_test.go
+++ b/pkg/descheduler/apis/config/validation/validation_loadaware_test.go
@@ -154,6 +154,7 @@ func TestValidateLowLoadUtilizationArgs_NodePoolThresholds(t *testing.T) {
 			lowThresholds:  50,
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 5,
+				ConsecutiveNormalities:   3,
 			},
 			expectedError: false,
 		},
@@ -162,6 +163,16 @@ func TestValidateLowLoadUtilizationArgs_NodePoolThresholds(t *testing.T) {
 			lowThresholds:  50,
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 0,
+				ConsecutiveNormalities:   3,
+			},
+			expectedError: true,
+		},
+		{
+			highThresholds: 100,
+			lowThresholds:  50,
+			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
+				ConsecutiveAbnormalities: 5,
+				ConsecutiveNormalities:   0,
 			},
 			expectedError: true,
 		},
@@ -181,8 +192,10 @@ func TestValidateLowLoadUtilizationArgs_NodePoolThresholds(t *testing.T) {
 		anomalyCondition := &deschedulerconfig.LoadAnomalyCondition{}
 		if tc.anomalyCondition != nil {
 			anomalyCondition.ConsecutiveAbnormalities = tc.anomalyCondition.ConsecutiveAbnormalities
+			anomalyCondition.ConsecutiveNormalities = tc.anomalyCondition.ConsecutiveNormalities
 		} else {
 			anomalyCondition.ConsecutiveAbnormalities = 5
+			anomalyCondition.ConsecutiveNormalities = 3
 		}
 		args := &deschedulerconfig.LowNodeLoadArgs{
 			NodePools: []deschedulerconfig.LowNodeLoadNodePool{

--- a/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
@@ -1430,6 +1430,7 @@ func TestLowNodeLoad(t *testing.T) {
 										UseDeviationThresholds: tt.useDeviationThresholds,
 										AnomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 											ConsecutiveAbnormalities: 1,
+											ConsecutiveNormalities:   1,
 										},
 									},
 								},
@@ -1595,6 +1596,7 @@ func TestMaxEvictionTotal(t *testing.T) {
 										UseDeviationThresholds: tt.useDeviationThresholds,
 										AnomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 											ConsecutiveAbnormalities: 1,
+											ConsecutiveNormalities:   1,
 										},
 									},
 								},
@@ -1933,6 +1935,7 @@ func Test_filterRealAbnormalNodes(t *testing.T) {
 			sourceNodes: []string{"test-node-1", "test-node-2"},
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 1,
+				ConsecutiveNormalities:   1,
 			},
 			want: []string{"test-node-1", "test-node-2"},
 		},
@@ -1941,6 +1944,7 @@ func Test_filterRealAbnormalNodes(t *testing.T) {
 			sourceNodes: []string{"test-node-1", "test-node-2"},
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 2,
+				ConsecutiveNormalities:   1,
 			},
 			want: nil,
 		},
@@ -1949,6 +1953,7 @@ func Test_filterRealAbnormalNodes(t *testing.T) {
 			sourceNodes: []string{"test-node-1", "test-node-2"},
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 2,
+				ConsecutiveNormalities:   1,
 			},
 			detectCounts: 2,
 			want:         []string{"test-node-1", "test-node-2"},
@@ -1959,6 +1964,7 @@ func Test_filterRealAbnormalNodes(t *testing.T) {
 			abnormalNodes: []string{"test-node-2"},
 			anomalyCondition: &deschedulerconfig.LoadAnomalyCondition{
 				ConsecutiveAbnormalities: 2,
+				ConsecutiveNormalities:   1,
 			},
 			want: []string{"test-node-2"},
 		},


### PR DESCRIPTION


### Ⅰ. Describe what this PR does
When configuring nodePools in `koord-descheduler-config` with only nodeSelector, name, and low/high thresholds (without explicitly setting AnomalyCondition), the descheduler will panic because:
1. The validation logic accessed nodePool.AnomalyCondition without nil check, causing nil pointer panic
2. The nodePools did not inherit default values from top-level config like AnomalyCondition, ResourceWeights, etc.

other bugs:
1. There was no validation for ConsecutiveNormalities field.


<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
When nodePools are added to koord-descheduler-config but anomalyCondition is not added, a panic will occur.
- koord-descheduler-config eg
```
  koord-descheduler-config: |
    apiVersion: descheduler/v1alpha2
    kind: DeschedulerConfiguration
    enableContentionProfiling: true
    enableProfiling: true
    ...
    profiles:
    - name: koord-descheduler
    ...
          lowThresholds:
            cpu: 30
            memory: 30
          highThresholds:
            cpu: 80
            memory: 80
          anomalyCondition:
            timeout: 1m
            consecutiveAbnormalities: 1
            consecutiveNormalities: 1
          nodePools:
          - name: test-pools1
            nodeSelector:
              matchLabels:
                dedicated: test-pools1
            lowThresholds:
              cpu: 30
            highThresholds:
              cpu: 60
      - name: MigrationController
        ...
```
- part koord-descheduler panic logs:
``` 
$ k -n koordinator-system logs koord-descheduler-69f9854988-wjs29
W0227 08:32:18.260692       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1d1bb8d]

goroutine 1 [running]:
github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config/validation.ValidateLowLoadUtilizationArgs(0x0, 0xc00039c8f0)
        /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config/validation/validation_loadaware.go:88 +0xc2d
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware.NewLowNodeLoad({0x2846358?, 0xc00039c8f0?}, {0x286b298?, 0xc00028e600})
        /go/src/github.com/koordinator-sh/koordinator/pkg/descheduler/framework/plugins/loadaware/low_node_load.go:68 +0xe5
github.com/koordinator-sh/koordinator/pkg/descheduler/framework/runtime.(*frameworkImpl).initPlugins(0x212a840?, 0xc0008af1a0?, 0xc0003a9520?, {0xc0008af1d0, 0x4, 0xc0008af260?}, 0xc00019a5d0?)
```


<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Pass the test unit or create koord-descheduler-config like issue described.

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
