### PR TITLE
koord-descheduler: use raw-allocatable for threshold calculation in descheduler lowNodeLoad plugin.

### DIFF
--- a/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
+++ b/pkg/descheduler/framework/plugins/loadaware/low_node_load_test.go
@@ -35,6 +35,7 @@ import (
 	coretesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
@@ -1643,6 +1644,9 @@ func TestOverUtilizedEvictionReason(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: `{"cpu":96,"memory":"512Gi"}`,
+					},
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
@@ -1666,6 +1670,9 @@ func TestOverUtilizedEvictionReason(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: `{"cpu":96,"memory":"512Gi"}`,
+					},
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
@@ -1694,6 +1701,9 @@ func TestOverUtilizedEvictionReason(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: `{"cpu":96,"memory":"512Gi"}`,
+					},
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
@@ -1726,6 +1736,9 @@ func TestOverUtilizedEvictionReason(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: `{"cpu":96,"memory":"512Gi"}`,
+					},
 				},
 				Status: corev1.NodeStatus{
 					Allocatable: corev1.ResourceList{
@@ -1995,6 +2008,81 @@ func Test_filterRealAbnormalNodes(t *testing.T) {
 				gotNodes = append(gotNodes, v.node.Name)
 			}
 			assert.Equal(t, tt.want, gotNodes)
+		})
+	}
+}
+
+func Test_GetNodeRawAllocatableForDescheduler(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want corev1.ResourceList
+	}{
+		{
+			name: "node has no annotation - use allocatable",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("16"),
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+					},
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+		},
+		{
+			name: "node has valid raw allocatable annotation - use raw allocatable",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: `{"cpu":"8","memory":"16Gi"}`,
+					},
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("32"),
+						corev1.ResourceMemory: resource.MustParse("64Gi"),
+					},
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+		{
+			name: "node has invalid raw allocatable annotation - fallback to allocatable",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						extension.AnnotationNodeRawAllocatable: "invalid",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("16"),
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+					},
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetNodeRawAllocatableFromNode(tt.node)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/descheduler/framework/plugins/loadaware/utilization_util.go
+++ b/pkg/descheduler/framework/plugins/loadaware/utilization_util.go
@@ -102,7 +102,7 @@ func getNodeThresholds(
 			prodLowResourceThreshold:  map[corev1.ResourceName]*resource.Quantity{},
 			prodHighResourceThreshold: map[corev1.ResourceName]*resource.Quantity{},
 		}
-		allocatable := nodeUsage.node.Status.Allocatable
+		allocatable := GetNodeRawAllocatableFromNode(nodeUsage.node)
 		for _, resourceName := range resourceNames {
 			if useDeviationThresholds {
 				resourceCapacity := allocatable[resourceName]
@@ -287,7 +287,7 @@ func classifyNodes(
 }
 
 func resourceUsagePercentages(nodeUsage *NodeUsage, prod bool) map[corev1.ResourceName]float64 {
-	allocatable := nodeUsage.node.Status.Allocatable
+	allocatable := GetNodeRawAllocatableFromNode(nodeUsage.node)
 	resourceUsagePercentage := map[corev1.ResourceName]float64{}
 	var usage map[corev1.ResourceName]*resource.Quantity
 	if prod {
@@ -585,8 +585,8 @@ func sortNodesByUsage(nodes []NodeInfo, resourceToWeightMap map[corev1.ResourceN
 			jNodeUsage = usageToResourceList(nodes[j].usage)
 		}
 
-		iScore := scorer(iNodeUsage, nodes[i].node.Status.Allocatable)
-		jScore := scorer(jNodeUsage, nodes[j].node.Status.Allocatable)
+		iScore := scorer(iNodeUsage, GetNodeRawAllocatableFromNode(nodes[i].node))
+		jScore := scorer(jNodeUsage, GetNodeRawAllocatableFromNode(nodes[j].node))
 		if ascending {
 			return iScore < jScore
 		}
@@ -661,7 +661,7 @@ func calcAverageResourceUsagePercent(nodeUsages map[string]*NodeUsage) (Resource
 	for _, nodeUsage := range nodeUsages {
 		usage := nodeUsage.usage
 		prodUsage := nodeUsage.prodUsage
-		allocatable := nodeUsage.node.Status.Allocatable
+		allocatable := GetNodeRawAllocatableFromNode(nodeUsage.node)
 		for resourceName, used := range usage {
 			total := allocatable[resourceName]
 			if total.IsZero() {
@@ -721,7 +721,7 @@ func sortPodsOnOneOverloadedNode(srcNode NodeInfo, removablePods []*corev1.Pod, 
 		resourcesThatExceedThresholds,
 		removablePods,
 		srcNode.podMetrics,
-		map[string]corev1.ResourceList{srcNode.node.Name: srcNode.node.Status.Allocatable},
+		map[string]corev1.ResourceList{srcNode.node.Name: GetNodeRawAllocatableFromNode(srcNode.node)},
 		weights,
 	)
 }
@@ -776,4 +776,22 @@ func podFitsAnyNodeWithThreshold(nodeIndexer podutil.GetPodsAssignedToNodeFunc, 
 		}
 	}
 	return false
+}
+
+// GetNodeRawAllocatableFromNode gets the raw allocatable from node annotation.
+// In the cpu-normalization or amplification scenario, node Allocatable will be amplified,
+// so raw-allocatable needs to be obtained during descheduling to accurately calculate node usage percent.
+// If raw-allocatable is not set or fails to parse, returns the amplified Allocatable as fallback.
+func GetNodeRawAllocatableFromNode(node *corev1.Node) corev1.ResourceList {
+	allocatable := node.Status.Allocatable
+	rawAllocatable, err := extension.GetNodeRawAllocatable(node.Annotations)
+	if err != nil {
+		klog.Errorf("Failed to parse %s raw allocatable, using amplified allocatable as fallback, err: %v", node.Name, err)
+		return allocatable
+	}
+	if rawAllocatable == nil {
+		klog.V(3).Infof("Node %s has no raw-allocatable annotation, using node status allocatable", node.Name)
+		return allocatable
+	}
+	return rawAllocatable
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Problem:

In the cpu-normalization or resource amplification scenario, the node's Status.Allocatable is amplified (eg: 16 cores → 32 cores). However, the descheduler lowNodeLoad plugin calculates thresholds using this amplified allocatable:
`threshold = allocatable * thresholdPercent  (eg: 32 * 70% = 22.4)`
This causes the threshold to be much higher than expected. Even when actual node usage reaches 100% (16 cores), it still cannot trigger the hotspot threshold (22.4 cores), making the descheduler ineffective.

Fix:

Use the raw-allocatable stored in node annotation (node.koordinator.sh/raw-allocatable) for threshold calculations instead of the amplified Status.Allocatable. This ensures the usage percentage is calculated correctly based on the actual physical resources.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
