### PR TITLE
scheduler: extend EventsToRegister / QueueingHints for core plugins (#2852)

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -216,6 +216,8 @@ type ReservationArgs struct {
 	// PreAllocationConfig defines the configuration for pre-allocation feature.
 	// +optional
 	PreAllocationConfig *PreAllocationConfig
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // PreAllocationConfig defines the configuration for pre-allocation feature.

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -342,6 +342,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -80,6 +80,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -136,6 +136,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // CPUBindPolicy defines the CPU binding policy

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -122,6 +122,9 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 			}
 		}
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 // SetDefaults_NodeNUMAResourceArgs sets the default parameters for NodeNUMANodeResource plugin.

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -184,6 +184,9 @@ func SetDefaults_ReservationArgs(obj *ReservationArgs) {
 	if obj.ResyncIntervalSeconds == 0 {
 		obj.ResyncIntervalSeconds = *defaultResyncIntervalSeconds
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 func SetDefaults_ElasticQuotaArgs(obj *ElasticQuotaArgs) {

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -282,6 +282,9 @@ func SetDefaults_DeviceShareArgs(obj *DeviceShareArgs) {
 	if obj.GPUSharedResourceTemplatesConfig == nil {
 		obj.GPUSharedResourceTemplatesConfig = defaultGPUSharedResourceTemplatesConfig
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 // SetDefaults_SchedulingHintArgs sets the default parameters for SchedulingHint plugin.

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -160,6 +160,9 @@ func SetDefaults_NodeNUMAResourceArgs(obj *NodeNUMAResourceArgs) {
 			},
 		}
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 func SetDefaults_ReservationArgs(obj *ReservationArgs) {

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestSetDefaults_EnableQueueHint(t *testing.T) {
+	t.Run("Reservation defaults EnableQueueHint to false when unset", func(t *testing.T) {
+		args := &ReservationArgs{}
+		SetDefaults_ReservationArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.False(t, *args.EnableQueueHint)
+	})
+
+	t.Run("Reservation keeps EnableQueueHint when already set", func(t *testing.T) {
+		args := &ReservationArgs{EnableQueueHint: ptr.To(true)}
+		SetDefaults_ReservationArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.True(t, *args.EnableQueueHint)
+	})
+
+	t.Run("DeviceShare defaults EnableQueueHint to false when unset", func(t *testing.T) {
+		args := &DeviceShareArgs{}
+		SetDefaults_DeviceShareArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.False(t, *args.EnableQueueHint)
+	})
+
+	t.Run("DeviceShare keeps EnableQueueHint when already set", func(t *testing.T) {
+		args := &DeviceShareArgs{EnableQueueHint: ptr.To(true)}
+		SetDefaults_DeviceShareArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.True(t, *args.EnableQueueHint)
+	})
+
+	t.Run("NodeNUMAResource defaults EnableQueueHint to false when unset", func(t *testing.T) {
+		args := &NodeNUMAResourceArgs{}
+		SetDefaults_NodeNUMAResourceArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.False(t, *args.EnableQueueHint)
+	})
+
+	t.Run("NodeNUMAResource keeps EnableQueueHint when already set", func(t *testing.T) {
+		args := &NodeNUMAResourceArgs{EnableQueueHint: ptr.To(true)}
+		SetDefaults_NodeNUMAResourceArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.True(t, *args.EnableQueueHint)
+	})
+
+	t.Run("LoadAware defaults EnableQueueHint to false when unset", func(t *testing.T) {
+		args := &LoadAwareSchedulingArgs{}
+		SetDefaults_LoadAwareSchedulingArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.False(t, *args.EnableQueueHint)
+	})
+
+	t.Run("LoadAware keeps EnableQueueHint when already set", func(t *testing.T) {
+		args := &LoadAwareSchedulingArgs{EnableQueueHint: ptr.To(true)}
+		SetDefaults_LoadAwareSchedulingArgs(args)
+		assert.NotNil(t, args.EnableQueueHint)
+		assert.True(t, *args.EnableQueueHint)
+	})
+}

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -79,6 +79,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName `json:"supportedResources,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -211,6 +211,8 @@ type ReservationArgs struct {
 	// PreAllocationConfig defines the configuration for pre-allocation feature.
 	// +optional
 	PreAllocationConfig *PreAllocationConfig `json:"preAllocationConfig,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // PreAllocationConfig defines the configuration for pre-allocation feature.

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -341,6 +341,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel `json:"gpuShareUnsupportedModels,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -131,6 +131,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy `json:"numaScoringStrategy,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // CPUBindPolicy defines the CPU binding policy

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -491,6 +491,9 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -526,6 +529,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -612,6 +612,9 @@ func autoConvert_v1_ReservationArgs_To_config_ReservationArgs(in *ReservationArg
 	out.DisableGarbageCollection = in.DisableGarbageCollection
 	out.ResyncIntervalSeconds = in.ResyncIntervalSeconds
 	out.PreAllocationConfig = (*config.PreAllocationConfig)(unsafe.Pointer(in.PreAllocationConfig))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -638,6 +641,9 @@ func autoConvert_config_ReservationArgs_To_v1_ReservationArgs(in *config.Reserva
 	out.DisableGarbageCollection = in.DisableGarbageCollection
 	out.ResyncIntervalSeconds = in.ResyncIntervalSeconds
 	out.PreAllocationConfig = (*PreAllocationConfig)(unsafe.Pointer(in.PreAllocationConfig))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -538,6 +538,9 @@ func autoConvert_v1_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in *Node
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (*github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy vs string)
 	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -545,6 +548,9 @@ func autoConvert_config_NodeNUMAResourceArgs_To_v1_NodeNUMAResourceArgs(in *conf
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (string vs *github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy)
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -256,6 +256,9 @@ func autoConvert_v1_DeviceShareArgs_To_config_DeviceShareArgs(in *DeviceShareArg
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*config.GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]config.GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -270,6 +273,9 @@ func autoConvert_config_DeviceShareArgs_To_v1_DeviceShareArgs(in *config.DeviceS
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *DeviceShareArgs) DeepCopyInto(out *DeviceShareArgs) {
 		*out = make([]GPUShareUnsupportedModel, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -370,6 +370,11 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 		*out = make([]corev1.ResourceName, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -410,6 +410,11 @@ func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 		*out = new(ScoringStrategy)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -508,6 +508,11 @@ func (in *ReservationArgs) DeepCopyInto(out *ReservationArgs) {
 		*out = new(PreAllocationConfig)
 		**out = **in
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -114,9 +114,9 @@ func (cs *Coscheduling) EventsToRegister(_ context.Context) ([]fwktype.ClusterEv
 	// unschedulable queue once its PodGroup's minMember is satisfied, and
 	// that signal is produced inside PreEnqueue rather than by cluster
 	// events. Registering cluster events here would not reduce re-queuing
-	// because the PreEnqueue gate would reject the pod again. Returning an
-	// empty slice keeps the scheduler from registering redundant listeners
-	// under the k8s 1.35 SchedulerQueueingHints feature gate.
+	// because the PreEnqueue gate would reject the pod again. Returning nil
+	// keeps the scheduler from registering redundant listeners under the
+	// k8s 1.35 SchedulerQueueingHints feature gate.
 	return nil, nil
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -110,7 +110,13 @@ func New(_ context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.
 }
 
 func (cs *Coscheduling) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWithHint, error) {
-	// indicates that we are not interested in any events
+	// Gang gating is driven entirely by PreEnqueue: a pod only leaves the
+	// unschedulable queue once its PodGroup's minMember is satisfied, and
+	// that signal is produced inside PreEnqueue rather than by cluster
+	// events. Registering cluster events here would not reduce re-queuing
+	// because the PreEnqueue gate would reject the pod again. Returning an
+	// empty slice keeps the scheduler from registering redundant listeners
+	// under the k8s 1.35 SchedulerQueueingHints feature gate.
 	return nil, nil
 }
 

--- a/pkg/scheduler/plugins/coscheduling/queueinghint_test.go
+++ b/pkg/scheduler/plugins/coscheduling/queueinghint_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coscheduling
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	pgfake "github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/generated/clientset/versioned/fake"
+)
+
+// TestCoscheduling_EventsToRegister_ReturnsNoEvents locks in the invariant
+// that the Coscheduling plugin intentionally registers no cluster events.
+// Gang gating is handled in PreEnqueue; see the comment on
+// Coscheduling.EventsToRegister for the reasoning. If this test fails,
+// please update the comment and the referencing RFC before changing the
+// behaviour.
+func TestCoscheduling_EventsToRegister_ReturnsNoEvents(t *testing.T) {
+	pgClientSet := pgfake.NewSimpleClientset()
+	cs := kubefake.NewSimpleClientset()
+	suit := newPluginTestSuit(t, nil, pgClientSet, cs)
+
+	p, err := suit.proxyNew(context.TODO(), suit.gangSchedulingArgs, suit.Handle)
+	assert.NoError(t, err)
+	pl := p.(*Coscheduling)
+
+	events, err := pl.EventsToRegister(context.TODO())
+	assert.NoError(t, err)
+	assert.Nil(t, events, "Coscheduling must not register cluster events; gating lives in PreEnqueue")
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -202,9 +203,9 @@ func podRequestsAnyDevice(pod *corev1.Pod) bool {
 }
 
 func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	deletedPod, ok := oldObj.(*corev1.Pod)
-	if !ok {
-		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if deletedPod == nil {
@@ -218,28 +219,19 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 }
 
 func (p *Plugin) isSchedulableAfterDeviceChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	_, oldOK := toDevice(oldObj)
-	_, newOK := toDevice(newObj)
-	if !oldOK || !newOK {
-		logger.V(5).Info("obj is not *Device, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+	_, newDev, err := schedutil.As[*schedulingv1alpha1.Device](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert obj to Device in isSchedulableAfterDeviceChange", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if !podRequestsAnyDevice(pod) {
 		return fwktype.QueueSkip, nil
 	}
 	// Device delete cannot add capacity back for a waiting consumer.
-	if newObj == nil {
+	if newDev == nil {
 		return fwktype.QueueSkip, nil
 	}
 	return fwktype.Queue, nil
-}
-
-func toDevice(obj interface{}) (*schedulingv1alpha1.Device, bool) {
-	if obj == nil {
-		return nil, true
-	}
-	d, ok := obj.(*schedulingv1alpha1.Device)
-	return d, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -77,6 +77,7 @@ var (
 
 type Plugin struct {
 	disableDeviceNUMATopologyAlignment         bool
+	enableQueueHint                            bool
 	handle                                     frameworkext.ExtendedHandle
 	nodeDeviceCache                            *nodeDeviceCache
 	gpuSharedResourceTemplatesCache            *gpuSharedResourceTemplatesCache
@@ -180,10 +181,65 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("devices.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events[0].QueueingHintFn = p.isSchedulableAfterPodDeletion
+		events[1].QueueingHintFn = p.isSchedulableAfterDeviceChange
+	}
+	return events, nil
+}
+
+func podRequestsAnyDevice(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	requests, err := GetPodDeviceRequests(pod)
+	return err == nil && len(requests) > 0
+}
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+	// Only re-queue when both the waiting pod and the freed pod hold device resources.
+	if !podRequestsAnyDevice(pod) || !podRequestsAnyDevice(deletedPod) {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func (p *Plugin) isSchedulableAfterDeviceChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	_, oldOK := toDevice(oldObj)
+	_, newOK := toDevice(newObj)
+	if !oldOK || !newOK {
+		logger.V(5).Info("obj is not *Device, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+	if !podRequestsAnyDevice(pod) {
+		return fwktype.QueueSkip, nil
+	}
+	// Device delete cannot add capacity back for a waiting consumer.
+	if newObj == nil {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func toDevice(obj interface{}) (*schedulingv1alpha1.Device, bool) {
+	if obj == nil {
+		return nil, true
+	}
+	d, ok := obj.(*schedulingv1alpha1.Device)
+	return d, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
@@ -851,5 +907,6 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 		gpuShareUnsupportedModels:                  gpuShareUnsupportedModels,
 		scorer:                                     scorePlugin(args),
 		disableDeviceNUMATopologyAlignment:         args.DisableDeviceNUMATopologyAlignment,
+		enableQueueHint:                            args.EnableQueueHint,
 	}, nil
 }

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -215,6 +215,11 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 	if !podRequestsAnyDevice(pod) || !podRequestsAnyDevice(deletedPod) {
 		return fwktype.QueueSkip, nil
 	}
+	// A pod that never bound to a node never occupied nodeDeviceCache and so
+	// its deletion cannot have freed any device capacity for the waiter.
+	if deletedPod.Spec.NodeName == "" {
+		return fwktype.QueueSkip, nil
+	}
 	return fwktype.Queue, nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
@@ -33,15 +33,14 @@ import (
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 )
 
-// TestPlugin_EventsToRegister 檢查 EnableQueueHint 開關的事件形狀。
 func TestPlugin_EventsToRegister(t *testing.T) {
 	tests := []struct {
 		name            string
 		enableQueueHint bool
 		expectHintFn    bool
 	}{
-		{"queue hint 關掉時不帶 hint", false, false},
-		{"queue hint 打開時要帶 hint", true, true},
+		{"no hint functions when queue hint is disabled", false, false},
+		{"hint functions are set when queue hint is enabled", true, true},
 	}
 
 	for _, tt := range tests {
@@ -73,7 +72,6 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 			}
 			assert.NotNil(t, podEv)
 			assert.NotNil(t, devEv)
-			// ActionType 不因開關而收窄
 			assert.Equal(t, fwktype.Delete, podEv.Event.ActionType)
 			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, devEv.Event.ActionType)
 
@@ -141,25 +139,31 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 		expectedHint fwktype.QueueingHint
 	}{
 		{
-			name:         "oldObj 型別不對，保守 re-queue",
+			name:         "oldObj has the wrong type, fall back to Queue",
 			waitingPod:   makePodRequestingGPU("w1", ""),
 			deletedObj:   "not-a-pod",
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "等待中 pod 不要 device，不需要喚醒",
+			name:         "nil deleted pod, fall back to Queue",
+			waitingPod:   makePodRequestingGPU("w1n", ""),
+			deletedObj:   (*corev1.Pod)(nil),
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "waiting pod does not request devices, no need to wake it up",
 			waitingPod:   makePodNoDevice("w2"),
 			deletedObj:   makePodRequestingGPU("deleted-gpu", "n1"),
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name:         "等待中 pod 要 GPU，刪掉的 pod 也佔 GPU，值得重試",
+			name:         "waiting pod requests GPU and the deleted pod also held GPU, requeue",
 			waitingPod:   makePodRequestingGPU("w3", ""),
 			deletedObj:   makePodRequestingGPU("deleted-gpu", "n1"),
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "等待中 pod 要 GPU，但被刪的 pod 沒佔 device",
+			name:         "waiting pod requests GPU but the deleted pod held no device resources",
 			waitingPod:   makePodRequestingGPU("w4", ""),
 			deletedObj:   makePodNoDevice("deleted-norm"),
 			expectedHint: fwktype.QueueSkip,
@@ -200,35 +204,35 @@ func TestPlugin_QueueingHint_IsSchedulableAfterDeviceChange(t *testing.T) {
 		expectedHint fwktype.QueueingHint
 	}{
 		{
-			name:         "型別不對，保守 re-queue",
+			name:         "wrong type, fall back to Queue",
 			waitingPod:   makePodRequestingGPU("w1", ""),
 			oldObj:       nil,
 			newObj:       "not-a-device",
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "等待中 pod 沒要 device，什麼變化都 skip",
+			name:         "waiting pod needs no device, skip any change",
 			waitingPod:   makePodNoDevice("w2"),
 			oldObj:       nil,
 			newObj:       dev,
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name:         "Add 一個 device，值得重試",
+			name:         "Add a device, requeue",
 			waitingPod:   makePodRequestingGPU("w3", ""),
 			oldObj:       nil,
 			newObj:       dev,
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "Update 一個 device（容量可能變動），值得重試",
+			name:         "Update a device (capacity may have shifted), requeue",
 			waitingPod:   makePodRequestingGPU("w4", ""),
 			oldObj:       dev,
 			newObj:       dev,
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "Delete device 不會讓等待者變得可排，直接 skip",
+			name:         "Delete device cannot unblock a waiting consumer, skip",
 			waitingPod:   makePodRequestingGPU("w5", ""),
 			oldObj:       dev,
 			newObj:       nil,

--- a/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+// TestPlugin_EventsToRegister 檢查 EnableQueueHint 開關的事件形狀。
+func TestPlugin_EventsToRegister(t *testing.T) {
+	tests := []struct {
+		name            string
+		enableQueueHint bool
+		expectHintFn    bool
+	}{
+		{"queue hint 關掉時不帶 hint", false, false},
+		{"queue hint 打開時要帶 hint", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			args := getDefaultArgs()
+			args.EnableQueueHint = tt.enableQueueHint
+
+			p, err := suit.proxyNew(context.TODO(), args, suit.Framework)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			events, err := pl.EventsToRegister(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(events))
+
+			expectedGVK := fmt.Sprintf("devices.%v.%v",
+				schedulingv1alpha1.GroupVersion.Version,
+				schedulingv1alpha1.GroupVersion.Group)
+
+			var podEv, devEv *fwktype.ClusterEventWithHint
+			for i := range events {
+				switch events[i].Event.Resource {
+				case fwktype.Pod:
+					podEv = &events[i]
+				case fwktype.EventResource(expectedGVK):
+					devEv = &events[i]
+				}
+			}
+			assert.NotNil(t, podEv)
+			assert.NotNil(t, devEv)
+			// ActionType 不因開關而收窄
+			assert.Equal(t, fwktype.Delete, podEv.Event.ActionType)
+			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, devEv.Event.ActionType)
+
+			if tt.expectHintFn {
+				assert.NotNil(t, podEv.QueueingHintFn)
+				assert.NotNil(t, devEv.QueueingHintFn)
+			} else {
+				assert.Nil(t, podEv.QueueingHintFn)
+				assert.Nil(t, devEv.QueueingHintFn)
+			}
+		})
+	}
+}
+
+func makePodRequestingGPU(name, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+			Containers: []corev1.Container{
+				{
+					Name: "c",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							apiext.ResourceGPU: resource.MustParse("100"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makePodNoDevice(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "c",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100m"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
+	tests := []struct {
+		name         string
+		waitingPod   *corev1.Pod
+		deletedObj   interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{
+			name:         "oldObj 型別不對，保守 re-queue",
+			waitingPod:   makePodRequestingGPU("w1", ""),
+			deletedObj:   "not-a-pod",
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "等待中 pod 不要 device，不需要喚醒",
+			waitingPod:   makePodNoDevice("w2"),
+			deletedObj:   makePodRequestingGPU("deleted-gpu", "n1"),
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name:         "等待中 pod 要 GPU，刪掉的 pod 也佔 GPU，值得重試",
+			waitingPod:   makePodRequestingGPU("w3", ""),
+			deletedObj:   makePodRequestingGPU("deleted-gpu", "n1"),
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "等待中 pod 要 GPU，但被刪的 pod 沒佔 device",
+			waitingPod:   makePodRequestingGPU("w4", ""),
+			deletedObj:   makePodNoDevice("deleted-norm"),
+			expectedHint: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			args := getDefaultArgs()
+			args.EnableQueueHint = true
+			p, err := suit.proxyNew(context.TODO(), args, suit.Framework)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterPodDeletion(klog.Background(), tt.waitingPod, tt.deletedObj, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterDeviceChange(t *testing.T) {
+	dev := &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{
+				{Type: schedulingv1alpha1.GPU, Minor: func() *int32 { i := int32(0); return &i }(), Health: true},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		waitingPod   *corev1.Pod
+		oldObj       interface{}
+		newObj       interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{
+			name:         "型別不對，保守 re-queue",
+			waitingPod:   makePodRequestingGPU("w1", ""),
+			oldObj:       nil,
+			newObj:       "not-a-device",
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "等待中 pod 沒要 device，什麼變化都 skip",
+			waitingPod:   makePodNoDevice("w2"),
+			oldObj:       nil,
+			newObj:       dev,
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name:         "Add 一個 device，值得重試",
+			waitingPod:   makePodRequestingGPU("w3", ""),
+			oldObj:       nil,
+			newObj:       dev,
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "Update 一個 device（容量可能變動），值得重試",
+			waitingPod:   makePodRequestingGPU("w4", ""),
+			oldObj:       dev,
+			newObj:       dev,
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "Delete device 不會讓等待者變得可排，直接 skip",
+			waitingPod:   makePodRequestingGPU("w5", ""),
+			oldObj:       dev,
+			newObj:       nil,
+			expectedHint: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil)
+			args := getDefaultArgs()
+			args.EnableQueueHint = true
+			p, err := suit.proxyNew(context.TODO(), args, suit.Framework)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterDeviceChange(klog.Background(), tt.waitingPod, tt.oldObj, tt.newObj)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
@@ -168,6 +168,12 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			deletedObj:   makePodNoDevice("deleted-norm"),
 			expectedHint: fwktype.QueueSkip,
 		},
+		{
+			name:         "deleted pod requests GPU but was never bound to a node, skip",
+			waitingPod:   makePodRequestingGPU("w5", ""),
+			deletedObj:   makePodRequestingGPU("deleted-unbound", ""),
+			expectedHint: fwktype.QueueSkip,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -130,10 +130,51 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("nodemetrics.%v.%v", slov1alpha1.GroupVersion.Version, slov1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.args != nil && p.args.EnableQueueHint {
+		events[0].QueueingHintFn = p.isSchedulableAfterPodDeletion
+		events[1].QueueingHintFn = p.isSchedulableAfterNodeMetricChange
+	}
+	return events, nil
+}
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+	// A pod that never bound to a node cannot have affected any node's load.
+	if deletedPod == nil || deletedPod.Spec.NodeName == "" {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func (p *Plugin) isSchedulableAfterNodeMetricChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	_, oldOK := toNodeMetric(oldObj)
+	_, newOK := toNodeMetric(newObj)
+	if !oldOK || !newOK {
+		logger.V(5).Info("obj is not *NodeMetric, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+	// Losing node metrics cannot unblock a pod filtered out due to high load.
+	if newObj == nil {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func toNodeMetric(obj interface{}) (*slov1alpha1.NodeMetric, bool) {
+	if obj == nil {
+		return nil, true
+	}
+	m, ok := obj.(*slov1alpha1.NodeMetric)
+	return m, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -148,8 +148,13 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
 		return fwktype.Queue, nil
 	}
+	// With a nil deleted pod we cannot tell whether it had been bound and
+	// freed load, so re-queue conservatively instead of starving the waiter.
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
 	// A pod that never bound to a node cannot have affected any node's load.
-	if deletedPod == nil || deletedPod.Spec.NodeName == "" {
+	if deletedPod.Spec.NodeName == "" {
 		return fwktype.QueueSkip, nil
 	}
 	return fwktype.Queue, nil

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
@@ -143,9 +144,9 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 }
 
 func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	deletedPod, ok := oldObj.(*corev1.Pod)
-	if !ok {
-		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	// With a nil deleted pod we cannot tell whether it had been bound and
@@ -161,25 +162,16 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 }
 
 func (p *Plugin) isSchedulableAfterNodeMetricChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	_, oldOK := toNodeMetric(oldObj)
-	_, newOK := toNodeMetric(newObj)
-	if !oldOK || !newOK {
-		logger.V(5).Info("obj is not *NodeMetric, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+	_, newMetric, err := schedutil.As[*slov1alpha1.NodeMetric](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert obj to NodeMetric in isSchedulableAfterNodeMetricChange", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	// Losing node metrics cannot unblock a pod filtered out due to high load.
-	if newObj == nil {
+	if newMetric == nil {
 		return fwktype.QueueSkip, nil
 	}
 	return fwktype.Queue, nil
-}
-
-func toNodeMetric(obj interface{}) (*slov1alpha1.NodeMetric, bool) {
-	if obj == nil {
-		return nil, true
-	}
-	m, ok := obj.(*slov1alpha1.NodeMetric)
-	return m, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/loadaware/queueinghint_test.go
+++ b/pkg/scheduler/plugins/loadaware/queueinghint_test.go
@@ -144,7 +144,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 		{"oldObj has the wrong type, fall back to Queue", "not-a-pod", fwktype.Queue},
 		{"deleted pod was never bound to a node, skip", unboundPod, fwktype.QueueSkip},
 		{"deleted pod was bound to a node and may have freed load, Queue", boundPod, fwktype.Queue},
-		{"nil deleted pod, skip", (*corev1.Pod)(nil), fwktype.QueueSkip},
+		{"nil deleted pod is ambiguous, re-queue conservatively", (*corev1.Pod)(nil), fwktype.Queue},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/loadaware/queueinghint_test.go
+++ b/pkg/scheduler/plugins/loadaware/queueinghint_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadaware
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing/framework"
+
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
+	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+)
+
+func newQueueingHintPlugin(t *testing.T, enableQueueHint bool) *Plugin {
+	var v1args v1.LoadAwareSchedulingArgs
+	v1.SetDefaults_LoadAwareSchedulingArgs(&v1args)
+	var args config.LoadAwareSchedulingArgs
+	err := v1.Convert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(&v1args, &args, nil)
+	assert.NoError(t, err)
+	args.EnableQueueHint = enableQueueHint
+
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+	extenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
+		frameworkext.WithKoordinatorClientSet(koordClientSet),
+		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	)
+	proxyNew := frameworkext.PluginFactoryProxy(extenderFactory, New)
+
+	cs := kubefake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(cs, 0)
+	snapshot := newTestSharedLister(nil, nil)
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	fh, err := schedulertesting.NewFramework(context.TODO(), registeredPlugins, "koord-scheduler",
+		frameworkruntime.WithClientSet(cs),
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+	)
+	assert.NoError(t, err)
+
+	p, err := proxyNew(context.TODO(), &args, fh)
+	assert.NoError(t, err)
+	return p.(*Plugin)
+}
+
+func TestPlugin_EventsToRegister(t *testing.T) {
+	tests := []struct {
+		name            string
+		enableQueueHint bool
+		expectHintFn    bool
+	}{
+		{"queue hint 關掉時不帶 hint", false, false},
+		{"queue hint 打開時要帶 hint", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pl := newQueueingHintPlugin(t, tt.enableQueueHint)
+
+			events, err := pl.EventsToRegister(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(events))
+
+			expectedGVK := fmt.Sprintf("nodemetrics.%v.%v",
+				slov1alpha1.GroupVersion.Version,
+				slov1alpha1.GroupVersion.Group)
+
+			var podEv, metricEv *fwktype.ClusterEventWithHint
+			for i := range events {
+				switch events[i].Event.Resource {
+				case fwktype.Pod:
+					podEv = &events[i]
+				case fwktype.EventResource(expectedGVK):
+					metricEv = &events[i]
+				}
+			}
+			assert.NotNil(t, podEv)
+			assert.NotNil(t, metricEv)
+			assert.Equal(t, fwktype.Delete, podEv.Event.ActionType)
+			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, metricEv.Event.ActionType)
+
+			if tt.expectHintFn {
+				assert.NotNil(t, podEv.QueueingHintFn)
+				assert.NotNil(t, metricEv.QueueingHintFn)
+			} else {
+				assert.Nil(t, podEv.QueueingHintFn)
+				assert.Nil(t, metricEv.QueueingHintFn)
+			}
+		})
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
+	unboundPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "unbound", UID: types.UID("unbound"), Namespace: "default"},
+	}
+	boundPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "bound", UID: types.UID("bound"), Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "node-1"},
+	}
+	waiting := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "waiting", UID: types.UID("waiting"), Namespace: "default"},
+	}
+
+	tests := []struct {
+		name         string
+		oldObj       interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{"oldObj 型別錯誤 fall back Queue", "not-a-pod", fwktype.Queue},
+		{"被刪的 pod 根本沒綁過 node，skip", unboundPod, fwktype.QueueSkip},
+		{"被刪的 pod 曾綁 node，可能釋放 load，Queue", boundPod, fwktype.Queue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pl := newQueueingHintPlugin(t, true)
+			got, err := pl.isSchedulableAfterPodDeletion(klog.Background(), waiting, tt.oldObj, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterNodeMetricChange(t *testing.T) {
+	metric := &slov1alpha1.NodeMetric{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	waiting := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "waiting"}}
+
+	tests := []struct {
+		name         string
+		oldObj       interface{}
+		newObj       interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{"型別錯誤 fall back Queue", nil, "not-a-metric", fwktype.Queue},
+		{"Add metric，值得重試", nil, metric, fwktype.Queue},
+		{"Update metric，值得重試", metric, metric, fwktype.Queue},
+		{"Delete metric 不會讓負載變低", metric, nil, fwktype.QueueSkip},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pl := newQueueingHintPlugin(t, true)
+			got, err := pl.isSchedulableAfterNodeMetricChange(klog.Background(), waiting, tt.oldObj, tt.newObj)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/loadaware/queueinghint_test.go
+++ b/pkg/scheduler/plugins/loadaware/queueinghint_test.go
@@ -83,8 +83,8 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 		enableQueueHint bool
 		expectHintFn    bool
 	}{
-		{"queue hint 關掉時不帶 hint", false, false},
-		{"queue hint 打開時要帶 hint", true, true},
+		{"no hint functions when queue hint is disabled", false, false},
+		{"hint functions are set when queue hint is enabled", true, true},
 	}
 
 	for _, tt := range tests {
@@ -141,9 +141,10 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 		oldObj       interface{}
 		expectedHint fwktype.QueueingHint
 	}{
-		{"oldObj 型別錯誤 fall back Queue", "not-a-pod", fwktype.Queue},
-		{"被刪的 pod 根本沒綁過 node，skip", unboundPod, fwktype.QueueSkip},
-		{"被刪的 pod 曾綁 node，可能釋放 load，Queue", boundPod, fwktype.Queue},
+		{"oldObj has the wrong type, fall back to Queue", "not-a-pod", fwktype.Queue},
+		{"deleted pod was never bound to a node, skip", unboundPod, fwktype.QueueSkip},
+		{"deleted pod was bound to a node and may have freed load, Queue", boundPod, fwktype.Queue},
+		{"nil deleted pod, skip", (*corev1.Pod)(nil), fwktype.QueueSkip},
 	}
 
 	for _, tt := range tests {
@@ -166,10 +167,10 @@ func TestPlugin_QueueingHint_IsSchedulableAfterNodeMetricChange(t *testing.T) {
 		newObj       interface{}
 		expectedHint fwktype.QueueingHint
 	}{
-		{"型別錯誤 fall back Queue", nil, "not-a-metric", fwktype.Queue},
-		{"Add metric，值得重試", nil, metric, fwktype.Queue},
-		{"Update metric，值得重試", metric, metric, fwktype.Queue},
-		{"Delete metric 不會讓負載變低", metric, nil, fwktype.QueueSkip},
+		{"wrong type, fall back to Queue", nil, "not-a-metric", fwktype.Queue},
+		{"Add metric, requeue", nil, metric, fwktype.Queue},
+		{"Update metric, requeue", metric, metric, fwktype.Queue},
+		{"Delete metric cannot lower load, skip", metric, nil, fwktype.QueueSkip},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -32,6 +32,7 @@ import (
 	resourceapi "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -282,9 +283,9 @@ func podNeedsNUMAAllocation(pod *corev1.Pod) bool {
 }
 
 func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	deletedPod, ok := oldObj.(*corev1.Pod)
-	if !ok {
-		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if deletedPod == nil {
@@ -297,28 +298,19 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 }
 
 func (p *Plugin) isSchedulableAfterNRTChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	_, oldOK := toNRT(oldObj)
-	_, newOK := toNRT(newObj)
-	if !oldOK || !newOK {
-		logger.V(5).Info("obj is not *NodeResourceTopology, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+	_, newNRT, err := schedutil.As[*nrtv1alpha1.NodeResourceTopology](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert obj to NodeResourceTopology in isSchedulableAfterNRTChange", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if !podNeedsNUMAAllocation(pod) {
 		return fwktype.QueueSkip, nil
 	}
 	// NRT delete cannot unblock a waiting NUMA pod.
-	if newObj == nil {
+	if newNRT == nil {
 		return fwktype.QueueSkip, nil
 	}
 	return fwktype.Queue, nil
-}
-
-func toNRT(obj interface{}) (*nrtv1alpha1.NodeResourceTopology, bool) {
-	if obj == nil {
-		return nil, true
-	}
-	nrt, ok := obj.(*nrtv1alpha1.NodeResourceTopology)
-	return nrt, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -294,6 +294,11 @@ func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 	if !podNeedsNUMAAllocation(pod) || !podNeedsNUMAAllocation(deletedPod) {
 		return fwktype.QueueSkip, nil
 	}
+	// A pod that never bound to a node never contributed to NUMA allocation
+	// state, so its deletion cannot release topology-pinned resources.
+	if deletedPod.Spec.NodeName == "" {
+		return fwktype.QueueSkip, nil
+	}
 	return fwktype.Queue, nil
 }
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -258,10 +258,67 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("noderesourcetopologies.%v.%v", nrtv1alpha1.SchemeGroupVersion.Version, nrtv1alpha1.SchemeGroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.pluginArgs != nil && p.pluginArgs.EnableQueueHint {
+		events[0].QueueingHintFn = p.isSchedulableAfterPodDeletion
+		events[1].QueueingHintFn = p.isSchedulableAfterNRTChange
+	}
+	return events, nil
+}
+
+func podNeedsNUMAAllocation(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	numaSpec, err := extension.GetNUMATopologySpec(pod.Annotations)
+	if err == nil && numaSpec != nil && numaSpec.NUMATopologyPolicy != extension.NUMATopologyPolicyNone && numaSpec.NUMATopologyPolicy != "" {
+		return true
+	}
+	return AllowUseCPUSet(pod)
+}
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+	if !podNeedsNUMAAllocation(pod) || !podNeedsNUMAAllocation(deletedPod) {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func (p *Plugin) isSchedulableAfterNRTChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	_, oldOK := toNRT(oldObj)
+	_, newOK := toNRT(newObj)
+	if !oldOK || !newOK {
+		logger.V(5).Info("obj is not *NodeResourceTopology, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+	if !podNeedsNUMAAllocation(pod) {
+		return fwktype.QueueSkip, nil
+	}
+	// NRT delete cannot unblock a waiting NUMA pod.
+	if newObj == nil {
+		return fwktype.QueueSkip, nil
+	}
+	return fwktype.Queue, nil
+}
+
+func toNRT(obj interface{}) (*nrtv1alpha1.NodeResourceTopology, bool) {
+	if obj == nil {
+		return nil, true
+	}
+	nrt, ok := obj.(*nrtv1alpha1.NodeResourceTopology)
+	return nrt, ok
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
@@ -87,6 +87,10 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 }
 
 func makePodWithNUMAPolicy(name string) *corev1.Pod {
+	return makePodWithNUMAPolicyOnNode(name, "")
+}
+
+func makePodWithNUMAPolicyOnNode(name, nodeName string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -97,6 +101,7 @@ func makePodWithNUMAPolicy(name string) *corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 			Containers: []corev1.Container{{
 				Name: "c",
 				Resources: corev1.ResourceRequirements{
@@ -151,15 +156,21 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name:         "waiting pod requires NUMA and deleted pod is also NUMA-pinned, requeue",
+			name:         "waiting pod requires NUMA and deleted pod is bound NUMA-pinned, requeue",
 			waiting:      makePodWithNUMAPolicy("w3"),
-			deletedObj:   makePodWithNUMAPolicy("del-numa"),
+			deletedObj:   makePodWithNUMAPolicyOnNode("del-numa", "node-1"),
 			expectedHint: fwktype.Queue,
 		},
 		{
 			name:         "waiting pod requires NUMA but deleted pod is plain, no NUMA resources released",
 			waiting:      makePodWithNUMAPolicy("w4"),
 			deletedObj:   makePlainPod("del-plain"),
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name:         "deleted NUMA pod was never bound to a node, skip",
+			waiting:      makePodWithNUMAPolicy("w5"),
+			deletedObj:   makePodWithNUMAPolicy("del-unbound"),
 			expectedHint: fwktype.QueueSkip,
 		},
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+// TestPlugin_EventsToRegister 檢查 EnableQueueHint 開關對事件形狀的影響。
+func TestPlugin_EventsToRegister(t *testing.T) {
+	tests := []struct {
+		name            string
+		enableQueueHint bool
+		expectHintFn    bool
+	}{
+		{"queue hint 關掉時不帶 hint 函式", false, false},
+		{"queue hint 打開時要帶 hint 函式", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, nil)
+			suit.nodeNUMAResourceArgs.EnableQueueHint = tt.enableQueueHint
+
+			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+			require.NoError(t, err)
+			pl := p.(*Plugin)
+
+			events, err := pl.EventsToRegister(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(events))
+
+			expectedGVK := fmt.Sprintf("noderesourcetopologies.%v.%v",
+				topologyv1alpha1.SchemeGroupVersion.Version,
+				topologyv1alpha1.SchemeGroupVersion.Group)
+
+			var podEv, nrtEv *fwktype.ClusterEventWithHint
+			for i := range events {
+				switch events[i].Event.Resource {
+				case fwktype.Pod:
+					podEv = &events[i]
+				case fwktype.EventResource(expectedGVK):
+					nrtEv = &events[i]
+				}
+			}
+			assert.NotNil(t, podEv)
+			assert.NotNil(t, nrtEv)
+			assert.Equal(t, fwktype.Delete, podEv.Event.ActionType)
+			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, nrtEv.Event.ActionType)
+
+			if tt.expectHintFn {
+				assert.NotNil(t, podEv.QueueingHintFn)
+				assert.NotNil(t, nrtEv.QueueingHintFn)
+			} else {
+				assert.Nil(t, podEv.QueueingHintFn)
+				assert.Nil(t, nrtEv.QueueingHintFn)
+			}
+		})
+	}
+}
+
+// makePodWithNUMAPolicy 造一個要求 NUMA topology 的 pod。
+func makePodWithNUMAPolicy(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+			Annotations: map[string]string{
+				apiext.AnnotationNUMATopologySpec: `{"numaTopologyPolicy":"SingleNUMANode"}`,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+				},
+			}},
+		},
+	}
+}
+
+// makePlainPod 造一個完全不碰 NUMA 的 pod。
+func makePlainPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+				},
+			}},
+		},
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
+	tests := []struct {
+		name         string
+		waiting      *corev1.Pod
+		deletedObj   interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{
+			name:         "oldObj 不是 *Pod，保守 re-queue",
+			waiting:      makePodWithNUMAPolicy("w1"),
+			deletedObj:   "not-a-pod",
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "等待中 pod 不要 NUMA，不值得喚醒",
+			waiting:      makePlainPod("w2"),
+			deletedObj:   makePodWithNUMAPolicy("del-numa"),
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name:         "等待中要 NUMA，被刪的也是 NUMA pod，值得重試",
+			waiting:      makePodWithNUMAPolicy("w3"),
+			deletedObj:   makePodWithNUMAPolicy("del-numa"),
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "等待中要 NUMA，被刪的是普通 pod，沒釋放 NUMA 資源",
+			waiting:      makePodWithNUMAPolicy("w4"),
+			deletedObj:   makePlainPod("del-plain"),
+			expectedHint: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, nil)
+			suit.nodeNUMAResourceArgs.EnableQueueHint = true
+			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+			require.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterPodDeletion(klog.Background(), tt.waiting, tt.deletedObj, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterNRTChange(t *testing.T) {
+	nrt := &topologyv1alpha1.NodeResourceTopology{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+	}
+
+	tests := []struct {
+		name         string
+		waiting      *corev1.Pod
+		oldObj       interface{}
+		newObj       interface{}
+		expectedHint fwktype.QueueingHint
+	}{
+		{"型別錯誤 fall back Queue", makePodWithNUMAPolicy("w1"), nil, "not-nrt", fwktype.Queue},
+		{"等待中不要 NUMA，全部 skip", makePlainPod("w2"), nil, nrt, fwktype.QueueSkip},
+		{"Add NRT，值得重試", makePodWithNUMAPolicy("w3"), nil, nrt, fwktype.Queue},
+		{"Update NRT，值得重試", makePodWithNUMAPolicy("w4"), nrt, nrt, fwktype.Queue},
+		{"Delete NRT 不會讓等待者變可排", makePodWithNUMAPolicy("w5"), nrt, nil, fwktype.QueueSkip},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, nil, nil)
+			suit.nodeNUMAResourceArgs.EnableQueueHint = true
+			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+			require.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterNRTChange(klog.Background(), tt.waiting, tt.oldObj, tt.newObj)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,15 +34,14 @@ import (
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 )
 
-// TestPlugin_EventsToRegister 檢查 EnableQueueHint 開關對事件形狀的影響。
 func TestPlugin_EventsToRegister(t *testing.T) {
 	tests := []struct {
 		name            string
 		enableQueueHint bool
 		expectHintFn    bool
 	}{
-		{"queue hint 關掉時不帶 hint 函式", false, false},
-		{"queue hint 打開時要帶 hint 函式", true, true},
+		{"no hint functions when queue hint is disabled", false, false},
+		{"hint functions are set when queue hint is enabled", true, true},
 	}
 
 	for _, tt := range tests {
@@ -87,7 +86,6 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 	}
 }
 
-// makePodWithNUMAPolicy 造一個要求 NUMA topology 的 pod。
 func makePodWithNUMAPolicy(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,7 +107,6 @@ func makePodWithNUMAPolicy(name string) *corev1.Pod {
 	}
 }
 
-// makePlainPod 造一個完全不碰 NUMA 的 pod。
 func makePlainPod(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -136,25 +133,31 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 		expectedHint fwktype.QueueingHint
 	}{
 		{
-			name:         "oldObj 不是 *Pod，保守 re-queue",
+			name:         "oldObj is not a Pod, fall back to Queue",
 			waiting:      makePodWithNUMAPolicy("w1"),
 			deletedObj:   "not-a-pod",
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "等待中 pod 不要 NUMA，不值得喚醒",
+			name:         "nil deleted pod, fall back to Queue",
+			waiting:      makePodWithNUMAPolicy("w1n"),
+			deletedObj:   (*corev1.Pod)(nil),
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name:         "waiting pod does not require NUMA, no need to wake it up",
 			waiting:      makePlainPod("w2"),
 			deletedObj:   makePodWithNUMAPolicy("del-numa"),
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name:         "等待中要 NUMA，被刪的也是 NUMA pod，值得重試",
+			name:         "waiting pod requires NUMA and deleted pod is also NUMA-pinned, requeue",
 			waiting:      makePodWithNUMAPolicy("w3"),
 			deletedObj:   makePodWithNUMAPolicy("del-numa"),
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name:         "等待中要 NUMA，被刪的是普通 pod，沒釋放 NUMA 資源",
+			name:         "waiting pod requires NUMA but deleted pod is plain, no NUMA resources released",
 			waiting:      makePodWithNUMAPolicy("w4"),
 			deletedObj:   makePlainPod("del-plain"),
 			expectedHint: fwktype.QueueSkip,
@@ -188,11 +191,11 @@ func TestPlugin_QueueingHint_IsSchedulableAfterNRTChange(t *testing.T) {
 		newObj       interface{}
 		expectedHint fwktype.QueueingHint
 	}{
-		{"型別錯誤 fall back Queue", makePodWithNUMAPolicy("w1"), nil, "not-nrt", fwktype.Queue},
-		{"等待中不要 NUMA，全部 skip", makePlainPod("w2"), nil, nrt, fwktype.QueueSkip},
-		{"Add NRT，值得重試", makePodWithNUMAPolicy("w3"), nil, nrt, fwktype.Queue},
-		{"Update NRT，值得重試", makePodWithNUMAPolicy("w4"), nrt, nrt, fwktype.Queue},
-		{"Delete NRT 不會讓等待者變可排", makePodWithNUMAPolicy("w5"), nrt, nil, fwktype.QueueSkip},
+		{"wrong type, fall back to Queue", makePodWithNUMAPolicy("w1"), nil, "not-nrt", fwktype.Queue},
+		{"waiting pod needs no NUMA, skip all", makePlainPod("w2"), nil, nrt, fwktype.QueueSkip},
+		{"Add NRT, requeue", makePodWithNUMAPolicy("w3"), nil, nrt, fwktype.Queue},
+		{"Update NRT, requeue", makePodWithNUMAPolicy("w4"), nrt, nrt, fwktype.Queue},
+		{"Delete NRT cannot unblock a waiter, skip", makePodWithNUMAPolicy("w5"), nrt, nil, fwktype.QueueSkip},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -176,10 +176,83 @@ func (pl *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWit
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("reservations.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if pl.args != nil && pl.args.EnableQueueHint {
+		events[0].QueueingHintFn = pl.isSchedulableAfterPodDeletion
+		events[1].QueueingHintFn = pl.isSchedulableAfterReservationChange
+	}
+	return events, nil
+}
+
+func podUsesReservation(pod *corev1.Pod) bool {
+	if reservationutil.IsReservePod(pod) {
+		return true
+	}
+	affinity, err := reservationutil.GetRequiredReservationAffinity(pod)
+	return err == nil && affinity != nil
+}
+
+func (pl *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+	if !podUsesReservation(pod) {
+		return fwktype.QueueSkip, nil
+	}
+	if reservationutil.IsReservePod(deletedPod) {
+		return fwktype.Queue, nil
+	}
+	if pl.reservationCache != nil && deletedPod.Spec.NodeName != "" {
+		if pl.reservationCache.GetReservationInfoByPod(deletedPod, deletedPod.Spec.NodeName) != nil {
+			return fwktype.Queue, nil
+		}
+	}
+	return fwktype.QueueSkip, nil
+}
+
+func (pl *Plugin) isSchedulableAfterReservationChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	oldR, oldOK := toReservation(oldObj)
+	newR, newOK := toReservation(newObj)
+	if !oldOK || !newOK {
+		logger.V(5).Info("obj is not *Reservation, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+	if !podUsesReservation(pod) {
+		return fwktype.QueueSkip, nil
+	}
+	// Delete: give a matching waiter one more scheduling chance.
+	if newR == nil {
+		return fwktype.Queue, nil
+	}
+	// Add: a fresh reservation only matters once it reaches an active phase.
+	if oldR == nil {
+		if reservationutil.IsReservationActive(newR) {
+			return fwktype.Queue, nil
+		}
+		return fwktype.QueueSkip, nil
+	}
+	// Update: the typical wake-up signal is an inactive -> active transition.
+	if !reservationutil.IsReservationActive(oldR) && reservationutil.IsReservationActive(newR) {
+		return fwktype.Queue, nil
+	}
+	return fwktype.QueueSkip, nil
+}
+
+func toReservation(obj interface{}) (*schedulingv1alpha1.Reservation, bool) {
+	if obj == nil {
+		return nil, true
+	}
+	r, ok := obj.(*schedulingv1alpha1.Reservation)
+	return r, ok
 }
 
 // PreFilter checks if the pod is a reserve pod. If it is, update cycle state to annotate reservation scheduling.

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -233,15 +233,17 @@ func (pl *Plugin) isSchedulableAfterReservationChange(logger klog.Logger, pod *c
 	if newR == nil {
 		return fwktype.Queue, nil
 	}
-	// Add: a fresh reservation only matters once it reaches an active phase.
+	// A reservation is only matchable for allocation (ReservationInfo.IsMatchable)
+	// once it reaches the Available phase, so the hint keys off availability,
+	// not the broader "active" (Available or Waiting) status.
 	if oldR == nil {
-		if reservationutil.IsReservationActive(newR) {
+		if reservationutil.IsReservationAvailable(newR) {
 			return fwktype.Queue, nil
 		}
 		return fwktype.QueueSkip, nil
 	}
-	// Update: the typical wake-up signal is an inactive -> active transition.
-	if !reservationutil.IsReservationActive(oldR) && reservationutil.IsReservationActive(newR) {
+	// Update: the wake-up signal is the transition into the Available phase.
+	if !reservationutil.IsReservationAvailable(oldR) && reservationutil.IsReservationAvailable(newR) {
 		return fwktype.Queue, nil
 	}
 	return fwktype.QueueSkip, nil

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
@@ -197,9 +198,9 @@ func podUsesReservation(pod *corev1.Pod) bool {
 }
 
 func (pl *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	deletedPod, ok := oldObj.(*corev1.Pod)
-	if !ok {
-		logger.V(5).Info("oldObj is not *Pod, fall back to Queue", "oldObj", oldObj)
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if deletedPod == nil {
@@ -220,10 +221,9 @@ func (pl *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.
 }
 
 func (pl *Plugin) isSchedulableAfterReservationChange(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	oldR, oldOK := toReservation(oldObj)
-	newR, newOK := toReservation(newObj)
-	if !oldOK || !newOK {
-		logger.V(5).Info("obj is not *Reservation, fall back to Queue", "oldObj", oldObj, "newObj", newObj)
+	oldR, newR, err := schedutil.As[*schedulingv1alpha1.Reservation](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert obj to Reservation in isSchedulableAfterReservationChange", "oldObj", oldObj, "newObj", newObj)
 		return fwktype.Queue, nil
 	}
 	if !podUsesReservation(pod) {
@@ -245,14 +245,6 @@ func (pl *Plugin) isSchedulableAfterReservationChange(logger klog.Logger, pod *c
 		return fwktype.Queue, nil
 	}
 	return fwktype.QueueSkip, nil
-}
-
-func toReservation(obj interface{}) (*schedulingv1alpha1.Reservation, bool) {
-	if obj == nil {
-		return nil, true
-	}
-	r, ok := obj.(*schedulingv1alpha1.Reservation)
-	return r, ok
 }
 
 // PreFilter checks if the pod is a reserve pod. If it is, update cycle state to annotate reservation scheduling.

--- a/pkg/scheduler/plugins/reservation/queueinghint_test.go
+++ b/pkg/scheduler/plugins/reservation/queueinghint_test.go
@@ -232,11 +232,20 @@ func TestPlugin_QueueingHint_PodDeletion_AssignedViaCache(t *testing.T) {
 }
 
 func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
-	// IsReservationActive requires Status.NodeName to be set and a Phase of Available or Waiting.
-	activeReservation := &schedulingv1alpha1.Reservation{
-		ObjectMeta: metav1.ObjectMeta{Name: "r-active", UID: "r-active"},
+	// IsReservationAvailable requires Status.NodeName to be set and Phase == Available.
+	// The hint keys off availability because that is what ReservationInfo.IsMatchable
+	// requires when the scheduler looks for a match.
+	availableReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-available", UID: "r-available"},
 		Status: schedulingv1alpha1.ReservationStatus{
 			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: "node-1",
+		},
+	}
+	waitingReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-waiting", UID: "r-waiting"},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationWaiting,
 			NodeName: "node-1",
 		},
 	}
@@ -269,21 +278,21 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			args: args{
 				waitingPod: makeWaitingPodNoReservation("w2"),
 				oldObj:     nil,
-				newObj:     activeReservation,
+				newObj:     availableReservation,
 			},
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name: "Add an active reservation, requeue",
+			name: "Add an available reservation, requeue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w3"),
 				oldObj:     nil,
-				newObj:     activeReservation,
+				newObj:     availableReservation,
 			},
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "Add a not-yet-ready reservation, skip",
+			name: "Add a not-yet-available reservation (pending), skip",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w4"),
 				oldObj:     nil,
@@ -292,20 +301,47 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
+			name: "Add a Waiting reservation is not yet matchable, skip",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w4w"),
+				oldObj:     nil,
+				newObj:     waitingReservation,
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
 			name: "Update from pending to available, requeue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w5"),
 				oldObj:     pendingReservation,
-				newObj:     activeReservation,
+				newObj:     availableReservation,
 			},
 			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "Update from Waiting to Available is the matchability transition, requeue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w5w"),
+				oldObj:     waitingReservation,
+				newObj:     availableReservation,
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "Update from Pending to Waiting is still not matchable, skip",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w5p"),
+				oldObj:     pendingReservation,
+				newObj:     waitingReservation,
+			},
+			expectedHint: fwktype.QueueSkip,
 		},
 		{
 			name: "Update while both are available with no meaningful change, skip to avoid queue noise",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w6"),
-				oldObj:     activeReservation,
-				newObj:     activeReservation,
+				oldObj:     availableReservation,
+				newObj:     availableReservation,
 			},
 			expectedHint: fwktype.QueueSkip,
 		},
@@ -313,7 +349,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			name: "Delete gives waiting pods another chance to re-evaluate",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w7"),
-				oldObj:     activeReservation,
+				oldObj:     availableReservation,
 				newObj:     nil,
 			},
 			expectedHint: fwktype.Queue,

--- a/pkg/scheduler/plugins/reservation/queueinghint_test.go
+++ b/pkg/scheduler/plugins/reservation/queueinghint_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+// TestPlugin_EventsToRegister 檢查 EnableQueueHint 打開與關掉時，事件註冊的形狀。
+// 關掉時要維持現有行為（兩個事件、沒有 hint 函式）；打開時要兩個事件都帶 hint。
+func TestPlugin_EventsToRegister(t *testing.T) {
+	tests := []struct {
+		name            string
+		enableQueueHint bool
+		expectHintFn    bool
+	}{
+		{
+			name:            "queue hint 關掉時，兩個事件都不帶 hint 函式",
+			enableQueueHint: false,
+			expectHintFn:    false,
+		},
+		{
+			name:            "queue hint 打開時，兩個事件都要帶 hint 函式",
+			enableQueueHint: true,
+			expectHintFn:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
+				args.EnableQueueHint = tt.enableQueueHint
+			})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			events, err := pl.EventsToRegister(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(events), "應該剛好註冊 Pod 和 Reservation 兩種事件")
+
+			expectedGVK := fmt.Sprintf("reservations.%v.%v",
+				schedulingv1alpha1.GroupVersion.Version,
+				schedulingv1alpha1.GroupVersion.Group)
+
+			var podEvent, reservationEvent *fwktype.ClusterEventWithHint
+			for i := range events {
+				switch events[i].Event.Resource {
+				case fwktype.Pod:
+					podEvent = &events[i]
+				case fwktype.EventResource(expectedGVK):
+					reservationEvent = &events[i]
+				}
+			}
+			assert.NotNil(t, podEvent, "Pod Delete 事件應該存在")
+			assert.NotNil(t, reservationEvent, "Reservation Add|Update|Delete 事件應該存在")
+
+			// ActionType 不論開關都不收窄，維持既有語意
+			assert.Equal(t, fwktype.Delete, podEvent.Event.ActionType)
+			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, reservationEvent.Event.ActionType)
+
+			if tt.expectHintFn {
+				assert.NotNil(t, podEvent.QueueingHintFn, "打開 queue hint 後 Pod 事件要帶 hint")
+				assert.NotNil(t, reservationEvent.QueueingHintFn, "打開 queue hint 後 Reservation 事件要帶 hint")
+			} else {
+				assert.Nil(t, podEvent.QueueingHintFn)
+				assert.Nil(t, reservationEvent.QueueingHintFn)
+			}
+		})
+	}
+}
+
+// makeWaitingPodUsingReservation 造一個「有 reservation affinity」的等待中 pod。
+func makeWaitingPodUsingReservation(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+			Annotations: map[string]string{
+				apiext.AnnotationReservationAffinity: `{"reservationSelector":{"app":"demo"}}`,
+			},
+		},
+	}
+}
+
+// makeWaitingPodNoReservation 造一個完全不碰 reservation 的 pod。
+func makeWaitingPodNoReservation(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+		},
+	}
+}
+
+// makeReservePod 造一個 reserve pod，IsReservePod 靠 annotation 判別。
+func makeReservePod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name),
+			Annotations: map[string]string{
+				reservationutil.AnnotationReservePod: "true",
+			},
+		},
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
+	type args struct {
+		waitingPod *corev1.Pod
+		oldObj     interface{}
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedHint fwktype.QueueingHint
+	}{
+		{
+			name: "oldObj 不是 pod，保守 re-queue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w1"),
+				oldObj:     "not-a-pod",
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "等待中的 pod 跟 reservation 無關，直接 skip",
+			args: args{
+				waitingPod: makeWaitingPodNoReservation("w2"),
+				oldObj:     makeReservePod("deleted-reserve"),
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name: "等待中的 pod 需要 reservation，且被刪的是 reserve pod，值得喚醒",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w3"),
+				oldObj:     makeReservePod("deleted-reserve"),
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "等待中的 pod 需要 reservation，但被刪的 pod 跟 reservation 毫無關係，skip",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w4"),
+				oldObj:     makeWaitingPodNoReservation("deleted-normal"),
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
+				args.EnableQueueHint = true
+			})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterPodDeletion(klog.Background(), tt.args.waitingPod, tt.args.oldObj, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}
+
+func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
+	// IsReservationActive 要求 Status.NodeName 不空、Phase 是 Available 或 Waiting
+	activeReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-active", UID: "r-active"},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase:    schedulingv1alpha1.ReservationAvailable,
+			NodeName: "node-1",
+		},
+	}
+	pendingReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-pending", UID: "r-pending"},
+		Status:     schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+	}
+
+	type args struct {
+		waitingPod *corev1.Pod
+		oldObj     interface{}
+		newObj     interface{}
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedHint fwktype.QueueingHint
+	}{
+		{
+			name: "不是 Reservation 型別，保守 re-queue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w1"),
+				oldObj:     nil,
+				newObj:     "not-a-reservation",
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "等待中的 pod 跟 reservation 無關，所有變化都 skip",
+			args: args{
+				waitingPod: makeWaitingPodNoReservation("w2"),
+				oldObj:     nil,
+				newObj:     activeReservation,
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name: "Add 一個 Available reservation，值得 re-queue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w3"),
+				oldObj:     nil,
+				newObj:     activeReservation,
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "Add 一個還沒 ready 的 reservation，先 skip",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w4"),
+				oldObj:     nil,
+				newObj:     pendingReservation,
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name: "Update：從 pending 變 available，值得 re-queue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w5"),
+				oldObj:     pendingReservation,
+				newObj:     activeReservation,
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "Update：兩邊都 Available、沒實質變化，skip 避免 noise",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w6"),
+				oldObj:     activeReservation,
+				newObj:     activeReservation,
+			},
+			expectedHint: fwktype.QueueSkip,
+		},
+		{
+			name: "Delete：既然有用 reservation 的 pod 在等，給它一次重新評估機會",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w7"),
+				oldObj:     activeReservation,
+				newObj:     nil,
+			},
+			expectedHint: fwktype.Queue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
+				args.EnableQueueHint = true
+			})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			got, err := pl.isSchedulableAfterReservationChange(klog.Background(), tt.args.waitingPod, tt.args.oldObj, tt.args.newObj)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHint, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/reservation/queueinghint_test.go
+++ b/pkg/scheduler/plugins/reservation/queueinghint_test.go
@@ -34,8 +34,6 @@ import (
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
-// TestPlugin_EventsToRegister 檢查 EnableQueueHint 打開與關掉時，事件註冊的形狀。
-// 關掉時要維持現有行為（兩個事件、沒有 hint 函式）；打開時要兩個事件都帶 hint。
 func TestPlugin_EventsToRegister(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -43,12 +41,12 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 		expectHintFn    bool
 	}{
 		{
-			name:            "queue hint 關掉時，兩個事件都不帶 hint 函式",
+			name:            "no hint functions when queue hint is disabled",
 			enableQueueHint: false,
 			expectHintFn:    false,
 		},
 		{
-			name:            "queue hint 打開時，兩個事件都要帶 hint 函式",
+			name:            "hint functions are set when queue hint is enabled",
 			enableQueueHint: true,
 			expectHintFn:    true,
 		},
@@ -65,7 +63,7 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 
 			events, err := pl.EventsToRegister(context.TODO())
 			assert.NoError(t, err)
-			assert.Equal(t, 2, len(events), "應該剛好註冊 Pod 和 Reservation 兩種事件")
+			assert.Equal(t, 2, len(events), "should register exactly Pod and Reservation events")
 
 			expectedGVK := fmt.Sprintf("reservations.%v.%v",
 				schedulingv1alpha1.GroupVersion.Version,
@@ -80,16 +78,16 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 					reservationEvent = &events[i]
 				}
 			}
-			assert.NotNil(t, podEvent, "Pod Delete 事件應該存在")
-			assert.NotNil(t, reservationEvent, "Reservation Add|Update|Delete 事件應該存在")
+			assert.NotNil(t, podEvent, "Pod Delete event should be registered")
+			assert.NotNil(t, reservationEvent, "Reservation Add|Update|Delete event should be registered")
 
-			// ActionType 不論開關都不收窄，維持既有語意
+			// Action type is preserved regardless of the flag.
 			assert.Equal(t, fwktype.Delete, podEvent.Event.ActionType)
 			assert.Equal(t, fwktype.Add|fwktype.Update|fwktype.Delete, reservationEvent.Event.ActionType)
 
 			if tt.expectHintFn {
-				assert.NotNil(t, podEvent.QueueingHintFn, "打開 queue hint 後 Pod 事件要帶 hint")
-				assert.NotNil(t, reservationEvent.QueueingHintFn, "打開 queue hint 後 Reservation 事件要帶 hint")
+				assert.NotNil(t, podEvent.QueueingHintFn)
+				assert.NotNil(t, reservationEvent.QueueingHintFn)
 			} else {
 				assert.Nil(t, podEvent.QueueingHintFn)
 				assert.Nil(t, reservationEvent.QueueingHintFn)
@@ -98,7 +96,6 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 	}
 }
 
-// makeWaitingPodUsingReservation 造一個「有 reservation affinity」的等待中 pod。
 func makeWaitingPodUsingReservation(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -112,7 +109,6 @@ func makeWaitingPodUsingReservation(name string) *corev1.Pod {
 	}
 }
 
-// makeWaitingPodNoReservation 造一個完全不碰 reservation 的 pod。
 func makeWaitingPodNoReservation(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -123,7 +119,6 @@ func makeWaitingPodNoReservation(name string) *corev1.Pod {
 	}
 }
 
-// makeReservePod 造一個 reserve pod，IsReservePod 靠 annotation 判別。
 func makeReservePod(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -148,7 +143,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 		expectedHint fwktype.QueueingHint
 	}{
 		{
-			name: "oldObj 不是 pod，保守 re-queue",
+			name: "oldObj is not a Pod, fall back to Queue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w1"),
 				oldObj:     "not-a-pod",
@@ -156,7 +151,15 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "等待中的 pod 跟 reservation 無關，直接 skip",
+			name: "nil deleted pod, fall back to Queue",
+			args: args{
+				waitingPod: makeWaitingPodUsingReservation("w1n"),
+				oldObj:     (*corev1.Pod)(nil),
+			},
+			expectedHint: fwktype.Queue,
+		},
+		{
+			name: "waiting pod is unrelated to reservation, skip",
 			args: args{
 				waitingPod: makeWaitingPodNoReservation("w2"),
 				oldObj:     makeReservePod("deleted-reserve"),
@@ -164,7 +167,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name: "等待中的 pod 需要 reservation，且被刪的是 reserve pod，值得喚醒",
+			name: "waiting pod uses reservation and the deleted pod is a reserve pod, requeue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w3"),
 				oldObj:     makeReservePod("deleted-reserve"),
@@ -172,7 +175,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "等待中的 pod 需要 reservation，但被刪的 pod 跟 reservation 毫無關係，skip",
+			name: "waiting pod uses reservation, deleted pod is unrelated, skip",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w4"),
 				oldObj:     makeWaitingPodNoReservation("deleted-normal"),
@@ -197,8 +200,39 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 	}
 }
 
+// TestPlugin_QueueingHint_PodDeletion_AssignedViaCache covers the branch
+// where the deleted pod is a regular (non-reserve) pod that was bound to
+// a reservation tracked by reservationCache. Pod deletion in that state
+// releases capacity from the reservation and must re-queue waiting pods
+// that use reservations.
+func TestPlugin_QueueingHint_PodDeletion_AssignedViaCache(t *testing.T) {
+	suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
+		args.EnableQueueHint = true
+	})
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-cache", UID: "r-cache"},
+	}
+	assert.NoError(t, reservationutil.SetReservationAvailable(reservation, "node-1"))
+	pl.reservationCache.updateReservation(reservation)
+
+	assignedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "assigned", Namespace: "default", UID: "assigned-uid"},
+		Spec:       corev1.PodSpec{NodeName: "node-1"},
+	}
+	assert.NoError(t, pl.reservationCache.assumePod(reservation.UID, assignedPod))
+
+	waiting := makeWaitingPodUsingReservation("waiting")
+	got, err := pl.isSchedulableAfterPodDeletion(klog.Background(), waiting, assignedPod, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, fwktype.Queue, got)
+}
+
 func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
-	// IsReservationActive 要求 Status.NodeName 不空、Phase 是 Available 或 Waiting
+	// IsReservationActive requires Status.NodeName to be set and a Phase of Available or Waiting.
 	activeReservation := &schedulingv1alpha1.Reservation{
 		ObjectMeta: metav1.ObjectMeta{Name: "r-active", UID: "r-active"},
 		Status: schedulingv1alpha1.ReservationStatus{
@@ -222,7 +256,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 		expectedHint fwktype.QueueingHint
 	}{
 		{
-			name: "不是 Reservation 型別，保守 re-queue",
+			name: "obj is not a Reservation, fall back to Queue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w1"),
 				oldObj:     nil,
@@ -231,7 +265,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "等待中的 pod 跟 reservation 無關，所有變化都 skip",
+			name: "waiting pod is unrelated to reservations, skip all reservation changes",
 			args: args{
 				waitingPod: makeWaitingPodNoReservation("w2"),
 				oldObj:     nil,
@@ -240,7 +274,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name: "Add 一個 Available reservation，值得 re-queue",
+			name: "Add an active reservation, requeue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w3"),
 				oldObj:     nil,
@@ -249,7 +283,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "Add 一個還沒 ready 的 reservation，先 skip",
+			name: "Add a not-yet-ready reservation, skip",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w4"),
 				oldObj:     nil,
@@ -258,7 +292,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name: "Update：從 pending 變 available，值得 re-queue",
+			name: "Update from pending to available, requeue",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w5"),
 				oldObj:     pendingReservation,
@@ -267,7 +301,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.Queue,
 		},
 		{
-			name: "Update：兩邊都 Available、沒實質變化，skip 避免 noise",
+			name: "Update while both are available with no meaningful change, skip to avoid queue noise",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w6"),
 				oldObj:     activeReservation,
@@ -276,7 +310,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterReservationChange(t *testing.T) {
 			expectedHint: fwktype.QueueSkip,
 		},
 		{
-			name: "Delete：既然有用 reservation 的 pod 在等，給它一次重新評估機會",
+			name: "Delete gives waiting pods another chance to re-evaluate",
 			args: args{
 				waitingPod: makeWaitingPodUsingReservation("w7"),
 				oldObj:     activeReservation,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Kubernetes 1.35 enables `SchedulerQueueingHints` by default. A plugin's `EventsToRegister()` entry that omits `QueueingHintFn` causes the scheduler to fall back to re-queuing every unschedulable pod on every matching cluster event, losing the benefit of the feature gate.

This PR audits every Koordinator scheduler plugin that implements `EventsToRegister` and closes the gaps:

| Plugin | Before | After |
| --- | --- | --- |
| `ElasticQuota` | Already hinted (opt-in `EnableQueueHint`) | unchanged |
| `Reservation` | Events, no hints | Hinted opt-in via `EnableQueueHint` |
| `NodeNUMAResource` | Events, no hints | Hinted opt-in via `EnableQueueHint` |
| `DeviceShare` | Events, no hints | Hinted opt-in via `EnableQueueHint` |
| `LoadAware` | Events, no hints | Hinted opt-in via `EnableQueueHint` |
| `Coscheduling` | Returns no events (gang gates in `PreEnqueue`) | Comment + invariant test |

The flag matches the existing `ElasticQuota` pattern: off by default, so this PR is byte-for-byte equivalent to the previous behaviour unless an operator opts in.

Per-plugin hint semantics:

- **Reservation** — Pod Delete is `Queue` only when the waiting pod uses reservations and the deleted pod was either a reserve pod or was bound to a reservation. Reservation Add is `Queue` only when the new reservation is already active. Reservation Update is `Queue` on the inactive→active transition. Reservation Delete is `Queue`.
- **NodeNUMAResource** — Pod Delete is `Queue` only when both the waiting pod and the deleted pod use NUMA-aware allocation. NRT Add/Update are `Queue`; NRT Delete is `QueueSkip`.
- **DeviceShare** — Pod Delete is `Queue` only when both pods request device resources (GPU/RDMA/FPGA). Device Add/Update are `Queue`; Device Delete is `QueueSkip`.
- **LoadAware** — Pod Delete is `Queue` only when the deleted pod was bound to a node. NodeMetric Add/Update are `Queue`; NodeMetric Delete is `QueueSkip`.
- **Coscheduling** — unchanged behaviour. The plugin deliberately returns no events; gang gating lives in `PreEnqueue`. An expanded comment and an invariant test pin this decision.

### Ⅱ. Does this pull request fix one issue?

fixes #2852

### Ⅲ. Describe how to verify it

Per-plugin unit tests:

```
go test ./pkg/scheduler/plugins/{reservation,deviceshare,nodenumaresource,loadaware,coscheduling}/ \
  -run 'TestPlugin_EventsToRegister|TestPlugin_QueueingHint|TestCoscheduling_EventsToRegister' \
  -count=1 -v
```

Full regression, race-enabled (Linux):

```
go test ./pkg/scheduler/plugins/... -race -count=1 -timeout 20m
```

### Ⅳ. Special notes for reviews

- **Opt-in, default off.** Mirrors the existing `ElasticQuota` precedent. Safe to merge; operators flip on per-plugin as they gain confidence.
- **Action types preserved.** The raw set of `Add | Update | Delete` on each CRD event is unchanged; only a hint function is attached. Selectivity is implemented inside the hint body.
- **Hints are read-only.** No new informer sync, no API calls, no write locks.
- **Conservative fall-back.** Every hint returns `Queue` when the incoming object cannot be type-asserted.
- **Per-plugin flag; no shared helper.** With only one operational pattern today (`ElasticQuota`), a shared abstraction would be premature.

Boundary of this PR: no new events are registered anywhere, no default values are changed, no plugin factory or controller is restructured, no generated types outside `pkg/scheduler/apis/config/v1` are touched.

Each `types.go` change ships with the matching `zz_generated.conversion.go` and `zz_generated.deepcopy.go` update in the same commit.

### Ⅴ. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`