### PR TITLE
scheduler: fix flaky test in reservation plugin

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -5846,6 +5846,7 @@ func createTestPreAllocatablePodWithOwnerLabel(name, nodeName, cpu, memory strin
 	for k, v := range ownerLabels {
 		pod.Labels[k] = v
 	}
+	pod.Labels[apiext.LabelPodPreAllocatable] = "true"
 	return pod
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Flaky Test Failure:

```
=== RUN   TestPreAllocationDefaultModeMultipleDisabled/sufficient_node-unallocated,_with_2_owner-matched_pre-allocatable_pods,_expect_success
    plugin_test.go:5705: Testing with PreAllocationConfig: PreferNoPreAllocatedPods=false
=== NAME  TestPreAllocationDefaultModeMultipleDisabled
    plugin_test.go:5561: 
        	Error Trace:	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation/plugin_test.go:5561
        	            				/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation/plugin_test.go:6426
        	            				/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation/plugin_test.go:5706
        	Error:      	"[&Pod{ObjectMeta:{pod1  default  pod1  0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[app:test-app] map[] [] [] []},Spec:PodSpec{Volumes:[]Volume{},Containers:[]Container{Container{Name:,Image:,Command:[],Args:[],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{cpu: {{2 0} {<nil>} 2 DecimalSI},memory: {{4294967296 0} {<nil>} 4Gi BinarySI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:,ImagePullPolicy:,SecurityContext:nil,Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},},RestartPolicy:,TerminationGracePeriodSeconds:nil,ActiveDeadlineSeconds:nil,DNSPolicy:,NodeSelector:map[string]string{},ServiceAccountName:,DeprecatedServiceAccount:,NodeName:test-node,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:nil,ImagePullSecrets:[]LocalObjectReference{},Hostname:,Subdomain:,Affinity:nil,SchedulerName:,InitContainers:[]Container{},AutomountServiceAccountToken:nil,Tolerations:[]Toleration{},HostAliases:[]HostAlias{},PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[]PodReadinessGate{},RuntimeClassName:nil,EnableServiceLinks:nil,PreemptionPolicy:nil,Overhead:ResourceList{},TopologySpreadConstraints:[]TopologySpreadConstraint{},EphemeralContainers:[]EphemeralContainer{},SetHostnameAsFQDN:nil,OS:nil,HostUsers:nil,SchedulingGates:[]PodSchedulingGate{},ResourceClaims:[]PodResourceClaim{},},Status:PodStatus{Phase:,Conditions:[]PodCondition{},Message:,Reason:,HostIP:,PodIP:,StartTime:<nil>,ContainerStatuses:[]ContainerStatus{},QOSClass:,InitContainerStatuses:[]ContainerStatus{},NominatedNodeName:,PodIPs:[]PodIP{},EphemeralContainerStatuses:[]ContainerStatus{},Resize:,ResourceClaimStatuses:[]PodResourceClaimStatus{},HostIPs:[]HostIP{},},}]" should have 2 item(s), but has 1
        	Test:       	TestPreAllocationDefaultModeMultipleDisabled
        	Messages:   	pre-allocatable pods count mismatch
```

The root cause was that `createTestPreAllocatablePodWithOwnerLabel`, the test helper did not set the `LabelPodPreAllocatable = "true"` label on the pods it created.

To resolve this issue, it's required to add `pod.Labels[apiext.LabelPodPreAllocatable] = "true"` to `createTestPreAllocatablePodWithOwnerLabel`, consistent with `createTestPreAllocatablePod`. 
This ensures `waitForPAPodsCached` correctly counts owner-label-matched pods as pre-allocatable candidates and waits until the cache (and by extension the `podLister`) is fully synced before proceeding.


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
