### PR TITLE
fix(e2e): stabilize deviceshare reservation restore tests

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -37,7 +37,12 @@ import (
 )
 
 func Test_Plugin_ReservationRestore(t *testing.T) {
-	suit := newPluginTestSuit(t, nil)
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-1",
+		},
+	}
+	suit := newPluginTestSuit(t, []*corev1.Node{testNode})
 	p, err := suit.proxyNew(getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)
@@ -224,7 +229,12 @@ func Test_Plugin_ReservationRestore(t *testing.T) {
 }
 
 func Test_Plugin_RestoreReservationPreAllocation(t *testing.T) {
-	suit := newPluginTestSuit(t, nil)
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-1",
+		},
+	}
+	suit := newPluginTestSuit(t, []*corev1.Node{testNode})
 	p, err := suit.proxyNew(getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?
close #2831 
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

The failure was caused by test flakiness rather than the reservation restore logic itself. These tests created device cache entries for test-node-1, but the fake scheduler environment did not include a corresponding Node object in the informer cache. Since the plugin starts a background nodeDeviceCache.gcNodeDevice() loop, the cache entry could be garbage-collected during the test, causing RestoreReservation to see a missing nodeDevice and return nil. The fix is to register the test nodes explicitly in the fake framework setup so the cache is not removed unexpectedly.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
