### PR TITLE
fix(koordlet): add GPU device info to OCI spec in NRI injection to prevent permission loss

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/gpu/gpu.go
+++ b/pkg/koordlet/runtimehooks/hooks/gpu/gpu.go
@@ -33,7 +33,21 @@ import (
 	rmconfig "github.com/koordinator-sh/koordinator/pkg/runtimeproxy/config"
 )
 
-const GpuAllocEnv = "NVIDIA_VISIBLE_DEVICES"
+const (
+	GpuAllocEnv = "NVIDIA_VISIBLE_DEVICES"
+
+	nvidiaDevicePrefix   = "/dev/nvidia"
+	nvidiaCtlDevice      = "/dev/nvidiactl"
+	nvidiaUVMDevice      = "/dev/nvidia-uvm"
+	nvidiaUVMToolsDevice = "/dev/nvidia-uvm-tools"
+)
+
+// nvidiaControlDevices are common NVIDIA control devices shared by all GPU containers.
+var nvidiaControlDevices = []string{nvidiaCtlDevice, nvidiaUVMDevice, nvidiaUVMToolsDevice}
+
+// getDeviceNumbers is a function variable for getting device major/minor numbers,
+// allowing substitution in tests.
+var getDeviceNumbers = system.GetDeviceNumbers
 
 type gpuPlugin struct{}
 
@@ -66,68 +80,131 @@ func (p *gpuPlugin) InjectContainerGPUEnv(proto protocol.HooksProtocol) error {
 		klog.V(5).Infof("no gpu alloc info in pod anno, %s", containerReq.PodMeta.Name)
 		return nil
 	}
-	gpuIDs := []string{}
-	for _, d := range devices {
-		gpuIDs = append(gpuIDs, fmt.Sprintf("%d", d.Minor))
-	}
+
 	if containerCtx.Response.AddContainerEnvs == nil {
 		containerCtx.Response.AddContainerEnvs = make(map[string]string)
 	}
-	containerCtx.Response.AddContainerEnvs[GpuAllocEnv] = strings.Join(gpuIDs, ",")
+
+	injectGPUEnv(containerCtx, devices)
+	if err := injectGPUDevices(containerCtx, devices); err != nil {
+		return err
+	}
 	if containerReq.PodLabels[ext.LabelGPUIsolationProvider] == string(ext.GPUIsolationProviderHAMICore) {
-		gpuResources := devices[0].Resources
-		gpuMemoryRatio, ok := gpuResources[ext.ResourceGPUMemoryRatio]
-		if !ok {
-			return fmt.Errorf("gpu memory ratio not found in gpu resource")
-		}
-		if gpuMemoryRatio.Value() < 100 {
-			gpuMemory, ok := gpuResources[ext.ResourceGPUMemory]
-			if !ok {
-				return fmt.Errorf("gpu memory not found in gpu resource")
-			}
-			containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_MEMORY_LIMIT"] = fmt.Sprintf("%d", gpuMemory.Value())
-			gpuCore, ok := gpuResources[ext.ResourceGPUCore]
-			if ok {
-				containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprintf("%d", gpuCore.Value())
-			}
-			containerCtx.Response.AddContainerEnvs["LD_PRELOAD"] = system.Conf.HAMICoreLibraryDirectoryPath
-
-			containerCtx.Response.AddContainerMounts = append(containerCtx.Response.AddContainerMounts,
-				&protocol.Mount{
-					Destination: system.Conf.HAMICoreLibraryDirectoryPath,
-					Type:        "bind",
-					Source:      system.Conf.HAMICoreLibraryDirectoryPath,
-					Options:     []string{"rbind"},
-				},
-				// Because https://github.com/Project-HAMi/HAMi/issues/696, we create the directory in pod.
-				&protocol.Mount{
-					Destination: "/tmp/vgpulock",
-					Type:        "bind",
-					Source:      "/tmp/vgpulock",
-					Options:     []string{"rbind"},
-				},
-			)
-
-			if features.DefaultKoordletFeatureGate.Enabled(features.HamiCoreVGPUMonitor) {
-				hamiDirPath := filepath.Dir(system.Conf.HAMICoreLibraryDirectoryPath)
-				containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/%s_%s.cache", hamiDirPath, containerReq.PodMeta.UID, containerReq.ContainerMeta.Name)
-				cacheFileHostDirectory := fmt.Sprintf("%s/containers/%s_%s", hamiDirPath, containerReq.PodMeta.UID, containerReq.ContainerMeta.Name)
-				// TODO: Move this operation into the pkg resource-executor.​
-				klog.V(5).Infof("​​create a vgpu monitoring data directory [%s] and grant it 0777 permissions", cacheFileHostDirectory)
-				os.RemoveAll(cacheFileHostDirectory)
-				os.MkdirAll(cacheFileHostDirectory, 0777)
-				os.Chmod(cacheFileHostDirectory, 0777)
-				containerCtx.Response.AddContainerMounts = append(containerCtx.Response.AddContainerMounts,
-					&protocol.Mount{
-						Destination: hamiDirPath,
-						Type:        "bind",
-						Source:      cacheFileHostDirectory,
-						Options:     []string{"rbind"},
-					},
-				)
-			}
+		if err := injectHAMiResources(containerCtx, devices); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
+// injectGPUEnv sets the NVIDIA_VISIBLE_DEVICES environment variable with allocated GPU minor numbers.
+func injectGPUEnv(containerCtx *protocol.ContainerContext, devices []*ext.DeviceAllocation) {
+	gpuIDs := make([]string, 0, len(devices))
+	for _, d := range devices {
+		gpuIDs = append(gpuIDs, fmt.Sprintf("%d", d.Minor))
+	}
+	containerCtx.Response.AddContainerEnvs[GpuAllocEnv] = strings.Join(gpuIDs, ",")
+}
+
+// injectGPUDevices adds GPU device information to the OCI spec so that runc can persist device
+// cgroup rules in systemd transient units. Without this, a `systemctl daemon-reload` would reset
+// the device cgroup and cause GPU permission loss for containers using the nvidia-container-runtime
+// legacy mode.
+func injectGPUDevices(containerCtx *protocol.ContainerContext, devices []*ext.DeviceAllocation) error {
+	var gpuDevices []*protocol.LinuxDevice
+
+	for _, d := range devices {
+		devicePath := fmt.Sprintf("%s%d", nvidiaDevicePrefix, d.Minor)
+		deviceInfo, err := getDeviceNumbers(devicePath)
+		if err != nil {
+			klog.Warningf("injectGPUDevices: GetDeviceNumbers from %s error: %v, skip device injection", devicePath, err)
+			return nil
+		}
+		gpuDevices = append(gpuDevices, &protocol.LinuxDevice{
+			Path:          devicePath,
+			Type:          "c",
+			Major:         deviceInfo[0],
+			Minor:         deviceInfo[1],
+			FileModeValue: 0666,
+		})
+	}
+
+	for _, ctlDevice := range nvidiaControlDevices {
+		deviceInfo, err := getDeviceNumbers(ctlDevice)
+		if err != nil {
+			klog.V(5).Infof("injectGPUDevices: skip control device %s, GetDeviceNumbers error: %v", ctlDevice, err)
+			continue
+		}
+		gpuDevices = append(gpuDevices, &protocol.LinuxDevice{
+			Path:          ctlDevice,
+			Type:          "c",
+			Major:         deviceInfo[0],
+			Minor:         deviceInfo[1],
+			FileModeValue: 0666,
+		})
+	}
+
+	containerCtx.Response.AddContainerDevices = append(containerCtx.Response.AddContainerDevices, gpuDevices...)
+	klog.V(4).Infof("injectGPUDevices: AddContainerDevices: %v", containerCtx.Response.AddContainerDevices)
+	return nil
+}
+
+// injectHAMiResources injects HAMi-specific environment variables and mounts for GPU memory/SM isolation.
+func injectHAMiResources(containerCtx *protocol.ContainerContext, devices []*ext.DeviceAllocation) error {
+	gpuResources := devices[0].Resources
+	gpuMemoryRatio, ok := gpuResources[ext.ResourceGPUMemoryRatio]
+	if !ok {
+		return fmt.Errorf("gpu memory ratio not found in gpu resource")
+	}
+	if gpuMemoryRatio.Value() >= 100 {
+		return nil
+	}
+
+	gpuMemory, ok := gpuResources[ext.ResourceGPUMemory]
+	if !ok {
+		return fmt.Errorf("gpu memory not found in gpu resource")
+	}
+	containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_MEMORY_LIMIT"] = fmt.Sprintf("%d", gpuMemory.Value())
+	gpuCore, ok := gpuResources[ext.ResourceGPUCore]
+	if ok {
+		containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprintf("%d", gpuCore.Value())
+	}
+	containerCtx.Response.AddContainerEnvs["LD_PRELOAD"] = system.Conf.HAMICoreLibraryDirectoryPath
+
+	containerCtx.Response.AddContainerMounts = append(containerCtx.Response.AddContainerMounts,
+		&protocol.Mount{
+			Destination: system.Conf.HAMICoreLibraryDirectoryPath,
+			Type:        "bind",
+			Source:      system.Conf.HAMICoreLibraryDirectoryPath,
+			Options:     []string{"rbind"},
+		},
+		// Because https://github.com/Project-HAMi/HAMi/issues/696, we create the directory in pod.
+		&protocol.Mount{
+			Destination: "/tmp/vgpulock",
+			Type:        "bind",
+			Source:      "/tmp/vgpulock",
+			Options:     []string{"rbind"},
+		},
+	)
+
+	if features.DefaultKoordletFeatureGate.Enabled(features.HamiCoreVGPUMonitor) {
+		containerReq := containerCtx.Request
+		hamiDirPath := filepath.Dir(system.Conf.HAMICoreLibraryDirectoryPath)
+		containerCtx.Response.AddContainerEnvs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/%s_%s.cache", hamiDirPath, containerReq.PodMeta.UID, containerReq.ContainerMeta.Name)
+		cacheFileHostDirectory := fmt.Sprintf("%s/containers/%s_%s", hamiDirPath, containerReq.PodMeta.UID, containerReq.ContainerMeta.Name)
+		// TODO: Move this operation into the pkg resource-executor.
+		klog.V(5).Infof("create a vgpu monitoring data directory [%s] and grant it 0777 permissions", cacheFileHostDirectory)
+		os.RemoveAll(cacheFileHostDirectory)
+		os.MkdirAll(cacheFileHostDirectory, 0777)
+		os.Chmod(cacheFileHostDirectory, 0777)
+		containerCtx.Response.AddContainerMounts = append(containerCtx.Response.AddContainerMounts,
+			&protocol.Mount{
+				Destination: hamiDirPath,
+				Type:        "bind",
+				Source:      cacheFileHostDirectory,
+				Options:     []string{"rbind"},
+			},
+		)
+	}
 	return nil
 }

--- a/pkg/koordlet/runtimehooks/hooks/gpu/gpu_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/gpu/gpu_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gpu
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,4 +141,130 @@ func Test_InjectContainerGPUEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_injectGPUEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		devices      []*ext.DeviceAllocation
+		expectedEnvs map[string]string
+	}{
+		{
+			name: "single gpu",
+			devices: []*ext.DeviceAllocation{
+				{Minor: 0},
+			},
+			expectedEnvs: map[string]string{GpuAllocEnv: "0"},
+		},
+		{
+			name: "multiple gpus",
+			devices: []*ext.DeviceAllocation{
+				{Minor: 0},
+				{Minor: 1},
+				{Minor: 3},
+			},
+			expectedEnvs: map[string]string{GpuAllocEnv: "0,1,3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerCtx := &protocol.ContainerContext{}
+			containerCtx.Response.AddContainerEnvs = make(map[string]string)
+			injectGPUEnv(containerCtx, tt.devices)
+			assert.Equal(t, tt.expectedEnvs, containerCtx.Response.AddContainerEnvs)
+		})
+	}
+}
+
+func mockGetDeviceNumbers(path string) ([]int64, error) {
+	// Simulate real device numbers for known NVIDIA device paths.
+	knownDevices := map[string][]int64{
+		"/dev/nvidia0":          {195, 0},
+		"/dev/nvidia1":          {195, 1},
+		"/dev/nvidiactl":        {195, 255},
+		"/dev/nvidia-uvm":       {510, 0},
+		"/dev/nvidia-uvm-tools": {510, 1},
+	}
+	if info, ok := knownDevices[path]; ok {
+		return info, nil
+	}
+	return nil, fmt.Errorf("device not found: %s", path)
+}
+
+func Test_injectGPUDevices(t *testing.T) {
+	original := getDeviceNumbers
+	getDeviceNumbers = mockGetDeviceNumbers
+	defer func() { getDeviceNumbers = original }()
+
+	tests := []struct {
+		name            string
+		devices         []*ext.DeviceAllocation
+		expectedDevices []*protocol.LinuxDevice
+	}{
+		{
+			name: "single gpu",
+			devices: []*ext.DeviceAllocation{
+				{Minor: 0},
+			},
+			expectedDevices: []*protocol.LinuxDevice{
+				{Path: "/dev/nvidia0", Type: "c", Major: 195, Minor: 0, FileModeValue: 0666},
+				{Path: nvidiaCtlDevice, Type: "c", Major: 195, Minor: 255, FileModeValue: 0666},
+				{Path: nvidiaUVMDevice, Type: "c", Major: 510, Minor: 0, FileModeValue: 0666},
+				{Path: nvidiaUVMToolsDevice, Type: "c", Major: 510, Minor: 1, FileModeValue: 0666},
+			},
+		},
+		{
+			name: "multiple gpus",
+			devices: []*ext.DeviceAllocation{
+				{Minor: 0},
+				{Minor: 1},
+			},
+			expectedDevices: []*protocol.LinuxDevice{
+				{Path: "/dev/nvidia0", Type: "c", Major: 195, Minor: 0, FileModeValue: 0666},
+				{Path: "/dev/nvidia1", Type: "c", Major: 195, Minor: 1, FileModeValue: 0666},
+				{Path: nvidiaCtlDevice, Type: "c", Major: 195, Minor: 255, FileModeValue: 0666},
+				{Path: nvidiaUVMDevice, Type: "c", Major: 510, Minor: 0, FileModeValue: 0666},
+				{Path: nvidiaUVMToolsDevice, Type: "c", Major: 510, Minor: 1, FileModeValue: 0666},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerCtx := &protocol.ContainerContext{}
+			err := injectGPUDevices(containerCtx, tt.devices)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedDevices, containerCtx.Response.AddContainerDevices)
+		})
+	}
+}
+
+func Test_injectGPUDevices_deviceNotFound(t *testing.T) {
+	original := getDeviceNumbers
+	getDeviceNumbers = func(path string) ([]int64, error) {
+		return nil, fmt.Errorf("device not found: %s", path)
+	}
+	defer func() { getDeviceNumbers = original }()
+
+	containerCtx := &protocol.ContainerContext{}
+	err := injectGPUDevices(containerCtx, []*ext.DeviceAllocation{{Minor: 0}})
+	assert.NoError(t, err)
+	assert.Nil(t, containerCtx.Response.AddContainerDevices)
+}
+
+func Test_injectGPUDevices_partialFailure(t *testing.T) {
+	original := getDeviceNumbers
+	getDeviceNumbers = func(path string) ([]int64, error) {
+		// GPU0 exists, GPU1 does not.
+		if path == "/dev/nvidia0" {
+			return []int64{195, 0}, nil
+		}
+		return nil, fmt.Errorf("device not found: %s", path)
+	}
+	defer func() { getDeviceNumbers = original }()
+
+	containerCtx := &protocol.ContainerContext{}
+	err := injectGPUDevices(containerCtx, []*ext.DeviceAllocation{{Minor: 0}, {Minor: 1}})
+	assert.NoError(t, err)
+	// On partial failure, no devices should be injected (atomic all-or-nothing).
+	assert.Nil(t, containerCtx.Response.AddContainerDevices)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

/kind bug

### Ⅱ. Does this pull request fix one issue?

When using NRI to inject GPU access into containers, the GPU hook only sets the NVIDIA_VISIBLE_DEVICES environment variable. It does not add GPU device information (/dev/nvidia*) to the OCI spec via AddContainerDevices.
This causes a problem: runc never writes GPU device cgroup rules to /run/systemd/transient/*/50-DeviceAllow.conf. When systemctl daemon-reload is triggered on the node, systemd resets the cgroup configuration, and all GPU device permissions for NRI-injected containers are lost.
﻿This fix adds GPU device entries (per-GPU devices + control devices like nvidiactl, nvidia-uvm, nvidia-uvm-tools) to AddContainerDevices, following the same pattern as the existing RDMA device injection. The devices are collected atomically to avoid partial injection on failure.
﻿
Additionally, the original monolithic InjectContainerGPUEnv function is refactored into three focused helpers for better readability:
injectGPUEnv 
injectGPUDevices
injectHAMiResources

Fixes https://github.com/koordinator-sh/koordinator/issues/2809

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
