### PR TITLE
scheduler: fix broken reservation-ignored filtering

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -395,6 +395,14 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState *framew
 	state := getStateData(cycleState)
 	nodeRState := state.nodeReservationStates[node.Name]
 
+	// For reservation-ignored pods, the transformer has already restored all reservation resources back to the node.
+	// NodeResourceFit plugin will validate if the node has sufficient resources for the pod.
+	// So we can skip the resource validation here and return success directly.
+	if apiext.IsReservationIgnored(pod) {
+		klog.V(5).InfoS("Skip duplicated filter for reservation-ignored pod", "pod", klog.KObj(pod), "node", node.Name, "matchedReservations", len(matchedReservations))
+		return nil
+	}
+
 	// Contextualization: If a pod only have one reservation matched, the fitsNode should be equivalent to
 	// the NodeResourceFit's Filter, so we can skip the fitsNode to reduce overhead.
 	isFitsNodeSkipped := pl.enableSkipReservationFitsNode && len(matchedReservations) <= 1

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -773,6 +773,94 @@ func TestFilter(t *testing.T) {
 			want:     nil,
 		},
 		{
+			name: "reservation-ignored pod should skip reservation filter and let NodeResourceFit handle validation",
+			pod:  testReservationIgnoredPod,
+			reservations: []*schedulingv1alpha1.Reservation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-reservation-with-available",
+						UID:  uuid.NewUUID(),
+					},
+					Spec: schedulingv1alpha1.ReservationSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								NodeName: testNode.Name,
+								Containers: []corev1.Container{
+									{
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("8"),
+												corev1.ResourceMemory: resource.MustParse("16Gi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Status: schedulingv1alpha1.ReservationStatus{
+						Phase:    schedulingv1alpha1.ReservationAvailable,
+						NodeName: testNode.Name,
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+						Allocated: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+			nodeInfo: testNodeInfo,
+			stateData: &stateData{
+				schedulingStateData: schedulingStateData{
+					podRequests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					},
+					podRequestsResources: &framework.Resource{
+						MilliCPU: 4000,
+					},
+					podResourceNames: []corev1.ResourceName{corev1.ResourceCPU},
+					nodeReservationStates: map[string]*nodeReservationState{
+						testNode.Name: {
+							nodeName: testNode.Name,
+							podRequested: &framework.Resource{
+								MilliCPU: 28000, // 32 - 4 (node unallocated)
+							},
+							rAllocated: &framework.Resource{
+								MilliCPU: 4000, // reservation allocated 4
+							},
+							matchedOrIgnored: []*frameworkext.ReservationInfo{
+								frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "test-reservation-with-available",
+										UID:  uuid.NewUUID(),
+									},
+									Spec: schedulingv1alpha1.ReservationSpec{
+										Template: &corev1.PodTemplateSpec{},
+									},
+									Status: schedulingv1alpha1.ReservationStatus{
+										Phase:    schedulingv1alpha1.ReservationAvailable,
+										NodeName: testNode.Name,
+										Allocatable: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("8"),
+										},
+										Allocated: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("4"),
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			// Should succeed: reservation plugin skips validation for reservation-ignored pods
+			// NodeResourceFit will handle the actual resource validation
+			want: nil,
+		},
+		{
 			name: "filter pre-allocation reservation",
 			pod:  reservationutil.NewReservePod(preAllocationReservation),
 			reservations: []*schedulingv1alpha1.Reservation{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix the broken functionality of the reservation ignored after #2738.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

1. Submit a reservation-ignored pod.
2. Verify if it can schedule on a node with a reservation reserving all the node resources.
3. Before #2738, the reservation-ignored pod is expected to schedule successfully with the reserved resources.
4. After #2738, the reservation-ignored pod may fail to schedule since it is predicated by the `fitsNode` with only the node unreserved resources.

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
