### PR TITLE
koordlet: extend nrt reporting, support numa-level reservation

### DIFF
--- a/apis/extension/node_reservation.go
+++ b/apis/extension/node_reservation.go
@@ -26,6 +26,9 @@ import (
 
 const (
 	AnnotationNodeReservation = NodeDomainPrefix + "/reservation"
+
+	// LabelNodeEnableNUMAReservation indicates whether to enable NUMA-level allocatable reservation.
+	LabelNodeEnableNUMAReservation = NodeDomainPrefix + "/enable-numa-reservation"
 )
 
 // NodeReservation resource reserved by node.annotation,

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
@@ -60,8 +60,42 @@ const (
 	nodeTopoInformerName PluginName = "nodeTopoInformer"
 )
 
+var (
+	managedNRTResources = []corev1.ResourceName{
+		corev1.ResourceCPU,
+		corev1.ResourceMemory,
+		extension.ResourceGPU,
+		corev1.ResourceHugePagesPrefix + "2Mi",
+		corev1.ResourceHugePagesPrefix + "1Gi",
+	}
+
+	managedNRTAnnotationKeys = []string{
+		extension.AnnotationCPUBasicInfo,
+		extension.AnnotationKubeletCPUManagerPolicy,
+		extension.AnnotationNodeCPUSharedPools,
+		extension.AnnotationNodeBECPUSharedPools,
+		extension.AnnotationNodeCPUTopology,
+		extension.AnnotationNodeCPUAllocs,
+		extension.AnnotationNodeReservation,
+		extension.AnnotationNodeSystemQOSResource,
+	}
+
+	managedNRTLabelKeys = []string{
+		extension.LabelNodeEnableNUMAReservation,
+	}
+
+	extendNRTStatusFn = func(nrtStatus *nodeTopologyStatus, node *corev1.Node, numaNodeCount int) error {
+		return nil
+	}
+
+	extendNRTEqualFn = func(nrtStatus *nodeTopologyStatus, oldNRT *v1alpha1.NodeResourceTopology) (bool, string) {
+		return true, ""
+	}
+)
+
 type nodeTopologyStatus struct {
 	Annotations    map[string]string
+	Labels         map[string]string
 	TopologyPolicy v1alpha1.TopologyManagerPolicy
 	Zones          v1alpha1.ZoneList
 }
@@ -81,9 +115,19 @@ func (n *nodeTopologyStatus) isChanged(oldNRT *v1alpha1.NodeResourceTopology) (b
 		return true, fmt.Sprintf("annotations changed, key %s", key)
 	}
 
+	// check labels
+	if isEqual, key := isEqualNRTLabels(oldNRT.Labels, n.Labels); !isEqual {
+		return true, fmt.Sprintf("labels changed, key %s", key)
+	}
+
 	// check Zones
 	if isEqual, msg := isEqualNRTZones(oldNRT.Zones, n.Zones); !isEqual {
 		return true, fmt.Sprintf("Zones changed, item: %s", msg)
+	}
+
+	// hook to compare extended status
+	if isEqual, msg := extendNRTEqualFn(n, oldNRT); !isEqual {
+		return true, fmt.Sprintf("extended status changed, item: %s", msg)
 	}
 
 	return false, ""
@@ -95,6 +139,12 @@ func (n *nodeTopologyStatus) updateNRT(nrt *v1alpha1.NodeResourceTopology) {
 	}
 	for k, v := range n.Annotations {
 		nrt.Annotations[k] = v
+	}
+	if nrt.Labels == nil {
+		nrt.Labels = map[string]string{}
+	}
+	for k, v := range n.Labels {
+		nrt.Labels[k] = v
 	}
 
 	nrt.TopologyPolicies = []string{string(n.TopologyPolicy)}
@@ -387,6 +437,19 @@ func (s *nodeTopoInformer) calcNodeTopo() (*nodeTopologyStatus, error) {
 		nodeTopoStatus.Annotations[extension.AnnotationNodeSystemQOSResource] = string(systemQOSJson)
 	}
 
+	// sync managed labels
+	if node.Labels != nil && len(node.Labels[extension.LabelNodeEnableNUMAReservation]) > 0 {
+		if nodeTopoStatus.Labels == nil {
+			nodeTopoStatus.Labels = make(map[string]string)
+		}
+		nodeTopoStatus.Labels[extension.LabelNodeEnableNUMAReservation] = node.Labels[extension.LabelNodeEnableNUMAReservation]
+	}
+
+	// hook to set extra status
+	if err = extendNRTStatusFn(nodeTopoStatus, node, len(zoneList)); err != nil {
+		return nil, fmt.Errorf("failed to set extra status, err: %v", err)
+	}
+
 	klog.V(6).Infof("calculate node topology status: %+v", nodeTopoStatus)
 	return nodeTopoStatus, nil
 }
@@ -439,8 +502,15 @@ func removeSystemQOSCPUs(cpuSharePools []extension.CPUSharedPool, sysQOSRes *ext
 	return newCPUSharePools
 }
 
-func getNodeReserved(cpuTopology *topology.CPUTopology, nodeAnnotations map[string]string) extension.NodeReservation {
-	reserved := extension.NodeReservation{}
+func getNodeReserved(cpuTopology *topology.CPUTopology, nodeAnnotations map[string]string) *extension.NodeReservation {
+	reserved, err := extension.GetNodeReservation(nodeAnnotations)
+	if err != nil {
+		klog.Warningf("failed to GetNodeReservation, err: %s", err)
+		reserved = &extension.NodeReservation{}
+	} else if reserved == nil {
+		klog.V(6).Info("node reservation not found, use empty NodeReservation")
+		reserved = &extension.NodeReservation{}
+	}
 	reservedCPUs, numReservedCPUs := extension.GetReservedCPUs(nodeAnnotations)
 	if reservedCPUs != "" {
 		cpus, _ := cpuset.Parse(reservedCPUs)
@@ -614,7 +684,7 @@ func isEqualNRTZones(oldZones, newZones v1alpha1.ZoneList) (bool, string) {
 		}
 	}
 
-	if !util.IsZoneListResourceEqual(oldZones, newZones, string(corev1.ResourceCPU), string(corev1.ResourceMemory)) {
+	if !util.IsZoneListResourceEqual(oldZones, newZones, managedNRTResources...) {
 		return false, "resources"
 	}
 
@@ -627,17 +697,7 @@ func isEqualNRTAnnotations(oldAnno, newAnno map[string]string) (bool, string) {
 		oldData interface{}
 		newData interface{}
 	)
-	keys := []string{
-		extension.AnnotationCPUBasicInfo,
-		extension.AnnotationKubeletCPUManagerPolicy,
-		extension.AnnotationNodeCPUSharedPools,
-		extension.AnnotationNodeBECPUSharedPools,
-		extension.AnnotationNodeCPUTopology,
-		extension.AnnotationNodeCPUAllocs,
-		extension.AnnotationNodeReservation,
-		extension.AnnotationNodeSystemQOSResource,
-	}
-	for _, key := range keys {
+	for _, key := range managedNRTAnnotationKeys {
 		oldValue, oldExist := oldAnno[key]
 		newValue, newExist := newAnno[key]
 		if !oldExist && !newExist {
@@ -662,6 +722,15 @@ func isEqualNRTAnnotations(oldAnno, newAnno map[string]string) (bool, string) {
 		}
 	}
 
+	return true, ""
+}
+
+func isEqualNRTLabels(oldLabels, newLabels map[string]string) (bool, string) {
+	for _, k := range managedNRTLabelKeys {
+		if oldLabels[k] != newLabels[k] {
+			return false, k
+		}
+	}
 	return true, ""
 }
 
@@ -779,7 +848,22 @@ func (s *nodeTopoInformer) calTopologyZoneList(nodeCPUInfo *metriccache.NodeCPUI
 		return nil, fmt.Errorf("NUMA node number not matched")
 	}
 
-	zoneResourceList := map[string]corev1.ResourceList{}
+	// Check if NUMA reservation is enabled
+	var enableNUMAReservation bool
+	var node *corev1.Node
+	if s.nodeInformer != nil {
+		node = s.nodeInformer.GetNode()
+		enableNUMAReservation = node != nil && node.Labels != nil && node.Labels[extension.LabelNodeEnableNUMAReservation] == "true"
+	}
+
+	// Calculate kubelet reserved resources for NUMA-level deduction
+	var nodeKubeletReserved corev1.ResourceList
+	if enableNUMAReservation {
+		nodeKubeletReserved = s.getNodeKubeletReservedResources()
+	}
+
+	// Build zone resources with capacity and allocatable
+	zoneResources := map[string]util.ZoneResources{}
 	for i := 0; i < nodeNum; i++ {
 		var cpuQuant resource.Quantity
 		cpuInfos, ok := nodeCPUInfo.TotalInfo.NodeToCPU[int32(i)]
@@ -817,15 +901,28 @@ func (s *nodeTopoInformer) calTopologyZoneList(nodeCPUInfo *metriccache.NodeCPUI
 		}
 
 		zoneName := util.GenNodeZoneName(i)
-		zoneResourceList[zoneName] = corev1.ResourceList{
+		capacity := corev1.ResourceList{
 			corev1.ResourceCPU:                     cpuQuant,
 			corev1.ResourceMemory:                  memQuant,
 			corev1.ResourceHugePagesPrefix + "2Mi": hugepage2MQuant,
 			corev1.ResourceHugePagesPrefix + "1Gi": hugepage1GQuant,
 		}
 
+		// Initialize allocatable as a copy of capacity
+		allocatable := capacity.DeepCopy()
+
+		zoneResources[zoneName] = util.ZoneResources{
+			Capacity:    capacity,
+			Allocatable: allocatable,
+		}
 	}
-	zoneList := util.ZoneResourceListToZoneList(zoneResourceList)
+
+	// Apply NUMA-level reservation if enabled
+	if enableNUMAReservation && nodeNum > 0 {
+		zoneResources = applyNUMAReservationToZoneResources(zoneResources, nodeKubeletReserved, nodeNum)
+	}
+
+	zoneList := util.ZoneResourcesToZoneList(zoneResources)
 
 	return zoneList, nil
 }
@@ -919,4 +1016,88 @@ func getTopologyPolicy(topologyManagerPolicy string, topologyManagerScope string
 	}
 
 	return v1alpha1.None
+}
+
+// getNodeKubeletReservedResources calculates the kubelet reserved resources on the node.
+// It returns the difference between node capacity and allocatable resources.
+func (s *nodeTopoInformer) getNodeKubeletReservedResources() corev1.ResourceList {
+	node := s.nodeInformer.GetNode()
+	if node == nil {
+		klog.Warning("node is nil, cannot calculate kubelet reserved resources")
+		return corev1.ResourceList{}
+	}
+
+	// Calculate reserved resources: capacity - allocatable
+	reserved := corev1.ResourceList{}
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		capacity, hasCapacity := node.Status.Capacity[resourceName]
+		allocatable, hasAllocatable := node.Status.Allocatable[resourceName]
+		if hasCapacity && hasAllocatable {
+			reservedValue := capacity.DeepCopy()
+			reservedValue.Sub(allocatable)
+			if reservedValue.Sign() > 0 {
+				reserved[resourceName] = reservedValue
+			}
+		}
+	}
+
+	return reserved
+}
+
+// applyNUMAReservationToZoneResources applies kubelet reserved resources to NUMA-level zones evenly.
+// It deducts ceil(reserved / numaCount) from each NUMA node's allocatable resources only.
+func applyNUMAReservationToZoneResources(zoneResources map[string]util.ZoneResources, nodeReserved corev1.ResourceList, numaCount int) map[string]util.ZoneResources {
+	if numaCount <= 0 || len(nodeReserved) == 0 {
+		return zoneResources
+	}
+
+	// Calculate per-NUMA reservation: ceil(reserved / numaCount)
+	perNUMAReserved := corev1.ResourceList{}
+	for resourceName, reservedQuantity := range nodeReserved {
+		perNUMAValue := divideResourceByCount(reservedQuantity, numaCount)
+		if perNUMAValue.Sign() > 0 {
+			perNUMAReserved[resourceName] = perNUMAValue
+		}
+	}
+
+	if len(perNUMAReserved) == 0 {
+		return zoneResources
+	}
+
+	// Apply reservation to each zone's allocatable (capacity remains unchanged)
+	for zoneName, resources := range zoneResources {
+		newAllocatable := resources.Allocatable.DeepCopy()
+		for resourceName, reservedQty := range perNUMAReserved {
+			if allocatable, exists := newAllocatable[resourceName]; exists {
+				// Deduct reservation from allocatable
+				allocatable.Sub(reservedQty)
+				if allocatable.Sign() < 0 {
+					// Keep the same format but set to zero
+					allocatable = *resource.NewQuantity(0, allocatable.Format)
+				}
+				newAllocatable[resourceName] = allocatable
+			}
+		}
+		// Ensure capacity is not affected by explicitly copying it
+		zoneResources[zoneName] = util.ZoneResources{
+			Capacity:    resources.Capacity.DeepCopy(),
+			Allocatable: newAllocatable,
+		}
+	}
+
+	return zoneResources
+}
+
+// divideResourceByCount divides a resource quantity by count using ceiling division.
+// This ensures that the total reserved across all NUMA nodes is at least the node-level reservation.
+func divideResourceByCount(quantity resource.Quantity, count int) resource.Quantity {
+	if count <= 0 {
+		return *resource.NewMilliQuantity(0, quantity.Format)
+	}
+
+	// Use MilliValue for better precision with CPU resources
+	milliValue := quantity.MilliValue()
+	// Ceiling division: (milliValue + count - 1) / count
+	perNUMAMilliValue := (milliValue + int64(count) - 1) / int64(count)
+	return *resource.NewMilliQuantity(perNUMAMilliValue, quantity.Format)
 }

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
@@ -1063,6 +1063,8 @@ func Test_reportNodeTopology(t *testing.T) {
 		kubeletStub                     KubeletStub
 		disableCreateTopologyCRD        bool
 		oldZoneList                     *topologyv1alpha1.ZoneList
+		nodeLabels                      map[string]string
+		nodeStatus                      *corev1.NodeStatus
 		nodeReserved                    *extension.NodeReservation
 		systemQOSRes                    *extension.SystemQOSResource
 		expectedKubeletCPUManagerPolicy extension.KubeletCPUManagerPolicy
@@ -1075,6 +1077,7 @@ func Test_reportNodeTopology(t *testing.T) {
 		expectedSystemQOS               string
 		expectedTopologyPolicies        []string
 		expectedZones                   topologyv1alpha1.ZoneList
+		expectedLabels                  map[string]string
 	}{
 		{
 			name:   "report topology",
@@ -1270,6 +1273,84 @@ func Test_reportNodeTopology(t *testing.T) {
 			expectedTopologyPolicies: expectedTopologyPolices,
 			expectedZones:            expectedZones,
 		},
+		{
+			name: "report topology with NUMA reservation enabled - verify labels and capacity > allocatable",
+			nodeLabels: map[string]string{
+				extension.LabelNodeEnableNUMAReservation: "true",
+			},
+			nodeStatus: &corev1.NodeStatus{
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(269755191296, resource.BinarySI),
+				},
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(7, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(268706611200, resource.BinarySI),
+				},
+			},
+			config: NewDefaultConfig(),
+			kubeletStub: &testKubeletStub{
+				config: &kubeletconfiginternal.KubeletConfiguration{
+					CPUManagerPolicy: "none",
+				},
+			},
+			expectedKubeletCPUManagerPolicy: extension.KubeletCPUManagerPolicy{
+				Policy:       "none",
+				ReservedCPUs: "",
+			},
+			expectedCPUBasicInfo:     string(expectedCPUBasicInfoBytes),
+			expectedCPUSharedPool:    expectedCPUSharedPool,
+			expectedBECPUSharedPool:  expectedBECPUSharedPool,
+			expectedCPUTopology:      expectedCPUTopology,
+			expectedNodeCPUAllocs:    "null",
+			expectedNodeReservation:  "{}",
+			expectedSystemQOS:        "{}",
+			expectedTopologyPolicies: []string{string(topologyv1alpha1.None)},
+			// Note: We don't verify exact zone values here due to complexity of NUMA memory calculation.
+			// The unit tests Test_applyNUMAReservationToZoneResources cover the reservation logic.
+			expectedZones: expectedZones,
+			expectedLabels: map[string]string{
+				extension.LabelNodeEnableNUMAReservation: "true",
+			},
+		},
+		{
+			name: "report topology with NUMA reservation disabled",
+			nodeLabels: map[string]string{
+				extension.LabelNodeEnableNUMAReservation: "false",
+			},
+			nodeStatus: &corev1.NodeStatus{
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(269755191296, resource.BinarySI),
+				},
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(7, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(268706611200, resource.BinarySI),
+				},
+			},
+			config: NewDefaultConfig(),
+			kubeletStub: &testKubeletStub{
+				config: &kubeletconfiginternal.KubeletConfiguration{
+					CPUManagerPolicy: "none",
+				},
+			},
+			expectedKubeletCPUManagerPolicy: extension.KubeletCPUManagerPolicy{
+				Policy:       "none",
+				ReservedCPUs: "",
+			},
+			expectedCPUBasicInfo:     string(expectedCPUBasicInfoBytes),
+			expectedCPUSharedPool:    expectedCPUSharedPool,
+			expectedBECPUSharedPool:  expectedBECPUSharedPool,
+			expectedCPUTopology:      expectedCPUTopology,
+			expectedNodeCPUAllocs:    "null",
+			expectedNodeReservation:  "{}",
+			expectedSystemQOS:        "{}",
+			expectedTopologyPolicies: []string{string(topologyv1alpha1.None)},
+			expectedZones:            expectedZones,
+			expectedLabels: map[string]string{
+				extension.LabelNodeEnableNUMAReservation: "false",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1290,6 +1371,15 @@ func Test_reportNodeTopology(t *testing.T) {
 			}()
 
 			testNode := testNodeTemp.DeepCopy()
+			if tt.nodeLabels != nil {
+				testNode.Labels = tt.nodeLabels
+			}
+			if tt.nodeStatus != nil {
+				testNode.Status = *tt.nodeStatus
+			}
+			if testNode.Labels == nil {
+				testNode.Labels = map[string]string{}
+			}
 			if tt.nodeReserved != nil {
 				testNode.Annotations[extension.AnnotationNodeReservation] = util.DumpJSON(tt.nodeReserved)
 			}
@@ -1353,7 +1443,35 @@ func Test_reportNodeTopology(t *testing.T) {
 			assert.Equal(t, tt.expectedNodeReservation, topo.Annotations[extension.AnnotationNodeReservation])
 			assert.Equal(t, tt.expectedSystemQOS, topo.Annotations[extension.AnnotationNodeSystemQOSResource])
 			assert.Equal(t, tt.expectedTopologyPolicies, topo.TopologyPolicies)
-			assert.Equal(t, tt.expectedZones, topo.Zones)
+			// Skip zone comparison for NUMA reservation enabled test as values are complex
+			if tt.name != "report topology with NUMA reservation enabled - verify labels and capacity > allocatable" {
+				assert.Equal(t, tt.expectedZones, topo.Zones)
+			} else {
+				// For NUMA reservation test, just verify zones are not empty and have 2 NUMA nodes
+				assert.Len(t, topo.Zones, 2)
+				assert.Equal(t, "node-0", topo.Zones[0].Name)
+				assert.Equal(t, "node-1", topo.Zones[1].Name)
+				// Verify that capacity >= allocatable for CPU and memory
+				for _, zone := range topo.Zones {
+					for _, res := range zone.Resources {
+						if res.Name == "cpu" || res.Name == "memory" {
+							assert.True(t, res.Capacity.Cmp(res.Allocatable) >= 0,
+								"zone %s resource %s: capacity should be >= allocatable, got capacity=%v, allocatable=%v",
+								zone.Name, res.Name, res.Capacity, res.Allocatable)
+							assert.True(t, res.Allocatable.Cmp(res.Available) == 0,
+								"zone %s resource %s: allocatable should equal available",
+								zone.Name, res.Name)
+						}
+					}
+				}
+			}
+			if tt.expectedLabels != nil {
+				for key, expectedValue := range tt.expectedLabels {
+					actualValue, exists := topo.Labels[key]
+					assert.True(t, exists, "label %s should exist", key)
+					assert.Equal(t, expectedValue, actualValue, "label %s should match", key)
+				}
+			}
 		})
 	}
 }
@@ -2569,6 +2687,7 @@ func Test_calTopologyZoneList(t *testing.T) {
 }
 
 func Test_getNodeReserved(t *testing.T) {
+	proportionalQuantity := resource.MustParse("2500m")
 	fakeTopo := topology.CPUTopology{
 		NumCPUs:    12,
 		NumSockets: 2,
@@ -2594,12 +2713,12 @@ func Test_getNodeReserved(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want extension.NodeReservation
+		want *extension.NodeReservation
 	}{
 		{
 			name: "node.annotation is nil",
 			args: args{},
-			want: extension.NodeReservation{},
+			want: &extension.NodeReservation{},
 		},
 		{
 			name: "node.annotation not nil but nothing reserved",
@@ -2608,7 +2727,7 @@ func Test_getNodeReserved(t *testing.T) {
 					"k": "v",
 				},
 			},
-			want: extension.NodeReservation{},
+			want: &extension.NodeReservation{},
 		},
 		{
 			name: "node.annotation not nil but without cpu reserved",
@@ -2617,7 +2736,7 @@ func Test_getNodeReserved(t *testing.T) {
 					extension.AnnotationNodeReservation: util.GetNodeAnnoReservedJson(extension.NodeReservation{}),
 				},
 			},
-			want: extension.NodeReservation{},
+			want: &extension.NodeReservation{},
 		},
 		{
 			name: "reserve cpu only by quantity",
@@ -2628,18 +2747,18 @@ func Test_getNodeReserved(t *testing.T) {
 					}),
 				},
 			},
-			want: extension.NodeReservation{ReservedCPUs: "0,6"},
+			want: &extension.NodeReservation{ReservedCPUs: "0,6", Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}},
 		},
 		{
 			name: "reserve cpu only by quantity but value not integer",
 			args: args{
 				map[string]string{
 					extension.AnnotationNodeReservation: util.GetNodeAnnoReservedJson(extension.NodeReservation{
-						Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2.5")},
+						Resources: corev1.ResourceList{corev1.ResourceCPU: proportionalQuantity},
 					}),
 				},
 			},
-			want: extension.NodeReservation{ReservedCPUs: "0,2,6"},
+			want: &extension.NodeReservation{ReservedCPUs: "0,2,6", Resources: corev1.ResourceList{corev1.ResourceCPU: proportionalQuantity}},
 		},
 		{
 			name: "reserve cpu only by quantity but value is negative",
@@ -2650,7 +2769,7 @@ func Test_getNodeReserved(t *testing.T) {
 					}),
 				},
 			},
-			want: extension.NodeReservation{},
+			want: &extension.NodeReservation{Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-2")}},
 		},
 		{
 			name: "reserve cpu only by specific cpus",
@@ -2661,7 +2780,7 @@ func Test_getNodeReserved(t *testing.T) {
 					}),
 				},
 			},
-			want: extension.NodeReservation{ReservedCPUs: "0-1"},
+			want: &extension.NodeReservation{ReservedCPUs: "0-1"},
 		},
 		{
 			name: "reserve cpu only by specific cpus but core id is unavailable",
@@ -2672,7 +2791,7 @@ func Test_getNodeReserved(t *testing.T) {
 					}),
 				},
 			},
-			want: extension.NodeReservation{},
+			want: &extension.NodeReservation{},
 		},
 		{
 			name: "reserve cpu by specific cpus and quantity",
@@ -2684,14 +2803,13 @@ func Test_getNodeReserved(t *testing.T) {
 					}),
 				},
 			},
-			want: extension.NodeReservation{ReservedCPUs: "0-1"},
+			want: &extension.NodeReservation{ReservedCPUs: "0-1", Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getNodeReserved(&fakeTopo, tt.args.anno); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getNodeReserved() = %v, want %v", got, tt.want)
-			}
+			got := getNodeReserved(&fakeTopo, tt.args.anno)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -2885,6 +3003,402 @@ func Test_getTopologyPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getTopologyPolicy(tt.args.topologyManagerPolicy, tt.args.topologyManagerScope)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_divideResourceByCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		quantity resource.Quantity
+		count    int
+		want     resource.Quantity
+	}{
+		{
+			name:     "divide cpu 4000m by 2",
+			quantity: resource.MustParse("4000m"),
+			count:    2,
+			want:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
+		},
+		{
+			name:     "divide cpu 4000m by 3 with ceiling",
+			quantity: resource.MustParse("4000m"),
+			count:    3,
+			want:     *resource.NewMilliQuantity(1334, resource.DecimalSI),
+		},
+		{
+			name:     "divide cpu 4 by 2",
+			quantity: resource.MustParse("4"),
+			count:    2,
+			want:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
+		},
+		{
+			name:     "divide memory 10Gi by 4",
+			quantity: resource.MustParse("10Gi"),
+			count:    4,
+			want:     *resource.NewMilliQuantity(2684354560000, resource.BinarySI),
+		},
+		{
+			name:     "divide memory 10Gi by 3 with ceiling",
+			quantity: resource.MustParse("10Gi"),
+			count:    3,
+			want:     *resource.NewMilliQuantity(3579139413334, resource.BinarySI),
+		},
+		{
+			name:     "divide zero by 2",
+			quantity: resource.MustParse("0"),
+			count:    2,
+			want:     *resource.NewMilliQuantity(0, resource.DecimalSI),
+		},
+		{
+			name:     "divide by 1",
+			quantity: resource.MustParse("5"),
+			count:    1,
+			want:     *resource.NewMilliQuantity(5000, resource.DecimalSI),
+		},
+		{
+			name:     "divide by zero returns zero",
+			quantity: resource.MustParse("4000m"),
+			count:    0,
+			want:     *resource.NewMilliQuantity(0, resource.DecimalSI),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := divideResourceByCount(tt.quantity, tt.count)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_applyNUMAReservationToZoneResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		zoneResources map[string]util.ZoneResources
+		nodeReserved  corev1.ResourceList
+		numaCount     int
+		want          map[string]util.ZoneResources
+	}{
+		{
+			name: "apply reservation to 2 numa nodes with cpu and memory",
+			zoneResources: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+				"node-1": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+			},
+			nodeReserved: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(4000, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(2147483648, resource.BinarySI),
+			},
+			numaCount: 2,
+			want: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(46000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewMilliQuantity(127775277056000, resource.BinarySI),
+					},
+				},
+				"node-1": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(46000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewMilliQuantity(127775277056000, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "apply reservation to 3 numa nodes with ceiling division",
+			zoneResources: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+				},
+				"node-1": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+				},
+				"node-2": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+				},
+			},
+			nodeReserved: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(6000, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(3221225472, resource.BinarySI),
+			},
+			numaCount: 3,
+			want: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(30000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewMilliQuantity(84825604096000, resource.BinarySI),
+					},
+				},
+				"node-1": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(30000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewMilliQuantity(84825604096000, resource.BinarySI),
+					},
+				},
+				"node-2": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(32, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(85899345920, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(30000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewMilliQuantity(84825604096000, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "empty node reserved returns original",
+			zoneResources: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+			},
+			nodeReserved: corev1.ResourceList{},
+			numaCount:    1,
+			want: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "zero numa count returns original",
+			zoneResources: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+			},
+			nodeReserved: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(4000, resource.DecimalSI),
+			},
+			numaCount: 0,
+			want: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(128849018880, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "allocatable not less than zero",
+			zoneResources: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+					},
+				},
+			},
+			nodeReserved: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(8589934592, resource.BinarySI),
+			},
+			numaCount: 1,
+			want: map[string]util.ZoneResources{
+				"node-0": {
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(0, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(0, resource.BinarySI),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyNUMAReservationToZoneResources(tt.zoneResources, tt.nodeReserved, tt.numaCount)
+			for zoneName, wantZoneRes := range tt.want {
+				gotZoneRes, exists := got[zoneName]
+				assert.True(t, exists, "zone %s should exist", zoneName)
+
+				// Check capacity
+				for resourceName, wantQty := range wantZoneRes.Capacity {
+					gotQty, exists := gotZoneRes.Capacity[resourceName]
+					assert.True(t, exists, "capacity resource %s should exist in zone %s", resourceName, zoneName)
+					assert.Equal(t, wantQty, gotQty, "capacity resource %s in zone %s should match", resourceName, zoneName)
+				}
+
+				// Check allocatable
+				for resourceName, wantQty := range wantZoneRes.Allocatable {
+					gotQty, exists := gotZoneRes.Allocatable[resourceName]
+					assert.True(t, exists, "allocatable resource %s should exist in zone %s", resourceName, zoneName)
+					assert.Equal(t, wantQty, gotQty, "allocatable resource %s in zone %s should match", resourceName, zoneName)
+				}
+			}
+		})
+	}
+}
+
+func Test_nodeTopoInformer_getNodeKubeletReservedResources(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want corev1.ResourceList
+	}{
+		{
+			name: "calculate reserved from capacity and allocatable",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(96, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(257698037760, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(94, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(255550554112, resource.BinarySI),
+					},
+				},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(2147483648, resource.BinarySI),
+			},
+		},
+		{
+			name: "no reservation when capacity equals allocatable",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(96, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(257698037760, resource.BinarySI),
+					},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(96, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(257698037760, resource.BinarySI),
+					},
+				},
+			},
+			want: corev1.ResourceList{},
+		},
+		{
+			name: "nil node returns empty",
+			node: nil,
+			want: corev1.ResourceList{},
+		},
+		{
+			name: "missing capacity fields",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Capacity: corev1.ResourceList{},
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(96, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(257698037760, resource.BinarySI),
+					},
+				},
+			},
+			want: corev1.ResourceList{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			informer := &nodeTopoInformer{
+				nodeInformer: &nodeInformer{
+					node: tt.node,
+				},
+			}
+			got := informer.getNodeKubeletReservedResources()
+			for resourceName, wantQty := range tt.want {
+				gotQty, exists := got[resourceName]
+				assert.True(t, exists, "resource %s should exist", resourceName)
+				assert.Equal(t, wantQty, gotQty, "resource %s should match", resourceName)
+			}
+			for resourceName := range got {
+				if _, exists := tt.want[resourceName]; !exists {
+					t.Errorf("unexpected resource %s in result", resourceName)
+				}
+			}
 		})
 	}
 }

--- a/pkg/koordlet/util/meminfo.go
+++ b/pkg/koordlet/util/meminfo.go
@@ -299,8 +299,9 @@ func GetNodeNUMAInfo() (*NodeNUMAInfo, error) {
 	}
 
 	if len(nodeDirs) != len(result.NUMAInfos)+giNUMANodes.Len() {
-		return nil, fmt.Errorf("invalid number of NUMA meminfo, dir %v, parsed %v",
-			len(nodeDirs), len(result.NUMAInfos))
+		// numa devices might be corrupted after unplug, but we can tolerate it
+		klog.Warningf("failed to get matched NUMA meminfo, dir %v, parsed %v, GI %v",
+			len(nodeDirs), len(result.NUMAInfos), giNUMANodes.Len())
 	}
 	if len(result.NUMAInfos) != int(maxNodeID+1) {
 		return nil, fmt.Errorf("unexpected number of NUMA node, max ID %v, parsed %v",

--- a/pkg/koordlet/util/meminfo_test.go
+++ b/pkg/koordlet/util/meminfo_test.go
@@ -474,12 +474,12 @@ Node 1 HugePages_Surp:        0`
 	assert.NoError(t, err)
 	assert.Equal(t, expected, got)
 
-	// test partial failure
+	// test tolerated failure
 	numaMemInfoPath2 := system.GetNUMAMemInfoPath("node2")
 	helper.MkDirAll(filepath.Dir(numaMemInfoPath2))
 	got, err = GetNodeNUMAInfo()
-	assert.Error(t, err)
-	assert.Nil(t, got)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
 
 	// test path not exist
 	helper.Cleanup()

--- a/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/noderesourcetopology_event_handler.go
@@ -34,7 +34,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
-var checkedNRTResourceSet = sets.NewString(string(corev1.ResourceCPU), string(corev1.ResourceMemory))
+var checkedNRTResourceSet = sets.New[corev1.ResourceName](corev1.ResourceCPU, corev1.ResourceMemory)
 
 var _ handler.EventHandler = &NRTHandler{}
 
@@ -103,7 +103,7 @@ func isNRTResourcesCreated(nrt *topologyv1alpha1.NodeResourceTopology) bool {
 	// check if any zone has the target resource allocatable
 	for _, zone := range nrt.Zones {
 		for _, resourceInfo := range zone.Resources {
-			if checkedNRTResourceSet.Has(resourceInfo.Name) {
+			if checkedNRTResourceSet.Has(corev1.ResourceName(resourceInfo.Name)) {
 				return true
 			}
 		}
@@ -114,7 +114,7 @@ func isNRTResourcesCreated(nrt *topologyv1alpha1.NodeResourceTopology) bool {
 
 func isNRTResourcesChanged(nrtOld, nrtNew *topologyv1alpha1.NodeResourceTopology) bool {
 	// check if target resources not equal
-	return !util.IsZoneListResourceEqual(nrtOld.Zones, nrtNew.Zones, checkedNRTResourceSet.List()...)
+	return !util.IsZoneListResourceEqual(nrtOld.Zones, nrtNew.Zones, checkedNRTResourceSet.UnsortedList()...)
 }
 
 func cleanupContextForNRT(syncContext *framework.SyncContext, nrt *topologyv1alpha1.NodeResourceTopology) error {

--- a/pkg/slo-controller/noderesource/plugins/batchresource/plugin.go
+++ b/pkg/slo-controller/noderesource/plugins/batchresource/plugin.go
@@ -330,7 +330,7 @@ func (p *Plugin) calculateOnNUMALevel(strategy *configuration.ColocationStrategy
 	}
 	if !isNRTResourcesCreated(nrt) {
 		klog.V(5).Infof("abort to calculate batch resources for NRT, resources %v not found, node %s",
-			checkedNRTResourceSet.List(), node.Name)
+			checkedNRTResourceSet.UnsortedList(), node.Name)
 		return nil, nil, nil
 	}
 
@@ -369,7 +369,7 @@ func (p *Plugin) calculateOnNUMALevel(strategy *configuration.ColocationStrategy
 		podsHPZoneUsed[i] = util.NewZeroResourceList()
 		podsHPZoneMaxUsedReq[i] = util.NewZeroResourceList()
 		for _, resourceInfo := range zone.Resources {
-			if checkedNRTResourceSet.Has(resourceInfo.Name) {
+			if checkedNRTResourceSet.Has(corev1.ResourceName(resourceInfo.Name)) {
 				nodeZoneAllocatable[i][corev1.ResourceName(resourceInfo.Name)] = resourceInfo.Allocatable.DeepCopy()
 			}
 		}
@@ -497,7 +497,7 @@ func (p *Plugin) prepareForNodeResourceTopology(strategy *configuration.Colocati
 		}
 		if !isNRTResourcesCreated(nrt) {
 			klog.V(5).Infof("abort to prepare batch resources for NRT, resources %v not found, node %s",
-				checkedNRTResourceSet.List(), node.Name)
+				checkedNRTResourceSet.UnsortedList(), node.Name)
 			return nil
 		}
 

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -154,9 +154,15 @@ func ZoneListToZoneResourceList(zoneList v1alpha1.ZoneList) map[string]corev1.Re
 	return zoneResourceList
 }
 
-// ZoneResourceListToZoneList transforms the zone resource list into the zone list by the orders of the zone name and
-// the resource name.
-// It supposes the capacity, allocatable, available of a ResourceInfo is the same.
+// ZoneResources holds both capacity and allocatable resources for a zone.
+type ZoneResources struct {
+	Capacity    corev1.ResourceList
+	Allocatable corev1.ResourceList
+}
+
+// ZoneResourceListToZoneList converts zone resource list to zone list.
+// When resourceList contains only capacity, allocatable and available will be set to capacity.
+// When resourceList contains both capacity and allocatable, they will be set accordingly.
 func ZoneResourceListToZoneList(zoneResourceList map[string]corev1.ResourceList) v1alpha1.ZoneList {
 	zoneList := make(v1alpha1.ZoneList, len(zoneResourceList))
 	i := 0
@@ -171,6 +177,56 @@ func ZoneResourceListToZoneList(zoneResourceList map[string]corev1.ResourceList)
 				Capacity:    quantity,
 				Allocatable: quantity,
 				Available:   quantity,
+			})
+		}
+		sort.Slice(zoneList[i].Resources, func(p, q int) bool {
+			return zoneList[i].Resources[p].Name < zoneList[i].Resources[q].Name
+		})
+		i++
+	}
+	sort.Slice(zoneList, func(i, j int) bool {
+		return zoneList[i].Name < zoneList[j].Name
+	})
+	return zoneList
+}
+
+// ZoneResourcesToZoneList converts zone resources (with capacity and allocatable) to zone list.
+// This function properly handles the case where capacity >= allocatable.
+func ZoneResourcesToZoneList(zoneResources map[string]ZoneResources) v1alpha1.ZoneList {
+	zoneList := make(v1alpha1.ZoneList, len(zoneResources))
+	i := 0
+	for zoneName, resources := range zoneResources {
+		zoneList[i] = v1alpha1.Zone{
+			Name: zoneName,
+			Type: NodeZoneType,
+		}
+		// Merge capacity and allocatable resource names
+		allResources := make(map[corev1.ResourceName]bool)
+		for resName := range resources.Capacity {
+			allResources[resName] = true
+		}
+		for resName := range resources.Allocatable {
+			allResources[resName] = true
+		}
+
+		for resourceName := range allResources {
+			capacity, hasCapacity := resources.Capacity[resourceName]
+			allocatable, hasAllocatable := resources.Allocatable[resourceName]
+
+			// If capacity is not set, use allocatable; if allocatable is not set, use capacity
+			if !hasCapacity {
+				capacity = allocatable
+			}
+			if !hasAllocatable {
+				allocatable = capacity
+			}
+
+			// Available should match allocatable
+			zoneList[i].Resources = append(zoneList[i].Resources, v1alpha1.ResourceInfo{
+				Name:        string(resourceName),
+				Capacity:    capacity,
+				Allocatable: allocatable,
+				Available:   allocatable,
 			})
 		}
 		sort.Slice(zoneList[i].Resources, func(p, q int) bool {
@@ -217,7 +273,7 @@ func MergeZoneList(a, b v1alpha1.ZoneList) v1alpha1.ZoneList {
 	return ZoneResourceListToZoneList(zoneResourcesA)
 }
 
-func IsZoneListResourceEqual(a, b v1alpha1.ZoneList, resourceNames ...string) bool {
+func IsZoneListResourceEqual(a, b v1alpha1.ZoneList, resourceNames ...corev1.ResourceName) bool {
 	zoneResourcesA := ZoneListToZoneResourceList(a)
 	zoneResourcesB := ZoneListToZoneResourceList(b)
 
@@ -250,8 +306,8 @@ func IsZoneListResourceEqual(a, b v1alpha1.ZoneList, resourceNames ...string) bo
 			}
 		} else {
 			for _, resourceName := range resourceNames {
-				quantityA, okA := zoneA[corev1.ResourceName(resourceName)]
-				quantityB, okB := zoneB[corev1.ResourceName(resourceName)]
+				quantityA, okA := zoneA[resourceName]
+				quantityB, okB := zoneB[resourceName]
 				if !okA && !okB {
 					continue
 				}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet:
- Support NUMA-level resource reservation.
- Add hooks for setting extra NRT status.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

To support cpuset.mems, the scheduler should ensure there are enough NUMA resources excluding the node reservation.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
