### PR TITLE
koordlet: ignore xid 109 event, GPU is still healthy

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_device_linux.go
+++ b/pkg/koordlet/statesinformer/impl/states_device_linux.go
@@ -525,7 +525,7 @@ func checkHealth(stopCh <-chan struct{}, devs []string, xids chan<- gpuHealthEve
 
 		// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
 		// Application errors: the GPU should still be healthy
-		if e.EventData == 13 || e.EventData == 31 || e.EventData == 43 || e.EventData == 45 || e.EventData == 68 {
+		if e.EventData == 13 || e.EventData == 31 || e.EventData == 43 || e.EventData == 45 || e.EventData == 68 || e.EventData == 109 {
 			continue
 		}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Added 109 XEvent to the list of ignored events, which preserve GPU in healthy state if event is occurred.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #2834

### Ⅲ. Describe how to verify it

This is stochastic issue fix, requires HAMi + Koordinator k8s setup + heavy GPU loader, that sometimes emits XID 109.

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
