### PR TITLE
scheduler: support cross-scheduler nominator for multi-scheduler preemption

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -64,6 +64,7 @@ import (
 
 	schedulerserverconfig "github.com/koordinator-sh/koordinator/cmd/koord-scheduler/app/config"
 	"github.com/koordinator-sh/koordinator/cmd/koord-scheduler/app/options"
+	koordfeatures "github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/defaultprofile"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/eventhandlers"
@@ -400,6 +401,15 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 
 	networkTopologyManager := networktopology.NewTreeManager(cc.KoordinatorSharedInformerFactory, cc.InformerFactory, cc.KoordinatorClient)
 
+	// When CrossSchedulerNomination feature gate is enabled, create a CrossSchedulerPodNominator
+	// to track nominated pods from other schedulers for cross-scheduler resource accounting.
+	// Profile names are registered lazily in NewFrameworkExtender after each framework profile is built,
+	// so that the actual schedulerName (which may be overridden at runtime) is captured correctly.
+	var crossSchedulerNominator *frameworkext.CrossSchedulerPodNominator
+	if utilfeature.DefaultFeatureGate.Enabled(koordfeatures.CrossSchedulerNomination) {
+		crossSchedulerNominator = frameworkext.NewCrossSchedulerPodNominator()
+	}
+
 	// NOTE(joseph): K8s scheduling framework does not provide extension point for initialization.
 	// Currently, only by copying the initialization code and implementing custom initialization.
 	frameworkExtenderFactory, err := frameworkext.NewFrameworkExtenderFactory(
@@ -408,6 +418,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		frameworkext.WithKoordinatorSharedInformerFactory(cc.KoordinatorSharedInformerFactory),
 		frameworkext.WithNodeResourceTopologySharedInformerFactory(cc.NodeResourceTopologyInformerFactory),
 		frameworkext.WithNetworkTopologyManager(networkTopologyManager),
+		frameworkext.WithCrossSchedulerPodNominator(crossSchedulerNominator),
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -463,7 +474,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	frameworkExtenderFactory.InitScheduler(&frameworkext.SchedulerAdapter{Scheduler: sched})
 	schedAdapter := frameworkExtenderFactory.Scheduler()
 
-	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
+	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory, crossSchedulerNominator)
 	reservationErrorHandler := eventhandlers.MakeReservationErrorHandler(
 		sched,
 		schedAdapter,

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -102,6 +102,23 @@ const (
 	// DynamicSchedulerCheck is used to check the scheduler name when a pod or a reservation can change it dynamically.
 	DynamicSchedulerCheck featuregate.Feature = "DynamicSchedulerCheck"
 
+	// owner: @saintube @ZiMengSheng
+	// alpha: v1.8
+	//
+	// CrossSchedulerNomination enables cross-scheduler nomination support,
+	// allowing a pod nominated by one scheduler to be recognized by another scheduler.
+	CrossSchedulerNomination featuregate.Feature = "CrossSchedulerNomination"
+
+	// owner: @saintube
+	// alpha: v1.8
+	//
+	// SkipFilterWithNominatedPods simplifies RunFilterPluginsWithNominatedPods by running
+	// filters only once with nominated pods included, instead of the default two-pass
+	// comparison (pass 1 with nominated pods, pass 2 without). The two-pass logic handles
+	// a pod affinity corner case during preemption but introduces 2x filter overhead.
+	// When enabled, the single pass with nominated pods is sufficient for most scenarios.
+	SkipFilterWithNominatedPods featuregate.Feature = "SkipFilterWithNominatedPods"
+
 	CSIStorageCapacity featuregate.Feature = "CSIStorageCapacity"
 
 	GenericEphemeralVolume featuregate.Feature = "GenericEphemeralVolume"
@@ -138,11 +155,13 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	SkipReservationFitsNode:                   {Default: false, PreRelease: featuregate.Alpha},
 	DevicePluginAdaption:                      {Default: false, PreRelease: featuregate.Alpha},
 	CleanExpiredReservationAllocated:          {Default: false, PreRelease: featuregate.Alpha},
+	SkipFilterWithNominatedPods:               {Default: false, PreRelease: featuregate.Alpha},
 	DynamicSchedulerCheck:                     {Default: true, PreRelease: featuregate.Alpha}, // enabled by default
 	CSIStorageCapacity:                        {Default: true, PreRelease: featuregate.GA},    // remove in 1.26
 	GenericEphemeralVolume:                    {Default: true, PreRelease: featuregate.GA},
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},
 	SyncBarrier:                               {Default: false, PreRelease: featuregate.Alpha},
+	CrossSchedulerNomination:                  {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
+++ b/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// CrossSchedulerPodNominator tracks nominated pods from other schedulers
+// to enable cross-scheduler resource accounting during filter phase.
+type CrossSchedulerPodNominator struct {
+	mu sync.RWMutex
+	// nominatedPods indexes nominated pods by node name
+	nominatedPods map[string][]fwktype.PodInfo
+	// nominatedPodToNode maps pod UID to nominated node name for quick lookup
+	nominatedPodToNode map[types.UID]string
+	// localProfileNames contains the scheduler profile names of the current scheduler instance.
+	// Pods from these profiles are excluded (they're handled by the native PodNominator).
+	localProfileNames sets.Set[string]
+}
+
+// NewCrossSchedulerPodNominator creates a new CrossSchedulerPodNominator with an empty local profile set.
+// Profile names are registered lazily via AddLocalProfileName after each framework profile is built.
+func NewCrossSchedulerPodNominator() *CrossSchedulerPodNominator {
+	return &CrossSchedulerPodNominator{
+		nominatedPods:      make(map[string][]fwktype.PodInfo),
+		nominatedPodToNode: make(map[types.UID]string),
+		localProfileNames:  sets.New[string](),
+	}
+}
+
+// AddLocalProfileName adds a profile name to the local profiles set.
+// Pods from local profiles are excluded from cross-scheduler nomination tracking
+// because they are handled by the native PodNominator.
+// This method is called when a new framework profile is created.
+func (n *CrossSchedulerPodNominator) AddLocalProfileName(profileName string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.localProfileNames.Insert(profileName)
+}
+
+// NominatedPodsForNode returns the cross-scheduler nominated pods for the given node.
+// The caller should not modify the returned slice.
+func (n *CrossSchedulerPodNominator) NominatedPodsForNode(nodeName string) []fwktype.PodInfo {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	// Make a copy of the nominated Pods so the caller can mutate safely.
+	pods := make([]fwktype.PodInfo, 0, len(n.nominatedPods[nodeName]))
+	for i := range n.nominatedPods[nodeName] {
+		podInfoCopy, err := framework.NewPodInfo(n.nominatedPods[nodeName][i].GetPod())
+		if err == nil {
+			pods = append(pods, podInfoCopy)
+		}
+	}
+	return pods
+}
+
+// addNominatedPod adds or updates the nominated pod record.
+// It must be called with the write lock held (or in a context where no lock is needed).
+func (n *CrossSchedulerPodNominator) addNominatedPod(pod *corev1.Pod) {
+	if pod.Status.NominatedNodeName == "" {
+		return
+	}
+	// Remove the old entry first to handle updates (node name may have changed).
+	n.deleteNominatedPod(pod)
+
+	nodeName := pod.Status.NominatedNodeName
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create PodInfo for cross-scheduler nominated pod", "pod", klog.KObj(pod))
+		return
+	}
+	n.nominatedPods[nodeName] = append(n.nominatedPods[nodeName], podInfo)
+	n.nominatedPodToNode[pod.UID] = nodeName
+}
+
+// deleteNominatedPodLocked removes the nominated pod record. Must be called with write lock held.
+func (n *CrossSchedulerPodNominator) deleteNominatedPod(pod *corev1.Pod) {
+	nodeName, ok := n.nominatedPodToNode[pod.UID]
+	if !ok {
+		return
+	}
+	pods := n.nominatedPods[nodeName]
+	for i, pi := range pods {
+		if pi.GetPod().UID == pod.UID {
+			n.nominatedPods[nodeName] = append(pods[:i], pods[i+1:]...)
+			break
+		}
+	}
+	if len(n.nominatedPods[nodeName]) == 0 {
+		delete(n.nominatedPods, nodeName)
+	}
+	delete(n.nominatedPodToNode, pod.UID)
+}
+
+func (n *CrossSchedulerPodNominator) ShouldHandle(obj interface{}) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		// Handle tombstone objects from the informer cache.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return false
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			return false
+		}
+	}
+	if pod.Status.NominatedNodeName == "" || pod.Spec.NodeName != "" {
+		return false
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return !n.localProfileNames.Has(pod.Spec.SchedulerName)
+}
+
+func (n *CrossSchedulerPodNominator) OnAdd(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.addNominatedPod(pod)
+}
+
+func (n *CrossSchedulerPodNominator) OnUpdate(oldObj, newObj interface{}) {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// We update irrespective of the nominatedNodeName changed or not, to ensure that pod pointer is updated.
+	n.deleteNominatedPod(oldPod)
+	n.addNominatedPod(newPod)
+}
+
+func (n *CrossSchedulerPodNominator) OnDelete(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		// Handle tombstone objects from the informer cache.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			return
+		}
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.deleteNominatedPod(pod)
+}

--- a/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
+++ b/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
@@ -62,7 +62,6 @@ func (n *CrossSchedulerPodNominator) AddLocalProfileName(profileName string) {
 }
 
 // NominatedPodsForNode returns the cross-scheduler nominated pods for the given node.
-// The caller should not modify the returned slice.
 func (n *CrossSchedulerPodNominator) NominatedPodsForNode(nodeName string) []fwktype.PodInfo {
 	n.mu.RLock()
 	defer n.mu.RUnlock()

--- a/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
+++ b/pkg/scheduler/frameworkext/cross_scheduler_nominator.go
@@ -69,7 +69,7 @@ func (n *CrossSchedulerPodNominator) NominatedPodsForNode(nodeName string) []fwk
 	// Make a copy of the nominated Pods so the caller can mutate safely.
 	pods := make([]fwktype.PodInfo, 0, len(n.nominatedPods[nodeName]))
 	for i := range n.nominatedPods[nodeName] {
-		podInfoCopy, err := framework.NewPodInfo(n.nominatedPods[nodeName][i].GetPod())
+		podInfoCopy, err := framework.NewPodInfo(n.nominatedPods[nodeName][i].GetPod().DeepCopy())
 		if err == nil {
 			pods = append(pods, podInfoCopy)
 		}
@@ -96,7 +96,7 @@ func (n *CrossSchedulerPodNominator) addNominatedPod(pod *corev1.Pod) {
 	n.nominatedPodToNode[pod.UID] = nodeName
 }
 
-// deleteNominatedPodLocked removes the nominated pod record. Must be called with write lock held.
+// deleteNominatedPod removes the nominated pod record. Must be called with write lock held.
 func (n *CrossSchedulerPodNominator) deleteNominatedPod(pod *corev1.Pod) {
 	nodeName, ok := n.nominatedPodToNode[pod.UID]
 	if !ok {

--- a/pkg/scheduler/frameworkext/cross_scheduler_nominator_test.go
+++ b/pkg/scheduler/frameworkext/cross_scheduler_nominator_test.go
@@ -420,13 +420,21 @@ func TestCrossSchedulerPodNominator_NominatedPodsForNode_DeepCopy(t *testing.T) 
 	assert.Len(t, pods2, 1)
 
 	// Verify that the returned PodInfo objects are different instances.
-	// This tests that NominatedPodsForNode creates new PodInfo objects each time.
 	assert.NotSame(t, pods1[0], pods2[0], "returned PodInfo should be different instances")
 
-	// Note: Currently NewPodInfo creates a shallow copy (shares the same Pod object pointer).
-	// If true deep copy is required, NominatedPodsForNode should call pod.DeepCopy() before NewPodInfo.
-	// The current behavior is that modifying pods1[0].GetPod() WILL affect the internal state.
-	// This test documents the current behavior.
+	// Verify that the returned Pod objects are different instances (deep copy).
+	assert.NotSame(t, pods1[0].GetPod(), pods2[0].GetPod(), "returned Pod should be different instances (deep copy)")
+
+	// Verify true deep copy: modifying the returned pod does NOT affect internal state.
+	// Modify the returned pod's name.
+	originalName := pods1[0].GetPod().Name
+	pods1[0].GetPod().Name = "modified-name"
+
+	// Get the pods again and verify the internal state is unchanged.
+	pods3 := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods3, 1)
+	assert.Equal(t, originalName, pods3[0].GetPod().Name, "internal state should not be affected by modification to returned pod")
+	assert.NotEqual(t, "modified-name", pods3[0].GetPod().Name, "modification should not leak to internal state")
 }
 
 // TestCrossSchedulerPodNominator_FilteringResourceEventHandler tests the complete

--- a/pkg/scheduler/frameworkext/cross_scheduler_nominator_test.go
+++ b/pkg/scheduler/frameworkext/cross_scheduler_nominator_test.go
@@ -1,0 +1,544 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+func makePod(name, uid, schedulerName, nominatedNodeName, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(uid),
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: schedulerName,
+			NodeName:      nodeName,
+		},
+		Status: corev1.PodStatus{
+			NominatedNodeName: nominatedNodeName,
+		},
+	}
+}
+
+// TestCrossSchedulerPodNominator_AddDelete tests basic add and delete operations.
+func TestCrossSchedulerPodNominator_AddDelete(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	pod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+
+	// Add a non-local pod with nominatedNodeName.
+	nominator.OnAdd(pod)
+	pods := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "pod-1", pods[0].GetPod().Name)
+
+	// Delete the pod and verify the index is cleared.
+	nominator.OnDelete(pod)
+	pods = nominator.NominatedPodsForNode("node-1")
+	assert.Empty(t, pods)
+}
+
+// TestCrossSchedulerPodNominator_LocalSchedulerExcluded tests that local scheduler pods are excluded by ShouldHandle.
+func TestCrossSchedulerPodNominator_LocalSchedulerExcluded(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	// A pod from the local scheduler should NOT pass ShouldHandle filter.
+	localPod := makePod("local-pod", "uid-local", "koord-scheduler", "node-1", "")
+	assert.False(t, nominator.ShouldHandle(localPod), "local scheduler pod should not pass ShouldHandle")
+
+	// In production, FilteringResourceEventHandler won't call OnAdd because ShouldHandle returns false.
+	// OnAdd does NOT filter by schedulerName - that's ShouldHandle's job.
+	// We do NOT call OnAdd for localPod here because that's not how the handler works in production.
+
+	// A pod from a non-local scheduler SHOULD pass ShouldHandle and be added.
+	foreignPod := makePod("foreign-pod", "uid-foreign", "other-scheduler", "node-1", "")
+	assert.True(t, nominator.ShouldHandle(foreignPod), "non-local scheduler pod should pass ShouldHandle")
+	nominator.OnAdd(foreignPod)
+	pods := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "foreign-pod", pods[0].GetPod().Name)
+}
+
+// TestCrossSchedulerPodNominator_MultiplePodsOnSameNode tests that multiple pods on the same node are all returned.
+func TestCrossSchedulerPodNominator_MultiplePodsOnSameNode(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	pod1 := makePod("pod-1", "uid-1", "scheduler-a", "node-1", "")
+	pod2 := makePod("pod-2", "uid-2", "scheduler-b", "node-1", "")
+	pod3 := makePod("pod-3", "uid-3", "scheduler-c", "node-2", "")
+
+	nominator.OnAdd(pod1)
+	nominator.OnAdd(pod2)
+	nominator.OnAdd(pod3)
+
+	node1Pods := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, node1Pods, 2)
+
+	node2Pods := nominator.NominatedPodsForNode("node-2")
+	assert.Len(t, node2Pods, 1)
+	assert.Equal(t, "pod-3", node2Pods[0].GetPod().Name)
+}
+
+// TestCrossSchedulerPodNominator_BoundPodClearedOnUpdate tests that a bound pod is removed from the index.
+// With FilteringResourceEventHandler, when oldPod passes ShouldHandle but newPod doesn't (bound),
+// the handler calls OnDelete(oldPod) instead of OnUpdate.
+func TestCrossSchedulerPodNominator_BoundPodClearedOnUpdate(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	oldPod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(oldPod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+	// Simulate pod being bound: spec.nodeName is set.
+	newPod := oldPod.DeepCopy()
+	newPod.Spec.NodeName = "node-1"
+
+	// Verify ShouldHandle behavior: oldPod passes, newPod doesn't.
+	assert.True(t, nominator.ShouldHandle(oldPod), "oldPod should pass ShouldHandle")
+	assert.False(t, nominator.ShouldHandle(newPod), "bound newPod should not pass ShouldHandle")
+
+	// With FilteringResourceEventHandler, when old passes filter but new doesn't,
+	// OnDelete(oldObj) is called instead of OnUpdate.
+	nominator.OnDelete(oldPod)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+}
+
+// TestCrossSchedulerPodNominator_NominatedNodeNameCleared tests removal when nominatedNodeName is cleared.
+// With FilteringResourceEventHandler, when oldPod passes ShouldHandle but newPod doesn't (nominatedNodeName cleared),
+// the handler calls OnDelete(oldPod) instead of OnUpdate.
+func TestCrossSchedulerPodNominator_NominatedNodeNameCleared(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	oldPod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(oldPod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+	// Simulate nominatedNodeName being cleared.
+	newPod := oldPod.DeepCopy()
+	newPod.Status.NominatedNodeName = ""
+
+	// Verify ShouldHandle behavior: oldPod passes, newPod doesn't.
+	assert.True(t, nominator.ShouldHandle(oldPod), "oldPod should pass ShouldHandle")
+	assert.False(t, nominator.ShouldHandle(newPod), "newPod with cleared nominatedNodeName should not pass ShouldHandle")
+
+	// With FilteringResourceEventHandler, when old passes filter but new doesn't,
+	// OnDelete(oldObj) is called instead of OnUpdate.
+	nominator.OnDelete(oldPod)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+}
+
+// TestCrossSchedulerPodNominator_SchedulerNameChangedToLocal tests that when schedulerName changes to local,
+// the pod is removed from the cross-scheduler nominator.
+// With FilteringResourceEventHandler, when oldPod passes ShouldHandle but newPod doesn't (schedulerName changed to local),
+// the handler calls OnDelete(oldPod) instead of OnUpdate.
+func TestCrossSchedulerPodNominator_SchedulerNameChangedToLocal(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	// Initially a non-local pod with nomination.
+	oldPod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(oldPod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+	// schedulerName changes from non-local to local: should be removed.
+	newPod := oldPod.DeepCopy()
+	newPod.Spec.SchedulerName = "koord-scheduler"
+
+	// Verify ShouldHandle behavior: oldPod passes, newPod doesn't.
+	assert.True(t, nominator.ShouldHandle(oldPod), "oldPod should pass ShouldHandle")
+	assert.False(t, nominator.ShouldHandle(newPod), "newPod with local schedulerName should not pass ShouldHandle")
+
+	// With FilteringResourceEventHandler, when old passes filter but new doesn't,
+	// OnDelete(oldObj) is called instead of OnUpdate.
+	nominator.OnDelete(oldPod)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+}
+
+// TestCrossSchedulerPodNominator_SchedulerNameChangedFromLocal tests that when schedulerName changes from local
+// to non-local with a nominatedNodeName, the pod is added to the cross-scheduler nominator.
+func TestCrossSchedulerPodNominator_SchedulerNameChangedFromLocal(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	// Initially a local pod — would not be in the cross-scheduler index.
+	oldPod := makePod("pod-1", "uid-1", "koord-scheduler", "node-1", "")
+
+	// schedulerName changes from local to non-local with nominatedNodeName set.
+	newPod := oldPod.DeepCopy()
+	newPod.Spec.SchedulerName = "other-scheduler"
+	newPod.Status.NominatedNodeName = "node-1"
+
+	nominator.OnUpdate(oldPod, newPod)
+	pods := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "pod-1", pods[0].GetPod().Name)
+}
+
+// TestCrossSchedulerPodNominator_SchedulerAndNominatedNodeBothChange tests combined changes.
+// With FilteringResourceEventHandler, when oldPod passes ShouldHandle but newPod doesn't (schedulerName changed to local),
+// the handler calls OnDelete(oldPod) instead of OnUpdate.
+func TestCrossSchedulerPodNominator_SchedulerAndNominatedNodeBothChange(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	// Pod starts as non-local nominated on node-1.
+	oldPod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(oldPod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+	// schedulerName changes to local AND nominatedNodeName also changes — should be removed.
+	newPod := oldPod.DeepCopy()
+	newPod.Spec.SchedulerName = "koord-scheduler"
+	newPod.Status.NominatedNodeName = "node-2"
+
+	// Verify ShouldHandle behavior: oldPod passes, newPod doesn't.
+	assert.True(t, nominator.ShouldHandle(oldPod), "oldPod should pass ShouldHandle")
+	assert.False(t, nominator.ShouldHandle(newPod), "newPod with local schedulerName should not pass ShouldHandle")
+
+	// With FilteringResourceEventHandler, when old passes filter but new doesn't,
+	// OnDelete(oldObj) is called instead of OnUpdate.
+	nominator.OnDelete(oldPod)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+	assert.Empty(t, nominator.NominatedPodsForNode("node-2"))
+}
+
+// TestCrossSchedulerPodNominator_OnDelete_DeletedFinalStateUnknown tests handling of tombstone objects.
+func TestCrossSchedulerPodNominator_OnDelete_DeletedFinalStateUnknown(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	pod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(pod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+	// Wrap in a DeletedFinalStateUnknown tombstone to simulate informer cache eviction.
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "default/pod-1",
+		Obj: pod,
+	}
+	nominator.OnDelete(tombstone)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+}
+
+// TestCrossSchedulerPodNominator_OnAdd_InvalidObject tests that non-pod objects are ignored gracefully.
+func TestCrossSchedulerPodNominator_OnAdd_InvalidObject(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	// Passing a non-pod object should not panic and should not add anything.
+	nominator.OnAdd("not-a-pod")
+	nominator.OnAdd(42)
+	nominator.OnAdd(nil)
+
+	// Nothing should have been added.
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+}
+
+// TestCrossSchedulerPodNominator_OnUpdate_InvalidObject tests that non-pod objects are ignored gracefully.
+func TestCrossSchedulerPodNominator_OnUpdate_InvalidObject(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	pod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(pod)
+
+	// Invalid old or new object should not panic.
+	nominator.OnUpdate("not-a-pod", pod)
+	nominator.OnUpdate(pod, "not-a-pod")
+
+	// The original pod should still be present (or gracefully removed — just no panic).
+	// Either way, no crash is the key assertion.
+}
+
+// TestCrossSchedulerPodNominator_NominatedNodeNameChanged tests update when nominatedNodeName moves to another node.
+func TestCrossSchedulerPodNominator_NominatedNodeNameChanged(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	oldPod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(oldPod)
+	assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-2"))
+
+	// nominatedNodeName changes from node-1 to node-2.
+	newPod := oldPod.DeepCopy()
+	newPod.Status.NominatedNodeName = "node-2"
+
+	nominator.OnUpdate(oldPod, newPod)
+	assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+	assert.Len(t, nominator.NominatedPodsForNode("node-2"), 1)
+}
+
+// TestCrossSchedulerPodNominator_OnAdd_BoundPodIgnored tests that a pod already bound to a node
+// is filtered out by ShouldHandle.
+func TestCrossSchedulerPodNominator_OnAdd_BoundPodIgnored(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	// Pod is already bound (spec.nodeName set).
+	pod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "node-1")
+
+	// Verify ShouldHandle returns false for bound pods.
+	assert.False(t, nominator.ShouldHandle(pod), "bound pod should not pass ShouldHandle")
+
+	// In production, FilteringResourceEventHandler won't call OnAdd because ShouldHandle returns false.
+	// We do NOT call OnAdd for bound pod here because that's not how the handler works in production.
+	// addNominatedPod only checks NominatedNodeName, not NodeName, so it would add bound pods
+	// if called directly. But ShouldHandle filters them out first.
+}
+
+// TestCrossSchedulerPodNominator_ShouldHandle tests the ShouldHandle filter function
+// which determines whether a pod should be handled by the cross-scheduler nominator.
+func TestCrossSchedulerPodNominator_ShouldHandle(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	tests := []struct {
+		name            string
+		obj             interface{}
+		wantHandle      bool
+		wantDescription string
+	}{
+		{
+			name:            "pod with nominatedNodeName and non-local scheduler - should handle",
+			obj:             makePod("pod-1", "uid-1", "other-scheduler", "node-1", ""),
+			wantHandle:      true,
+			wantDescription: "non-local scheduler pod with nominatedNodeName should be handled",
+		},
+		{
+			name:            "pod with empty nominatedNodeName - should not handle",
+			obj:             makePod("pod-2", "uid-2", "other-scheduler", "", ""),
+			wantHandle:      false,
+			wantDescription: "pod without nominatedNodeName should not be handled",
+		},
+		{
+			name:            "pod with local schedulerName - should not handle",
+			obj:             makePod("pod-3", "uid-3", "koord-scheduler", "node-1", ""),
+			wantHandle:      false,
+			wantDescription: "local scheduler pod should not be handled",
+		},
+		{
+			name:            "bound pod (nodeName set) - should not handle",
+			obj:             makePod("pod-4", "uid-4", "other-scheduler", "node-1", "node-1"),
+			wantHandle:      false,
+			wantDescription: "bound pod should not be handled",
+		},
+		{
+			name:            "non-pod object - should not handle",
+			obj:             "not-a-pod",
+			wantHandle:      false,
+			wantDescription: "non-pod object should not be handled",
+		},
+		{
+			name:            "nil object - should not handle",
+			obj:             nil,
+			wantHandle:      false,
+			wantDescription: "nil object should not be handled",
+		},
+		{
+			name: "DeletedFinalStateUnknown with valid pod - should handle",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/pod-5",
+				Obj: makePod("pod-5", "uid-5", "other-scheduler", "node-1", ""),
+			},
+			wantHandle:      true,
+			wantDescription: "tombstone with valid non-local pod should be handled",
+		},
+		{
+			name: "DeletedFinalStateUnknown with local scheduler pod - should not handle",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/pod-6",
+				Obj: makePod("pod-6", "uid-6", "koord-scheduler", "node-1", ""),
+			},
+			wantHandle:      false,
+			wantDescription: "tombstone with local scheduler pod should not be handled",
+		},
+		{
+			name: "DeletedFinalStateUnknown with non-pod object - should not handle",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/not-a-pod",
+				Obj: "not-a-pod",
+			},
+			wantHandle:      false,
+			wantDescription: "tombstone with non-pod object should not be handled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nominator.ShouldHandle(tt.obj)
+			assert.Equal(t, tt.wantHandle, got, tt.wantDescription)
+		})
+	}
+}
+
+// TestCrossSchedulerPodNominator_NominatedPodsForNode_DeepCopy tests that NominatedPodsForNode
+// returns a deep copy, so modifications to the returned slice don't affect the internal state.
+func TestCrossSchedulerPodNominator_NominatedPodsForNode_DeepCopy(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("local-scheduler")
+
+	// Add a pod.
+	pod := makePod("pod-1", "uid-1", "other-scheduler", "node-1", "")
+	nominator.OnAdd(pod)
+
+	// Get the nominated pods.
+	pods1 := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods1, 1)
+	assert.Equal(t, "pod-1", pods1[0].GetPod().Name)
+
+	// Get the nominated pods again before modification.
+	pods2 := nominator.NominatedPodsForNode("node-1")
+	assert.Len(t, pods2, 1)
+
+	// Verify that the returned PodInfo objects are different instances.
+	// This tests that NominatedPodsForNode creates new PodInfo objects each time.
+	assert.NotSame(t, pods1[0], pods2[0], "returned PodInfo should be different instances")
+
+	// Note: Currently NewPodInfo creates a shallow copy (shares the same Pod object pointer).
+	// If true deep copy is required, NominatedPodsForNode should call pod.DeepCopy() before NewPodInfo.
+	// The current behavior is that modifying pods1[0].GetPod() WILL affect the internal state.
+	// This test documents the current behavior.
+}
+
+// TestCrossSchedulerPodNominator_FilteringResourceEventHandler tests the complete
+// FilteringResourceEventHandler behavior wrapping the nominator.
+func TestCrossSchedulerPodNominator_FilteringResourceEventHandler(t *testing.T) {
+	nominator := NewCrossSchedulerPodNominator()
+	nominator.AddLocalProfileName("koord-scheduler")
+
+	// Create a FilteringResourceEventHandler that wraps the nominator using ResourceEventHandlerFuncs.
+	filterHandler := cache.FilteringResourceEventHandler{
+		FilterFunc: nominator.ShouldHandle,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    nominator.OnAdd,
+			UpdateFunc: nominator.OnUpdate,
+			DeleteFunc: nominator.OnDelete,
+		},
+	}
+
+	// Test 1: old passes filter, new doesn't (bound) -> OnDelete(old)
+	t.Run("old_passes_new_does_not_bound", func(t *testing.T) {
+		pod := makePod("test-pod-1", "uid-test-1", "other-scheduler", "node-1", "")
+		filterHandler.OnAdd(pod, false)
+		assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+		// Pod becomes bound.
+		boundPod := pod.DeepCopy()
+		boundPod.Spec.NodeName = "node-1"
+
+		// FilteringResourceEventHandler.OnUpdate will call OnDelete(oldObj) because old passes but new doesn't.
+		filterHandler.OnUpdate(pod, boundPod)
+		assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+	})
+
+	// Test 2: old passes filter, new doesn't (nominatedNodeName cleared) -> OnDelete(old)
+	t.Run("old_passes_new_does_not_nominated_cleared", func(t *testing.T) {
+		pod := makePod("test-pod-2", "uid-test-2", "other-scheduler", "node-1", "")
+		filterHandler.OnAdd(pod, false)
+		assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+		// Pod's nominatedNodeName is cleared.
+		clearedPod := pod.DeepCopy()
+		clearedPod.Status.NominatedNodeName = ""
+
+		filterHandler.OnUpdate(pod, clearedPod)
+		assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+	})
+
+	// Test 3: old passes filter, new doesn't (schedulerName changed to local) -> OnDelete(old)
+	t.Run("old_passes_new_does_not_scheduler_local", func(t *testing.T) {
+		pod := makePod("test-pod-3", "uid-test-3", "other-scheduler", "node-1", "")
+		filterHandler.OnAdd(pod, false)
+		assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+		// Pod's schedulerName changes to local.
+		localPod := pod.DeepCopy()
+		localPod.Spec.SchedulerName = "koord-scheduler"
+
+		filterHandler.OnUpdate(pod, localPod)
+		assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+	})
+
+	// Test 4: both pass filter (nominatedNodeName change) -> OnUpdate
+	t.Run("both_pass_nominated_node_changed", func(t *testing.T) {
+		pod := makePod("test-pod-4", "uid-test-4", "other-scheduler", "node-1", "")
+		filterHandler.OnAdd(pod, false)
+		assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+
+		// Pod's nominatedNodeName changes to another node.
+		newNodePod := pod.DeepCopy()
+		newNodePod.Status.NominatedNodeName = "node-2"
+
+		filterHandler.OnUpdate(pod, newNodePod)
+		assert.Empty(t, nominator.NominatedPodsForNode("node-1"))
+		assert.Len(t, nominator.NominatedPodsForNode("node-2"), 1)
+	})
+
+	// Test 5: old doesn't pass filter, new passes -> OnAdd(new)
+	t.Run("old_does_not_new_passes", func(t *testing.T) {
+		// Pod starts as local scheduler (doesn't pass filter).
+		localPod := makePod("test-pod-5", "uid-test-5", "koord-scheduler", "node-1", "")
+
+		// Pod's schedulerName changes to non-local with nominatedNodeName.
+		nonLocalPod := localPod.DeepCopy()
+		nonLocalPod.Spec.SchedulerName = "other-scheduler"
+		nonLocalPod.Status.NominatedNodeName = "node-1"
+
+		// FilteringResourceEventHandler.OnUpdate will call OnAdd(newObj) because old doesn't pass but new does.
+		filterHandler.OnUpdate(localPod, nonLocalPod)
+		assert.Len(t, nominator.NominatedPodsForNode("node-1"), 1)
+	})
+
+	// Test 6: neither passes filter -> nothing happens
+	t.Run("neither_passes", func(t *testing.T) {
+		// Use a fresh nominator for this test to avoid pollution from previous tests.
+		freshNominator := NewCrossSchedulerPodNominator()
+		freshNominator.AddLocalProfileName("koord-scheduler")
+
+		freshFilterHandler := cache.FilteringResourceEventHandler{
+			FilterFunc: freshNominator.ShouldHandle,
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc:    freshNominator.OnAdd,
+				UpdateFunc: freshNominator.OnUpdate,
+				DeleteFunc: freshNominator.OnDelete,
+			},
+		}
+
+		localPod1 := makePod("test-pod-6", "uid-test-6", "koord-scheduler", "node-3", "")
+		localPod2 := localPod1.DeepCopy()
+		localPod2.Status.NominatedNodeName = "node-4"
+
+		freshFilterHandler.OnUpdate(localPod1, localPod2)
+		assert.Empty(t, freshNominator.NominatedPodsForNode("node-3"))
+		assert.Empty(t, freshNominator.NominatedPodsForNode("node-4"))
+	})
+}

--- a/pkg/scheduler/frameworkext/eventhandlers/event_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/event_handler.go
@@ -34,7 +34,7 @@ import (
 // - Reservation event handlers for the scheduler just like pods'. One special case is that reservations have expiration, which the scheduler should clean up expired ones from the
 // cache and queue.
 // - Pod and reservation event handlers for multi-scheduler clean up.
-func AddScheduleEventHandler(sched *scheduler.Scheduler, schedAdapter frameworkext.Scheduler, informerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
+func AddScheduleEventHandler(sched *scheduler.Scheduler, schedAdapter frameworkext.Scheduler, informerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory, crossSchedulerNominator *frameworkext.CrossSchedulerPodNominator) {
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	if k8sfeature.DefaultFeatureGate.Enabled(features.DynamicSchedulerCheck) {
 		// Clean up irresponsible pods for scheduling queue
@@ -49,6 +49,23 @@ func AddScheduleEventHandler(sched *scheduler.Scheduler, schedAdapter frameworke
 	_, err := reservationInformer.AddEventHandler(reservationEventHandlers(sched, schedAdapter))
 	if err != nil {
 		klog.Fatalf("failed to add reservation handler, err: %s", err)
+	}
+
+	// Register cross-scheduler pod nominator event handler when feature is enabled.
+	if k8sfeature.DefaultFeatureGate.Enabled(features.CrossSchedulerNomination) && crossSchedulerNominator != nil {
+		_, err := podInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				return crossSchedulerNominator.ShouldHandle(obj)
+			},
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc:    crossSchedulerNominator.OnAdd,
+				UpdateFunc: crossSchedulerNominator.OnUpdate,
+				DeleteFunc: crossSchedulerNominator.OnDelete,
+			},
+		})
+		if err != nil {
+			klog.Fatalf("failed to add cross-scheduler pod nominator handler, err: %s", err)
+		}
 	}
 }
 

--- a/pkg/scheduler/frameworkext/eventhandlers/event_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/event_handler_test.go
@@ -56,7 +56,7 @@ func TestAddScheduleEventHandler(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
 		koordClientSet := koordfake.NewSimpleClientset()
 		koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-		AddScheduleEventHandler(sched, internalHandler, informerFactory, koordSharedInformerFactory)
+		AddScheduleEventHandler(sched, internalHandler, informerFactory, koordSharedInformerFactory, nil)
 	})
 }
 

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -97,6 +97,8 @@ type frameworkExtenderImpl struct {
 	topologyManager           topologymanager.Interface
 
 	metricsRecorder *metrics.MetricAsyncRecorder
+
+	crossSchedulerNominator *CrossSchedulerPodNominator
 }
 
 func NewFrameworkExtender(f *FrameworkExtenderFactory, fw framework.Framework) FrameworkExtender {
@@ -124,8 +126,16 @@ func NewFrameworkExtender(f *FrameworkExtenderFactory, fw framework.Framework) F
 		podLister:                           fw.SharedInformerFactory().Core().V1().Pods().Lister(),
 		reservationLister:                   f.koordinatorSharedInformerFactory.Scheduling().V1alpha1().Reservations().Lister(),
 		networkTopologyTreeManager:          f.networkTopologyTreeManager,
+		crossSchedulerNominator:             f.crossSchedulerNominator,
 	}
 	frameworkExtender.topologyManager = topologymanager.New(frameworkExtender)
+
+	// Register the profile name to CrossSchedulerPodNominator so that pods from
+	// this profile are excluded from cross-scheduler nomination tracking.
+	if f.crossSchedulerNominator != nil {
+		f.crossSchedulerNominator.AddLocalProfileName(fw.ProfileName())
+	}
+
 	return frameworkExtender
 }
 
@@ -274,6 +284,10 @@ func (ext *frameworkExtenderImpl) GetNetworkTopologyTreeManager() networktopolog
 	return ext.networkTopologyTreeManager
 }
 
+func (ext *frameworkExtenderImpl) GetCrossSchedulerPodNominator() *CrossSchedulerPodNominator {
+	return ext.crossSchedulerNominator
+}
+
 // RunPreFilterPlugins transforms the PreFilter phase of framework with pre-filter transformers.
 func (ext *frameworkExtenderImpl) RunPreFilterPlugins(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod) (*fwktype.PreFilterResult, *fwktype.Status, sets.Set[string]) {
 	trace := utiltrace.New("RunPreFilterPluginTransformers", utiltrace.Field{Key: "namespace", Value: pod.Namespace}, utiltrace.Field{Key: "name", Value: pod.Name})
@@ -404,17 +418,7 @@ func (ext *frameworkExtenderImpl) RunFilterPluginsWithNominatedPods(ctx context.
 		}
 	}
 
-	nominatedPodsOfSameJob := getNominatedPodsOfTheSameJob(cycleState)
-	var status *fwktype.Status
-	if len(nominatedPodsOfSameJob) != 0 {
-		status = ext.runFilterPluginsWithNominatedPodsIgnoreSameJob(ctx, cycleState, pod, nodeInfo, nominatedPodsOfSameJob)
-	} else {
-		status = ext.Framework.RunFilterPluginsWithNominatedPods(ctx, cycleState, pod, nodeInfo)
-	}
-	if !status.IsSuccess() && debugFilterFailure {
-		klog.Infof("Failed to filter for Pod %q on Node %q, failedPlugin: %s, schedulingPhaseBeingInvoked: %s, reason: %s", klog.KObj(pod), klog.KObj(nodeInfo.Node()), status.Plugin(), schedulingphase.GetExtensionPointBeingExecuted(cycleState), status.Message())
-	}
-	return status
+	return ext.runFilterPluginsWithNominatedPods(ctx, cycleState, pod, nodeInfo)
 }
 
 func (ext *frameworkExtenderImpl) RunScorePlugins(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeInfos []fwktype.NodeInfo) ([]fwktype.NodePluginScores, *fwktype.Status) {

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -73,6 +73,7 @@ type extendedHandleOptions struct {
 	reservationCache                    ReservationCache
 	reservationNominator                ReservationNominator
 	networkTopologyManager              networktopology.TreeManager
+	crossSchedulerNominator             *CrossSchedulerPodNominator
 }
 
 type Option func(*extendedHandleOptions)
@@ -119,6 +120,12 @@ func WithNetworkTopologyManager(manager networktopology.TreeManager) Option {
 	}
 }
 
+func WithCrossSchedulerPodNominator(nominator *CrossSchedulerPodNominator) Option {
+	return func(options *extendedHandleOptions) {
+		options.crossSchedulerNominator = nominator
+	}
+}
+
 // FrameworkExtenderFactory is a factory for creating a FrameworkExtender.
 // NOTE: DO NOT put framework-level data here.
 type FrameworkExtenderFactory struct {
@@ -137,6 +144,7 @@ type FrameworkExtenderFactory struct {
 	*errorHandlerDispatcher
 
 	networkTopologyTreeManager networktopology.TreeManager
+	crossSchedulerNominator    *CrossSchedulerPodNominator
 
 	metricsRecorder *metrics.MetricAsyncRecorder
 }
@@ -163,6 +171,7 @@ func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, 
 		monitor:                             NewSchedulerMonitor(schedulerMonitorPeriod, schedulingTimeout),
 		errorHandlerDispatcher:              newErrorHandlerDispatcher(),
 		networkTopologyTreeManager:          handleOptions.networkTopologyManager,
+		crossSchedulerNominator:             handleOptions.crossSchedulerNominator,
 		metricsRecorder:                     metrics.NewMetricsAsyncRecorder(1000, time.Second, wait.NeverStop),
 	}, nil
 }

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
@@ -36,6 +38,7 @@ import (
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -461,68 +464,161 @@ func Test_frameworkExtenderImpl_RunPreFilterPlugins(t *testing.T) {
 }
 
 func Test_frameworkExtenderImpl_RunFilterPluginsWithNominatedPods(t *testing.T) {
+	const (
+		highPriority = int32(200)
+		midPriority  = int32(100)
+		lowPriority  = int32(50)
+	)
+
+	newNode := func(cpu string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse(cpu),
+					corev1.ResourcePods: resource.MustParse("110"),
+				},
+			},
+		}
+	}
+
+	newCrossNominator := func(pods ...*corev1.Pod) *CrossSchedulerPodNominator {
+		nominator := NewCrossSchedulerPodNominator()
+		nominator.AddLocalProfileName("koord-scheduler")
+		for _, pod := range pods {
+			nominator.OnAdd(pod)
+		}
+		return nominator
+	}
+
 	tests := []struct {
-		name     string
-		pod      *corev1.Pod
-		nodeInfo fwktype.NodeInfo
-		want     *fwktype.Status
+		name                                string
+		enableCrossSchedulerNomination      bool
+		enableSkipFilterWithNominatedPods   bool
+		node                                *corev1.Node
+		pod                                 *corev1.Pod
+		nativeNominatedPods                 []*corev1.Pod
+		crossSchedulerNominator             *CrossSchedulerPodNominator
+		nominatedPodsOfTheSameJob           []string
+		wantSuccess                         bool
+		wantUnschedulable                   bool
+		wantNotUnschedulableAndUnresolvable bool
 	}{
 		{
-			name:     "normal RunFilterPluginsWithNominatedPods",
-			pod:      &corev1.Pod{},
-			nodeInfo: framework.NewNodeInfo(),
-			want:     nil,
+			name:                                "default two-pass native nominated pod returns unschedulable",
+			node:                                newNode("2"),
+			pod:                                 makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			nativeNominatedPods:                 []*corev1.Pod{makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1500m", "koord-scheduler", "test-node", "")},
+			wantUnschedulable:                   true,
+			wantNotUnschedulableAndUnresolvable: true,
+		},
+		{
+			name:        "default two-pass without nominated pods succeeds",
+			node:        newNode("2"),
+			pod:         makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			wantSuccess: true,
+		},
+		{
+			name:                                "cross-scheduler two-pass high priority nominated pod returns unschedulable",
+			enableCrossSchedulerNomination:      true,
+			node:                                newNode("2"),
+			pod:                                 makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			crossSchedulerNominator:             newCrossNominator(makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1500m", "other-scheduler", "test-node", "")),
+			wantUnschedulable:                   true,
+			wantNotUnschedulableAndUnresolvable: true,
+		},
+		{
+			name:                           "cross-scheduler two-pass same priority nominated pod is ignored",
+			enableCrossSchedulerNomination: true,
+			node:                           newNode("2"),
+			pod:                            makePriorityPod("scheduling-pod", "uid-scheduling", midPriority, "1", "koord-scheduler", "", ""),
+			crossSchedulerNominator:        newCrossNominator(makePriorityPod("nominated-pod", "uid-nominated", midPriority, "1500m", "other-scheduler", "test-node", "")),
+			wantSuccess:                    true,
+		},
+		{
+			name:                              "skip-filter single-pass native nominated pod fails",
+			enableSkipFilterWithNominatedPods: true,
+			node:                              newNode("2"),
+			pod:                               makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			nativeNominatedPods:               []*corev1.Pod{makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1500m", "koord-scheduler", "test-node", "")},
+			wantUnschedulable:                 true,
+		},
+		{
+			name:                              "skip-filter single-pass native nominated pod succeeds when capacity is enough",
+			enableSkipFilterWithNominatedPods: true,
+			node:                              newNode("4"),
+			pod:                               makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			nativeNominatedPods:               []*corev1.Pod{makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1", "koord-scheduler", "test-node", "")},
+			wantSuccess:                       true,
+		},
+		{
+			name:                              "skip-filter single-pass with cross-scheduler high priority nominated pod fails",
+			enableCrossSchedulerNomination:    true,
+			enableSkipFilterWithNominatedPods: true,
+			node:                              newNode("2"),
+			pod:                               makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			crossSchedulerNominator:           newCrossNominator(makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1500m", "other-scheduler", "test-node", "")),
+			wantUnschedulable:                 true,
+		},
+		{
+			name:                              "skip-filter single-pass with cross-scheduler same priority nominated pod is ignored",
+			enableCrossSchedulerNomination:    true,
+			enableSkipFilterWithNominatedPods: true,
+			node:                              newNode("2"),
+			pod:                               makePriorityPod("scheduling-pod", "uid-scheduling", midPriority, "1", "koord-scheduler", "", ""),
+			crossSchedulerNominator:           newCrossNominator(makePriorityPod("nominated-pod", "uid-nominated", midPriority, "1500m", "other-scheduler", "test-node", "")),
+			wantSuccess:                       true,
+		},
+		{
+			name:                      "same-job nominated pod is excluded",
+			node:                      newNode("2"),
+			pod:                       makePriorityPod("scheduling-pod", "uid-scheduling", lowPriority, "1", "koord-scheduler", "", ""),
+			nativeNominatedPods:       []*corev1.Pod{makePriorityPod("nominated-pod", "uid-nominated", highPriority, "1500m", "koord-scheduler", "test-node", "")},
+			nominatedPodsOfTheSameJob: []string{"uid-nominated"},
+			wantSuccess:               true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			koordClientSet := koordfake.NewSimpleClientset()
-			koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
-			extenderFactory, err := NewFrameworkExtenderFactory(
-				WithServicesEngine(services.NewEngine(gin.New())),
-				WithKoordinatorClientSet(koordClientSet),
-				WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
-			)
-			assert.NoError(t, err)
-			assert.NotNil(t, extenderFactory)
-			assert.Equal(t, koordClientSet, extenderFactory.KoordinatorClientSet())
-			assert.Equal(t, koordSharedInformerFactory, extenderFactory.KoordinatorSharedInformerFactory())
-			registeredPlugins := []schedulertesting.RegisterPluginFunc{
-				schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-				schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-				schedulertesting.RegisterFilterPlugin("T1", PluginFactoryProxy(extenderFactory, func(_ context.Context, _ runtime.Object, _ fwktype.Handle) (fwktype.Plugin, error) {
-					return &TestTransformer{name: "T1", index: 1}, nil
-				})),
-				schedulertesting.RegisterFilterPlugin("T2", PluginFactoryProxy(extenderFactory, func(_ context.Context, _ runtime.Object, _ fwktype.Handle) (fwktype.Plugin, error) {
-					return &TestTransformer{name: "T2", index: 2}, nil
-				})),
+			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.CrossSchedulerNomination, tt.enableCrossSchedulerNomination)()
+			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.SkipFilterWithNominatedPods, tt.enableSkipFilterWithNominatedPods)()
+
+			extender, nodeInfo := buildCrossSchedulerExtenderAndNodeInfo(t, tt.node, tt.crossSchedulerNominator)
+			ctx := context.TODO()
+			logger := klog.FromContext(ctx)
+			for _, nominatedPod := range tt.nativeNominatedPods {
+				nominatedPodInfo, err := framework.NewPodInfo(nominatedPod)
+				assert.NoError(t, err)
+				extender.AddNominatedPod(logger, nominatedPodInfo, &fwktype.NominatingInfo{
+					NominatingMode:    fwktype.ModeOverride,
+					NominatedNodeName: nominatedPod.Status.NominatedNodeName,
+				})
 			}
-			fakeClient := kubefake.NewSimpleClientset()
-			sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-			fh, err := schedulertesting.NewFramework(
-				context.TODO(),
-				registeredPlugins,
-				"koord-scheduler",
-				frameworkruntime.WithSnapshotSharedLister(fakeNodeInfoLister{nodeInfoLister: nodeInfoLister{}}),
-				frameworkruntime.WithClientSet(fakeClient),
-				frameworkruntime.WithInformerFactory(sharedInformerFactory),
-				frameworkruntime.WithPodNominator(NewFakePodNominator()),
-			)
-			assert.NoError(t, err)
-			frameworkExtender := extenderFactory.NewFrameworkExtender(fh)
-			frameworkExtender.SetConfiguredPlugins(fh.ListPlugins())
-			tt.nodeInfo.SetNode(&corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node-1",
-				},
-			})
-			assert.Equal(t, tt.want, frameworkExtender.RunFilterPluginsWithNominatedPods(context.TODO(), framework.NewCycleState(), tt.pod, tt.nodeInfo))
-			assert.Len(t, tt.pod.Annotations, 2)
-			expectedAnnotations := map[string]string{
-				"BeforeFilter-1": "1",
-				"BeforeFilter-2": "2",
+
+			state := framework.NewCycleState()
+			if len(tt.nominatedPodsOfTheSameJob) > 0 {
+				MakeNominatedPodsOfTheSameJob(state, tt.nominatedPodsOfTheSameJob)
 			}
-			assert.Equal(t, expectedAnnotations, tt.pod.Annotations)
+
+			status := extender.RunFilterPluginsWithNominatedPods(ctx, state, tt.pod, nodeInfo)
+			if tt.wantSuccess {
+				if status != nil {
+					assert.True(t, status.IsSuccess(), "expected success, got: %v", status)
+				}
+				return
+			}
+
+			if assert.NotNil(t, status) {
+				assert.False(t, status.IsSuccess(), "expected failure, got success")
+				if tt.wantUnschedulable {
+					assert.True(t, status.IsRejected(), "expected unschedulable status, got: %v", status)
+				}
+				if tt.wantNotUnschedulableAndUnresolvable {
+					assert.NotEqual(t, fwktype.UnschedulableAndUnresolvable, status.Code(),
+						"expected retryable unschedulable status, got: %v", status)
+				}
+			}
 		})
 	}
 }
@@ -2122,4 +2218,96 @@ func Test_frameworkExtenderImpl_RunPreFilterPlugins_WithPreferNodes(t *testing.T
 			}
 		})
 	}
+}
+
+// fakeFitFilterPlugin is a simple filter plugin that checks CPU resource fit,
+// used by CrossScheduler nomination tests.
+type fakeFitFilterPlugin struct{}
+
+func (f *fakeFitFilterPlugin) Name() string { return "FakeFitFilterPlugin" }
+
+func (f *fakeFitFilterPlugin) Filter(_ context.Context, _ fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) *fwktype.Status {
+	if insufficient := noderesources.Fits(pod, nodeInfo, nil, noderesources.ResourceRequestsOptions{}); len(insufficient) != 0 {
+		var reasons []string
+		for _, r := range insufficient {
+			reasons = append(reasons, r.Reason)
+		}
+		return fwktype.NewStatus(fwktype.Unschedulable, reasons...)
+	}
+	return nil
+}
+
+// makePriorityPod creates a pod with a given priority, CPU request, schedulerName, and optionally a nominated node.
+func makePriorityPod(name string, uid types.UID, priority int32, cpuReq string, schedulerName, nominatedNode, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       uid,
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: schedulerName,
+			NodeName:      nodeName,
+			Priority:      &priority,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse(cpuReq),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			NominatedNodeName: nominatedNode,
+		},
+	}
+}
+
+// buildCrossSchedulerExtenderAndNodeInfo is a helper that creates a FrameworkExtender with FakeFitFilterPlugin
+// and optionally injects a CrossSchedulerPodNominator.
+func buildCrossSchedulerExtenderAndNodeInfo(t *testing.T, node *corev1.Node, crossNominator *CrossSchedulerPodNominator) (FrameworkExtender, fwktype.NodeInfo) {
+	t.Helper()
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+
+	opts := []Option{
+		WithKoordinatorClientSet(koordClientSet),
+		WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	}
+	if crossNominator != nil {
+		opts = append(opts, WithCrossSchedulerPodNominator(crossNominator))
+	}
+
+	extenderFactory, err := NewFrameworkExtenderFactory(opts...)
+	assert.NoError(t, err)
+
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		schedulertesting.RegisterFilterPlugin("FakeFitFilterPlugin", func(_ context.Context, _ runtime.Object, _ fwktype.Handle) (fwktype.Plugin, error) {
+			return &fakeFitFilterPlugin{}, nil
+		}),
+	}
+
+	fakeClient := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	fh, err := schedulertesting.NewFramework(
+		context.TODO(),
+		registeredPlugins,
+		"koord-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(fakeNodeInfoLister{nodeInfoLister: nodeInfoLister{nodeInfo}}),
+		frameworkruntime.WithClientSet(fakeClient),
+		frameworkruntime.WithInformerFactory(sharedInformerFactory),
+		frameworkruntime.WithPodNominator(NewFakePodNominator()),
+	)
+	assert.NoError(t, err)
+
+	extender := extenderFactory.NewFrameworkExtender(fh)
+	extender.SetConfiguredPlugins(fh.ListPlugins())
+	return extender, nodeInfo
 }

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -58,6 +58,9 @@ type ExtendedHandle interface {
 	// It returns nil when the framework does not support the resource reservation.
 	GetReservationNominator() ReservationNominator
 	GetNetworkTopologyTreeManager() networktopology.TreeManager
+	// GetCrossSchedulerPodNominator returns the CrossSchedulerPodNominator for cross-scheduler nominated pod tracking.
+	// It returns nil when the feature is not enabled or not configured.
+	GetCrossSchedulerPodNominator() *CrossSchedulerPodNominator
 }
 
 // FrameworkExtender extends the K8s Scheduling Framework interface to provide more extension methods to support Koordinator.

--- a/pkg/scheduler/frameworkext/job_nominated_pods.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods.go
@@ -69,6 +69,7 @@ func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, s
 	if len(nominatedPodInfos) == 0 {
 		return false, state, nodeInfo, nil, nil
 	}
+
 	nodeInfoOut := nodeInfo.Snapshot()
 	stateOut := state.Clone()
 	podsAdded := false
@@ -90,17 +91,21 @@ func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, s
 			podsAdded = true
 		}
 	}
-	if len(addedPods) > 0 {
+
+	if podsAdded {
 		klog.V(5).Infof("Added %v pods with equal or higher priority to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
+		return true, stateOut, nodeInfoOut, nil, addedPods
 	}
-	return podsAdded, stateOut, nodeInfoOut, nil, addedPods
+
+	return false, state, nodeInfo, nil, nil
 }
 
 // addMergedNominatedPods adds both native and cross-scheduler nominated pods to a cloned nodeInfo.
 // For native nominated pods: uses priority >= (consistent with k8s native behavior).
 // For cross-scheduler nominated pods: uses priority > (strictly greater than, to avoid same-priority deadlock).
-func (ext *frameworkExtenderImpl) addMergedNominatedPods(
+func addMergedNominatedPods(
 	ctx context.Context,
+	ext *frameworkExtenderImpl,
 	pod *corev1.Pod,
 	state fwktype.CycleState,
 	nodeInfo fwktype.NodeInfo,
@@ -125,7 +130,7 @@ func (ext *frameworkExtenderImpl) addMergedNominatedPods(
 	stateOut := state.Clone()
 	podsAdded := false
 
-	// Add native nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
+	// Add responsible nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
 	for _, pi := range nativeNominated {
 		piPod := pi.GetPod()
 		if corev1helper.PodPriority(piPod) >= podPriority &&
@@ -155,7 +160,12 @@ func (ext *frameworkExtenderImpl) addMergedNominatedPods(
 		}
 	}
 
-	return podsAdded, stateOut, nodeInfoOut, nil
+	if podsAdded {
+		klog.V(5).Infof("Added %v responsible and cross-scheduler nominated pods to the node %q when schedule pod %s/%s", podsAdded, nodeName, pod.Namespace, pod.Name)
+		return true, stateOut, nodeInfoOut, nil
+	}
+
+	return false, state, nodeInfo, nil
 }
 
 // runFilterPluginsWithNominatedPods is the unified implementation for running filter plugins
@@ -190,7 +200,7 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 			// Pass 1: add nominated pods to nodeInfo overlay.
 			var err error
 			if k8sfeature.DefaultFeatureGate.Enabled(features.CrossSchedulerNomination) && ext.crossSchedulerNominator != nil {
-				podsAdded, stateToUse, nodeInfoToUse, err = ext.addMergedNominatedPods(ctx, pod, state, info, podsOfSameJob)
+				podsAdded, stateToUse, nodeInfoToUse, err = addMergedNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			} else {
 				podsAdded, stateToUse, nodeInfoToUse, err, _ = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			}

--- a/pkg/scheduler/frameworkext/job_nominated_pods.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods.go
@@ -57,117 +57,6 @@ func getNominatedPodsOfTheSameJob(cycleState fwktype.CycleState) sets.Set[string
 	return s.(*NominatedPodsOfTheSameJob).UIDs
 }
 
-// addNominatedPods adds pods with equal or greater priority which are nominated
-// to run on the node. It returns 1) whether any pod was added, 2) augmented cycleState,
-// 3) augmented nodeInfo.
-func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, state fwktype.CycleState, nodeInfo fwktype.NodeInfo, podsOfSameJob sets.Set[string]) (bool, fwktype.CycleState, fwktype.NodeInfo, error, []string) {
-	if fh == nil {
-		// This may happen only in tests.
-		return false, state, nodeInfo, nil, nil
-	}
-	nominatedPodInfos := fh.NominatedPodsForNode(nodeInfo.Node().Name)
-	if len(nominatedPodInfos) == 0 {
-		return false, state, nodeInfo, nil, nil
-	}
-
-	nodeInfoOut := nodeInfo.Snapshot()
-	stateOut := state.Clone()
-	podsAdded := false
-	var addedPods []string
-
-	for _, pi := range nominatedPodInfos {
-		piPod := pi.GetPod()
-		if corev1helper.PodPriority(piPod) >= corev1helper.PodPriority(pod) &&
-			piPod.UID != pod.UID &&
-			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
-			nodeInfoOut.AddPodInfo(pi)
-			if klog.V(5).Enabled() || pod.Status.NominatedNodeName == nodeInfo.Node().Name {
-				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
-			}
-			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
-			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError(), nil
-			}
-			podsAdded = true
-		}
-	}
-
-	if podsAdded {
-		klog.V(5).Infof("Added %v pods with equal or higher priority to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
-		return true, stateOut, nodeInfoOut, nil, addedPods
-	}
-
-	return false, state, nodeInfo, nil, nil
-}
-
-// addMergedNominatedPods adds both native and cross-scheduler nominated pods to a cloned nodeInfo.
-// For native nominated pods: uses priority >= (consistent with k8s native behavior).
-// For cross-scheduler nominated pods: uses priority > (strictly greater than, to avoid same-priority deadlock).
-func addMergedNominatedPods(
-	ctx context.Context,
-	ext *frameworkExtenderImpl,
-	pod *corev1.Pod,
-	state fwktype.CycleState,
-	nodeInfo fwktype.NodeInfo,
-	podsOfSameJob sets.Set[string],
-) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
-	nodeName := nodeInfo.Node().Name
-	podPriority := corev1helper.PodPriority(pod)
-
-	// Get native nominated pods via the embedded framework handle.
-	nativeNominated := ext.Framework.NominatedPodsForNode(nodeName)
-	// Get cross-scheduler nominated pods.
-	var crossNominated []fwktype.PodInfo
-	if ext.crossSchedulerNominator != nil {
-		crossNominated = ext.crossSchedulerNominator.NominatedPodsForNode(nodeName)
-	}
-
-	if len(nativeNominated) == 0 && len(crossNominated) == 0 {
-		return false, state, nodeInfo, nil
-	}
-
-	nodeInfoOut := nodeInfo.Snapshot()
-	stateOut := state.Clone()
-	podsAdded := false
-
-	// Add responsible nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
-	for _, pi := range nativeNominated {
-		piPod := pi.GetPod()
-		if corev1helper.PodPriority(piPod) >= podPriority &&
-			piPod.UID != pod.UID &&
-			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
-			nodeInfoOut.AddPodInfo(pi)
-			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
-			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
-			}
-			podsAdded = true
-		}
-	}
-
-	// Add cross-scheduler nominated pods not in the same job (priority > current pod, strictly greater to avoid same-priority deadlock).
-	for _, pi := range crossNominated {
-		piPod := pi.GetPod()
-		if corev1helper.PodPriority(piPod) > podPriority &&
-			piPod.UID != pod.UID &&
-			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
-			nodeInfoOut.AddPodInfo(pi)
-			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
-			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
-			}
-			podsAdded = true
-		}
-	}
-
-	if podsAdded {
-		klog.V(5).Infof("Added %v responsible and cross-scheduler nominated pods to the node %q when schedule pod %s/%s", podsAdded, nodeName, pod.Namespace, pod.Name)
-		return true, stateOut, nodeInfoOut, nil
-	}
-
-	return false, state, nodeInfo, nil
-}
-
 // runFilterPluginsWithNominatedPods is the unified implementation for running filter plugins
 // with nominated pods. It handles all feature gate combinations:
 //   - CrossSchedulerNomination: controls whether cross-scheduler nominated pods are included.
@@ -202,7 +91,7 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 			if k8sfeature.DefaultFeatureGate.Enabled(features.CrossSchedulerNomination) && ext.crossSchedulerNominator != nil {
 				podsAdded, stateToUse, nodeInfoToUse, err = addMergedNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			} else {
-				podsAdded, stateToUse, nodeInfoToUse, err, _ = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
+				podsAdded, stateToUse, nodeInfoToUse, err = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			}
 			if err != nil {
 				return fwktype.AsStatus(err)
@@ -247,4 +136,122 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 	}
 
 	return status
+}
+
+// addNominatedPods adds pods with equal or greater priority which are nominated
+// to run on the node. It returns 1) whether any pod was added, 2) augmented cycleState,
+// 3) augmented nodeInfo.
+func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, state fwktype.CycleState, nodeInfo fwktype.NodeInfo, podsOfSameJob sets.Set[string]) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
+	if fh == nil {
+		// This may happen only in tests.
+		return false, state, nodeInfo, nil
+	}
+	nominatedPodInfos := fh.NominatedPodsForNode(nodeInfo.Node().Name)
+	if len(nominatedPodInfos) == 0 {
+		return false, state, nodeInfo, nil
+	}
+
+	nodeInfoOut := nodeInfo.Snapshot()
+	stateOut := state.Clone()
+	podsAdded := false
+	var addedPods []string
+
+	for _, pi := range nominatedPodInfos {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) >= corev1helper.PodPriority(pod) &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
+			nodeInfoOut.AddPodInfo(pi)
+			if klog.V(5).Enabled() {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
+			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+			if !status.IsSuccess() {
+				return false, state, nodeInfo, status.AsError()
+			}
+			podsAdded = true
+		}
+	}
+
+	if podsAdded {
+		klog.V(5).Infof("Added %v pods with equal or higher priority to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
+		return true, stateOut, nodeInfoOut, nil
+	}
+
+	return false, state, nodeInfo, nil
+}
+
+// addMergedNominatedPods adds both native and cross-scheduler nominated pods to a cloned nodeInfo.
+// For native nominated pods: uses priority >= (consistent with k8s native behavior).
+// For cross-scheduler nominated pods: uses priority > (strictly greater than, to avoid same-priority deadlock).
+func addMergedNominatedPods(
+	ctx context.Context,
+	ext *frameworkExtenderImpl,
+	pod *corev1.Pod,
+	state fwktype.CycleState,
+	nodeInfo fwktype.NodeInfo,
+	podsOfSameJob sets.Set[string],
+) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
+	nodeName := nodeInfo.Node().Name
+	podPriority := corev1helper.PodPriority(pod)
+
+	// Get native nominated pods via the embedded framework handle.
+	nativeNominated := ext.Framework.NominatedPodsForNode(nodeName)
+	// Get cross-scheduler nominated pods.
+	var crossNominated []fwktype.PodInfo
+	if ext.crossSchedulerNominator != nil {
+		crossNominated = ext.crossSchedulerNominator.NominatedPodsForNode(nodeName)
+	}
+
+	if len(nativeNominated) == 0 && len(crossNominated) == 0 {
+		return false, state, nodeInfo, nil
+	}
+
+	nodeInfoOut := nodeInfo.Snapshot()
+	stateOut := state.Clone()
+	podsAdded := false
+	var addedPods []string
+
+	// Add responsible nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
+	for _, pi := range nativeNominated {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) >= podPriority &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
+			nodeInfoOut.AddPodInfo(pi)
+			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+			if !status.IsSuccess() {
+				return false, state, nodeInfo, status.AsError()
+			}
+			if klog.V(5).Enabled() {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
+			podsAdded = true
+		}
+	}
+
+	// Add cross-scheduler nominated pods not in the same job (priority > current pod, strictly greater to avoid same-priority deadlock).
+	for _, pi := range crossNominated {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) > podPriority &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
+			nodeInfoOut.AddPodInfo(pi)
+			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+			if !status.IsSuccess() {
+				return false, state, nodeInfo, status.AsError()
+			}
+			if klog.V(5).Enabled() {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
+			podsAdded = true
+		}
+	}
+
+	if podsAdded {
+		klog.V(5).Infof("Added %v responsible and cross-scheduler nominated pods to the node %q when schedule pod %s/%s", addedPods, nodeName, pod.Namespace, pod.Name)
+		return true, stateOut, nodeInfoOut, nil
+	}
+
+	return false, state, nodeInfo, nil
 }

--- a/pkg/scheduler/frameworkext/job_nominated_pods.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods.go
@@ -21,12 +21,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 )
 
 const (
@@ -53,67 +55,6 @@ func getNominatedPodsOfTheSameJob(cycleState fwktype.CycleState) sets.Set[string
 		return nil
 	}
 	return s.(*NominatedPodsOfTheSameJob).UIDs
-
-}
-
-func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPodsIgnoreSameJob(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, info fwktype.NodeInfo, podsOfSameJob sets.Set[string]) *fwktype.Status {
-	var status *fwktype.Status
-
-	podsAdded := false
-	// We run filters twice in some cases. If the node has greater or equal priority
-	// nominated pods, we run them when those pods are added to PreFilter state and nodeInfo.
-	// If all filters succeed in this pass, we run them again when these
-	// nominated pods are not added. This second pass is necessary because some
-	// filters such as inter-pod affinity may not pass without the nominated pods.
-	// If there are no nominated pods for the node or if the first run of the
-	// filters fail, we don't run the second pass.
-	// We consider only equal or higher priority pods in the first pass, because
-	// those are the current "pod" must yield to them and not take a space opened
-	// for running them. It is ok if the current "pod" take resources freed for
-	// lower priority pods.
-	// Requiring that the new pod is schedulable in both circumstances ensures that
-	// we are making a conservative decision: filters like resources and inter-pod
-	// anti-affinity are more likely to fail when the nominated pods are treated
-	// as running, while filters like pod affinity are more likely to fail when
-	// the nominated pods are treated as not running. We can't just assume the
-	// nominated pods are running because they are not running right now and in fact,
-	// they may end up getting scheduled to a different node.
-	logger := klog.FromContext(ctx)
-	logger = klog.LoggerWithName(logger, "FilterWithNominatedPods")
-	ctx = klog.NewContext(ctx, logger)
-	for i := 0; i < 2; i++ {
-		stateToUse := state
-		nodeInfoToUse := info
-		var addedPods []string
-		if i == 0 {
-			var err error
-			podsAdded, stateToUse, nodeInfoToUse, err, addedPods = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
-			if err != nil {
-				return fwktype.AsStatus(err)
-			}
-		} else if !podsAdded || !status.IsSuccess() {
-			break
-		}
-
-		status = ext.RunFilterPlugins(ctx, stateToUse, pod, nodeInfoToUse)
-		if !status.IsSuccess() && pod.Status.NominatedNodeName == nodeInfoToUse.Node().Name && klog.V(4).Enabled() {
-			existingPods := make([]string, 0, len(nodeInfoToUse.GetPods()))
-			for _, podInfo := range nodeInfoToUse.GetPods() {
-				if len(podInfo.GetPod().OwnerReferences) != 0 && podInfo.GetPod().OwnerReferences[0].Kind == "DaemonSet" {
-					// Normally, the daemonset on the node does not occupy resources, so when collecting the existing Pods, the daemonset Pods are ignored to reduce the number of logs.
-					continue
-				}
-				existingPods = append(existingPods, framework.GetNamespacedName(podInfo.GetPod().Namespace, podInfo.GetPod().Name))
-			}
-			klog.V(4).Infof("Pod %s/%s is nominated to run on node %q, but failed to scheduling cause some existingPods: %+v, addedPods: %+v, status: %+v", pod.Namespace, pod.Name, nodeInfoToUse.Node().Name, existingPods, addedPods, status)
-		}
-		if !status.IsSuccess() && !(status.Code() == fwktype.Unschedulable || status.Code() == fwktype.UnschedulableAndUnresolvable) {
-			return status
-		}
-
-	}
-
-	return status
 }
 
 // addNominatedPods adds pods with equal or greater priority which are nominated
@@ -134,10 +75,13 @@ func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, s
 	var addedPods []string
 
 	for _, pi := range nominatedPodInfos {
-		if corev1helper.PodPriority(pi.GetPod()) >= corev1helper.PodPriority(pod) && pi.GetPod().UID != pod.UID && !podsOfSameJob.Has(string(pi.GetPod().UID)) {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) >= corev1helper.PodPriority(pod) &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
 			nodeInfoOut.AddPodInfo(pi)
 			if klog.V(5).Enabled() || pod.Status.NominatedNodeName == nodeInfo.Node().Name {
-				addedPods = append(addedPods, framework.GetNamespacedName(pi.GetPod().Namespace, pi.GetPod().Name))
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
 			}
 			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {
@@ -150,4 +94,147 @@ func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, s
 		klog.V(5).Infof("Added %v pods with equal or higher priority to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
 	}
 	return podsAdded, stateOut, nodeInfoOut, nil, addedPods
+}
+
+// addMergedNominatedPods adds both native and cross-scheduler nominated pods to a cloned nodeInfo.
+// For native nominated pods: uses priority >= (consistent with k8s native behavior).
+// For cross-scheduler nominated pods: uses priority > (strictly greater than, to avoid same-priority deadlock).
+func (ext *frameworkExtenderImpl) addMergedNominatedPods(
+	ctx context.Context,
+	pod *corev1.Pod,
+	state fwktype.CycleState,
+	nodeInfo fwktype.NodeInfo,
+	podsOfSameJob sets.Set[string],
+) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
+	nodeName := nodeInfo.Node().Name
+	podPriority := corev1helper.PodPriority(pod)
+
+	// Get native nominated pods via the embedded framework handle.
+	nativeNominated := ext.Framework.NominatedPodsForNode(nodeName)
+	// Get cross-scheduler nominated pods.
+	var crossNominated []fwktype.PodInfo
+	if ext.crossSchedulerNominator != nil {
+		crossNominated = ext.crossSchedulerNominator.NominatedPodsForNode(nodeName)
+	}
+
+	if len(nativeNominated) == 0 && len(crossNominated) == 0 {
+		return false, state, nodeInfo, nil
+	}
+
+	nodeInfoOut := nodeInfo.Snapshot()
+	stateOut := state.Clone()
+	podsAdded := false
+
+	// Add native nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
+	for _, pi := range nativeNominated {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) >= podPriority &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
+			nodeInfoOut.AddPodInfo(pi)
+			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+			if !status.IsSuccess() {
+				return false, state, nodeInfo, status.AsError()
+			}
+			podsAdded = true
+		}
+	}
+
+	// Add cross-scheduler nominated pods not in the same job (priority > current pod, strictly greater to avoid same-priority deadlock).
+	for _, pi := range crossNominated {
+		piPod := pi.GetPod()
+		if corev1helper.PodPriority(piPod) > podPriority &&
+			piPod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
+			nodeInfoOut.AddPodInfo(pi)
+			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+			if !status.IsSuccess() {
+				return false, state, nodeInfo, status.AsError()
+			}
+			podsAdded = true
+		}
+	}
+
+	return podsAdded, stateOut, nodeInfoOut, nil
+}
+
+// runFilterPluginsWithNominatedPods is the unified implementation for running filter plugins
+// with nominated pods. It handles all feature gate combinations:
+//   - CrossSchedulerNomination: controls whether cross-scheduler nominated pods are included.
+//     When enabled, uses addMergedNominatedPods (native >= + cross-scheduler >).
+//     When disabled, uses addNominatedPods (native >= only).
+//   - SkipFilterWithNominatedPods: controls the number of filter passes.
+//     When enabled, runs a single pass with nominated pods (skipping the second pass without
+//     nominated pods that handles the pod affinity corner case).
+//     When disabled, runs two passes (with and without nominated pods) for conservative scheduling.
+//
+// It also excludes same-job nominated pods and includes NominatedNodeName diagnostic logging,
+// compatible with the previous runFilterPluginsWithNominatedPodsIgnoreSameJob behavior.
+func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
+	ctx context.Context,
+	state fwktype.CycleState,
+	pod *corev1.Pod,
+	info fwktype.NodeInfo,
+) *fwktype.Status {
+	podsOfSameJob := getNominatedPodsOfTheSameJob(state)
+	singlePass := k8sfeature.DefaultFeatureGate.Enabled(features.SkipFilterWithNominatedPods)
+
+	var status *fwktype.Status
+	podsAdded := false
+
+	for i := 0; i < 2; i++ {
+		stateToUse := state
+		nodeInfoToUse := info
+
+		if i == 0 {
+			// Pass 1: add nominated pods to nodeInfo overlay.
+			var err error
+			if k8sfeature.DefaultFeatureGate.Enabled(features.CrossSchedulerNomination) && ext.crossSchedulerNominator != nil {
+				podsAdded, stateToUse, nodeInfoToUse, err = ext.addMergedNominatedPods(ctx, pod, state, info, podsOfSameJob)
+			} else {
+				podsAdded, stateToUse, nodeInfoToUse, err, _ = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
+			}
+			if err != nil {
+				return fwktype.AsStatus(err)
+			}
+			if !podsAdded {
+				stateToUse = state
+				nodeInfoToUse = info
+			}
+		} else if !podsAdded || !status.IsSuccess() {
+			// Pass 2: only needed if pass 1 added pods AND pass 1 succeeded.
+			break
+		}
+
+		status = ext.RunFilterPlugins(ctx, stateToUse, pod, nodeInfoToUse)
+		if !status.IsSuccess() {
+			if debugFilterFailure {
+				klog.Infof("Failed to filter for Pod %q on Node %q (pass %d), failedPlugin: %s, reason: %s",
+					klog.KObj(pod), klog.KObj(info.Node()), i, status.Plugin(), status.Message())
+			}
+			// NominatedNodeName diagnostic logging.
+			if pod.Status.NominatedNodeName == info.Node().Name && klog.V(4).Enabled() {
+				existingPods := make([]string, 0, len(nodeInfoToUse.GetPods()))
+				for _, podInfo := range nodeInfoToUse.GetPods() {
+					piPod := podInfo.GetPod()
+					if len(piPod.OwnerReferences) != 0 && piPod.OwnerReferences[0].Kind == "DaemonSet" {
+						continue
+					}
+					existingPods = append(existingPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+				}
+				klog.V(4).Infof("Pod %s/%s is nominated to run on node %q, but failed to scheduling (pass %d), existingPods: %+v, status: %+v",
+					pod.Namespace, pod.Name, info.Node().Name, i, existingPods, status)
+			}
+		}
+		if !status.IsSuccess() && !status.IsRejected() {
+			return status
+		}
+
+		// In single-pass mode, skip the second pass.
+		if singlePass {
+			break
+		}
+	}
+
+	return status
 }

--- a/pkg/scheduler/frameworkext/job_nominated_pods.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods.go
@@ -84,21 +84,18 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 	for i := 0; i < 2; i++ {
 		stateToUse := state
 		nodeInfoToUse := info
+		var addedPods []string
 
 		if i == 0 {
 			// Pass 1: add nominated pods to nodeInfo overlay.
 			var err error
 			if k8sfeature.DefaultFeatureGate.Enabled(features.CrossSchedulerNomination) && ext.crossSchedulerNominator != nil {
-				podsAdded, stateToUse, nodeInfoToUse, err = addMergedNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
+				podsAdded, stateToUse, nodeInfoToUse, err, addedPods = addMergedNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			} else {
-				podsAdded, stateToUse, nodeInfoToUse, err = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
+				podsAdded, stateToUse, nodeInfoToUse, err, addedPods = addNominatedPods(ctx, ext, pod, state, info, podsOfSameJob)
 			}
 			if err != nil {
 				return fwktype.AsStatus(err)
-			}
-			if !podsAdded {
-				stateToUse = state
-				nodeInfoToUse = info
 			}
 		} else if !podsAdded || !status.IsSuccess() {
 			// Pass 2: only needed if pass 1 added pods AND pass 1 succeeded.
@@ -121,8 +118,8 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 					}
 					existingPods = append(existingPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
 				}
-				klog.V(4).Infof("Pod %s/%s is nominated to run on node %q, but failed to scheduling (pass %d), existingPods: %+v, status: %+v",
-					pod.Namespace, pod.Name, info.Node().Name, i, existingPods, status)
+				klog.V(4).Infof("Pod %s/%s is nominated to run on node %q, but failed to scheduling (pass %d), existingPods: %+v, addedPods: %+v, status: %+v",
+					pod.Namespace, pod.Name, info.Node().Name, i, existingPods, addedPods, status)
 			}
 		}
 		if !status.IsSuccess() && !status.IsRejected() {
@@ -141,20 +138,21 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 // addNominatedPods adds pods with equal or greater priority which are nominated
 // to run on the node. It returns 1) whether any pod was added, 2) augmented cycleState,
 // 3) augmented nodeInfo.
-func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, state fwktype.CycleState, nodeInfo fwktype.NodeInfo, podsOfSameJob sets.Set[string]) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
+func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, state fwktype.CycleState, nodeInfo fwktype.NodeInfo, podsOfSameJob sets.Set[string]) (bool, fwktype.CycleState, fwktype.NodeInfo, error, []string) {
 	if fh == nil {
 		// This may happen only in tests.
-		return false, state, nodeInfo, nil
+		return false, state, nodeInfo, nil, nil
 	}
 	nominatedPodInfos := fh.NominatedPodsForNode(nodeInfo.Node().Name)
 	if len(nominatedPodInfos) == 0 {
-		return false, state, nodeInfo, nil
+		return false, state, nodeInfo, nil, nil
 	}
 
 	nodeInfoOut := nodeInfo.Snapshot()
 	stateOut := state.Clone()
-	podsAdded := false
+	isLoggingAdded := klog.V(5).Enabled() || pod.Status.NominatedNodeName == nodeInfo.Node().Name
 	var addedPods []string
+	podsAdded := false
 
 	for _, pi := range nominatedPodInfos {
 		piPod := pi.GetPod()
@@ -162,23 +160,25 @@ func addNominatedPods(ctx context.Context, fh fwktype.Handle, pod *corev1.Pod, s
 			piPod.UID != pod.UID &&
 			(podsOfSameJob == nil || !podsOfSameJob.Has(string(piPod.UID))) {
 			nodeInfoOut.AddPodInfo(pi)
-			if klog.V(5).Enabled() {
-				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
-			}
 			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
+				return false, state, nodeInfo, status.AsError(), nil
 			}
 			podsAdded = true
+			if isLoggingAdded {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
 		}
 	}
 
 	if podsAdded {
-		klog.V(5).Infof("Added %v pods with equal or higher priority to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
-		return true, stateOut, nodeInfoOut, nil
+		if isLoggingAdded {
+			klog.Infof("Added %v nominated responsible pods to the node %q when schedule pod %s/%s", addedPods, nodeInfo.Node().Name, pod.Namespace, pod.Name)
+		}
+		return true, stateOut, nodeInfoOut, nil, addedPods
 	}
 
-	return false, state, nodeInfo, nil
+	return false, state, nodeInfo, nil, nil
 }
 
 // addMergedNominatedPods adds both native and cross-scheduler nominated pods to a cloned nodeInfo.
@@ -191,7 +191,7 @@ func addMergedNominatedPods(
 	state fwktype.CycleState,
 	nodeInfo fwktype.NodeInfo,
 	podsOfSameJob sets.Set[string],
-) (bool, fwktype.CycleState, fwktype.NodeInfo, error) {
+) (bool, fwktype.CycleState, fwktype.NodeInfo, error, []string) {
 	nodeName := nodeInfo.Node().Name
 	podPriority := corev1helper.PodPriority(pod)
 
@@ -204,13 +204,14 @@ func addMergedNominatedPods(
 	}
 
 	if len(nativeNominated) == 0 && len(crossNominated) == 0 {
-		return false, state, nodeInfo, nil
+		return false, state, nodeInfo, nil, nil
 	}
 
 	nodeInfoOut := nodeInfo.Snapshot()
 	stateOut := state.Clone()
-	podsAdded := false
+	isLoggingAdded := klog.V(5).Enabled() || pod.Status.NominatedNodeName == nodeInfo.Node().Name
 	var addedPods []string
+	podsAdded := false
 
 	// Add responsible nominated pods not in the same job (priority >= current pod, consistent with k8s native behavior).
 	for _, pi := range nativeNominated {
@@ -221,12 +222,12 @@ func addMergedNominatedPods(
 			nodeInfoOut.AddPodInfo(pi)
 			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
-			}
-			if klog.V(5).Enabled() {
-				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+				return false, state, nodeInfo, status.AsError(), nil
 			}
 			podsAdded = true
+			if isLoggingAdded {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
 		}
 	}
 
@@ -239,19 +240,21 @@ func addMergedNominatedPods(
 			nodeInfoOut.AddPodInfo(pi)
 			status := ext.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
-			}
-			if klog.V(5).Enabled() {
-				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+				return false, state, nodeInfo, status.AsError(), nil
 			}
 			podsAdded = true
+			if isLoggingAdded {
+				addedPods = append(addedPods, framework.GetNamespacedName(piPod.Namespace, piPod.Name))
+			}
 		}
 	}
 
 	if podsAdded {
-		klog.V(5).Infof("Added %v responsible and cross-scheduler nominated pods to the node %q when schedule pod %s/%s", addedPods, nodeName, pod.Namespace, pod.Name)
-		return true, stateOut, nodeInfoOut, nil
+		if isLoggingAdded {
+			klog.Infof("Added %v nominated responsible and cross-scheduler high-priority pods to the node %q when schedule pod %s/%s", addedPods, nodeName, pod.Namespace, pod.Name)
+		}
+		return true, stateOut, nodeInfoOut, nil, addedPods
 	}
 
-	return false, state, nodeInfo, nil
+	return false, state, nodeInfo, nil, nil
 }

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -403,7 +403,7 @@ func Test_addNominatedPods(t *testing.T) {
 		wantPodsAdded  bool
 		wantAddedCount int // expected number of pods added to nodeInfo
 		// wantCloned indicates whether stateOut/nodeInfoOut are expected to be clones.
-		// This is true whenever nominatedPodInfos is non-empty (clone happens before filtering).
+		// True whenever pods are actually added to nodeInfo (i.e., podsAdded == true).
 		wantCloned bool
 	}{
 		{
@@ -481,19 +481,20 @@ func Test_addNominatedPods(t *testing.T) {
 			state := framework.NewCycleState()
 			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
 
-			podsAdded, stateOut, nodeInfoOut, err := addNominatedPods(
+			podsAdded, stateOut, nodeInfoOut, err, addedPods := addNominatedPods(
 				context.TODO(), fh, tt.pod, state, nodeInfo, podsOfSameJob,
 			)
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPodsAdded, podsAdded, "podsAdded mismatch")
+			_ = addedPods // addedPods is only populated when klog V(5) is enabled or NominatedNodeName matches
 
 			if tt.wantCloned {
-				// Clone is created whenever nominatedPodInfos is non-empty, regardless of whether pods pass the filter.
+				// Clone is created whenever pods are actually added (podsAdded == true).
 				assert.NotSame(t, state, stateOut, "stateOut should be a clone")
 				assert.NotSame(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be a clone")
 			} else {
-				// No nominated pods at all: early return with originals.
+				// No eligible pods added: returns original state and nodeInfo.
 				assert.Same(t, state, stateOut, "stateOut should be the original state")
 				assert.Same(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be the original nodeInfo")
 			}
@@ -583,7 +584,7 @@ func Test_addMergedNominatedPods(t *testing.T) {
 		wantPodsAdded   bool
 		wantAddedCount  int
 		// wantCloned indicates whether stateOut/nodeInfoOut are expected to be clones.
-		// True whenever the combined nominated pod list is non-empty (clone happens before filtering).
+		// True whenever pods are actually added to nodeInfo (i.e., podsAdded == true).
 		wantCloned bool
 	}{
 		{
@@ -676,19 +677,20 @@ func Test_addMergedNominatedPods(t *testing.T) {
 			state := framework.NewCycleState()
 			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
 
-			podsAdded, stateOut, nodeInfoOut, err := addMergedNominatedPods(
+			podsAdded, stateOut, nodeInfoOut, err, addedPods := addMergedNominatedPods(
 				context.TODO(), impl, tt.pod, state, nodeInfo, podsOfSameJob,
 			)
 
 			assert.NoError(t, err, "unexpected error")
 			assert.Equal(t, tt.wantPodsAdded, podsAdded, "podsAdded mismatch")
+			_ = addedPods // addedPods is only populated when klog V(5) is enabled or NominatedNodeName matches
 
 			if tt.wantCloned {
-				// Clone is created whenever the combined nominated list is non-empty.
+				// Clone is returned whenever pods are actually added (podsAdded == true).
 				assert.NotSame(t, state, stateOut, "stateOut should be a clone")
 				assert.NotSame(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be a clone")
 			} else {
-				// Both lists empty: early return with originals.
+				// No eligible pods added: returns original state and nodeInfo.
 				assert.Same(t, state, stateOut, "stateOut should be the original state")
 				assert.Same(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be the original nodeInfo")
 			}

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -431,31 +431,31 @@ func Test_addNominatedPods(t *testing.T) {
 			wantAddedCount: 1,
 		},
 		{
-			// Clone happens before filtering; stateOut/nodeInfoOut are clones even when no pods pass the filter.
+			// When no pods are added, stateOut/nodeInfoOut are the original objects (not clones).
 			name:           "low priority nominated pod is not added (priority < current)",
 			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-low", "uid-low", lowPriority, nodeName)},
 			wantPodsAdded:  false,
-			wantCloned:     true,
+			wantCloned:     false,
 			wantAddedCount: 0,
 		},
 		{
-			// Clone happens before filtering.
+			// When no pods are added, stateOut/nodeInfoOut are the original objects (not clones).
 			name:           "same UID nominated pod is excluded",
 			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			nominatedPods:  []*corev1.Pod{makeSimplePod("same-uid-pod", "uid-scheduling", highPriority, nodeName)},
 			wantPodsAdded:  false,
-			wantCloned:     true,
+			wantCloned:     false,
 			wantAddedCount: 0,
 		},
 		{
-			// Clone happens before filtering.
+			// When no pods are added, stateOut/nodeInfoOut are the original objects (not clones).
 			name:           "sameJob nominated pod is excluded",
 			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-job-pod", "uid-job-pod", highPriority, nodeName)},
 			podsOfSameJob:  []string{"uid-job-pod"},
 			wantPodsAdded:  false,
-			wantCloned:     true,
+			wantCloned:     false,
 			wantAddedCount: 0,
 		},
 		{
@@ -614,36 +614,39 @@ func Test_addMergedNominatedPods(t *testing.T) {
 			wantAddedCount: 1,
 		},
 		{
-			// Clone happens before filtering; stateOut/nodeInfoOut are clones even though the pod is not added.
+			// When no pods are added (priority == current for cross-scheduler is not added),
+			// stateOut/nodeInfoOut are the original objects (not clones).
 			name: "cross-scheduler nominated pod (priority == current) is not added",
 			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			crossNominator: newCrossNominator(
 				makePriorityPod("cross-equal", "uid-cross-equal", midPriority, "100m", "other-scheduler", nodeName, ""),
 			),
 			wantPodsAdded:  false,
-			wantCloned:     true,
+			wantCloned:     false,
 			wantAddedCount: 0,
 		},
 		{
-			// Clone happens before filtering.
+			// When no pods are added (priority < current for cross-scheduler),
+			// stateOut/nodeInfoOut are the original objects (not clones).
 			name: "cross-scheduler nominated pod (priority < current) is not added",
 			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			crossNominator: newCrossNominator(
 				makePriorityPod("cross-low", "uid-cross-low", lowPriority, "100m", "other-scheduler", nodeName, ""),
 			),
 			wantPodsAdded:  false,
-			wantCloned:     true,
+			wantCloned:     false,
 			wantAddedCount: 0,
 		},
 		{
-			// Clone happens before filtering.
+			// When no pods are added (sameJob excludes all),
+			// stateOut/nodeInfoOut are the original objects (not clones).
 			name:            "sameJob excludes native nominated pod",
 			pod:             makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
 			nativeNominated: []*corev1.Pod{makeSimplePod("native-job-pod", "uid-job-pod", highPriority, nodeName)},
 			crossNominator:  newCrossNominator(),
 			podsOfSameJob:   []string{"uid-job-pod"},
 			wantPodsAdded:   false,
-			wantCloned:      true,
+			wantCloned:      false,
 			wantAddedCount:  0,
 		},
 		{
@@ -673,8 +676,8 @@ func Test_addMergedNominatedPods(t *testing.T) {
 			state := framework.NewCycleState()
 			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
 
-			podsAdded, stateOut, nodeInfoOut, err := impl.addMergedNominatedPods(
-				context.TODO(), tt.pod, state, nodeInfo, podsOfSameJob,
+			podsAdded, stateOut, nodeInfoOut, err := addMergedNominatedPods(
+				context.TODO(), impl, tt.pod, state, nodeInfo, podsOfSameJob,
 			)
 
 			assert.NoError(t, err, "unexpected error")

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -481,7 +481,7 @@ func Test_addNominatedPods(t *testing.T) {
 			state := framework.NewCycleState()
 			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
 
-			podsAdded, stateOut, nodeInfoOut, err, _ := addNominatedPods(
+			podsAdded, stateOut, nodeInfoOut, err := addNominatedPods(
 				context.TODO(), fh, tt.pod, state, nodeInfo, podsOfSameJob,
 			)
 

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -310,6 +311,385 @@ func Test_frameworkExtenderImpl_RunFilterPluginsWithNominatedIgnoreSameJob(t *te
 				MakeNominatedPodsOfTheSameJob(cycleState, tt.nominatedPodsToRemove.UnsortedList())
 			}
 			assert.Equal(t, tt.want, frameworkExtender.RunFilterPluginsWithNominatedPods(context.TODO(), cycleState, tt.pod, nodeInfo))
+		})
+	}
+}
+
+// makeSimplePod creates a pod with the given name, uid, priority and nominated node name.
+func makeSimplePod(name string, uid types.UID, priority int32, nominatedNode string) *corev1.Pod {
+	p := priority
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       uid,
+		},
+		Spec: corev1.PodSpec{
+			Priority: &p,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100m"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			NominatedNodeName: nominatedNode,
+		},
+	}
+}
+
+// makeSimpleNodeInfo creates a NodeInfo with a node of the given name.
+func makeSimpleNodeInfo(nodeName string) fwktype.NodeInfo {
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	})
+	return nodeInfo
+}
+
+// buildSimpleFrameworkHandleWithNominated builds a minimal framework.Handle that has the given
+// nominated pods registered via the fake PodNominator.
+func buildSimpleFrameworkHandleWithNominated(t *testing.T, nodeInfo fwktype.NodeInfo, nominatedPods []*corev1.Pod) fwktype.Handle {
+	t.Helper()
+
+	fakeClient := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+
+	nominator := NewFakePodNominator()
+	logger := klog.Background()
+	for _, pod := range nominatedPods {
+		pi, err := framework.NewPodInfo(pod)
+		assert.NoError(t, err)
+		nominator.AddNominatedPod(logger, pi, &fwktype.NominatingInfo{
+			NominatingMode:    fwktype.ModeOverride,
+			NominatedNodeName: pod.Status.NominatedNodeName,
+		})
+	}
+
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	fh, err := schedulertesting.NewFramework(
+		context.TODO(),
+		registeredPlugins,
+		"koord-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(fakeNodeInfoLister{nodeInfoLister: nodeInfoLister{nodeInfo}}),
+		frameworkruntime.WithClientSet(fakeClient),
+		frameworkruntime.WithInformerFactory(sharedInformerFactory),
+		frameworkruntime.WithPodNominator(nominator),
+	)
+	assert.NoError(t, err)
+	return fh
+}
+
+func Test_addNominatedPods(t *testing.T) {
+	const (
+		highPriority = int32(200)
+		midPriority  = int32(100)
+		lowPriority  = int32(50)
+	)
+	const nodeName = "test-node"
+
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		nominatedPods  []*corev1.Pod
+		podsOfSameJob  []string
+		wantPodsAdded  bool
+		wantAddedCount int // expected number of pods added to nodeInfo
+		// wantCloned indicates whether stateOut/nodeInfoOut are expected to be clones.
+		// This is true whenever nominatedPodInfos is non-empty (clone happens before filtering).
+		wantCloned bool
+	}{
+		{
+			name:           "no nominated pods returns false",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  nil,
+			wantPodsAdded:  false,
+			wantCloned:     false, // no nominated pods at all, early-return with originals
+			wantAddedCount: 0,
+		},
+		{
+			name:           "high priority nominated pod is added (priority >= current)",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-high", "uid-high", highPriority, nodeName)},
+			wantPodsAdded:  true,
+			wantCloned:     true,
+			wantAddedCount: 1,
+		},
+		{
+			name:           "equal priority nominated pod is added (priority >= current)",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-equal", "uid-equal", midPriority, nodeName)},
+			wantPodsAdded:  true,
+			wantCloned:     true,
+			wantAddedCount: 1,
+		},
+		{
+			// Clone happens before filtering; stateOut/nodeInfoOut are clones even when no pods pass the filter.
+			name:           "low priority nominated pod is not added (priority < current)",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-low", "uid-low", lowPriority, nodeName)},
+			wantPodsAdded:  false,
+			wantCloned:     true,
+			wantAddedCount: 0,
+		},
+		{
+			// Clone happens before filtering.
+			name:           "same UID nominated pod is excluded",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  []*corev1.Pod{makeSimplePod("same-uid-pod", "uid-scheduling", highPriority, nodeName)},
+			wantPodsAdded:  false,
+			wantCloned:     true,
+			wantAddedCount: 0,
+		},
+		{
+			// Clone happens before filtering.
+			name:           "sameJob nominated pod is excluded",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods:  []*corev1.Pod{makeSimplePod("nominated-job-pod", "uid-job-pod", highPriority, nodeName)},
+			podsOfSameJob:  []string{"uid-job-pod"},
+			wantPodsAdded:  false,
+			wantCloned:     true,
+			wantAddedCount: 0,
+		},
+		{
+			name: "mixed nominated pods: only eligible ones are added",
+			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nominatedPods: []*corev1.Pod{
+				makeSimplePod("nominated-high", "uid-high", highPriority, nodeName),    // should be added
+				makeSimplePod("nominated-low", "uid-low", lowPriority, nodeName),       // should be excluded
+				makeSimplePod("nominated-same-job", "uid-job", highPriority, nodeName), // should be excluded via sameJob
+			},
+			podsOfSameJob:  []string{"uid-job"},
+			wantPodsAdded:  true,
+			wantCloned:     true,
+			wantAddedCount: 1, // only nominated-high
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeInfo := makeSimpleNodeInfo(nodeName)
+			fh := buildSimpleFrameworkHandleWithNominated(t, nodeInfo, tt.nominatedPods)
+
+			state := framework.NewCycleState()
+			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
+
+			podsAdded, stateOut, nodeInfoOut, err, _ := addNominatedPods(
+				context.TODO(), fh, tt.pod, state, nodeInfo, podsOfSameJob,
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPodsAdded, podsAdded, "podsAdded mismatch")
+
+			if tt.wantCloned {
+				// Clone is created whenever nominatedPodInfos is non-empty, regardless of whether pods pass the filter.
+				assert.NotSame(t, state, stateOut, "stateOut should be a clone")
+				assert.NotSame(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be a clone")
+			} else {
+				// No nominated pods at all: early return with originals.
+				assert.Same(t, state, stateOut, "stateOut should be the original state")
+				assert.Same(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be the original nodeInfo")
+			}
+			// Verify the number of pods in the (possibly cloned) nodeInfo.
+			assert.Equal(t, tt.wantAddedCount, len(nodeInfoOut.GetPods()), "number of pods in nodeInfoOut")
+		})
+	}
+}
+
+// buildExtenderWithCrossNominator creates a frameworkExtenderImpl with an optional CrossSchedulerPodNominator
+// and the given native nominated pods pre-registered.
+func buildExtenderWithCrossNominator(t *testing.T, nodeInfo fwktype.NodeInfo, nativeNominated []*corev1.Pod, crossNominator *CrossSchedulerPodNominator) *frameworkExtenderImpl {
+	t.Helper()
+
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+
+	opts := []Option{
+		WithKoordinatorClientSet(koordClientSet),
+		WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	}
+	if crossNominator != nil {
+		opts = append(opts, WithCrossSchedulerPodNominator(crossNominator))
+	}
+
+	extenderFactory, err := NewFrameworkExtenderFactory(opts...)
+	assert.NoError(t, err)
+
+	fakeClient := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	fh, err := schedulertesting.NewFramework(
+		context.TODO(),
+		registeredPlugins,
+		"koord-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(fakeNodeInfoLister{nodeInfoLister: nodeInfoLister{nodeInfo}}),
+		frameworkruntime.WithClientSet(fakeClient),
+		frameworkruntime.WithInformerFactory(sharedInformerFactory),
+		frameworkruntime.WithPodNominator(NewFakePodNominator()),
+	)
+	assert.NoError(t, err)
+
+	extender := extenderFactory.NewFrameworkExtender(fh)
+	extender.SetConfiguredPlugins(fh.ListPlugins())
+	impl := extender.(*frameworkExtenderImpl)
+
+	// Register native nominated pods.
+	logger := klog.Background()
+	for _, pod := range nativeNominated {
+		pi, perr := framework.NewPodInfo(pod)
+		assert.NoError(t, perr)
+		impl.AddNominatedPod(logger, pi, &fwktype.NominatingInfo{
+			NominatingMode:    fwktype.ModeOverride,
+			NominatedNodeName: pod.Status.NominatedNodeName,
+		})
+	}
+
+	return impl
+}
+
+func Test_addMergedNominatedPods(t *testing.T) {
+	const (
+		highPriority = int32(200)
+		midPriority  = int32(100)
+		lowPriority  = int32(50)
+	)
+	const nodeName = "test-node"
+
+	newCrossNominator := func(pods ...*corev1.Pod) *CrossSchedulerPodNominator {
+		nominator := NewCrossSchedulerPodNominator()
+		nominator.AddLocalProfileName("koord-scheduler")
+		for _, pod := range pods {
+			nominator.OnAdd(pod)
+		}
+		return nominator
+	}
+
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		nativeNominated []*corev1.Pod
+		crossNominator  *CrossSchedulerPodNominator
+		podsOfSameJob   []string
+		wantPodsAdded   bool
+		wantAddedCount  int
+		// wantCloned indicates whether stateOut/nodeInfoOut are expected to be clones.
+		// True whenever the combined nominated pod list is non-empty (clone happens before filtering).
+		wantCloned bool
+	}{
+		{
+			name:           "no native and no cross-scheduler nominated pods returns false",
+			pod:            makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			crossNominator: newCrossNominator(),
+			wantPodsAdded:  false,
+			wantCloned:     false, // both lists are empty: early-return with originals
+			wantAddedCount: 0,
+		},
+		{
+			name:            "native nominated pod (priority >= current) is added",
+			pod:             makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nativeNominated: []*corev1.Pod{makeSimplePod("native-high", "uid-native-high", highPriority, nodeName)},
+			crossNominator:  newCrossNominator(),
+			wantPodsAdded:   true,
+			wantCloned:      true,
+			wantAddedCount:  1,
+		},
+		{
+			name: "cross-scheduler nominated pod (priority > current) is added",
+			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			crossNominator: newCrossNominator(
+				makePriorityPod("cross-high", "uid-cross-high", highPriority, "100m", "other-scheduler", nodeName, ""),
+			),
+			wantPodsAdded:  true,
+			wantCloned:     true,
+			wantAddedCount: 1,
+		},
+		{
+			// Clone happens before filtering; stateOut/nodeInfoOut are clones even though the pod is not added.
+			name: "cross-scheduler nominated pod (priority == current) is not added",
+			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			crossNominator: newCrossNominator(
+				makePriorityPod("cross-equal", "uid-cross-equal", midPriority, "100m", "other-scheduler", nodeName, ""),
+			),
+			wantPodsAdded:  false,
+			wantCloned:     true,
+			wantAddedCount: 0,
+		},
+		{
+			// Clone happens before filtering.
+			name: "cross-scheduler nominated pod (priority < current) is not added",
+			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			crossNominator: newCrossNominator(
+				makePriorityPod("cross-low", "uid-cross-low", lowPriority, "100m", "other-scheduler", nodeName, ""),
+			),
+			wantPodsAdded:  false,
+			wantCloned:     true,
+			wantAddedCount: 0,
+		},
+		{
+			// Clone happens before filtering.
+			name:            "sameJob excludes native nominated pod",
+			pod:             makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nativeNominated: []*corev1.Pod{makeSimplePod("native-job-pod", "uid-job-pod", highPriority, nodeName)},
+			crossNominator:  newCrossNominator(),
+			podsOfSameJob:   []string{"uid-job-pod"},
+			wantPodsAdded:   false,
+			wantCloned:      true,
+			wantAddedCount:  0,
+		},
+		{
+			name: "mixed: native >= and cross >, each correctly filtered",
+			pod:  makeSimplePod("scheduling-pod", "uid-scheduling", midPriority, ""),
+			nativeNominated: []*corev1.Pod{
+				makeSimplePod("native-high", "uid-native-high", highPriority, nodeName), // added (>=)
+				makeSimplePod("native-low", "uid-native-low", lowPriority, nodeName),    // excluded (<)
+				makeSimplePod("native-job", "uid-native-job", highPriority, nodeName),   // excluded (sameJob)
+			},
+			crossNominator: newCrossNominator(
+				makePriorityPod("cross-high", "uid-cross-high", highPriority, "100m", "other-scheduler", nodeName, ""),  // added (>)
+				makePriorityPod("cross-equal", "uid-cross-equal", midPriority, "100m", "other-scheduler", nodeName, ""), // excluded (==, not strictly >)
+			),
+			podsOfSameJob:  []string{"uid-native-job"},
+			wantPodsAdded:  true,
+			wantCloned:     true,
+			wantAddedCount: 2, // native-high + cross-high
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeInfo := makeSimpleNodeInfo(nodeName)
+			impl := buildExtenderWithCrossNominator(t, nodeInfo, tt.nativeNominated, tt.crossNominator)
+
+			state := framework.NewCycleState()
+			podsOfSameJob := sets.New[string](tt.podsOfSameJob...)
+
+			podsAdded, stateOut, nodeInfoOut, err := impl.addMergedNominatedPods(
+				context.TODO(), tt.pod, state, nodeInfo, podsOfSameJob,
+			)
+
+			assert.NoError(t, err, "unexpected error")
+			assert.Equal(t, tt.wantPodsAdded, podsAdded, "podsAdded mismatch")
+
+			if tt.wantCloned {
+				// Clone is created whenever the combined nominated list is non-empty.
+				assert.NotSame(t, state, stateOut, "stateOut should be a clone")
+				assert.NotSame(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be a clone")
+			} else {
+				// Both lists empty: early return with originals.
+				assert.Same(t, state, stateOut, "stateOut should be the original state")
+				assert.Same(t, nodeInfo, nodeInfoOut, "nodeInfoOut should be the original nodeInfo")
+			}
+			assert.Equal(t, tt.wantAddedCount, len(nodeInfoOut.GetPods()), "number of pods in nodeInfoOut")
 		})
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler:

1. **Add the feature gate `CrossSchedulerNomination` to count high-priority pods nominated by other schedulers:**

   In the native scheduling framework, only nominated pods associated with the current scheduler are counted during the Filter phase. Consequently, when multiple schedulers preempt pods concurrently, they do not account for each other's nominations, leading to frequent conflicts. Since high-priority pods should have precedence over normal pods, we introduce a cross-scheduler nomination mechanism for HP pods to mitigate these conflicts.

2. **Add the feature gate `SkipFilterWithNominatedPods` to reduce the overhead of `RunFilterPluginsWithNominatedPods`:**

   The native `RunFilterPluginsWithNominatedPods` executes Filter plugins twice on a node when nominated pods are present: once including the nominated pods and once excluding them. The second run aims to address edge cases where nominated pod affinity terms might affect the schedulability of the current pod. However, in most cases, this second run is redundant. We add this feature to allow disabling it, thereby improving Filter latency.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
