### PR TITLE
koord-scheduler: support reservation scale update by spec

### DIFF
--- a/apis/scheduling/v1alpha1/reservation_types.go
+++ b/apis/scheduling/v1alpha1/reservation_types.go
@@ -203,8 +203,9 @@ const (
 type ReservationConditionType string
 
 const (
-	ReservationConditionScheduled ReservationConditionType = "Scheduled"
-	ReservationConditionReady     ReservationConditionType = "Ready"
+	ReservationConditionScheduled    ReservationConditionType = "Scheduled"
+	ReservationConditionReady        ReservationConditionType = "Ready"
+	ReservationConditionResizeFailed ReservationConditionType = "ResizeFailed"
 )
 
 type ConditionStatus string
@@ -222,6 +223,8 @@ const (
 	ReasonReservationAvailable = "Available"
 	ReasonReservationSucceeded = "Succeeded"
 	ReasonReservationExpired   = "Expired"
+
+	ReasonReservationResizeFailed = "InsufficientResources"
 )
 
 type ReservationCondition struct {

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -438,7 +438,10 @@ func updateReservation(sched *scheduler.Scheduler, schedAdapter frameworkext.Sch
 
 	// Case 1: Keep available
 	if oldAvailable && newAvailable {
-		// Update available reservation in cache (handles nodeName change internally)
+		// Update available reservation in cache.
+		// For in-place resize: when the controller updates status.allocatable, this path
+		// creates a new ReservePod with the updated size and calls cache.UpdatePod to
+		// adjust NodeInfo resources accordingly.
 		updateReservationInSchedulerCache(schedAdapter, oldR, newR)
 		return
 	}

--- a/pkg/scheduler/plugins/reservation/cache.go
+++ b/pkg/scheduler/plugins/reservation/cache.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/google/btree"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -66,6 +68,16 @@ func newPreAllocatablePodCache() *preAllocatablePodCache {
 	}
 }
 
+// resizeLockEntry stores the lock metadata for a reservation currently being resized.
+type resizeLockEntry struct {
+	nodeName string
+	lockTime time.Time
+}
+
+// resizeLockTimeout is the maximum duration a resize lock can be held before
+// being considered stale and eligible for forced cleanup.
+const resizeLockTimeout = 5 * time.Minute
+
 type reservationCache struct {
 	reservationLister  schedulinglister.ReservationLister
 	lock               sync.RWMutex
@@ -73,6 +85,7 @@ type reservationCache struct {
 	reservationsOnNode map[string]map[types.UID]struct{} // all reservations on node
 	matchableOnNode    map[string]map[types.UID]struct{} // look up available reservations on node
 	allocatedOnNode    map[string]map[types.UID]struct{} // look up allocated available reservations on node
+	lockedForResize    map[types.UID]*resizeLockEntry    // uid -> lock entry, locked during resize to block new allocation
 	// preAllocatablePodsOnNode caches sorted pre-allocatable candidate pods per node
 	// Uses btree for automatic ordering by priority
 	preAllocatablePodsOnNode map[string]*preAllocatablePodCache
@@ -89,6 +102,7 @@ func newReservationCache(reservationLister schedulinglister.ReservationLister) *
 		reservationsOnNode:       map[string]map[types.UID]struct{}{},
 		matchableOnNode:          map[string]map[types.UID]struct{}{},
 		allocatedOnNode:          map[string]map[types.UID]struct{}{},
+		lockedForResize:          map[types.UID]*resizeLockEntry{},
 		preAllocatablePodsOnNode: map[string]*preAllocatablePodCache{},
 	}
 	cache.preAllocatableLabelKey = apiext.LabelPodPreAllocatable
@@ -154,6 +168,12 @@ func (cache *reservationCache) updateReservation(newR *schedulingv1alpha1.Reserv
 	uid := newR.UID
 	if nodeName := newR.Status.NodeName; nodeName != "" {
 		cache.updateReservationsOnNode(nodeName, uid)
+		// Skip matchableOnNode update if the reservation is locked for resize.
+		// The lock prevents new pod allocation during resize; the explicit
+		// unlockReservationAfterResize call will restore matchability.
+		if _, locked := cache.lockedForResize[uid]; locked {
+			return
+		}
 		// refresh matchable and allocated
 		if rInfo.IsMatchable() { // matchable
 			if cache.matchableOnNode[nodeName] == nil {
@@ -226,12 +246,118 @@ func (cache *reservationCache) updateReservationIfExists(newR *schedulingv1alpha
 	}
 }
 
+// LockReservationForResize removes the reservation from matchableOnNode and sets the
+// lockedForResize flag to prevent updateReservation from re-adding it.
+// Called by the controller BEFORE UpdateStatus to close the race window between the
+// controller's decision to resize and the event handler processing the API change.
+// The lock is released by unlockReservationAfterResize when the event handler confirms
+// the resize state change is reflected in the cache.
+func (cache *reservationCache) LockReservationForResize(uid types.UID, nodeName string) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	cache.lockedForResize[uid] = &resizeLockEntry{nodeName: nodeName, lockTime: time.Now()}
+	if nodeName != "" && cache.matchableOnNode[nodeName] != nil {
+		delete(cache.matchableOnNode[nodeName], uid)
+		if len(cache.matchableOnNode[nodeName]) == 0 {
+			delete(cache.matchableOnNode, nodeName)
+		}
+	}
+}
+
+// UnlockReservationForResize is the exported version of unlockReservationAfterResize,
+// exposed for the controller to rollback the lock when an API call fails after locking.
+func (cache *reservationCache) UnlockReservationForResize(uid types.UID, nodeName string) {
+	cache.unlockReservationAfterResize(uid, nodeName)
+}
+
+// unlockReservationAfterResize clears the lockedForResize flag and adds the reservation
+// back to matchableOnNode if it is matchable. Called by the event handler after the
+// resize state change is reflected in the rInfo (i.e., after updateReservation).
+func (cache *reservationCache) unlockReservationAfterResize(uid types.UID, nodeName string) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	if _, locked := cache.lockedForResize[uid]; !locked {
+		return // not locked, nothing to do
+	}
+	delete(cache.lockedForResize, uid)
+	rInfo := cache.reservationInfos[uid]
+	if rInfo == nil || !rInfo.IsMatchable() {
+		return
+	}
+	if nodeName != "" {
+		if cache.matchableOnNode[nodeName] == nil {
+			cache.matchableOnNode[nodeName] = map[types.UID]struct{}{}
+		}
+		cache.matchableOnNode[nodeName][uid] = struct{}{}
+		if rInfo.GetAllocatedPods() > 0 {
+			if cache.allocatedOnNode[nodeName] == nil {
+				cache.allocatedOnNode[nodeName] = map[types.UID]struct{}{}
+			}
+			cache.allocatedOnNode[nodeName][uid] = struct{}{}
+		}
+	}
+}
+
+// cleanStaleLocks scans lockedForResize for entries that have exceeded resizeLockTimeout
+// and forcibly unlocks them. This is a safety net for any unforeseen scenario where the
+// normal unlock paths (event handler, PostFilter, defer rollback) fail to release the lock.
+// Returns the number of stale locks that were cleaned.
+func (cache *reservationCache) cleanStaleLocks() int {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	now := time.Now()
+	cleaned := 0
+	for uid, entry := range cache.lockedForResize {
+		if now.Sub(entry.lockTime) <= resizeLockTimeout {
+			continue
+		}
+		klog.Warningf("Force-unlocking stale resize lock for reservation %s (node=%s, locked since %v, age=%v)",
+			uid, entry.nodeName, entry.lockTime.Format(time.RFC3339), now.Sub(entry.lockTime))
+		delete(cache.lockedForResize, uid)
+		// Restore matchability if the reservation is still alive and matchable.
+		rInfo := cache.reservationInfos[uid]
+		if rInfo == nil || !rInfo.IsMatchable() {
+			cleaned++
+			continue
+		}
+		if entry.nodeName != "" {
+			if cache.matchableOnNode[entry.nodeName] == nil {
+				cache.matchableOnNode[entry.nodeName] = map[types.UID]struct{}{}
+			}
+			cache.matchableOnNode[entry.nodeName][uid] = struct{}{}
+			if rInfo.GetAllocatedPods() > 0 {
+				if cache.allocatedOnNode[entry.nodeName] == nil {
+					cache.allocatedOnNode[entry.nodeName] = map[types.UID]struct{}{}
+				}
+				cache.allocatedOnNode[entry.nodeName][uid] = struct{}{}
+			}
+		}
+		cleaned++
+	}
+	return cleaned
+}
+
+// GetResizeLockCount returns the current number of active resize locks.
+// Exposed for metrics collection and observability.
+func (cache *reservationCache) GetResizeLockCount() int {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	return len(cache.lockedForResize)
+}
+
+// CleanStaleLocks is the exported entry point for periodic stale lock cleanup.
+// Implements ReservationResizeLock interface.
+func (cache *reservationCache) CleanStaleLocks() int {
+	return cache.cleanStaleLocks()
+}
+
 func (cache *reservationCache) DeleteReservation(r *schedulingv1alpha1.Reservation) *frameworkext.ReservationInfo {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	uid := r.UID
 	rInfo := cache.reservationInfos[uid]
 	delete(cache.reservationInfos, uid)
+	delete(cache.lockedForResize, uid) // clean up any resize lock
 	nodeName := r.Status.NodeName
 	cache.deleteReservationOnNode(nodeName, uid)
 	// refresh matchable and allocated

--- a/pkg/scheduler/plugins/reservation/cache_test.go
+++ b/pkg/scheduler/plugins/reservation/cache_test.go
@@ -908,6 +908,350 @@ func TestReservationCache_PreAllocatableOperations(t *testing.T) {
 	})
 }
 
+// ==================== Resize Cache Consistency Tests ====================
+
+// TestCacheLockReservationForResize verifies that LockReservationForResize:
+// 1. Removes the reservation from matchableOnNode
+// 2. Sets the lockedForResize flag
+// 3. Does NOT remove from reservationsOnNode (node accounting still needed)
+func TestCacheLockReservationForResize(t *testing.T) {
+	cache := newReservationCache(nil)
+	nodeName := "test-node-1"
+	rUID := types.UID("resize-lock-uid")
+
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "lock-r"},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			NodeName: nodeName,
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+	}
+
+	cache.updateReservation(reservation)
+
+	// Pre-condition: reservation is matchable
+	assert.Contains(t, cache.matchableOnNode[nodeName], rUID, "should be in matchableOnNode before lock")
+	assert.Contains(t, cache.reservationsOnNode[nodeName], rUID, "should be in reservationsOnNode")
+
+	// Lock
+	cache.LockReservationForResize(rUID, nodeName)
+
+	// matchableOnNode: removed
+	if m := cache.matchableOnNode[nodeName]; m != nil {
+		assert.NotContains(t, m, rUID, "should be removed from matchableOnNode after lock")
+	}
+	// lockedForResize: set
+	entry := cache.lockedForResize[rUID]
+	assert.NotNil(t, entry, "lockedForResize should be set")
+	assert.Equal(t, nodeName, entry.nodeName, "lockedForResize should record nodeName")
+	// reservationsOnNode: still present
+	assert.Contains(t, cache.reservationsOnNode[nodeName], rUID, "should still be in reservationsOnNode")
+	// reservationInfos: still present
+	assert.NotNil(t, cache.reservationInfos[rUID], "rInfo should still exist")
+}
+
+// TestCacheUpdateReservation_LockedSkipsMatchable verifies that when a reservation is
+// locked for resize, updateReservation updates the rInfo but does NOT re-add to matchableOnNode.
+func TestCacheUpdateReservation_LockedSkipsMatchable(t *testing.T) {
+	cache := newReservationCache(nil)
+	nodeName := "test-node-1"
+	rUID := types.UID("locked-update-uid")
+
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "locked-r"},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("4"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			NodeName: nodeName,
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"),
+			},
+		},
+	}
+
+	cache.updateReservation(reservation)
+	assert.Contains(t, cache.matchableOnNode[nodeName], rUID)
+
+	// Lock for resize
+	cache.LockReservationForResize(rUID, nodeName)
+
+	// Simulate the event handler calling updateReservation after controller's UpdateStatus
+	// (e.g., shrink changed allocatable from 4 → 3)
+	updatedR := reservation.DeepCopy()
+	updatedR.Status.Allocatable = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("3"),
+	}
+	cache.updateReservation(updatedR)
+
+	// rInfo should be updated
+	rInfo := cache.reservationInfos[rUID]
+	assert.NotNil(t, rInfo)
+	wantCPU := resource.MustParse("3")
+	assert.True(t, rInfo.Allocatable[corev1.ResourceCPU].Equal(wantCPU),
+		"rInfo allocatable should be updated to 3")
+
+	// But matchableOnNode should still NOT contain this reservation (locked)
+	if m := cache.matchableOnNode[nodeName]; m != nil {
+		assert.NotContains(t, m, rUID,
+			"locked reservation should NOT be re-added to matchableOnNode by updateReservation")
+	}
+}
+
+// TestCacheUnlockReservationAfterResize verifies that unlockReservationAfterResize:
+// 1. Clears the lockedForResize flag
+// 2. Restores matchableOnNode if the reservation is matchable
+// 3. Restores allocatedOnNode if the reservation has assigned pods
+// 4. Is a no-op if not locked
+func TestCacheUnlockReservationAfterResize(t *testing.T) {
+	t.Run("unlock restores matchable and allocated", func(t *testing.T) {
+		cache := newReservationCache(nil)
+		nodeName := "test-node-1"
+		rUID := types.UID("unlock-uid")
+
+		reservation := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "unlock-r"},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				AllocateOnce: ptr.To[bool](false),
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						}},
+					},
+				},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{
+				NodeName: nodeName,
+				Phase:    schedulingv1alpha1.ReservationAvailable,
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+		}
+
+		cache.updateReservation(reservation)
+
+		// Add an owner pod so allocatedOnNode is populated
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: "pod-1", Namespace: "default", Name: "pod-1"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+					},
+				}},
+			},
+		}
+		cache.addPod(rUID, pod)
+		assert.Contains(t, cache.matchableOnNode[nodeName], rUID)
+		assert.Contains(t, cache.allocatedOnNode[nodeName], rUID)
+
+		// Lock → removes from matchableOnNode
+		cache.LockReservationForResize(rUID, nodeName)
+		if m := cache.matchableOnNode[nodeName]; m != nil {
+			assert.NotContains(t, m, rUID)
+		}
+
+		// Simulate shrink: updateReservation with new allocatable (locked, won't restore matchable)
+		shrunkR := reservation.DeepCopy()
+		shrunkR.Status.Allocatable = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}
+		cache.updateReservation(shrunkR)
+
+		// Unlock
+		cache.unlockReservationAfterResize(rUID, nodeName)
+
+		// lockedForResize cleared
+		assert.NotContains(t, cache.lockedForResize, rUID, "lock should be cleared")
+		// matchableOnNode restored
+		assert.Contains(t, cache.matchableOnNode[nodeName], rUID, "should be back in matchableOnNode")
+		// allocatedOnNode restored (has assigned pod)
+		assert.Contains(t, cache.allocatedOnNode[nodeName], rUID, "should be back in allocatedOnNode")
+	})
+
+	t.Run("unlock noop when not locked", func(t *testing.T) {
+		cache := newReservationCache(nil)
+		nodeName := "test-node-1"
+		rUID := types.UID("noop-uid")
+
+		reservation := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "noop-r"},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+							},
+						}},
+					},
+				},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{
+				NodeName: nodeName, Phase: schedulingv1alpha1.ReservationAvailable,
+				Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			},
+		}
+		cache.updateReservation(reservation)
+
+		// Call unlock without locking first — should be no-op
+		cache.unlockReservationAfterResize(rUID, nodeName)
+
+		// matchableOnNode should be untouched (still present)
+		assert.Contains(t, cache.matchableOnNode[nodeName], rUID)
+	})
+
+	t.Run("unlock non-matchable reservation does not restore matchable", func(t *testing.T) {
+		cache := newReservationCache(nil)
+		nodeName := "test-node-1"
+		rUID := types.UID("non-matchable-uid")
+
+		// Reservation that becomes non-matchable after resize (e.g., Pending phase after enlarge)
+		reservation := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "pending-r"},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+							},
+						}},
+					},
+				},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{
+				NodeName: nodeName, Phase: schedulingv1alpha1.ReservationAvailable,
+				Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			},
+		}
+		cache.updateReservation(reservation)
+		cache.LockReservationForResize(rUID, nodeName)
+
+		// Update rInfo to Pending (non-matchable) — simulating enlarge path
+		pendingR := reservation.DeepCopy()
+		pendingR.Status.Phase = schedulingv1alpha1.ReservationPending
+		pendingR.Status.NodeName = ""
+		cache.reservationInfos[rUID].UpdateReservation(pendingR)
+
+		// Unlock
+		cache.unlockReservationAfterResize(rUID, nodeName)
+
+		// lockedForResize cleared
+		assert.NotContains(t, cache.lockedForResize, rUID)
+		// NOT restored to matchableOnNode (it's Pending, not Available)
+		if m := cache.matchableOnNode[nodeName]; m != nil {
+			assert.NotContains(t, m, rUID, "non-matchable reservation should not be in matchableOnNode")
+		}
+	})
+}
+
+// TestCacheMarkResizingReservation verifies that markResizingReservation:
+// 1. Updates the rInfo with new reservation state
+// 2. Removes from matchableOnNode
+// 3. Keeps reservationsOnNode (owner pods are still on the node)
+// 4. Preserves assigned pods in rInfo
+// TestCacheMarkResizingReservation removed: markResizingReservation was replaced by
+// the lock-based resize pattern. See TestCacheResizeFullFlow_ShrinkEndToEnd.
+
+// TestCacheResizeFullFlow_ShrinkEndToEnd tests the complete shrink cache flow:
+// Lock → updateReservation (skips matchable) → unlock (restores matchable).
+func TestCacheResizeFullFlow_ShrinkEndToEnd(t *testing.T) {
+	cache := newReservationCache(nil)
+	nodeName := "test-node-1"
+	rUID := types.UID("e2e-shrink-uid")
+
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{UID: rUID, Name: "e2e-shrink-r"},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")},
+						},
+					}},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			NodeName: nodeName, Phase: schedulingv1alpha1.ReservationAvailable,
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")},
+		},
+	}
+	cache.updateReservation(reservation)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "pod-a", Namespace: "default", Name: "pod-a"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+				},
+			}},
+		},
+	}
+	cache.addPod(rUID, pod)
+
+	// Step 1: Controller locks
+	cache.LockReservationForResize(rUID, nodeName)
+	if m := cache.matchableOnNode[nodeName]; m != nil {
+		assert.NotContains(t, m, rUID, "step1: removed from matchable")
+	}
+
+	// Step 2: Controller calls UpdateStatus → event handler calls updateReservation
+	shrunkR := reservation.DeepCopy()
+	shrunkR.Status.Allocatable = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}
+	cache.updateReservation(shrunkR)
+	// Still locked, NOT in matchable
+	if m := cache.matchableOnNode[nodeName]; m != nil {
+		assert.NotContains(t, m, rUID, "step2: still locked, not matchable")
+	}
+
+	// Step 3: Event handler calls unlockReservationAfterResize
+	cache.unlockReservationAfterResize(rUID, nodeName)
+	assert.Contains(t, cache.matchableOnNode[nodeName], rUID, "step3: restored to matchable")
+	assert.Contains(t, cache.allocatedOnNode[nodeName], rUID, "step3: restored to allocated (has pod)")
+
+	// rInfo has updated allocatable
+	rInfo := cache.reservationInfos[rUID]
+	wantCPU := resource.MustParse("8")
+	assert.True(t, rInfo.Allocatable[corev1.ResourceCPU].Equal(wantCPU))
+}
+
 // BenchmarkPreAllocatablePodCache benchmarks the preAllocatablePodCache btree operations
 // with multi-node scenarios to simulate real cluster environments.
 func BenchmarkPreAllocatablePodCache(b *testing.B) {

--- a/pkg/scheduler/plugins/reservation/controller/controller.go
+++ b/pkg/scheduler/plugins/reservation/controller/controller.go
@@ -19,8 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	k8sfeature "k8s.io/apiserver/pkg/util/feature"
@@ -38,9 +42,12 @@ import (
 	corelister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/component-helpers/resource"
 	componentresource "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	koordclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
@@ -64,6 +71,17 @@ const (
 
 var _ frameworkext.Controller = &Controller{}
 
+// ReservationResizeLock allows the controller to lock a reservation in the scheduler's
+// in-process cache before making resize API calls. This closes the race window between
+// the controller deciding to resize and the event handler processing the API change.
+type ReservationResizeLock interface {
+	LockReservationForResize(uid types.UID, nodeName string)
+	UnlockReservationForResize(uid types.UID, nodeName string)
+	// CleanStaleLocks force-unlocks any resize lock held longer than the timeout.
+	// Called periodically as a safety net.
+	CleanStaleLocks() int
+}
+
 type Controller struct {
 	sharedInformerFactory      informers.SharedInformerFactory
 	koordSharedInformerFactory koordinatorinformers.SharedInformerFactory
@@ -78,6 +96,8 @@ type Controller struct {
 	gcDuration                 time.Duration
 	gcInterval                 time.Duration
 	resyncInterval             time.Duration
+	resizeLock                 ReservationResizeLock
+	addToSchedulerQueueFn      func(pod *corev1.Pod)
 
 	lock   sync.RWMutex
 	pods   map[string]map[types.UID]*corev1.Pod    // nodeName -> podUID -> pod
@@ -91,6 +111,8 @@ func New(
 	client clientset.Interface,
 	koordClientSet koordclientset.Interface,
 	args *config.ReservationArgs,
+	resizeLock ReservationResizeLock,
+	addToSchedulerQueueFn func(pod *corev1.Pod),
 ) *Controller {
 	nodeLister := sharedInformerFactory.Core().V1().Nodes().Lister()
 	podLister := sharedInformerFactory.Core().V1().Pods().Lister()
@@ -134,6 +156,8 @@ func New(
 		gcDuration:                 gcDuration,
 		gcInterval:                 gcInterval,
 		resyncInterval:             resyncInterval,
+		resizeLock:                 resizeLock,
+		addToSchedulerQueueFn:      addToSchedulerQueueFn,
 		pods:                       map[string]map[types.UID]*corev1.Pod{},
 		podToR:                     map[types.UID]types.UID{},
 		rToPod:                     map[types.UID]map[types.UID]*corev1.Pod{},
@@ -249,6 +273,31 @@ func (c *Controller) sync(key string) (result, error) {
 	}
 
 	reservation = reservation.DeepCopy()
+
+	// Fork: resize path takes priority over normal sync.
+	// Resize is triggered by a reservation update event (Generation change), not periodic resync.
+	// Keeping it separate from syncAssignedReservation ensures the status-refresh logic stays clean.
+	if reservation.Status.NodeName != "" && reservationutil.IsReservationSpecResourcesChanged(reservation) {
+		if err := c.syncReservationResize(reservation); err != nil {
+			klog.V(4).ErrorS(err, "failed to sync reservation resize", "reservation", reservationName, "uid", reservationUID)
+			return result{}, err
+		}
+		klog.V(5).InfoS("sync Reservation resize finished", "reservation", reservationName, "uid", reservationUID)
+		return result{requeueAfter: nextSyncTime(reservation)}, nil
+	}
+
+	// Fork: clear stale ResizeFailed condition if the user reverted the spec back to match allocatable.
+	if reservation.Status.NodeName != "" && hasResizeFailedCondition(reservation) {
+		klog.V(3).InfoS("Clearing stale ResizeFailed condition after spec reverted",
+			"reservation", klog.KObj(reservation), "uid", reservation.UID)
+		clearResizeFailedCondition(reservation)
+		if err := c.updateReservationStatus(reservation); err != nil {
+			return result{}, err
+		}
+		return result{requeueAfter: nextSyncTime(reservation)}, nil
+	}
+
+	// Normal path: sync allocated/ownership status only.
 	if err := c.syncAssignedReservation(reservation); err != nil {
 		klog.V(4).ErrorS(err, "failed to sync assigned Reservation", "reservation", reservationName, "uid", reservationUID)
 		return result{}, err
@@ -314,12 +363,394 @@ func (c *Controller) syncAssignedReservation(reservation *schedulingv1alpha1.Res
 	if reservation.Status.NodeName == "" {
 		return nil
 	}
+
 	// use a pods snapshot to avoid the inconsistency between pods and reservation status
 	pods := c.getPodsOnNode(reservation.Status.NodeName)
 	if err := c.syncStatus(reservation, pods); err != nil {
 		return fmt.Errorf("sync reservation status failed, err: %w", err)
 	}
 	return nil
+}
+
+// syncReservationResize handles the resize reconciliation path.
+// Triggered by a reservation update event when spec.template resources differ from status.allocatable.
+// This is separate from syncAssignedReservation to keep the normal allocated-refresh logic clean.
+func (c *Controller) syncReservationResize(reservation *schedulingv1alpha1.Reservation) error {
+	// If ResizeFailed exists, check if the user changed the spec to a different target.
+	// If the target is the same as the one that failed, skip retry to avoid loops.
+	// If the target is different, the user has a new intent — clear and retry.
+	if hasResizeFailedCondition(reservation) {
+		newTarget := allocatableFingerprint(c.computeNewAllocatable(reservation))
+		oldTarget := getResizeFailedTarget(reservation)
+		if newTarget == oldTarget {
+			klog.V(4).InfoS("Skipping automatic resize retry: same target as previous failure",
+				"reservation", klog.KObj(reservation), "uid", reservation.UID)
+			return nil
+		}
+		klog.V(3).InfoS("Spec changed to different target after ResizeFailed, clearing and retrying",
+			"reservation", klog.KObj(reservation), "uid", reservation.UID,
+			"oldTarget", oldTarget, "newTarget", newTarget)
+		clearResizeFailedCondition(reservation)
+	}
+	klog.V(3).InfoS("Reservation spec resources changed, handling resize",
+		"reservation", klog.KObj(reservation), "uid", reservation.UID, "node", reservation.Status.NodeName)
+	return c.handleReservationResize(reservation)
+}
+
+// handleReservationResize handles a reservation spec resource change.
+// Flow:
+//  1. Shrink short path: if all resources decrease or stay the same, update status.allocatable
+//     in-place (the event handler updates the cache).
+//  2. Enlarge: create a fake resize pod (new UID, new resources, pinned to the original node)
+//     and add it to the scheduler queue. The scheduler validates resource availability through
+//     the standard scheduling cycle. The reservation stays Available throughout.
+//
+// Lock behavior:
+//   - The controller locks the reservation in matchableOnNode before creating the fake pod.
+//   - For enlarge, the lock prevents new pod allocation during resize.
+//   - For shrink, the in-place allocatable update is atomic (single UpdateStatus).
+func (c *Controller) handleReservationResize(reservation *schedulingv1alpha1.Reservation) error {
+	// Lock in scheduler cache to prevent new pod allocation during resize.
+	// This removes the reservation from matchableOnNode immediately (in-process, zero API cost).
+	// The lock is released by the event handler's unlockReservationAfterResize call
+	// once the resize state change is reflected in the cache.
+	uid := reservation.UID
+	nodeName := reservation.Status.NodeName
+	c.resizeLock.LockReservationForResize(uid, nodeName)
+
+	// If the API call fails after locking, rollback the lock so the reservation
+	// remains matchable. Without this, a transient API error would permanently
+	// remove the reservation from matchableOnNode.
+	var committed bool
+	defer func() {
+		if !committed {
+			klog.V(3).InfoS("Resize API call failed, rolling back cache lock",
+				"reservation", klog.KObj(reservation), "uid", uid)
+			c.resizeLock.UnlockReservationForResize(uid, nodeName)
+		}
+	}()
+
+	newAllocatable := c.computeNewAllocatable(reservation)
+
+	// Reject resize if any resource in the new allocatable is below the current allocated.
+	// This applies to ALL resize types (shrink, enlarge, and mixed), because already-bound
+	// pods cannot be "un-allocated" — the user must free pods first.
+	// Example mixed case: cpu 4→8 (enlarge) + mem 8Gi→4Gi (shrink below allocated 6Gi) must be rejected.
+	if isBelowAllocated(reservation.Status.Allocated, newAllocatable) {
+		klog.V(3).InfoS("Reservation resize rejected: new allocatable below current allocated",
+			"reservation", klog.KObj(reservation), "uid", reservation.UID,
+			"allocated", reservation.Status.Allocated, "newAllocatable", newAllocatable)
+		setResizeFailedCondition(reservation, "new allocatable is less than current allocated resources", newAllocatable)
+		if err := c.updateReservationStatus(reservation); err != nil {
+			return err
+		}
+		committed = true
+		return nil
+	}
+
+	if c.isShrink(reservation.Status.Allocatable, newAllocatable) {
+		// Shrink short path: in-place update status.allocatable.
+		// The event handler (Case 1: keep available) calls updateReservationInSchedulerCache
+		// to adjust the ReservePod size in NodeInfo.
+		if err := c.resizeReservationInPlace(reservation, newAllocatable); err != nil {
+			return err
+		}
+		committed = true
+		return nil
+	}
+
+	// Enlarge: create a fake resize pod and add it to the scheduler queue.
+	// The reservation stays Available; the fake pod validates resources through the standard cycle.
+	klog.V(3).InfoS("Reservation enlarged, creating fake resize pod for scheduler validation",
+		"reservation", klog.KObj(reservation), "uid", reservation.UID,
+		"node", reservation.Status.NodeName, "newAllocatable", newAllocatable)
+	resizePod := c.makeResizePod(reservation, newAllocatable)
+	if c.addToSchedulerQueueFn != nil {
+		// Pre-enqueue safety check: verify the reservation still exists before adding the
+		// fake pod to the scheduling queue. This narrows the race window where the reservation
+		// is deleted between our initial Get and the enqueue, avoiding an orphaned pod in the
+		// queue. The PostFilter handler provides ultimate consistency if this check is bypassed.
+		if _, err := c.reservationLister.Get(reservation.Name); errors.IsNotFound(err) {
+			klog.V(3).InfoS("Reservation deleted before enqueue, aborting resize",
+				"reservation", klog.KObj(reservation), "uid", reservation.UID)
+			return nil
+		}
+		c.addToSchedulerQueueFn(resizePod)
+	}
+	committed = true
+	klog.V(3).InfoS("Successfully created fake resize pod and added to scheduler queue",
+		"reservation", klog.KObj(reservation), "uid", reservation.UID,
+		"resizePodUID", resizePod.UID, "node", reservation.Status.NodeName)
+	return nil
+}
+
+// makeResizePod creates a fake resize pod for scheduler validation during reservation enlarge.
+// The fake pod has:
+//   - A NEW UID (different from the reservation UID) to avoid cache conflicts
+//   - The new (enlarged) resource requirements
+//   - Annotations pinning it to the reservation's current node
+//   - Annotations identifying it as a resize pod and linking to the target reservation
+//
+// This follows the same pattern as pod inplace-update: create a fake pod with new resources,
+// schedule it through the standard cycle, then apply the result to the real target.
+func (c *Controller) makeResizePod(reservation *schedulingv1alpha1.Reservation, newAllocatable corev1.ResourceList) *corev1.Pod {
+	resizePod := &corev1.Pod{}
+	if reservation.Spec.Template != nil {
+		resizePod.ObjectMeta = *reservation.Spec.Template.ObjectMeta.DeepCopy()
+		resizePod.Spec = *reservation.Spec.Template.Spec.DeepCopy()
+	}
+
+	// Use a NEW UID to avoid conflicts with the existing ReservePod in scheduler cache
+	resizePod.UID = uuid.NewUUID()
+	resizePod.Name = string(reservation.UID) + "-resize-" + string(resizePod.UID)[:8]
+	if len(resizePod.Namespace) == 0 {
+		resizePod.Namespace = corev1.NamespaceDefault
+	}
+
+	// Copy labels from reservation
+	if resizePod.Labels == nil {
+		resizePod.Labels = map[string]string{}
+	}
+	for k, v := range reservation.Labels {
+		resizePod.Labels[k] = v
+	}
+
+	// Set annotations
+	if resizePod.Annotations == nil {
+		resizePod.Annotations = map[string]string{}
+	}
+	for k, v := range reservation.Annotations {
+		resizePod.Annotations[k] = v
+	}
+	// Mark as a reserve pod so existing reserve pod paths (error handler, etc.) work
+	resizePod.Annotations[reservationutil.AnnotationReservePod] = "true"
+	resizePod.Annotations[reservationutil.AnnotationReservationName] = reservation.Name
+	// Mark as a resize pod with target reservation info
+	resizePod.Annotations[reservationutil.AnnotationReservationResizePod] = "true"
+	resizePod.Annotations[reservationutil.AnnotationResizeTargetReservationUID] = string(reservation.UID)
+	// Pin to the current node
+	resizePod.Annotations[reservationutil.AnnotationReservationNode] = reservation.Status.NodeName
+	resizePod.Spec.NodeName = ""
+
+	// Set resources to the NEW allocatable (enlarged size)
+	// Clear existing containers so UpdateReservePodWithAllocatable creates a single
+	// fake container with the new resources (avoids leftover empty containers from template)
+	resizePod.Spec.Containers = nil
+	resizePod.Spec.InitContainers = nil
+	reservationutil.UpdateReservePodWithAllocatable(resizePod, nil, newAllocatable)
+
+	// Set priority to max to prevent preemption (same as NewReservePod)
+	if resizePod.Spec.Priority == nil {
+		if priorityVal, ok := reservation.Labels[extension.LabelPodPriority]; ok && priorityVal != "" {
+			priority, err := strconv.ParseInt(priorityVal, 10, 32)
+			if err == nil {
+				resizePod.Spec.Priority = ptr.To[int32](int32(priority))
+			}
+		}
+	}
+	if resizePod.Spec.Priority == nil {
+		resizePod.Spec.Priority = ptr.To[int32](math.MaxInt32)
+	}
+
+	resizePod.Spec.SchedulerName = reservationutil.GetReservationSchedulerName(reservation)
+
+	// Clear volumes to reduce overhead (not needed for resource validation)
+	resizePod.Spec.Volumes = nil
+
+	return resizePod
+}
+
+// computeNewAllocatable derives the new allocatable resources from the reservation spec template.
+// When template is nil, returns an empty ResourceList (consistent with IsReservationSpecResourcesChanged
+// which treats nil template as zero resources).
+func (c *Controller) computeNewAllocatable(reservation *schedulingv1alpha1.Reservation) corev1.ResourceList {
+	if reservation.Spec.Template == nil {
+		return corev1.ResourceList{}
+	}
+	return resource.PodRequests(&corev1.Pod{
+		Spec: reservation.Spec.Template.Spec,
+	}, resource.PodResourcesOptions{})
+}
+
+// isShrink checks whether the resize is a pure shrink (all resources decrease or stay the same).
+// Returns true if no resource in newAllocatable exceeds the corresponding resource in oldAllocatable.
+// Resources present in old but missing from new are treated as removed (shrink to 0).
+// Any resource increase means this is NOT a shrink and requires rescheduling.
+func (c *Controller) isShrink(oldAllocatable, newAllocatable corev1.ResourceList) bool {
+	for resourceName, newQty := range newAllocatable {
+		if oldQty, ok := oldAllocatable[resourceName]; ok {
+			if newQty.Cmp(oldQty) > 0 {
+				return false // new > old for some resource → enlargement
+			}
+		} else {
+			// New resource type not present in old → it's an addition → not a shrink
+			return false
+		}
+	}
+	return true
+}
+
+// resizeReservationInPlace updates the reservation's status.allocatable to the new size
+// without rescheduling. The event handler will detect the status change and update
+// the ReservePod in the scheduler cache (via updateReservationInSchedulerCache).
+func (c *Controller) resizeReservationInPlace(reservation *schedulingv1alpha1.Reservation, newAllocatable corev1.ResourceList) error {
+
+	// Clear any previous ResizeFailed condition since this is a new resize attempt
+	clearResizeFailedCondition(reservation)
+
+	reservation.Status.Allocatable = newAllocatable
+	_, err := c.koordClientSet.SchedulingV1alpha1().Reservations().UpdateStatus(
+		context.TODO(), reservation, metav1.UpdateOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to resize reservation in-place",
+			"reservation", klog.KObj(reservation), "uid", reservation.UID)
+		return err
+	}
+	klog.V(3).InfoS("Successfully resized reservation in-place",
+		"reservation", klog.KObj(reservation), "uid", reservation.UID,
+		"node", reservation.Status.NodeName, "newAllocatable", newAllocatable)
+	return nil
+}
+
+// unbindOwnerPods removes the reservation-allocated annotation from all pods
+// currently using this reservation, turning them into standalone pods.
+func (c *Controller) unbindOwnerPods(reservation *schedulingv1alpha1.Reservation) error {
+	pods := c.getPodsOnReservation(reservation.UID)
+	if len(pods) == 0 {
+		return nil
+	}
+	var errs []error
+	for _, pod := range pods {
+		curPod, err := c.podLister.Pods(pod.Namespace).Get(pod.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, err)
+			continue
+		}
+		modifiedPod := curPod.DeepCopy()
+		removed, err := apiext.RemoveReservationAllocated(modifiedPod, reservation)
+		if err != nil {
+			klog.V(4).ErrorS(err, "Failed to remove reservation allocated for pod during resize",
+				"reservation", klog.KObj(reservation), "pod", klog.KObj(curPod))
+			errs = append(errs, err)
+			continue
+		}
+		if !removed {
+			continue
+		}
+		_, err = util.PatchPodSafe(context.TODO(), c.client, curPod, modifiedPod)
+		if err != nil {
+			klog.ErrorS(err, "Failed to unbind pod from reservation for resize",
+				"reservation", klog.KObj(reservation), "pod", klog.KObj(curPod))
+			errs = append(errs, err)
+			continue
+		}
+		klog.V(4).InfoS("Successfully unbound pod from reservation for resize",
+			"reservation", klog.KObj(reservation), "uid", reservation.UID, "pod", klog.KObj(curPod))
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// hasResizeFailedCondition checks if the reservation has a ResizeFailed condition.
+func hasResizeFailedCondition(r *schedulingv1alpha1.Reservation) bool {
+	for _, c := range r.Status.Conditions {
+		if c.Type == schedulingv1alpha1.ReservationConditionResizeFailed &&
+			c.Status == schedulingv1alpha1.ConditionStatusTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// clearResizeFailedCondition removes the ResizeFailed condition from the reservation.
+// This is called when a new resize attempt starts (either handleReservationResize or resizeInPlace).
+func clearResizeFailedCondition(r *schedulingv1alpha1.Reservation) {
+	filtered := make([]schedulingv1alpha1.ReservationCondition, 0, len(r.Status.Conditions))
+	for _, c := range r.Status.Conditions {
+		if c.Type != schedulingv1alpha1.ReservationConditionResizeFailed {
+			filtered = append(filtered, c)
+		}
+	}
+	r.Status.Conditions = filtered
+}
+
+// isBelowAllocated checks if any resource in newAllocatable is less than the
+// corresponding resource in allocated. This is used to reject shrink operations
+// that would make the reservation smaller than what's already been allocated to pods.
+func isBelowAllocated(allocated, newAllocatable corev1.ResourceList) bool {
+	for resourceName, allocatedQty := range allocated {
+		if allocatedQty.IsZero() {
+			continue
+		}
+		if newQty, ok := newAllocatable[resourceName]; ok {
+			if newQty.Cmp(allocatedQty) < 0 {
+				return true
+			}
+		} else {
+			// Resource exists in allocated but not in new allocatable → effectively 0
+			return true
+		}
+	}
+	return false
+}
+
+// setResizeFailedCondition adds a ResizeFailed condition to the reservation.
+// Any existing ResizeFailed condition is replaced.
+// The Message field encodes the target allocatable that caused the failure, formatted as
+// "reason;cpu=<val>,memory=<val>,...". This allows detecting spec changes: if the user
+// modifies the spec to a different target, the controller clears ResizeFailed and retries.
+func setResizeFailedCondition(r *schedulingv1alpha1.Reservation, reason string, targetAllocatable corev1.ResourceList) {
+	clearResizeFailedCondition(r)
+	now := metav1.Now()
+	r.Status.Conditions = append(r.Status.Conditions, schedulingv1alpha1.ReservationCondition{
+		Type:               schedulingv1alpha1.ReservationConditionResizeFailed,
+		Status:             schedulingv1alpha1.ConditionStatusTrue,
+		Reason:             schedulingv1alpha1.ReasonReservationResizeFailed,
+		Message:            EncodeResizeFailedMessage(reason, targetAllocatable),
+		LastProbeTime:      now,
+		LastTransitionTime: now,
+	})
+}
+
+// EncodeResizeFailedMessage builds the Message field: "reason;cpu=100m,memory=1Gi".
+// The fingerprint is always appended after the LAST semicolon, so reason text
+// containing semicolons (e.g. joined scheduler reasons) won't break parsing.
+func EncodeResizeFailedMessage(reason string, target corev1.ResourceList) string {
+	return reason + ";" + allocatableFingerprint(target)
+}
+
+// getResizeFailedTarget extracts the target fingerprint from a ResizeFailed condition's Message.
+// It splits at the LAST semicolon to avoid misparse when the reason itself contains semicolons.
+// Returns empty string if no semicolon or no ResizeFailed condition.
+func getResizeFailedTarget(r *schedulingv1alpha1.Reservation) string {
+	for _, c := range r.Status.Conditions {
+		if c.Type == schedulingv1alpha1.ReservationConditionResizeFailed &&
+			c.Status == schedulingv1alpha1.ConditionStatusTrue {
+			if idx := strings.LastIndex(c.Message, ";"); idx >= 0 {
+				return c.Message[idx+1:]
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// allocatableFingerprint returns a stable, sorted string representation of a ResourceList
+// for comparison with the target stored in ResizeFailed condition.
+func allocatableFingerprint(rl corev1.ResourceList) string {
+	names := make([]string, 0, len(rl))
+	for name := range rl {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		qty := rl[corev1.ResourceName(name)]
+		parts = append(parts, name+"="+qty.String())
+	}
+	return strings.Join(parts, ",")
 }
 
 func (c *Controller) syncStatus(reservation *schedulingv1alpha1.Reservation, pods map[types.UID]*corev1.Pod) error {

--- a/pkg/scheduler/plugins/reservation/controller/controller_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -37,6 +39,7 @@ import (
 	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	basemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
@@ -68,6 +71,47 @@ func init() {
 	}
 }
 
+// noopResizeLock is a no-op implementation of ReservationResizeLock for testing.
+type noopResizeLock struct{}
+
+func (n *noopResizeLock) LockReservationForResize(_ types.UID, _ string)   {}
+func (n *noopResizeLock) UnlockReservationForResize(_ types.UID, _ string) {}
+func (n *noopResizeLock) CleanStaleLocks() int                             { return 0 }
+
+// trackingResizeLock records lock/unlock calls for test assertions.
+type trackingResizeLock struct {
+	mu        sync.Mutex
+	locked    map[types.UID]string // uid -> nodeName
+	lockLog   []types.UID
+	unlockLog []types.UID
+}
+
+func newTrackingResizeLock() *trackingResizeLock {
+	return &trackingResizeLock{locked: map[types.UID]string{}}
+}
+
+func (t *trackingResizeLock) LockReservationForResize(uid types.UID, nodeName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.locked[uid] = nodeName
+	t.lockLog = append(t.lockLog, uid)
+}
+
+func (t *trackingResizeLock) UnlockReservationForResize(uid types.UID, _ string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.locked, uid)
+	t.unlockLog = append(t.unlockLog, uid)
+}
+
+func (t *trackingResizeLock) CleanStaleLocks() int { return 0 }
+
+func (t *trackingResizeLock) isLocked(uid types.UID) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.locked[uid]
+	return ok
+}
 func TestFailedOrSucceededReservation(t *testing.T) {
 	fakeClientSet := kubefake.NewSimpleClientset()
 	fakeKoordClientSet := koordfake.NewSimpleClientset()
@@ -97,7 +141,7 @@ func TestFailedOrSucceededReservation(t *testing.T) {
 	_, err = fakeKoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), succededReservation, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -206,7 +250,7 @@ func TestExpireActiveReservation(t *testing.T) {
 	_, err := fakeClientSet.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -262,7 +306,20 @@ func TestSyncStatus(t *testing.T) {
 				Duration: 1 * time.Minute,
 			},
 			AllocateOnce: ptr.To[bool](true),
-			Template:     &corev1.PodTemplateSpec{},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10000m"),
+									corev1.ResourceMemory: resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
@@ -318,7 +375,7 @@ func TestSyncStatus(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{ControllerWorkers: 2, GCDurationSeconds: 3600, GCIntervalSeconds: 60})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{ControllerWorkers: 2, GCDurationSeconds: 3600, GCIntervalSeconds: 60}, &noopResizeLock{}, nil)
 	controller.Start()
 
 	time.Sleep(100 * time.Millisecond)
@@ -523,7 +580,7 @@ func Test_syncPodsForTerminatedReservation(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -579,7 +636,7 @@ func Test_podEventHandlers(t *testing.T) {
 	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -736,7 +793,7 @@ func TestPodEventHandlerUnassignedPod(t *testing.T) {
 	_, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -916,7 +973,7 @@ func TestResyncReservations(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)
@@ -975,6 +1032,799 @@ scheduler_reservation_status_phase{name="r-pending",phase="Succeeded"} 0
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedAfterSecondResync), "scheduler_reservation_status_phase"); err != nil {
 		t.Errorf("after second resync (deleted r-available): %v", err)
 	}
+}
+
+// ==================== Reservation Resize Tests ====================
+
+// newTestReservation creates an Available reservation on a node with the given allocatable.
+func newTestReservation(name string, uid types.UID, nodeName string, specCPU, specMem, statusCPU, statusMem string) *schedulingv1alpha1.Reservation {
+	r := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               uid,
+			Name:              name,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(specCPU),
+									corev1.ResourceMemory: resource.MustParse(specMem),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: nodeName,
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(statusCPU),
+				corev1.ResourceMemory: resource.MustParse(statusMem),
+			},
+		},
+	}
+	return r
+}
+
+func newTestNode(name string, cpu, mem string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(mem),
+			},
+		},
+	}
+}
+
+func newTestPod(name, ns, nodeName string, cpu, mem string, reservationName string, reservationUID types.UID) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(name + "-uid"),
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(cpu),
+							corev1.ResourceMemory: resource.MustParse(mem),
+						},
+					},
+				},
+			},
+		},
+	}
+	if reservationName != "" {
+		r := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: reservationName, UID: reservationUID},
+		}
+		apiext.SetReservationAllocated(pod, r)
+	}
+	return pod
+}
+
+func setupResizeTestController(
+	t *testing.T,
+	nodes []*corev1.Node,
+	reservations []*schedulingv1alpha1.Reservation,
+	pods []*corev1.Pod,
+) (*Controller, *kubefake.Clientset, *koordfake.Clientset) {
+	return setupResizeTestControllerWithLock(t, nodes, reservations, pods, &noopResizeLock{})
+}
+
+func setupResizeTestControllerWithLock(
+	t *testing.T,
+	nodes []*corev1.Node,
+	reservations []*schedulingv1alpha1.Reservation,
+	pods []*corev1.Pod,
+	resizeLock ReservationResizeLock,
+) (*Controller, *kubefake.Clientset, *koordfake.Clientset) {
+	fakeClientSet := kubefake.NewSimpleClientset()
+	fakeKoordClientSet := koordfake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
+
+	for _, node := range nodes {
+		_, err := fakeClientSet.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+	for _, r := range reservations {
+		_, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), r, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+	for _, pod := range pods {
+		_, err := fakeClientSet.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, resizeLock, nil)
+
+	sharedInformerFactory.Start(nil)
+	koordSharedInformerFactory.Start(nil)
+	sharedInformerFactory.WaitForCacheSync(nil)
+	koordSharedInformerFactory.WaitForCacheSync(nil)
+
+	// Populate controller internal cache for pods
+	for _, pod := range pods {
+		controller.onPodAdd(pod)
+	}
+
+	return controller, fakeClientSet, fakeKoordClientSet
+}
+
+func TestComputeNewAllocatable(t *testing.T) {
+	tests := []struct {
+		name        string
+		reservation *schedulingv1alpha1.Reservation
+		want        corev1.ResourceList
+	}{
+		{
+			name: "nil template returns empty ResourceList",
+			reservation: &schedulingv1alpha1.Reservation{
+				Spec: schedulingv1alpha1.ReservationSpec{Template: nil},
+				Status: schedulingv1alpha1.ReservationStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("10"),
+					},
+				},
+			},
+			want: corev1.ResourceList{},
+		},
+		{
+			name:        "template with resources returns computed requests",
+			reservation: newTestReservation("r1", "uid1", "node1", "8", "8Gi", "10", "10Gi"),
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{}
+			got := c.computeNewAllocatable(tt.reservation)
+			if len(tt.want) == 0 {
+				assert.Empty(t, got, "expected empty ResourceList")
+			} else {
+				assert.True(t, got.Cpu().Equal(*tt.want.Cpu()), "cpu: got %v, want %v", got.Cpu(), tt.want.Cpu())
+				assert.True(t, got.Memory().Equal(*tt.want.Memory()), "mem: got %v, want %v", got.Memory(), tt.want.Memory())
+			}
+		})
+	}
+}
+
+func TestIsShrink(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldAllocatable corev1.ResourceList
+		newAllocatable corev1.ResourceList
+		want           bool
+	}{
+		{
+			name: "pure shrink: all resources decrease",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			want: true,
+		},
+		{
+			name: "shrink with partial same",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			want: true,
+		},
+		{
+			name: "no change is a shrink",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("10"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("10"),
+			},
+			want: true,
+		},
+		{
+			name: "enlarge: CPU increases",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("12"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			want: false,
+		},
+		{
+			name: "mixed: CPU shrinks but memory enlarges",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("24Gi"),
+			},
+			want: false,
+		},
+		{
+			name: "new resource type added",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("10"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			want: false,
+		},
+		{
+			name: "resource removed is still shrink",
+			oldAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			newAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("10"),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{}
+			got := c.isShrink(tt.oldAllocatable, tt.newAllocatable)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnbindOwnerPods(t *testing.T) {
+	rUID := types.UID("r-uid")
+	rName := "test-reservation"
+
+	reservation := newTestReservation(rName, rUID, "node1", "10", "10Gi", "10", "10Gi")
+	ownerPod1 := newTestPod("pod1", "default", "node1", "2", "2Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", "node1", "3", "3Gi", rName, rUID)
+	otherPod := newTestPod("other-pod", "default", "node1", "1", "1Gi", "other-r", "other-uid")
+	node := newTestNode("node1", "32", "64Gi")
+
+	controller, fakeClientSet, _ := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2, otherPod},
+	)
+
+	err := controller.unbindOwnerPods(reservation)
+	assert.NoError(t, err)
+
+	// Owner pods should have reservation-allocated annotation removed
+	gotPod1, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod1", metav1.GetOptions{})
+	assert.Empty(t, gotPod1.Annotations[apiext.AnnotationReservationAllocated], "pod1 should be unbound")
+
+	gotPod2, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod2", metav1.GetOptions{})
+	assert.Empty(t, gotPod2.Annotations[apiext.AnnotationReservationAllocated], "pod2 should be unbound")
+
+	// Other pod should be untouched
+	gotOther, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "other-pod", metav1.GetOptions{})
+	assert.NotEmpty(t, gotOther.Annotations[apiext.AnnotationReservationAllocated], "other-pod should be untouched")
+}
+
+// TestRescheduleReservationOnSameNode removed: rescheduleReservationOnSameNode was replaced by
+// the fake resize pod pattern (makeResizePod + addToSchedulerQueueFn). See TestMakeResizePod.
+
+func TestHandleReservationResize(t *testing.T) {
+	t.Run("shrink: in-place resize", func(t *testing.T) {
+		rUID := types.UID("resize-r-uid")
+		rName := "resize-reservation"
+		nodeName := "node1"
+
+		reservation := newTestReservation(rName, rUID, nodeName, "8", "10Gi", "10", "10Gi")
+		node := newTestNode(nodeName, "32", "64Gi")
+
+		controller, _, fakeKoordClientSet := setupResizeTestController(t,
+			[]*corev1.Node{node},
+			[]*schedulingv1alpha1.Reservation{reservation},
+			nil,
+		)
+
+		err := controller.handleReservationResize(reservation)
+		assert.NoError(t, err)
+
+		gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(
+			context.TODO(), rName, metav1.GetOptions{})
+		assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+		wantCPU := resource.MustParse("8")
+		gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+		assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU: got %v, want 8", gotCPU.String())
+	})
+
+	t.Run("enlarge: fake resize pod queued, reservation stays Available", func(t *testing.T) {
+		rUID := types.UID("resize-r-uid")
+		rName := "resize-reservation"
+		nodeName := "node1"
+
+		reservation := newTestReservation(rName, rUID, nodeName, "14", "10Gi", "10", "10Gi")
+		node := newTestNode(nodeName, "32", "64Gi")
+
+		controller, _, fakeKoordClientSet := setupResizeTestController(t,
+			[]*corev1.Node{node},
+			[]*schedulingv1alpha1.Reservation{reservation},
+			nil,
+		)
+
+		// Capture queued pods
+		var queuedPods []*corev1.Pod
+		controller.addToSchedulerQueueFn = func(pod *corev1.Pod) {
+			queuedPods = append(queuedPods, pod)
+		}
+
+		err := controller.handleReservationResize(reservation)
+		assert.NoError(t, err)
+
+		// Reservation stays Available — no phase change, no API call for enlarge
+		gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(
+			context.TODO(), rName, metav1.GetOptions{})
+		assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+		assert.Equal(t, nodeName, gotR.Status.NodeName, "node should be unchanged")
+
+		// Allocatable unchanged (Bind will update it on success)
+		wantCPU := resource.MustParse("10")
+		gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+		assert.True(t, gotCPU.Equal(wantCPU), "allocatable should be unchanged: got %v", gotCPU.String())
+
+		// Fake resize pod should have been queued
+		assert.Len(t, queuedPods, 1, "should queue exactly 1 fake resize pod")
+		resizePod := queuedPods[0]
+		assert.Equal(t, "true", resizePod.Annotations[reservationutil.AnnotationReservationResizePod])
+		assert.Equal(t, string(rUID), resizePod.Annotations[reservationutil.AnnotationResizeTargetReservationUID])
+		assert.Equal(t, nodeName, resizePod.Annotations[reservationutil.AnnotationReservationNode])
+		// Fake pod should request the NEW (enlarged) resources
+		resizePodCPU := resizePod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+		wantEnlargedCPU := resource.MustParse("14")
+		assert.True(t, resizePodCPU.Equal(wantEnlargedCPU),
+			"resize pod CPU should be 14: got %v", resizePodCPU.String())
+	})
+}
+
+func TestMakeResizePod(t *testing.T) {
+	rUID := types.UID("test-r-uid")
+	rName := "test-reservation"
+	nodeName := "node1"
+
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rName,
+			UID:  rUID,
+			Labels: map[string]string{
+				"app": "test",
+			},
+			Annotations: map[string]string{
+				"custom-anno": "value",
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Gi"),
+							},
+						},
+					}},
+					SchedulerName: "koord-scheduler",
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			NodeName: nodeName,
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+		},
+	}
+
+	newAllocatable := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("14"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	}
+
+	c := &Controller{}
+	pod := c.makeResizePod(reservation, newAllocatable)
+
+	// UID must be different from reservation UID
+	assert.NotEqual(t, rUID, pod.UID, "resize pod should have a different UID")
+	assert.NotEmpty(t, pod.UID)
+
+	// Name should contain reservation UID and "-resize-"
+	assert.Contains(t, pod.Name, string(rUID))
+	assert.Contains(t, pod.Name, "-resize-")
+
+	// Namespace defaults to "default"
+	assert.Equal(t, corev1.NamespaceDefault, pod.Namespace)
+
+	// Annotations
+	assert.Equal(t, "true", pod.Annotations[reservationutil.AnnotationReservePod])
+	assert.Equal(t, rName, pod.Annotations[reservationutil.AnnotationReservationName])
+	assert.Equal(t, "true", pod.Annotations[reservationutil.AnnotationReservationResizePod])
+	assert.Equal(t, string(rUID), pod.Annotations[reservationutil.AnnotationResizeTargetReservationUID])
+	assert.Equal(t, nodeName, pod.Annotations[reservationutil.AnnotationReservationNode])
+
+	// Custom annotations preserved
+	assert.Equal(t, "value", pod.Annotations["custom-anno"])
+
+	// Labels preserved
+	assert.Equal(t, "test", pod.Labels["app"])
+
+	// Resources should be the NEW allocatable
+	podCPU := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	wantCPU := resource.MustParse("14")
+	assert.True(t, podCPU.Equal(wantCPU), "resize pod CPU should be 14: got %v", podCPU.String())
+
+	// NodeName should be empty (scheduled through normal cycle)
+	assert.Empty(t, pod.Spec.NodeName, "resize pod should not be pre-assigned to a node")
+
+	// Priority should be set
+	assert.NotNil(t, pod.Spec.Priority)
+
+	// Volumes should be cleared
+	assert.Nil(t, pod.Spec.Volumes)
+}
+
+func TestSyncReservationResize_ResizeTriggered(t *testing.T) {
+	t.Run("shrink triggers in-place resize", func(t *testing.T) {
+		rUID := types.UID("resize-uid")
+		rName := "resize-r"
+		nodeName := "node1"
+
+		// spec 8C < status 10C → triggers shrink (in-place)
+		reservation := newTestReservation(rName, rUID, nodeName, "8", "10Gi", "10", "10Gi")
+		node := newTestNode(nodeName, "32", "64Gi")
+
+		controller, _, fakeKoordClientSet := setupResizeTestController(t,
+			[]*corev1.Node{node},
+			[]*schedulingv1alpha1.Reservation{reservation},
+			nil,
+		)
+
+		err := controller.syncReservationResize(reservation)
+		assert.NoError(t, err)
+
+		gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(
+			context.TODO(), rName, metav1.GetOptions{})
+
+		// Should have been resized in-place to 8C
+		wantCPU := resource.MustParse("8")
+		gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+		assert.True(t, gotCPU.Equal(wantCPU),
+			"allocatable CPU should be updated: got %v, want %v", gotCPU.String(), wantCPU.String())
+
+		// Phase stays Available (in-place, no reschedule)
+		assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	})
+
+	t.Run("enlarge triggers fake resize pod", func(t *testing.T) {
+		rUID := types.UID("resize-uid")
+		rName := "resize-r"
+		nodeName := "node1"
+
+		// spec 12C > status 10C → triggers enlarge
+		reservation := newTestReservation(rName, rUID, nodeName, "12", "10Gi", "10", "10Gi")
+		node := newTestNode(nodeName, "32", "64Gi")
+
+		controller, _, fakeKoordClientSet := setupResizeTestController(t,
+			[]*corev1.Node{node},
+			[]*schedulingv1alpha1.Reservation{reservation},
+			nil,
+		)
+
+		var queuedPods []*corev1.Pod
+		controller.addToSchedulerQueueFn = func(pod *corev1.Pod) {
+			queuedPods = append(queuedPods, pod)
+		}
+
+		err := controller.syncReservationResize(reservation)
+		assert.NoError(t, err)
+
+		gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(
+			context.TODO(), rName, metav1.GetOptions{})
+
+		// Reservation stays Available (no phase transition for enlarge)
+		assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+		assert.Equal(t, nodeName, gotR.Status.NodeName)
+
+		// Allocatable unchanged (Bind will update on success)
+		wantCPU := resource.MustParse("10")
+		gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+		assert.True(t, gotCPU.Equal(wantCPU), "allocatable should be unchanged")
+
+		// Fake resize pod should have been queued
+		assert.Len(t, queuedPods, 1, "should queue 1 fake resize pod")
+	})
+}
+
+func TestSyncAssignedReservation_NoResize(t *testing.T) {
+	rUID := types.UID("normal-uid")
+	rName := "normal-r"
+	nodeName := "node1"
+
+	// spec == status (10C == 10C), no annotation → normal sync
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 1 * time.Minute}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		nil,
+	)
+
+	err := controller.syncAssignedReservation(reservation)
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(
+		context.TODO(), rName, metav1.GetOptions{})
+
+	// Should remain unchanged — no resize triggered
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU))
+}
+
+// ==================== Condition Helper Tests ====================
+
+func TestHasResizeFailedCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []schedulingv1alpha1.ReservationCondition
+		want       bool
+	}{
+		{
+			name:       "no conditions",
+			conditions: nil,
+			want:       false,
+		},
+		{
+			name: "has ResizeFailed=True",
+			conditions: []schedulingv1alpha1.ReservationCondition{
+				{
+					Type:   schedulingv1alpha1.ReservationConditionResizeFailed,
+					Status: schedulingv1alpha1.ConditionStatusTrue,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has ResizeFailed=False (not active)",
+			conditions: []schedulingv1alpha1.ReservationCondition{
+				{
+					Type:   schedulingv1alpha1.ReservationConditionResizeFailed,
+					Status: schedulingv1alpha1.ConditionStatusFalse,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "has other conditions only",
+			conditions: []schedulingv1alpha1.ReservationCondition{
+				{
+					Type:   schedulingv1alpha1.ReservationConditionScheduled,
+					Status: schedulingv1alpha1.ConditionStatusTrue,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &schedulingv1alpha1.Reservation{
+				Status: schedulingv1alpha1.ReservationStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			assert.Equal(t, tt.want, hasResizeFailedCondition(r))
+		})
+	}
+}
+
+func TestClearResizeFailedCondition(t *testing.T) {
+	t.Run("removes ResizeFailed, keeps others", func(t *testing.T) {
+		r := &schedulingv1alpha1.Reservation{
+			Status: schedulingv1alpha1.ReservationStatus{
+				Conditions: []schedulingv1alpha1.ReservationCondition{
+					{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+					{Type: schedulingv1alpha1.ReservationConditionResizeFailed, Status: schedulingv1alpha1.ConditionStatusTrue},
+					{Type: schedulingv1alpha1.ReservationConditionReady, Status: schedulingv1alpha1.ConditionStatusTrue},
+				},
+			},
+		}
+		clearResizeFailedCondition(r)
+		assert.Len(t, r.Status.Conditions, 2)
+		for _, c := range r.Status.Conditions {
+			assert.NotEqual(t, schedulingv1alpha1.ReservationConditionResizeFailed, c.Type)
+		}
+	})
+
+	t.Run("no-op when no ResizeFailed", func(t *testing.T) {
+		r := &schedulingv1alpha1.Reservation{
+			Status: schedulingv1alpha1.ReservationStatus{
+				Conditions: []schedulingv1alpha1.ReservationCondition{
+					{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+				},
+			},
+		}
+		clearResizeFailedCondition(r)
+		assert.Len(t, r.Status.Conditions, 1)
+	})
+}
+
+// TestClearResizingCondition removed: clearResizingCondition and the Resizing condition
+// were eliminated in the fake resize pod refactoring. Reservations stay Available throughout resize.
+
+// ==================== finishReservationResize Tests ====================
+
+// TestFinishReservationResize removed: finishReservationResize and the Resizing condition
+// were eliminated. Bind directly updates allocatable; no Resizing condition to clean up.
+
+// ==================== resizeReservationInPlace Tests ====================
+
+func TestResizeReservationInPlace(t *testing.T) {
+	t.Run("updates allocatable and clears ResizeFailed", func(t *testing.T) {
+		rUID := types.UID("inplace-uid")
+		rName := "inplace-r"
+		nodeName := "node1"
+
+		// Had a previous ResizeFailed condition
+		reservation := newTestReservation(rName, rUID, nodeName, "8", "10Gi", "10", "10Gi")
+		reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+			{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+			{Type: schedulingv1alpha1.ReservationConditionResizeFailed, Status: schedulingv1alpha1.ConditionStatusTrue},
+		}
+		node := newTestNode(nodeName, "32", "64Gi")
+
+		controller, _, fakeKoordClientSet := setupResizeTestController(t,
+			[]*corev1.Node{node},
+			[]*schedulingv1alpha1.Reservation{reservation},
+			nil,
+		)
+
+		newAlloc := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("10Gi"),
+		}
+		err := controller.resizeReservationInPlace(reservation, newAlloc)
+		assert.NoError(t, err)
+
+		gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+		// Allocatable updated
+		wantCPU := resource.MustParse("8")
+		gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+		assert.True(t, gotCPU.Equal(wantCPU))
+		// ResizeFailed condition cleared
+		assert.False(t, hasResizeFailedCondition(gotR), "ResizeFailed should be cleared")
+		// Phase unchanged
+		assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	})
+}
+
+// ==================== syncReservationResize Tests ====================
+
+// TestSyncAssignedReservation_ResizingCompleted removed: finishReservationResize and the
+// Resizing condition were eliminated. syncAssignedReservation no longer has a "resizing completed"
+// branch; resize completion is handled entirely by the Bind plugin hook.
+
+func TestSyncAssignedReservation_ResizeFailedSkip(t *testing.T) {
+	// Reservation has ResizeFailed + spec changed → should skip resize
+	rUID := types.UID("failed-uid")
+	rName := "failed-r"
+	nodeName := "node1"
+
+	// spec 14C > status 10C → resources changed, BUT ResizeFailed present with same target → skip
+	reservation := newTestReservation(rName, rUID, nodeName, "14", "10Gi", "10", "10Gi")
+	failedTarget := allocatableFingerprint(corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("14"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	})
+	reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{
+			Type:    schedulingv1alpha1.ReservationConditionResizeFailed,
+			Status:  schedulingv1alpha1.ConditionStatusTrue,
+			Reason:  schedulingv1alpha1.ReasonReservationResizeFailed,
+			Message: "previous failure;" + failedTarget,
+		},
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		nil,
+	)
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	// Should remain unchanged — resize skipped due to ResizeFailed
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable should be unchanged")
+	assert.True(t, hasResizeFailedCondition(gotR), "ResizeFailed should still be present")
+}
+
+func TestSyncAssignedReservation_UnassignedSkip(t *testing.T) {
+	// Reservation with empty NodeName → syncAssignedReservation should return nil immediately
+	r := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid", Name: "r"},
+		Status:     schedulingv1alpha1.ReservationStatus{NodeName: ""},
+	}
+	controller := &Controller{}
+	err := controller.syncAssignedReservation(r)
+	assert.NoError(t, err)
+}
+
+// TestSyncReservationResize_ClearStaleResizeFailed tests that when the user reverts
+// the spec back to match allocatable, the stale ResizeFailed condition is automatically cleared.
+// This is handled by the fork in sync() before syncAssignedReservation.
+func TestSyncReservationResize_ClearStaleResizeFailed(t *testing.T) {
+	rUID := types.UID("stale-failed-uid")
+	rName := "stale-failed-r"
+	nodeName := "node1"
+
+	// spec=10C == allocatable=10C (user reverted), but ResizeFailed is still present
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{Type: schedulingv1alpha1.ReservationConditionReady, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{
+			Type:   schedulingv1alpha1.ReservationConditionResizeFailed,
+			Status: schedulingv1alpha1.ConditionStatusTrue,
+			Reason: schedulingv1alpha1.ReasonReservationResizeFailed,
+		},
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		nil,
+	)
+
+	_, err := controller.sync(getReservationKey(reservation))
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	// ResizeFailed should be cleared
+	assert.False(t, hasResizeFailedCondition(gotR), "ResizeFailed should be cleared after spec reverted")
+	// Other conditions preserved
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName)
 }
 
 func TestNew(t *testing.T) {
@@ -1042,7 +1892,7 @@ func TestNew(t *testing.T) {
 			sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 			koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
 
-			controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, tt.args)
+			controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, tt.args, &noopResizeLock{}, nil)
 
 			assert.Equal(t, tt.expectedNumWorker, controller.numWorker)
 			assert.Equal(t, tt.expectedIsGCDisabled, controller.isGCDisabled)
@@ -1095,7 +1945,7 @@ func TestControllerStart(t *testing.T) {
 
 	// Create controller with GC and resync disabled to keep the test focused.
 	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet,
-		&config.ReservationArgs{DisableGarbageCollection: true, ResyncIntervalSeconds: 0})
+		&config.ReservationArgs{DisableGarbageCollection: true, ResyncIntervalSeconds: 0}, &noopResizeLock{}, nil)
 
 	// Start() calls ForceSyncFromInformer for the pod informer, which should add a registration.
 	controller.Start()
@@ -1117,4 +1967,733 @@ func TestControllerStart(t *testing.T) {
 
 	podsOnReservation := controller.getPodsOnReservation("res-uid-start-test")
 	assert.Len(t, podsOnReservation, 1, "expected test pod to be indexed by reservation UID")
+}
+
+// ==================== End-to-End Resize Scenario Tests ====================
+
+// TestReservationResizeScenario_Shrink tests a complete shrink scenario:
+// An Available reservation with 2 owner pods, user changes spec from 10C→8C.
+// Expected: allocatable updated in-place, phase stays Available, owner pods NOT unbound.
+func TestReservationResizeScenario_Shrink(t *testing.T) {
+	rUID := types.UID("scenario-shrink-uid")
+	rName := "scenario-shrink-r"
+	nodeName := "node1"
+
+	// Available reservation: spec=10C/10Gi, status.allocatable=10C/10Gi
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	// 2 owner pods allocated on this reservation
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "2", "2Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "3", "3Gi", rName, rUID)
+
+	controller, fakeClientSet, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	// --- User changes spec from 10C → 8C (shrink) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("8")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	// Verify API state
+	gotR, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Phase stays Available (no reschedule for shrink)
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName, "node should be unchanged")
+
+	// Allocatable updated to new spec value
+	wantCPU := resource.MustParse("8")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU: got %v, want 8", gotCPU.String())
+	wantMem := resource.MustParse("10Gi")
+	gotMem := gotR.Status.Allocatable[corev1.ResourceMemory]
+	assert.True(t, gotMem.Equal(wantMem), "allocatable Memory unchanged")
+
+	// Owner pods are NOT unbound — their reservation-allocated annotation is untouched
+	gotPod1, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod1", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod1.Annotations[apiext.AnnotationReservationAllocated],
+		"pod1 should still be bound to reservation")
+	gotPod2, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod2", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod2.Annotations[apiext.AnnotationReservationAllocated],
+		"pod2 should still be bound to reservation")
+}
+
+// TestReservationResizeScenario_Enlarge tests a complete enlarge scenario:
+// An Available reservation with 2 owner pods, user changes spec from 10C→14C.
+// Expected: phase stays Available, fake resize pod queued, allocatable unchanged,
+// owner pods NOT unbound.
+func TestReservationResizeScenario_Enlarge(t *testing.T) {
+	rUID := types.UID("scenario-enlarge-uid")
+	rName := "scenario-enlarge-r"
+	nodeName := "node1"
+
+	// Available reservation: spec=10C/10Gi, status.allocatable=10C/10Gi
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	// 2 owner pods allocated on this reservation
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "2", "2Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "3", "3Gi", rName, rUID)
+
+	controller, fakeClientSet, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	// Capture queued pods
+	var queuedPods []*corev1.Pod
+	controller.addToSchedulerQueueFn = func(pod *corev1.Pod) {
+		queuedPods = append(queuedPods, pod)
+	}
+
+	// --- User changes spec from 10C → 14C (enlarge) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("14")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	// Verify API state
+	gotR, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Phase stays Available (no phase change for enlarge)
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName, "node should be unchanged")
+
+	// Allocatable unchanged (Bind will update on success)
+	oldCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(oldCPU), "allocatable CPU should be unchanged: got %v, want 10", gotCPU.String())
+
+	// Fake resize pod should have been queued
+	assert.Len(t, queuedPods, 1, "should queue exactly 1 fake resize pod")
+	resizePod := queuedPods[0]
+	assert.Equal(t, "true", resizePod.Annotations[reservationutil.AnnotationReservationResizePod])
+	assert.Equal(t, string(rUID), resizePod.Annotations[reservationutil.AnnotationResizeTargetReservationUID])
+	assert.Equal(t, nodeName, resizePod.Annotations[reservationutil.AnnotationReservationNode])
+
+	// Owner pods are NOT unbound — their reservation-allocated annotation is untouched
+	gotPod1, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod1", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod1.Annotations[apiext.AnnotationReservationAllocated],
+		"pod1 should still be bound to reservation")
+	gotPod2, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod2", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod2.Annotations[apiext.AnnotationReservationAllocated],
+		"pod2 should still be bound to reservation")
+}
+
+// TestReservationResizeScenario_MixedResizeBelowAllocated tests that a mixed resize
+// (some resources enlarge, others shrink below allocated) is rejected.
+// Reservation has allocatable=10C/10Gi, allocated=8C/8Gi.
+// User changes spec to 14C/4Gi: CPU enlarges (14>10) but mem shrinks below allocated (4<8).
+// Expected: ResizeFailed set, allocatable unchanged, phase stays Available.
+func TestReservationResizeScenario_MixedResizeBelowAllocated(t *testing.T) {
+	rUID := types.UID("scenario-mixed-reject-uid")
+	rName := "scenario-mixed-reject-r"
+	nodeName := "node1"
+
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	reservation.Status.Allocated = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "4", "4Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "4", "4Gi", rName, rUID)
+
+	controller, fakeClientSet, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	// --- User changes spec from 10C/10Gi -> 14C/4Gi (CPU up, memory down below allocated 8Gi) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("14")
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("4Gi")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Phase stays Available
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName)
+
+	// Allocatable NOT updated -- still 10C/10Gi (mixed resize rejected)
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU should be unchanged: got %v, want 10", gotCPU.String())
+	wantMem := resource.MustParse("10Gi")
+	gotMem := gotR.Status.Allocatable[corev1.ResourceMemory]
+	assert.True(t, gotMem.Equal(wantMem), "allocatable Memory should be unchanged: got %v, want 10Gi", gotMem.String())
+
+	// ResizeFailed condition is set
+	assert.True(t, hasResizeFailedCondition(gotR), "should have ResizeFailed condition")
+
+	// Owner pods are NOT unbound
+	gotPod1, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod1", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod1.Annotations[apiext.AnnotationReservationAllocated],
+		"pod1 should still be bound to reservation")
+	gotPod2, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod2", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod2.Annotations[apiext.AnnotationReservationAllocated],
+		"pod2 should still be bound to reservation")
+}
+
+// TestReservationResizeScenario_ShrinkBelowAllocated tests that shrinking below
+// the current allocated amount is rejected with a ResizeFailed condition.
+// Reservation has allocatable=10C, allocated=8C (from owner pods), user shrinks spec to 6C.
+// Expected: ResizeFailed set, allocatable unchanged (still 10C), phase stays Available.
+func TestReservationResizeScenario_ShrinkBelowAllocated(t *testing.T) {
+	rUID := types.UID("scenario-shrink-reject-uid")
+	rName := "scenario-shrink-reject-r"
+	nodeName := "node1"
+
+	// Available reservation: spec=10C/10Gi, allocatable=10C/10Gi, allocated=8C/8Gi
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	reservation.Status.Allocated = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	// 2 owner pods: 4C+4C = 8C allocated total
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "4", "4Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "4", "4Gi", rName, rUID)
+
+	controller, fakeClientSet, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	// --- User changes spec from 10C → 6C (shrink below allocated 8C) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("6")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Phase stays Available — not rescheduled, not terminated
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName, "node should be unchanged")
+
+	// Allocatable NOT updated — still 10C (shrink rejected)
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU should be unchanged: got %v, want 10", gotCPU.String())
+
+	// ResizeFailed condition is set
+	assert.True(t, hasResizeFailedCondition(gotR), "should have ResizeFailed condition")
+
+	// Owner pods are NOT unbound
+	gotPod1, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod1", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod1.Annotations[apiext.AnnotationReservationAllocated],
+		"pod1 should still be bound to reservation")
+	gotPod2, _ := fakeClientSet.CoreV1().Pods("default").Get(context.TODO(), "pod2", metav1.GetOptions{})
+	assert.NotEmpty(t, gotPod2.Annotations[apiext.AnnotationReservationAllocated],
+		"pod2 should still be bound to reservation")
+}
+
+// TestReservationResizeScenario_ShrinkBelowAllocatedThenRetryWithNewSpec tests that
+// after a shrink is rejected (ResizeFailed set for target 6C), changing the spec to a
+// different valid target (8C >= allocated 8C) automatically clears ResizeFailed and retries.
+func TestReservationResizeScenario_ShrinkBelowAllocatedThenRetryWithNewSpec(t *testing.T) {
+	rUID := types.UID("scenario-retry-uid")
+	rName := "scenario-retry-r"
+	nodeName := "node1"
+
+	// State after a previous failed shrink to 6C:
+	// spec=6C, allocatable=10C, allocated=8C, ResizeFailed present with target=6C
+	reservation := newTestReservation(rName, rUID, nodeName, "6", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	reservation.Status.Allocated = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}
+	// ResizeFailed with target fingerprint for 6C/10Gi
+	failedTarget := allocatableFingerprint(corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("6"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	})
+	reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{Type: schedulingv1alpha1.ReservationConditionReady, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{
+			Type:    schedulingv1alpha1.ReservationConditionResizeFailed,
+			Status:  schedulingv1alpha1.ConditionStatusTrue,
+			Reason:  schedulingv1alpha1.ReasonReservationResizeFailed,
+			Message: "new allocatable is less than current allocated resources;" + failedTarget,
+		},
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "4", "4Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "4", "4Gi", rName, rUID)
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	// --- User changes spec from 6C → 8C (valid: 8C >= allocated 8C) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("8")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Shrink succeeded — allocatable updated to 8C
+	wantCPU := resource.MustParse("8")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU should be 8: got %v", gotCPU.String())
+
+	// ResizeFailed cleared after successful retry
+	assert.False(t, hasResizeFailedCondition(gotR), "ResizeFailed should be cleared after successful retry")
+
+	// Phase stays Available (shrink is in-place)
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName)
+}
+
+// TestReservationResizeScenario_ShrinkExactlyToAllocated tests shrinking to exactly
+// the current allocated amount — this should succeed (allocatable == allocated is valid).
+func TestReservationResizeScenario_ShrinkExactlyToAllocated(t *testing.T) {
+	rUID := types.UID("scenario-shrink-exact-uid")
+	rName := "scenario-shrink-exact-r"
+	nodeName := "node1"
+
+	// Available reservation: spec=10C/10Gi, allocatable=10C/10Gi, allocated=8C/8Gi
+	reservation := newTestReservation(rName, rUID, nodeName, "10", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	reservation.Status.Allocated = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		nil,
+	)
+
+	// --- User changes spec from 10C → 8C (exactly matches allocated) ---
+	reservation = reservation.DeepCopy()
+	reservation.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("8")
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+
+	// Should succeed — allocatable updated to 8C
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	wantCPU := resource.MustParse("8")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable CPU: got %v, want 8", gotCPU.String())
+
+	// No ResizeFailed — shrink to exactly allocated is allowed
+	assert.False(t, hasResizeFailedCondition(gotR), "should NOT have ResizeFailed")
+}
+
+// TestReservationResizeScenario_EnlargeWithPreviousResizeFailed tests that
+// a reservation with ResizeFailed condition skips resize even if spec changed.
+func TestReservationResizeScenario_EnlargeWithPreviousResizeFailed(t *testing.T) {
+	rUID := types.UID("scenario-failed-uid")
+	rName := "scenario-failed-r"
+	nodeName := "node1"
+
+	// spec=14C (user wants 14C), allocatable=10C (still old), ResizeFailed present with same target
+	reservation := newTestReservation(rName, rUID, nodeName, "14", "10Gi", "10", "10Gi")
+	// Build the target fingerprint that matches computeNewAllocatable for spec=14C/10Gi
+	failedTarget := allocatableFingerprint(corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("14"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	})
+	reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{Type: schedulingv1alpha1.ReservationConditionReady, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{
+			Type:    schedulingv1alpha1.ReservationConditionResizeFailed,
+			Status:  schedulingv1alpha1.ConditionStatusTrue,
+			Reason:  schedulingv1alpha1.ReasonReservationResizeFailed,
+			Message: "previous failure;" + failedTarget,
+		},
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		nil,
+	)
+
+	// Capture queued pods to verify resize is skipped
+	var queuedPods []*corev1.Pod
+	controller.addToSchedulerQueueFn = func(pod *corev1.Pod) {
+		queuedPods = append(queuedPods, pod)
+	}
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+	// Should remain Available, not reset to Pending (skip resize)
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+	assert.Equal(t, nodeName, gotR.Status.NodeName, "should stay on same node")
+	// Allocatable unchanged
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable should be unchanged")
+	// ResizeFailed still present
+	assert.True(t, hasResizeFailedCondition(gotR), "ResizeFailed should still be present")
+	// No fake resize pod should have been queued (resize skipped)
+	assert.Empty(t, queuedPods, "should NOT queue any resize pod when ResizeFailed is present")
+}
+
+// ==================== ResizeFailed Fingerprint Utility Tests ====================
+
+func TestAllocatableFingerprint(t *testing.T) {
+	t.Run("single resource", func(t *testing.T) {
+		rl := corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("4"),
+		}
+		fp := allocatableFingerprint(rl)
+		assert.Equal(t, "cpu=4", fp)
+	})
+
+	t.Run("multiple resources sorted", func(t *testing.T) {
+		rl := corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+			corev1.ResourceCPU:    resource.MustParse("4"),
+		}
+		fp := allocatableFingerprint(rl)
+		// Must be sorted alphabetically: cpu before memory
+		assert.Equal(t, "cpu=4,memory=8Gi", fp)
+	})
+
+	t.Run("deterministic across calls", func(t *testing.T) {
+		rl := corev1.ResourceList{
+			corev1.ResourceMemory:           resource.MustParse("16Gi"),
+			corev1.ResourceCPU:              resource.MustParse("8"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+		}
+		fp1 := allocatableFingerprint(rl)
+		fp2 := allocatableFingerprint(rl)
+		assert.Equal(t, fp1, fp2, "fingerprint must be deterministic")
+	})
+
+	t.Run("empty resource list", func(t *testing.T) {
+		fp := allocatableFingerprint(corev1.ResourceList{})
+		assert.Equal(t, "", fp)
+	})
+}
+
+func TestEncodeResizeFailedMessage(t *testing.T) {
+	target := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("6"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	}
+	msg := EncodeResizeFailedMessage("shrink below allocated", target)
+	assert.Contains(t, msg, "shrink below allocated;")
+	assert.Contains(t, msg, "cpu=6")
+	assert.Contains(t, msg, "memory=10Gi")
+
+	// Verify format: "reason;fingerprint"
+	parts := strings.SplitN(msg, ";", 2)
+	assert.Len(t, parts, 2)
+	assert.Equal(t, "shrink below allocated", parts[0])
+	assert.Equal(t, allocatableFingerprint(target), parts[1])
+}
+
+func TestGetResizeFailedTarget(t *testing.T) {
+	t.Run("extracts target from Message", func(t *testing.T) {
+		r := &schedulingv1alpha1.Reservation{
+			Status: schedulingv1alpha1.ReservationStatus{
+				Conditions: []schedulingv1alpha1.ReservationCondition{
+					{
+						Type:    schedulingv1alpha1.ReservationConditionResizeFailed,
+						Status:  schedulingv1alpha1.ConditionStatusTrue,
+						Message: "some reason;cpu=6,memory=10Gi",
+					},
+				},
+			},
+		}
+		got := getResizeFailedTarget(r)
+		assert.Equal(t, "cpu=6,memory=10Gi", got)
+	})
+
+	t.Run("no ResizeFailed condition", func(t *testing.T) {
+		r := &schedulingv1alpha1.Reservation{
+			Status: schedulingv1alpha1.ReservationStatus{
+				Conditions: []schedulingv1alpha1.ReservationCondition{
+					{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+				},
+			},
+		}
+		got := getResizeFailedTarget(r)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("Message without semicolon (legacy format)", func(t *testing.T) {
+		r := &schedulingv1alpha1.Reservation{
+			Status: schedulingv1alpha1.ReservationStatus{
+				Conditions: []schedulingv1alpha1.ReservationCondition{
+					{
+						Type:    schedulingv1alpha1.ReservationConditionResizeFailed,
+						Status:  schedulingv1alpha1.ConditionStatusTrue,
+						Message: "old message without target",
+					},
+				},
+			},
+		}
+		got := getResizeFailedTarget(r)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("roundtrip with encodeResizeFailedMessage", func(t *testing.T) {
+		target := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("16Gi"),
+		}
+		r := &schedulingv1alpha1.Reservation{}
+		setResizeFailedCondition(r, "test reason", target)
+
+		got := getResizeFailedTarget(r)
+		want := allocatableFingerprint(target)
+		assert.Equal(t, want, got, "roundtrip: encode then extract should match fingerprint")
+	})
+}
+
+// ==================== ResizeFailed Condition Lifecycle Scenario Tests ====================
+
+// TestReservationResizeScenario_ManualDeleteConditionRetriggers tests that manually
+// deleting the ResizeFailed condition causes the controller to re-evaluate and re-reject
+// (for the same invalid shrink) — proving the system is safe against condition deletion.
+func TestReservationResizeScenario_ManualDeleteConditionRetriggers(t *testing.T) {
+	rUID := types.UID("scenario-manual-delete-uid")
+	rName := "scenario-manual-delete-r"
+	nodeName := "node1"
+
+	// spec=6C, allocatable=10C, allocated=8C — same invalid shrink, but NO ResizeFailed
+	// (user manually deleted it)
+	reservation := newTestReservation(rName, rUID, nodeName, "6", "10Gi", "10", "10Gi")
+	reservation.Spec.TTL = &metav1.Duration{Duration: 10 * time.Minute}
+	reservation.Status.Allocated = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("8"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}
+	// No ResizeFailed condition — simulates manual deletion
+	reservation.Status.Conditions = []schedulingv1alpha1.ReservationCondition{
+		{Type: schedulingv1alpha1.ReservationConditionScheduled, Status: schedulingv1alpha1.ConditionStatusTrue},
+		{Type: schedulingv1alpha1.ReservationConditionReady, Status: schedulingv1alpha1.ConditionStatusTrue},
+	}
+	node := newTestNode(nodeName, "32", "64Gi")
+
+	ownerPod1 := newTestPod("pod1", "default", nodeName, "4", "4Gi", rName, rUID)
+	ownerPod2 := newTestPod("pod2", "default", nodeName, "4", "4Gi", rName, rUID)
+
+	controller, _, fakeKoordClientSet := setupResizeTestController(t,
+		[]*corev1.Node{node},
+		[]*schedulingv1alpha1.Reservation{reservation},
+		[]*corev1.Pod{ownerPod1, ownerPod2},
+	)
+
+	err := controller.syncReservationResize(reservation)
+	assert.NoError(t, err)
+
+	gotR, _ := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Get(context.TODO(), rName, metav1.GetOptions{})
+
+	// Re-evaluated and re-rejected: ResizeFailed set again
+	assert.True(t, hasResizeFailedCondition(gotR), "ResizeFailed should be re-set after manual deletion")
+
+	// Allocatable unchanged
+	wantCPU := resource.MustParse("10")
+	gotCPU := gotR.Status.Allocatable[corev1.ResourceCPU]
+	assert.True(t, gotCPU.Equal(wantCPU), "allocatable should remain 10C")
+
+	// Phase stays Available
+	assert.Equal(t, schedulingv1alpha1.ReservationAvailable, gotR.Status.Phase)
+
+	// Verify the new ResizeFailed has the correct target fingerprint
+	target := getResizeFailedTarget(gotR)
+	expectedTarget := allocatableFingerprint(corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("6"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	})
+	assert.Equal(t, expectedTarget, target, "ResizeFailed should record the failed target fingerprint")
+}
+
+// TestHandleReservationResize_LockRollbackOnAPIFailure verifies that when the API call
+// fails after locking, the lock is rolled back so the reservation remains matchable.
+func TestHandleReservationResize_LockRollbackOnAPIFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		specCPU   string // spec template CPU → determines shrink/enlarge vs status
+		statusCPU string // current status.allocatable CPU
+		allocCPU  string // current status.allocated CPU (for isBelowAllocated)
+		nodeCPU   string
+		failVerb  string // which verb to fail: "update" (for UpdateStatus) or "update" on reservations
+	}{
+		{
+			name:      "shrink rejected (isBelowAllocated) - UpdateStatus fails, lock rolled back",
+			specCPU:   "6",
+			statusCPU: "10",
+			allocCPU:  "8", // 6 < 8 → isBelowAllocated → setResizeFailedCondition → UpdateStatus
+			nodeCPU:   "32",
+			failVerb:  "update",
+		},
+		{
+			name:      "shrink in-place - UpdateStatus fails, lock rolled back",
+			specCPU:   "8",
+			statusCPU: "10",
+			allocCPU:  "5", // 8 > 5 → not below allocated → resizeReservationInPlace → UpdateStatus
+			nodeCPU:   "32",
+			failVerb:  "update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rUID := types.UID("lock-test-uid")
+			rName := "lock-test-reservation"
+			nodeName := "node1"
+
+			reservation := newTestReservation(rName, rUID, nodeName, tt.specCPU, "10Gi", tt.statusCPU, "10Gi")
+			if tt.allocCPU != "" {
+				reservation.Status.Allocated = corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(tt.allocCPU),
+					corev1.ResourceMemory: resource.MustParse("5Gi"),
+				}
+			}
+			node := newTestNode(nodeName, tt.nodeCPU, "64Gi")
+
+			lock := newTrackingResizeLock()
+			controller, _, fakeKoordClientSet := setupResizeTestControllerWithLock(t,
+				[]*corev1.Node{node},
+				[]*schedulingv1alpha1.Reservation{reservation},
+				nil,
+				lock,
+			)
+
+			// Inject API failure for UpdateStatus on reservations
+			injectedErr := fmt.Errorf("injected API error")
+			fakeKoordClientSet.PrependReactor(tt.failVerb, "reservations", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, injectedErr
+			})
+
+			err := controller.handleReservationResize(reservation)
+			assert.Error(t, err, "handleReservationResize should return error on API failure")
+
+			// Lock must be rolled back (unlocked)
+			assert.False(t, lock.isLocked(rUID),
+				"lock should be rolled back after API failure")
+			assert.Equal(t, 1, len(lock.lockLog), "should have locked once")
+			assert.Equal(t, 1, len(lock.unlockLog), "should have unlocked once (rollback)")
+		})
+	}
+}
+
+// TestHandleReservationResize_LockCommittedOnSuccess verifies that when the API call
+// succeeds, the lock is NOT rolled back (committed=true, defer is a no-op).
+func TestHandleReservationResize_LockCommittedOnSuccess(t *testing.T) {
+	tests := []struct {
+		name      string
+		specCPU   string
+		statusCPU string
+		allocCPU  string
+		nodeCPU   string
+	}{
+		{
+			name:      "shrink rejected (isBelowAllocated) - UpdateStatus succeeds, lock committed",
+			specCPU:   "6",
+			statusCPU: "10",
+			allocCPU:  "8",
+			nodeCPU:   "32",
+		},
+		{
+			name:      "shrink in-place - UpdateStatus succeeds, lock committed",
+			specCPU:   "8",
+			statusCPU: "10",
+			allocCPU:  "5",
+			nodeCPU:   "32",
+		},
+		{
+			name:      "enlarge - lock committed, fake pod queued",
+			specCPU:   "14",
+			statusCPU: "10",
+			allocCPU:  "5",
+			nodeCPU:   "32",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rUID := types.UID("commit-test-uid")
+			rName := "commit-test-reservation"
+			nodeName := "node1"
+
+			reservation := newTestReservation(rName, rUID, nodeName, tt.specCPU, "10Gi", tt.statusCPU, "10Gi")
+			if tt.allocCPU != "" {
+				reservation.Status.Allocated = corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(tt.allocCPU),
+					corev1.ResourceMemory: resource.MustParse("5Gi"),
+				}
+			}
+			node := newTestNode(nodeName, tt.nodeCPU, "64Gi")
+
+			lock := newTrackingResizeLock()
+			controller, _, _ := setupResizeTestControllerWithLock(t,
+				[]*corev1.Node{node},
+				[]*schedulingv1alpha1.Reservation{reservation},
+				nil,
+				lock,
+			)
+
+			// Capture queued pods for enlarge verification
+			var queuedPods []*corev1.Pod
+			controller.addToSchedulerQueueFn = func(pod *corev1.Pod) {
+				queuedPods = append(queuedPods, pod)
+			}
+
+			err := controller.handleReservationResize(reservation)
+			assert.NoError(t, err, "handleReservationResize should succeed")
+
+			// Lock should NOT be rolled back — committed=true
+			assert.True(t, lock.isLocked(rUID),
+				"lock should remain held after successful API call (event handler will unlock)")
+			assert.Equal(t, 1, len(lock.lockLog), "should have locked once")
+			assert.Equal(t, 0, len(lock.unlockLog), "should not have unlocked (committed)")
+
+			// For enlarge, a fake resize pod should have been queued (no API UpdateStatus)
+			if tt.specCPU == "14" {
+				assert.Len(t, queuedPods, 1, "enlarge should queue a fake resize pod")
+			} else {
+				assert.Empty(t, queuedPods, "shrink should not queue any pod")
+			}
+		})
+	}
 }

--- a/pkg/scheduler/plugins/reservation/controller/garbage_collection.go
+++ b/pkg/scheduler/plugins/reservation/controller/garbage_collection.go
@@ -52,6 +52,13 @@ func (c *Controller) gcReservations() {
 			}
 		}
 	}
+
+	// Periodically clean up stale resize locks as a safety net.
+	if c.resizeLock != nil {
+		if cleaned := c.resizeLock.CleanStaleLocks(); cleaned > 0 {
+			klog.V(3).InfoS("Cleaned stale resize locks during GC", "count", cleaned)
+		}
+	}
 }
 
 func missingNode(reservation *schedulingv1alpha1.Reservation, nodeLister corelister.NodeLister) bool {

--- a/pkg/scheduler/plugins/reservation/controller/garbage_collection_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/garbage_collection_test.go
@@ -122,7 +122,7 @@ func TestGC(t *testing.T) {
 	_, err := fakeClientSet.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	sharedInformerFactory.Start(nil)
 	koordSharedInformerFactory.Start(nil)

--- a/pkg/scheduler/plugins/reservation/controller/node_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/node_eventhandler_test.go
@@ -54,7 +54,7 @@ func newNodeEventHandlerController(t *testing.T, reservations ...*schedulingv1al
 	err := indexer.AddIndexers(koordSharedInformerFactory)
 	assert.NoError(t, err)
 
-	c := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	c := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	stopCh := make(chan struct{})
 	t.Cleanup(func() { close(stopCh) })
@@ -154,7 +154,7 @@ func TestOnNodeDelete_IndexerNotRegistered(t *testing.T) {
 	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
 
 	// intentionally skip indexer.AddIndexers so ByIndex returns an error
-	c := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	c := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 
 	stopCh := make(chan struct{})
 	t.Cleanup(func() { close(stopCh) })

--- a/pkg/scheduler/plugins/reservation/controller/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/pod_eventhandler_test.go
@@ -39,7 +39,7 @@ func newTestController(t *testing.T) *Controller {
 	fakeKoordClientSet := koordfake.NewSimpleClientset()
 	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
-	return New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	return New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{}, &noopResizeLock{}, nil)
 }
 
 func podWithReservation(uid, name, ns, nodeName, rName, rUID string) *corev1.Pod {

--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -67,6 +67,10 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 	if reservationutil.IsReservationActive(newR) {
 		h.cache.updateReservation(newR)
+		// Unlock if this reservation was locked for resize. For non-resize updates
+		// (not in lockedForResize), this is a no-op. For resize completions (shrink
+		// done, or enlarge Bind/PostFilter done), this restores matchableOnNode.
+		h.cache.unlockReservationAfterResize(newR.UID, newR.Status.NodeName)
 		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(newR))
 		klog.V(4).InfoS("update reservation into reservationCache",
 			"reservation", klog.KObj(newR), "uid", newR.UID, "node", reservationutil.GetReservationNodeName(newR))
@@ -98,6 +102,11 @@ func (h *reservationEventHandler) OnDelete(obj interface{}) {
 		return
 	}
 	h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(r))
+
+	// Clean up any resize lock held for this reservation. If the reservation is
+	// deleted while a resize is in progress, the lockedForResize entry would
+	// otherwise remain orphaned until scheduler restart.
+	h.cache.unlockReservationAfterResize(r.UID, r.Status.NodeName)
 
 	// Here it is only marked that ReservationInfo is unavailable,
 	// and the real deletion operation is executed in deleteReservationFromCache(pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go).

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -163,12 +163,19 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 func (pl *Plugin) Name() string { return Name }
 
 func (pl *Plugin) NewControllers() ([]frameworkext.Controller, error) {
+	// Create the addToSchedulerQueueFn closure that adds pods to the scheduler's scheduling queue.
+	// This is used by the controller to enqueue fake resize pods for scheduler validation.
+	addToQueueFn := func(pod *corev1.Pod) {
+		pl.handle.Scheduler().GetSchedulingQueue().Add(klog.Background(), pod)
+	}
 	reservationController := controller.New(
 		pl.handle.SharedInformerFactory(),
 		pl.handle.KoordinatorSharedInformerFactory(),
 		pl.handle.ClientSet(),
 		pl.handle.KoordinatorClientSet(),
-		pl.args)
+		pl.args,
+		pl.reservationCache,
+		addToQueueFn)
 	return []frameworkext.Controller{reservationController}, nil
 }
 
@@ -1024,6 +1031,12 @@ func fitsReservation(podRequest corev1.ResourceList, rInfo *frameworkext.Reserva
 
 func (pl *Plugin) PostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) (*fwktype.PostFilterResult, *fwktype.Status) {
 	var result *fwktype.PostFilterResult
+	// Handle resize scheduling failure: if the fake resize pod fails to schedule,
+	// set ResizeFailed condition on the reservation and unlock.
+	if reservationutil.IsResizePod(pod) {
+		return pl.handleResizeSchedulingFailure(ctx, pod, filteredNodeStatusMap)
+	}
+
 	var reasons []string
 
 	// If Reservation Preemption is enabled, try preemption before aggregating failure reasons.
@@ -1158,6 +1171,103 @@ func (pl *Plugin) FilterReservation(ctx context.Context, cycleState fwktype.Cycl
 	return nil
 }
 
+// handleResizeSchedulingFailure handles the case where a resizing reservation's reserve pod
+// fails to schedule (insufficient resources on the pinned node). It restores the reservation
+// to Available state on the original node with a ResizeFailed condition via a single UpdateStatus.
+// No Update call is needed because no annotations or spec fields were modified during resize.
+func (pl *Plugin) handleResizeSchedulingFailure(ctx context.Context, resizePod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) (*fwktype.PostFilterResult, *fwktype.Status) {
+	rName := reservationutil.GetReservationNameFromReservePod(resizePod)
+	klog.V(3).InfoS("Handling resize scheduling failure, setting ResizeFailed on reservation",
+		"resizePod", klog.KObj(resizePod), "reservation", rName)
+
+	r, err := pl.rLister.Get(rName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Reservation was deleted while the fake resize pod was in the scheduling queue.
+			// This is expected in the delete-during-resize race window. Just discard the pod.
+			klog.V(3).InfoS("Reservation not found during resize failure handling, likely deleted; discarding resize pod",
+				"resizePod", klog.KObj(resizePod), "reservation", rName)
+			// Clean up the orphaned lock entry from lockedForResize map.
+			if targetUID := reservationutil.GetResizeTargetReservationUID(resizePod); targetUID != "" {
+				pl.reservationCache.UnlockReservationForResize(targetUID, reservationutil.GetReservePodNodeName(resizePod))
+			}
+			return nil, fwktype.NewStatus(fwktype.Unschedulable, "reservation deleted during resize")
+		}
+		klog.ErrorS(err, "Failed to get reservation for resize failure handling", "reservation", rName)
+		return nil, fwktype.AsStatus(err)
+	}
+
+	// Get pinned node from the resize pod annotation
+	pinnedNode := reservationutil.GetReservePodNodeName(resizePod)
+	var failureMessage string
+	if pinnedNode != "" {
+		if nodeStatus := filteredNodeStatusMap.Get(pinnedNode); nodeStatus != nil && len(nodeStatus.Reasons()) > 0 {
+			failureMessage = fmt.Sprintf("resize failed on node %s: %s", pinnedNode, strings.Join(nodeStatus.Reasons(), "; "))
+		} else {
+			failureMessage = fmt.Sprintf("resize failed: pinned node %s not available", pinnedNode)
+		}
+	} else {
+		failureMessage = "resize failed: no pinned node found in resize pod annotations"
+	}
+
+	// Compute the target allocatable for the ResizeFailed fingerprint
+	var targetAllocatable corev1.ResourceList
+	if r.Spec.Template != nil {
+		targetAllocatable = resourceapi.PodRequests(&corev1.Pod{
+			Spec: r.Spec.Template.Spec,
+		}, resourceapi.PodResourcesOptions{})
+	}
+
+	err = util.RetryOnConflictOrTooManyRequests(func() error {
+		latest, err := pl.rLister.Get(rName)
+		if err != nil {
+			return err
+		}
+		latest = latest.DeepCopy()
+
+		// Set ResizeFailed condition on the reservation (reservation stays Available)
+		now := metav1.Now()
+		// Remove any existing ResizeFailed condition and add the new one
+		filtered := make([]schedulingv1alpha1.ReservationCondition, 0, len(latest.Status.Conditions))
+		for _, c := range latest.Status.Conditions {
+			if c.Type != schedulingv1alpha1.ReservationConditionResizeFailed {
+				filtered = append(filtered, c)
+			}
+		}
+		filtered = append(filtered, schedulingv1alpha1.ReservationCondition{
+			Type:               schedulingv1alpha1.ReservationConditionResizeFailed,
+			Status:             schedulingv1alpha1.ConditionStatusTrue,
+			Reason:             schedulingv1alpha1.ReasonReservationResizeFailed,
+			Message:            controller.EncodeResizeFailedMessage(failureMessage, targetAllocatable),
+			LastProbeTime:      now,
+			LastTransitionTime: now,
+		})
+		latest.Status.Conditions = filtered
+
+		_, err = pl.client.Reservations().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		if err != nil {
+			klog.ErrorS(err, "Failed to set ResizeFailed condition on reservation",
+				"reservation", klog.KObj(latest), "uid", latest.UID)
+			return err
+		}
+
+		klog.V(3).InfoS("Successfully set ResizeFailed condition after resize scheduling failure",
+			"reservation", klog.KObj(latest), "uid", latest.UID,
+			"node", latest.Status.NodeName, "reason", failureMessage)
+		return nil
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to handle resize scheduling failure", "reservation", rName)
+		return nil, fwktype.AsStatus(err)
+	}
+
+	// Unlock the reservation so it becomes matchable again
+	pl.reservationCache.UnlockReservationForResize(r.UID, r.Status.NodeName)
+
+	// Return Unschedulable to tell the scheduler not to proceed with preemption logic
+	return nil, fwktype.NewStatus(fwktype.Unschedulable,
+		fmt.Sprintf("reservation resize failed: %s", failureMessage))
+}
 func (pl *Plugin) FilterNominateReservation(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, rInfo *frameworkext.ReservationInfo, nodeName string) *fwktype.Status {
 	// TODO(joseph): We can consider optimizing these codes. It seems that there is no need to exist at present.
 	if rInfo.IsAllocateOnce() && rInfo.GetAllocatedPods() > 0 {
@@ -1570,6 +1680,12 @@ func (pl *Plugin) Bind(ctx context.Context, cycleState fwktype.CycleState, pod *
 		return fwktype.NewStatus(fwktype.Skip)
 	}
 
+	// Handle fake resize pod: update the reservation's allocatable to the new size
+	// and forget the fake pod from the scheduler cache.
+	if reservationutil.IsResizePod(pod) {
+		return pl.bindResizePod(ctx, pod, nodeName)
+	}
+
 	rName := reservationutil.GetReservationNameFromReservePod(pod)
 	klog.V(4).InfoS("Attempting to bind reservation to node", "pod", klog.KObj(pod), "reservation", rName, "node", nodeName)
 
@@ -1603,6 +1719,76 @@ func (pl *Plugin) Bind(ctx context.Context, cycleState fwktype.CycleState, pod *
 	}
 
 	pl.handle.EventRecorder().Eventf(reservation, nil, corev1.EventTypeNormal, "Scheduled", "Binding", "Successfully assigned %v to %v", rName, nodeName)
+	return nil
+}
+
+// bindResizePod handles the Bind phase for a fake resize pod.
+// It updates the reservation's status.allocatable to the new (enlarged) size,
+// then forgets the fake resize pod from the scheduler cache.
+// The reservation stays Available throughout - no phase change needed.
+func (pl *Plugin) bindResizePod(ctx context.Context, resizePod *corev1.Pod, nodeName string) *fwktype.Status {
+	rName := reservationutil.GetReservationNameFromReservePod(resizePod)
+	targetUID := reservationutil.GetResizeTargetReservationUID(resizePod)
+	klog.V(3).InfoS("Binding fake resize pod: updating reservation allocatable",
+		"resizePod", klog.KObj(resizePod), "reservation", rName, "node", nodeName)
+
+	// Compute the new allocatable from the resize pod's resources
+	newAllocatable := resourceapi.PodRequests(resizePod, resourceapi.PodResourcesOptions{})
+
+	var reservation *schedulingv1alpha1.Reservation
+	err := util.RetryOnConflictOrTooManyRequests(func() error {
+		var err error
+		reservation, err = pl.rLister.Get(rName)
+		if err != nil {
+			return err
+		}
+		if reservationutil.IsReservationFailed(reservation) {
+			return errors.New(ErrReasonReservationInactive)
+		}
+
+		reservation = reservation.DeepCopy()
+		// Update allocatable to the new size
+		reservation.Status.Allocatable = newAllocatable
+		// Clear any ResizeFailed condition since resize succeeded
+		filtered := make([]schedulingv1alpha1.ReservationCondition, 0, len(reservation.Status.Conditions))
+		for _, c := range reservation.Status.Conditions {
+			if c.Type != schedulingv1alpha1.ReservationConditionResizeFailed {
+				filtered = append(filtered, c)
+			}
+		}
+		reservation.Status.Conditions = filtered
+
+		_, err = pl.client.Reservations().UpdateStatus(ctx, reservation, metav1.UpdateOptions{})
+		if err != nil {
+			klog.V(4).ErrorS(err, "Failed to update reservation allocatable for resize",
+				"reservation", klog.KObj(reservation))
+		}
+		return err
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to bind resize pod", "reservation", rName)
+		// Bind failed after all retries. Explicitly unlock the reservation so it becomes
+		// matchable again. The controller's next resync will detect that spec still differs
+		// from allocatable and re-trigger the resize flow.
+		if targetUID != "" {
+			pl.reservationCache.UnlockReservationForResize(targetUID, reservationutil.GetReservePodNodeName(resizePod))
+		}
+		return fwktype.AsStatus(err)
+	}
+
+	// Forget the fake resize pod from the scheduler cache.
+	// The reservation update event will trigger updateReservationInSchedulerCache
+	// which adjusts the real ReservePod's resources in NodeInfo.
+	if err := pl.handle.ForgetPod(klog.Background(), resizePod); err != nil {
+		klog.ErrorS(err, "Failed to forget fake resize pod from cache",
+			"resizePod", klog.KObj(resizePod), "reservation", rName)
+	}
+
+	klog.V(3).InfoS("Successfully bound resize pod: reservation allocatable updated",
+		"reservation", rName, "targetUID", targetUID, "node", nodeName,
+		"newAllocatable", newAllocatable)
+	pl.handle.EventRecorder().Eventf(reservation, nil, corev1.EventTypeNormal, "Resized", "Binding",
+		"Successfully resized reservation %v on %v", rName, nodeName)
 	return nil
 }
 

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -342,6 +342,35 @@ func (pl *Plugin) prepareMatchReservationStateForReservePod(ctx context.Context,
 		skipRestoreNodeInfo = hintState.SkipRestoreNodeInfo
 	}
 
+	// Detect resize: if this pod is a fake resize pod, we need to subtract
+	// the owner pods' resources from NodeInfo on the pinned node. The resizing
+	// reservation is locked (removed from matchableOnNode) so
+	// ForEachMatchableReservationOnNode won't find it; we add it to unmatched manually.
+	isResize := reservationutil.IsResizePod(pod)
+	var resizingRInfo *frameworkext.ReservationInfo
+	var resizePinnedNode string
+	if isResize {
+		resizePinnedNode = pod.Annotations[reservationutil.AnnotationReservationNode]
+		targetUID := reservationutil.GetResizeTargetReservationUID(pod)
+		resizingRInfo = pl.reservationCache.getReservationInfoByUID(targetUID)
+		// Ensure the pinned node is in allNodes so processNode runs for it
+		if resizePinnedNode != "" && !hasHint {
+			found := false
+			for _, n := range allNodes {
+				if n == resizePinnedNode {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allNodes = append(allNodes, resizePinnedNode)
+			}
+		}
+		klog.V(4).InfoS("Detected resize pod, will subtract owner pod resources",
+			"pod", klog.KObj(pod), "reservation", rName, "pinnedNode", resizePinnedNode,
+			"hasResizingRInfo", resizingRInfo != nil)
+	}
+
 	preAllocationMode := schedulingv1alpha1.PreAllocationModeDefault
 	preAllocatableCandidatesOnNode := map[string][]*corev1.Pod{}
 	extender, _ := pl.handle.(frameworkext.FrameworkExtender)
@@ -419,6 +448,7 @@ func (pl *Plugin) prepareMatchReservationStateForReservePod(ctx context.Context,
 		}
 
 		var unmatched []*frameworkext.ReservationInfo
+		var matchedOrIgnored []*frameworkext.ReservationInfo
 		diagnosisState := &nodeDiagnosisState{
 			nodeName:                 nodeName,
 			ignored:                  0,
@@ -441,6 +471,35 @@ func (pl *Plugin) prepareMatchReservationStateForReservePod(ctx context.Context,
 			klog.ErrorS(err, "Failed to forEach reservations on node", "pod", klog.KObj(pod), "node", nodeName)
 			errCh.SendErrorWithCancel(err, cancel)
 			return
+		}
+
+		// For resize: remove the old ReservePod from NodeInfo and subtract owner pod resources.
+		// The reservation is locked (removed from matchableOnNode) during resize, so
+		// ForEachMatchableReservationOnNode won't find it. We add it to:
+		//   - matchedOrIgnored: so restoreMatchedReservation calls RemovePod to remove the old
+		//     ReservePod from NodeInfo (frees the old allocatable resources)
+		//   - unmatched: so restoreUnmatchedReservations subtracts owner pod allocated resources
+		//     (corrects double-counting of owner pods that are listed separately in NodeInfo)
+		// Together, this clears ALL reservation-related resources from NodeInfo, allowing the
+		// fake resize pod (with new allocatable) to be accurately validated against the node.
+		// This follows the same pattern as Pod InPlace Update (BeforePreFilter removes target pod).
+		if isResize && nodeName == resizePinnedNode && resizingRInfo != nil {
+			matchedOrIgnored = append(matchedOrIgnored, resizingRInfo.Clone())
+			if resizingRInfo.GetAllocatedPods() > 0 {
+				alreadyPresent := false
+				for _, u := range unmatched {
+					if u.UID() == resizingRInfo.UID() {
+						alreadyPresent = true
+						break
+					}
+				}
+				if !alreadyPresent {
+					unmatched = append(unmatched, resizingRInfo.Clone())
+				}
+			}
+			klog.V(5).InfoS("Added resizing reservation for resource restoration",
+				"pod", klog.KObj(pod), "node", nodeName, "reservation", resizingRInfo.GetName(),
+				"allocatedPods", resizingRInfo.GetAllocatedPods())
 		}
 
 		// handle pre-allocation
@@ -468,7 +527,7 @@ func (pl *Plugin) prepareMatchReservationStateForReservePod(ctx context.Context,
 			allNodeDiagnosisStates[idx-1] = diagnosisState
 		}
 
-		if len(unmatched) == 0 && len(preAllocatablePods) == 0 {
+		if len(unmatched) == 0 && len(matchedOrIgnored) == 0 && len(preAllocatablePods) == 0 {
 			return
 		}
 
@@ -479,7 +538,7 @@ func (pl *Plugin) prepareMatchReservationStateForReservePod(ctx context.Context,
 
 		nodeRState := &nodeReservationState{
 			nodeName:           nodeName,
-			matchedOrIgnored:   nil,
+			matchedOrIgnored:   matchedOrIgnored,
 			unmatched:          unmatched,
 			preAllocatablePods: preAllocatablePods,
 		}

--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -50,6 +50,14 @@ const (
 	AnnotationReservationNode = extension.SchedulingDomainPrefix + "/reservation-node"
 	// AnnotationReservationResizeAllocatable indicates the desired allocatable are to be updated.
 	AnnotationReservationResizeAllocatable = extension.SchedulingDomainPrefix + "/reservation-resize-allocatable"
+	// AnnotationReservationResizePod marks a pod as a fake resize pod used for scheduler validation.
+	// The fake resize pod has a new UID and the new resource requirements, and is scheduled
+	// through the standard cycle to validate that the node can fit the enlarged reservation.
+	// This is an internal protocol annotation, not exposed to users.
+	AnnotationReservationResizePod = extension.InternalSchedulingDomainPrefix + "/reservation-resize-pod"
+	// AnnotationResizeTargetReservationUID stores the UID of the reservation being resized.
+	// This is an internal protocol annotation, not exposed to users.
+	AnnotationResizeTargetReservationUID = extension.InternalSchedulingDomainPrefix + "/resize-target-reservation-uid"
 	// AnnotationIsPreAllocation indicates whether the pod is a reserve pod and enables the pre-allocation.
 	AnnotationIsPreAllocation = extension.SchedulingDomainPrefix + "/is-pre-allocation"
 )
@@ -247,6 +255,21 @@ func IsReservationFailed(r *schedulingv1alpha1.Reservation) bool {
 	return r != nil && r.Status.Phase == schedulingv1alpha1.ReservationFailed
 }
 
+// IsResizePod checks if the pod is a fake resize pod used for scheduler validation
+// during reservation enlarge. The fake resize pod has a new UID and the new resource
+// requirements, similar to the inplace-update pattern for pod resizing.
+func IsResizePod(pod *corev1.Pod) bool {
+	return pod != nil && pod.Annotations != nil && pod.Annotations[AnnotationReservationResizePod] == "true"
+}
+
+// GetResizeTargetReservationUID returns the UID of the target reservation from a resize pod.
+func GetResizeTargetReservationUID(pod *corev1.Pod) types.UID {
+	if pod == nil || pod.Annotations == nil {
+		return ""
+	}
+	return types.UID(pod.Annotations[AnnotationResizeTargetReservationUID])
+}
+
 func IsReservationExpired(r *schedulingv1alpha1.Reservation) bool {
 	if r == nil || r.Status.Phase != schedulingv1alpha1.ReservationFailed {
 		return false
@@ -401,6 +424,34 @@ func ReservationRequests(r *schedulingv1alpha1.Reservation) corev1.ResourceList 
 		return requests
 	}
 	return nil
+}
+
+// IsReservationSpecResourcesChanged checks if the spec template resources of an Available reservation
+// have changed compared to its current status.allocatable. This is used to detect if a user has modified
+// the reservation's spec resources and a re-scheduling is needed.
+func IsReservationSpecResourcesChanged(r *schedulingv1alpha1.Reservation) bool {
+	if !IsReservationAvailable(r) {
+		return false
+	}
+	var newSpecRequests corev1.ResourceList
+	if r.Spec.Template != nil {
+		newSpecRequests = resource.PodRequests(&corev1.Pod{
+			Spec: r.Spec.Template.Spec,
+		}, resource.PodResourcesOptions{})
+	}
+	// Compare using the union of resource names from both spec and allocatable.
+	// This detects three kinds of changes:
+	//   1. Quantity change for an existing resource (e.g. cpu: 4 -> 8)
+	//   2. New resource added in spec but absent from allocatable (e.g. add gpu)
+	//   3. Resource removed from spec but still in allocatable (including nil template)
+	allNames := quotav1.ResourceNames(newSpecRequests)
+	for name := range r.Status.Allocatable {
+		allNames = append(allNames, name)
+	}
+	return !quotav1.Equals(
+		quotav1.Mask(newSpecRequests, allNames),
+		quotav1.Mask(r.Status.Allocatable, allNames),
+	)
 }
 
 func ReservePorts(r *schedulingv1alpha1.Reservation) framework.HostPortInfo {

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apires "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
@@ -32,6 +33,73 @@ import (
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
+
+func TestIsReservationSpecResourcesChanged(t *testing.T) {
+	makeReservation := func(available bool, spec corev1.ResourceList, alloc corev1.ResourceList) *schedulingv1alpha1.Reservation {
+		r := &schedulingv1alpha1.Reservation{}
+		if spec != nil {
+			r.Spec.Template = &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "c",
+						Resources: corev1.ResourceRequirements{
+							Requests: spec,
+						},
+					}},
+				},
+			}
+		}
+		if available {
+			r.Status.Phase = schedulingv1alpha1.ReservationAvailable
+			r.Status.NodeName = "node"
+		}
+		if alloc != nil {
+			r.Status.Allocatable = alloc.DeepCopy()
+		}
+		return r
+	}
+
+	cpu100 := corev1.ResourceList{corev1.ResourceCPU: apires.MustParse("100m")}
+	cpu200 := corev1.ResourceList{corev1.ResourceCPU: apires.MustParse("200m")}
+	mem100 := corev1.ResourceList{corev1.ResourceMemory: apires.MustParse("100Mi")}
+	gpu1 := corev1.ResourceList{"nvidia.com/gpu": apires.MustParse("1")}
+
+	tests := []struct {
+		name string
+		r    *schedulingv1alpha1.Reservation
+		want bool
+	}{
+		{"not available", makeReservation(false, cpu100, cpu100), false},
+		{"identical resources", makeReservation(true, corev1.ResourceList{corev1.ResourceCPU: apires.MustParse("100m"), corev1.ResourceMemory: apires.MustParse("100Mi")}, corev1.ResourceList{corev1.ResourceCPU: apires.MustParse("100m"), corev1.ResourceMemory: apires.MustParse("100Mi")}), false},
+		{"quantity changed", makeReservation(true, cpu100, cpu200), true},
+		{"resource added in spec", makeReservation(true, merge(cpu100, gpu1), cpu100), true},
+		{"resource removed from spec", makeReservation(true, nil, mem100), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsReservationSpecResourcesChanged(tc.r)
+			if got != tc.want {
+				t.Fatalf("test %q: IsReservationSpecResourcesChanged = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// merge returns a new ResourceList that is the union of all inputs.
+func merge(lists ...corev1.ResourceList) corev1.ResourceList {
+	out := corev1.ResourceList{}
+	for _, l := range lists {
+		if l == nil {
+			continue
+		}
+		for k, v := range l {
+			out[k] = v
+		}
+	}
+	return out
+}
 
 func TestIsReservationActive(t *testing.T) {
 	t.Run("test not panic", func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

It is necessary to provide changes to the requested resources for reservations that are currently available. Since the source of resource requests is templates, it is hoped that changes can also be made through the same fields. However, currently only the status field can be provided to reverse correct the scheduling ledger, which results in template resource request changes being forcibly corrected even if they are modified.

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
