### PR TITLE
scheduler: provide schedule suggestion for job/pod scheduling failure

### DIFF
--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -464,7 +464,14 @@ func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, stat
 		if diagnosis != nil && diagnosis.IsRootCausePod && diagnosis.AuditType != "" && ext.workloadAuditor != nil {
 			ext.workloadAuditor.RecordDiagnosis(pod, diagnosis.QuestionedKey, diagnosis.AuditType, diagnosis.AuditMessage)
 		}
-
+		if diagnosis != nil {
+			if suggestion := diagnosis.GetSuggestion(); suggestion != nil {
+				if status == nil {
+					status = fwktype.NewStatus(fwktype.Success)
+				}
+				status.AppendReason(fmt.Sprintf("Suggestion: {type: %s, message: %s}", suggestion.Type, suggestion.Message))
+			}
+		}
 	}()
 
 	return ext.Framework.RunPostFilterPlugins(ctx, state, pod, filteredNodeStatusMap)

--- a/pkg/scheduler/frameworkext/framework_extender_factory_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory_test.go
@@ -317,7 +317,7 @@ func Test_recordScheduleDiagnosis(t *testing.T) {
 		name          string
 		pod           *corev1.Pod
 		err           error
-		wantDiagnosis Diagnosis
+		wantDiagnosis *Diagnosis
 	}{
 		{
 			name: "prefilterFailed",
@@ -346,7 +346,7 @@ func Test_recordScheduleDiagnosis(t *testing.T) {
 					),
 				},
 			},
-			wantDiagnosis: Diagnosis{
+			wantDiagnosis: &Diagnosis{
 				Timestamp:     metav1.Time{},
 				QuestionedKey: "default/test-pod",
 				TargetPod: &corev1.Pod{
@@ -397,7 +397,7 @@ func Test_recordScheduleDiagnosis(t *testing.T) {
 					),
 				},
 			},
-			wantDiagnosis: Diagnosis{
+			wantDiagnosis: &Diagnosis{
 				Timestamp:     metav1.Time{},
 				QuestionedKey: "default/test-pod",
 				TargetPod: &corev1.Pod{
@@ -435,7 +435,7 @@ func Test_recordScheduleDiagnosis(t *testing.T) {
 			InitDiagnosis(cycleState, tt.pod)
 			recordScheduleDiagnosis(cycleState, tt.err)
 			diagnosis := GetDiagnosis(cycleState)
-			assert.Equal(t, tt.wantDiagnosis, *diagnosis)
+			assert.Equal(t, tt.wantDiagnosis, diagnosis)
 		})
 	}
 }

--- a/pkg/scheduler/frameworkext/schedule_diagnosis.go
+++ b/pkg/scheduler/frameworkext/schedule_diagnosis.go
@@ -140,8 +140,34 @@ type Diagnosis struct {
 	ScheduleDiagnosis   *ScheduleDiagnosis   `json:"scheduleDiagnosis"`
 	PreemptionDiagnosis *PreemptionDiagnosis `json:"preemptionDiagnosis"`
 
+	// Suggestion is the scheduler's advice to external components (e.g. descheduler, autoscaler)
+	// after a job/pod scheduling failure. For example, it may suggest resubmitting the pod or job,
+	// waiting for victims to be deleted, or deleting the PVC bound to the pod.
+	// Use SetSuggestion to set this field; once set, it cannot be overwritten.
+	suggestionMu sync.RWMutex        `json:"-"`
+	Suggestion   *ScheduleSuggestion `json:"suggestion,omitempty"`
+
 	AuditType    workloadauditor.RecordType `json:"-"`
 	AuditMessage string                     `json:"-"`
+}
+
+// SetSuggestion atomically sets the Suggestion field. It returns true if the suggestion
+// was successfully set, or false if it was already set by a prior caller.
+func (d *Diagnosis) SetSuggestion(suggestion *ScheduleSuggestion) bool {
+	d.suggestionMu.Lock()
+	defer d.suggestionMu.Unlock()
+	if d.Suggestion != nil {
+		return false
+	}
+	d.Suggestion = suggestion
+	return true
+}
+
+// GetSuggestion returns the current Suggestion under a read lock.
+func (d *Diagnosis) GetSuggestion() *ScheduleSuggestion {
+	d.suggestionMu.RLock()
+	defer d.suggestionMu.RUnlock()
+	return d.Suggestion
 }
 
 type ScheduleDiagnosis struct {
@@ -154,6 +180,30 @@ type ScheduleDiagnosis struct {
 	// NodeFailedDetails
 	NodeFailedDetails v1alpha1.NodeFailedDetails `json:"nodeFailedDetails,omitempty"`
 }
+
+// ScheduleSuggestion represents the scheduler's suggestion to external components
+// when a job/pod scheduling failure occurs.
+type ScheduleSuggestion struct {
+	// Type indicates the category of the suggestion.
+	Type SuggestionType `json:"type,omitempty"`
+	// Message provides a human-readable explanation of the suggestion.
+	Message string `json:"message,omitempty"`
+}
+
+// SuggestionType defines the type of scheduler suggestion.
+type SuggestionType string
+
+const (
+	// SuggestionEvictWorkloadSelf indicates the current Job/Pod is no longer schedulable
+	// and suggests deleting the Pod and resubmitting it.
+	SuggestionEvictWorkloadSelf SuggestionType = "EvictWorkloadSelf"
+	// SuggestionWaitingVictimReleased indicates the scheduler is waiting for victims to be deleted
+	// before the Job/Pod can be scheduled.
+	SuggestionWaitingVictimReleased SuggestionType = "WaitingVictimReleased"
+	// SuggestionDeleteConflictPVC indicates the Pod's bound PVC is preventing scheduling
+	// and suggests deleting the PVC so the Pod can be rescheduled.
+	SuggestionDeleteConflictPVC SuggestionType = "DeleteConflictPVC"
+)
 
 type SchedulingMode string
 

--- a/pkg/scheduler/frameworkext/schedule_diagnosis_test.go
+++ b/pkg/scheduler/frameworkext/schedule_diagnosis_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package frameworkext
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -107,6 +109,23 @@ func TestDumpDiagnosis(t *testing.T) {
 			},
 			wantDumpMessage: `{"timestamp":null,"questionedKey":"default/test-pod","nominatedNode":"nominatedNode","preFilterMessage":"preFilterMessage","topologyKeyToExplain":"topologyKeyToExplain","isRootCausePod":true,"scheduleDiagnosis":{"alreadyWaitForBound":2,"nodeOfferSlot":{"node1":1,"node2":1},"nodeFailedDetails":[{"preemptMightHelp":true,"failedNodes":["node1"]},{"reason":"node2-reason","preemptMightHelp":true,"failedNodes":["node2"]}]},"preemptionDiagnosis":{"dryRunFilterDiagnosis":{"alreadyWaitForBound":0,"nodeOfferSlot":{"node1":1,"node2":2},"nodeFailedDetails":[{"preemptMightHelp":true,"failedNodes":["node1"]},{"reason":"node2-reason","preemptMightHelp":true,"failedNodes":["node2"]}]},"otherDiagnosis":{"TriggerPodKey":"default/test-pod","preemptorKey":"default/test-pod"}}}`,
 		},
+		{
+			name: "with suggestion",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			setDiagnosisFunc: func(state fwktype.CycleState) {
+				diagnosis := GetDiagnosis(state)
+				diagnosis.SetSuggestion(&ScheduleSuggestion{
+					Type:    SuggestionEvictWorkloadSelf,
+					Message: "pod is unschedulable, please delete and resubmit",
+				})
+			},
+			wantDumpMessage: `{"timestamp":null,"questionedKey":"default/test-pod","isRootCausePod":true,"scheduleDiagnosis":null,"preemptionDiagnosis":null,"suggestion":{"type":"EvictWorkloadSelf","message":"pod is unschedulable, please delete and resubmit"}}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -119,6 +138,92 @@ func TestDumpDiagnosis(t *testing.T) {
 			assert.Equal(t, tt.wantDumpMessage, gotDumpMessage)
 		})
 	}
+}
+
+func TestSetSuggestion(t *testing.T) {
+	tests := []struct {
+		name           string
+		initSuggestion *ScheduleSuggestion
+		setSuggestion  *ScheduleSuggestion
+		wantOk         bool
+		wantSuggestion *ScheduleSuggestion
+	}{
+		{
+			name: "set suggestion on empty diagnosis",
+			setSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionEvictWorkloadSelf,
+				Message: "pod is unschedulable, please resubmit",
+			},
+			wantOk: true,
+			wantSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionEvictWorkloadSelf,
+				Message: "pod is unschedulable, please resubmit",
+			},
+		},
+		{
+			name: "set suggestion when already set returns false",
+			initSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionWaitingVictimReleased,
+				Message: "waiting for victims",
+			},
+			setSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionEvictWorkloadSelf,
+				Message: "should not overwrite",
+			},
+			wantOk: false,
+			wantSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionWaitingVictimReleased,
+				Message: "waiting for victims",
+			},
+		},
+		{
+			name: "set DeleteConflictPVC suggestion",
+			setSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionDeleteConflictPVC,
+				Message: "PVC my-pvc conflicts",
+			},
+			wantOk: true,
+			wantSuggestion: &ScheduleSuggestion{
+				Type:    SuggestionDeleteConflictPVC,
+				Message: "PVC my-pvc conflicts",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Diagnosis{}
+			if tt.initSuggestion != nil {
+				d.Suggestion = tt.initSuggestion
+			}
+			gotOk := d.SetSuggestion(tt.setSuggestion)
+			assert.Equal(t, tt.wantOk, gotOk)
+			assert.Equal(t, tt.wantSuggestion, d.Suggestion)
+		})
+	}
+}
+
+func TestSetSuggestion_Concurrent(t *testing.T) {
+	d := &Diagnosis{}
+	const goroutines = 100
+	var wg sync.WaitGroup
+	var successCount int32
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			ok := d.SetSuggestion(&ScheduleSuggestion{
+				Type:    SuggestionEvictWorkloadSelf,
+				Message: "from goroutine",
+			})
+			if ok {
+				atomic.AddInt32(&successCount, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), successCount, "exactly one goroutine should succeed")
+	assert.NotNil(t, d.Suggestion)
 }
 
 // BenchmarkDumpDiagnosis benchmarks the DumpDiagnosis function with large datasets

--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -345,6 +345,9 @@ func (pgMgr *PodGroupManager) BeforePreFilter(ctx context.Context, cycleState fw
 	}
 	if gangSchedulingContext.failedMessage != "" {
 		diagnosis.IsRootCausePod = false
+		if gangSchedulingContext.suggestion != nil {
+			diagnosis.SetSuggestion(gangSchedulingContext.suggestion)
+		}
 		return fmt.Errorf("%s", gangSchedulingContext.failedMessage)
 	}
 	return nil
@@ -384,6 +387,15 @@ func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype
 	}
 
 	message := pgMgr.summaryAndRecordFailedMessage(state, pod, filteredNodeStatusMap)
+	diagnosis := frameworkext.GetDiagnosis(state)
+	if diagnosis != nil {
+		if suggestion := diagnosis.GetSuggestion(); suggestion != nil {
+			gangSchedulingContext := pgMgr.holder.getCurrentGangSchedulingContext()
+			if gangSchedulingContext != nil {
+				gangSchedulingContext.suggestion = suggestion
+			}
+		}
+	}
 	if gang.getGangMode() == extension.GangModeStrict {
 		gang.clearWaitingGang()
 		pgMgr.rejectGangGroupById(handle, pluginName, gang.Name, message)

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -567,6 +567,33 @@ func TestPodGroupManager_PostFilter(t *testing.T) {
 			wantStatus:           fwktype.NewStatus(fwktype.Unschedulable, "preemption: some message"),
 			wantFailedMessage:    `GangGroup "default/gangA" gets rejected due to member Pod "default/pod1" is unschedulable with reason "0/0 nodes are available:", alreadyWaitForBound: 0`,
 		},
+		{
+			name: "gang pod with suggestion propagated to gangSchedulingContext",
+			args: args{
+				state: framework.NewCycleState(),
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "pod2",
+						Labels: map[string]string{
+							v1alpha1.PodGroupLabel: "gangB",
+						},
+					},
+				},
+			},
+			enablePreemption: true,
+			gangSchedulingContext: &GangSchedulingContext{
+				gangGroupID: "default/gangB",
+				gangGroup:   sets.New[string]("default/gangB"),
+			},
+			preemptionEvaluator: &fakeEvaluator{
+				result: &fwktype.PostFilterResult{},
+				status: fwktype.NewStatus(fwktype.Unschedulable, "preemption failed"),
+			},
+			wantPostFilterResult: &fwktype.PostFilterResult{},
+			wantStatus:           fwktype.NewStatus(fwktype.Unschedulable, "preemption: preemption failed"),
+			wantFailedMessage:    `GangGroup "default/gangB" gets rejected due to member Pod "default/pod2" is unschedulable with reason "0/0 nodes are available:", alreadyWaitForBound: 0`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -588,6 +615,151 @@ func TestPodGroupManager_PostFilter(t *testing.T) {
 			if tt.gangSchedulingContext != nil {
 				assert.Equalf(t, tt.wantFailedMessage, tt.gangSchedulingContext.failedMessage, "PostFilter(%v, %v, %v, %v)", tt.args.ctx, tt.args.state, tt.args.pod, tt.args.m)
 			}
+		})
+	}
+}
+
+func TestAfterPostFilter_SuggestionPropagation(t *testing.T) {
+	tests := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		gangSchedulingContext *GangSchedulingContext
+		suggestion            *frameworkext.ScheduleSuggestion
+		wantSuggestion        *frameworkext.ScheduleSuggestion
+	}{
+		{
+			name: "suggestion propagated to gangSchedulingContext via AfterPostFilter",
+			pod:  st.MakePod().Name("pod-af").UID("pod-af").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangAF").Obj(),
+			gangSchedulingContext: &GangSchedulingContext{
+				gangGroupID:   "default/gangAF",
+				gangGroup:     sets.New[string]("default/gangAF"),
+				failedMessage: "already failed",
+			},
+			suggestion: &frameworkext.ScheduleSuggestion{
+				Type:    frameworkext.SuggestionEvictWorkloadSelf,
+				Message: "job is unschedulable, please resubmit",
+			},
+			wantSuggestion: &frameworkext.ScheduleSuggestion{
+				Type:    frameworkext.SuggestionEvictWorkloadSelf,
+				Message: "job is unschedulable, please resubmit",
+			},
+		},
+		{
+			name: "no suggestion when diagnosis has none",
+			pod:  st.MakePod().Name("pod-af2").UID("pod-af2").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangAF2").Obj(),
+			gangSchedulingContext: &GangSchedulingContext{
+				gangGroupID:   "default/gangAF2",
+				gangGroup:     sets.New[string]("default/gangAF2"),
+				failedMessage: "already failed",
+			},
+			suggestion:     nil,
+			wantSuggestion: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle := NewFakeExtendedFramework(t, []*corev1.Node{}, nil, nil, nil, nil)
+			gangCache := NewGangCache(nil, nil, nil, nil, handle)
+			gangCache.onPodAdd(tt.pod)
+			pgMgr := &PodGroupManager{
+				handle: handle,
+				holder: GangSchedulingContextHolder{
+					gangSchedulingContext: tt.gangSchedulingContext,
+				},
+				args:  &config.CoschedulingArgs{},
+				cache: gangCache,
+			}
+
+			cycleState := framework.NewCycleState()
+			frameworkext.InitDiagnosis(cycleState, tt.pod)
+			if tt.suggestion != nil {
+				diagnosis := frameworkext.GetDiagnosis(cycleState)
+				diagnosis.SetSuggestion(tt.suggestion)
+			}
+
+			pgMgr.AfterPostFilter(context.TODO(), cycleState, tt.pod, pgMgr.handle, "coscheduling", nil)
+			assert.Equal(t, tt.wantSuggestion, tt.gangSchedulingContext.suggestion, "suggestion propagation")
+		})
+	}
+}
+
+func TestBeforePreFilter_SuggestionPropagation(t *testing.T) {
+	gangCreatedTime := time.Now()
+	tests := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		pg                    *v1alpha1.PodGroup
+		gangSchedulingContext *GangSchedulingContext
+		wantSuggestion        *frameworkext.ScheduleSuggestion
+		wantIsRootCausePod    bool
+		wantErr               bool
+	}{
+		{
+			name: "subsequent pod gets suggestion from gangSchedulingContext",
+			pod:  st.MakePod().Name("pod-follower").UID("pod-follower").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangX").Obj(),
+			pg:   makePg("gangX", "default", 1, &gangCreatedTime, nil),
+			gangSchedulingContext: &GangSchedulingContext{
+				firstPod:      st.MakePod().Name("pod-leader").UID("pod-leader").Namespace("default").Obj(),
+				gangGroupID:   "default/gangX",
+				gangGroup:     sets.New[string]("default/gangX"),
+				failedMessage: "GangGroup failed",
+				suggestion: &frameworkext.ScheduleSuggestion{
+					Type:    frameworkext.SuggestionWaitingVictimReleased,
+					Message: "waiting for victim pods to be deleted",
+				},
+			},
+			wantSuggestion: &frameworkext.ScheduleSuggestion{
+				Type:    frameworkext.SuggestionWaitingVictimReleased,
+				Message: "waiting for victim pods to be deleted",
+			},
+			wantIsRootCausePod: false,
+			wantErr:            true,
+		},
+		{
+			name: "subsequent pod with no suggestion in gangSchedulingContext",
+			pod:  st.MakePod().Name("pod-follower2").UID("pod-follower2").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangY").Obj(),
+			pg:   makePg("gangY", "default", 1, &gangCreatedTime, nil),
+			gangSchedulingContext: &GangSchedulingContext{
+				firstPod:      st.MakePod().Name("pod-leader2").UID("pod-leader2").Namespace("default").Obj(),
+				gangGroupID:   "default/gangY",
+				gangGroup:     sets.New[string]("default/gangY"),
+				failedMessage: "GangGroup failed",
+			},
+			wantSuggestion:     nil,
+			wantIsRootCausePod: false,
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewManagerForTest().pgMgr
+			if tt.pg != nil {
+				mgr.cache.onPodGroupAdd(tt.pg)
+				// Mark gang as initialized so BeforePreFilter reaches the failedMessage check
+				gangId := util.GetId(tt.pg.Namespace, tt.pg.Name)
+				gang := mgr.cache.getGangFromCacheByGangId(gangId, false)
+				if gang != nil {
+					gang.HasGangInit = true
+				}
+			}
+			mgr.cache.onPodAdd(tt.pod)
+			if tt.gangSchedulingContext != nil {
+				mgr.holder.setGangSchedulingContext(tt.gangSchedulingContext, "test")
+			}
+
+			cycleState := framework.NewCycleState()
+			frameworkext.InitDiagnosis(cycleState, tt.pod)
+			err := mgr.BeforePreFilter(context.TODO(), cycleState, tt.pod)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			diagnosis := frameworkext.GetDiagnosis(cycleState)
+			assert.Equal(t, tt.wantIsRootCausePod, diagnosis.IsRootCausePod)
+			assert.Equal(t, tt.wantSuggestion, diagnosis.Suggestion)
 		})
 	}
 }

--- a/pkg/scheduler/plugins/coscheduling/core/gang_context.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_context.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/networktopology"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/util"
 )
@@ -94,6 +95,7 @@ type GangSchedulingContext struct {
 	triggerPod        *corev1.Pod
 	failedMessage     string
 	preemptionMessage string
+	suggestion        *frameworkext.ScheduleSuggestion
 
 	networkTopologySpec         *extension.NetworkTopologySpec
 	networkTopologySnapshot     *networktopology.TreeSnapshot


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR introduces a Suggestion mechanism in the scheduler's diagnosis system. After a job/pod scheduling failure, the scheduler can now provide actionable advice to external components (e.g., descheduler, autoscaler, or platform controllers) via a typed ScheduleSuggestion attached to the Diagnosis.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

Example Pod condition message:
```
message: '0/72 nodes are available: ..., Suggestion: {type: EvictWorkloadSelf, message: "XXX"}.'
```

### Ⅳ. Special notes for reviews

Diagnosis now embeds sync.Mutex (suggestionMu), so it must not be copied by value. Existing test assertions were updated to use pointer comparison (*Diagnosis → compare via pointer).
The SetSuggestion method enforces set-once semantics: the first plugin to set a suggestion wins, subsequent calls return false.


### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
