### PR TITLE
scheduler: refactor ForceSyncFromInformer to align with vanilla kube-scheduler behavior

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -68,6 +68,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/defaultprofile"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/eventhandlers"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/informer"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/networktopology"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
@@ -170,6 +171,12 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 
 // Run executes the scheduler based on the given configuration. It only returns on error or when context is done.
 func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *scheduler.Scheduler, extenderFactory *frameworkext.FrameworkExtenderFactory, customWorkflow CustomWorkflow) error {
+	// Wrap the incoming ctx so that Run itself owns a cancel function; this lets
+	// leader-election callbacks trigger a graceful shutdown (e.g. when plugin
+	// initialization fails) by canceling the scheduler context instead of
+	// abruptly terminating via klog.Fatalf.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	logger := klog.FromContext(ctx)
 	// To help debugging, immediately log version
 	logger.Info("Starting Koordinator Scheduler version", "version", version.Get())
@@ -232,8 +239,38 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		}
 	}
 
-	startInformersAndWaitForSync := func(ctx context.Context) {
-		// Start all informers.
+	startInformersAndWaitForSync := func(ctx context.Context) error {
+		// Startup order matters for data-race freedom: some plugins register
+		// AfterPluginInformersSynced hooks (via frameworkexthelper) that rebuild
+		// internal state from an initial-list snapshot of their private informers
+		// (e.g. ElasticQuota's ReplaceQuotas rebuilding groupQuotaManager). Those
+		// hooks must complete before the main informers (pods/nodes/etc.) start
+		// delivering events whose handlers read the same plugin state, so we
+		// sequence the pipeline as: (1) start+sync plugin informer factories,
+		// (2) run AfterPluginInformersSynced hooks, (3) start+sync main informer
+		// factories, (4) run AfterAllInformersSynced hooks.
+
+		// Step 1: start plugin informer factories registered via InformerFactoryProvider.
+		for _, f := range extenderFactory.GetPluginInformerFactories() {
+			f.Start(ctx.Done())
+		}
+		for _, f := range extenderFactory.GetPluginInformerFactories() {
+			f.WaitForCacheSync(ctx.Done())
+		}
+		// Step 2: run plugin-registered AfterPluginInformersSynced hooks. A hook
+		// failure is surfaced as a startup error so the caller can shut down
+		// gracefully (releasing the leader lease, running registered shutdown
+		// hooks) instead of abruptly terminating. A ctx cancellation (normal
+		// shutdown) is not treated as an error.
+		if err := frameworkexthelper.RunAfterPluginInformersSynced(ctx); err != nil {
+			if ctx.Err() != nil {
+				logger.Info("AfterPluginInformersSynced hooks interrupted", "err", err)
+				return nil
+			}
+			return fmt.Errorf("AfterPluginInformersSynced hook failed: %w", err)
+		}
+
+		// Step 3: start the remaining informer factories.
 		cc.InformerFactory.Start(ctx.Done())
 		// DynInformerFactory can be nil in tests.
 		if cc.DynInformerFactory != nil {
@@ -256,10 +293,30 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 			logger.Error(err, "waiting for handlers to sync")
 		}
 
+		// Wait for koordinator plugin handlers (registrations collected via
+		// ForceSyncFromInformer) to complete their initial list sync. These are
+		// not visible to sched.WaitForHandlersSync, so we check them separately.
+		if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+			logger.Error(err, "waiting for koordinator handlers to sync")
+		}
+
 		logger.V(3).Info("Handlers synced")
+
+		// Step 4: run plugin-registered AfterAllInformersSynced hooks. Same
+		// error/shutdown contract as Step 2.
+		if err := frameworkexthelper.RunAfterAllInformersSynced(ctx); err != nil {
+			if ctx.Err() != nil {
+				logger.Info("AfterAllInformersSynced hooks interrupted", "err", err)
+				return nil
+			}
+			return fmt.Errorf("AfterAllInformersSynced hook failed: %w", err)
+		}
+		return nil
 	}
 	if !cc.ComponentConfig.DelayCacheUntilActive || cc.LeaderElection == nil {
-		startInformersAndWaitForSync(ctx)
+		if err := startInformersAndWaitForSync(ctx); err != nil {
+			return err
+		}
 	}
 	// If leader election is enabled, runCommand via LeaderElector until done and exit.
 	if cc.LeaderElection != nil {
@@ -268,7 +325,15 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 				close(waitingForLeader)
 				if cc.ComponentConfig.DelayCacheUntilActive {
 					logger.Info("Starting informers and waiting for sync...")
-					startInformersAndWaitForSync(ctx)
+					if err := startInformersAndWaitForSync(ctx); err != nil {
+						// Trigger graceful shutdown by canceling the outer context:
+						// the leader elector observes ctx.Done() and invokes
+						// OnStoppedLeading, which runs gracefulShutdownSecureServer
+						// and exits cleanly.
+						logger.Error(err, "Failed to initialize plugin state; releasing leader lease for graceful shutdown")
+						cancel()
+						return
+					}
 					logger.Info("Sync completed")
 				} else {
 					waitForLatestSynced(ctx, cc, sched)

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -156,6 +156,8 @@ type FrameworkExtenderFactory struct {
 
 	workloadAuditor workloadauditor.WorkloadAuditor
 
+	pluginInformerFactories []SharedInformerFactory
+
 	metricsRecorder *metrics.MetricAsyncRecorder
 }
 
@@ -444,6 +446,15 @@ func (f *FrameworkExtenderFactory) updatePlugins(pl fwktype.Plugin, profileName 
 	if f.controllerMaps != nil {
 		f.controllerMaps.RegisterControllers(pl, profileName)
 	}
+	if provider, ok := pl.(InformerFactoryProvider); ok {
+		f.pluginInformerFactories = append(f.pluginInformerFactories, provider.GetInformerFactories()...)
+	}
+}
+
+// GetPluginInformerFactories returns all informer factories registered by plugins
+// via the InformerFactoryProvider interface.
+func (f *FrameworkExtenderFactory) GetPluginInformerFactories() []SharedInformerFactory {
+	return f.pluginInformerFactories
 }
 
 // PluginFactoryProxy is used to proxy the call to the PluginFactory function and pass in the ExtendedHandle for the custom plugin

--- a/pkg/scheduler/frameworkext/helper/forcesync_eventhandler.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_eventhandler.go
@@ -17,156 +17,142 @@ limitations under the License.
 package helper
 
 import (
+	"context"
+	"fmt"
 	"reflect"
-	"strconv"
+	"sync"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 )
 
+var (
+	registrationsMu sync.Mutex
+	registrations   []cache.ResourceEventHandlerRegistration
+)
+
+func addRegistration(reg cache.ResourceEventHandlerRegistration) {
+	registrationsMu.Lock()
+	defer registrationsMu.Unlock()
+	registrations = append(registrations, reg)
+}
+
+// GetRegistrations returns a snapshot of all collected registrations.
+func GetRegistrations() []cache.ResourceEventHandlerRegistration {
+	registrationsMu.Lock()
+	defer registrationsMu.Unlock()
+	return append([]cache.ResourceEventHandlerRegistration{}, registrations...)
+}
+
+// ResetRegistrations clears all collected registrations and any startup hooks
+// registered alongside them. Only for testing.
+func ResetRegistrations() {
+	registrationsMu.Lock()
+	registrations = nil
+	registrationsMu.Unlock()
+	ResetStartupHooks()
+}
+
+// forceSyncEventHandler holds configuration for event handler registration.
 type forceSyncEventHandler struct {
-	handler      cache.ResourceEventHandler
-	syncCh       chan struct{}
-	objects      map[apimachinerytypes.UID]int64
 	resyncPeriod time.Duration
 }
 
-func newForceSyncEventHandler(handler cache.ResourceEventHandler, options ...Option) *forceSyncEventHandler {
-	h := &forceSyncEventHandler{
-		handler: handler,
-		syncCh:  make(chan struct{}, 1),
-		objects: map[apimachinerytypes.UID]int64{},
-	}
-	for _, fn := range options {
-		fn(h)
-	}
-	return h
-}
-
-func (h *forceSyncEventHandler) syncDone() {
-	close(h.syncCh)
-}
-
-func (h *forceSyncEventHandler) waitForSyncDone() {
-	<-h.syncCh
-}
-
-func (h *forceSyncEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
-	h.waitForSyncDone()
-	if metaAccessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
-		objectMeta := metaAccessor.GetObjectMeta()
-		objectUID := objectMeta.GetUID()
-		if oldResourceVersion, ok := h.objects[objectUID]; ok && oldResourceVersion != 0 {
-			resourceVersion, err := strconv.ParseInt(objectMeta.GetResourceVersion(), 10, 64)
-			if err == nil && resourceVersion <= oldResourceVersion {
-				return
-			}
-			delete(h.objects, objectUID)
-			klog.Warningf("Object %q has been updated multiple times in a short period of time", klog.KObj(objectMeta).String())
-		}
-	}
-	if h.handler != nil {
-		h.handler.OnAdd(obj, isInInitialList)
-	}
-}
-
-func (h *forceSyncEventHandler) OnUpdate(oldObj, newObj interface{}) {
-	h.waitForSyncDone()
-	if h.objects != nil {
-		// Release objects map to reduce memory usage and reduce GC pressure
-		h.objects = nil
-	}
-	if h.handler != nil {
-		h.handler.OnUpdate(oldObj, newObj)
-	}
-}
-
-func (h *forceSyncEventHandler) OnDelete(obj interface{}) {
-	h.waitForSyncDone()
-	if h.objects != nil {
-		// Release objects map to reduce memory usage and reduce GC pressure
-		h.objects = nil
-	}
-	if h.handler != nil {
-		h.handler.OnDelete(obj)
-	}
-}
-
-func (h *forceSyncEventHandler) addDirectly(obj interface{}, isInInitialList bool) {
-	if h.handler == nil {
-		return
-	}
-	h.handler.OnAdd(obj, isInInitialList)
-	if metaAccessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
-		objectMeta := metaAccessor.GetObjectMeta()
-		resourceVersion, err := strconv.ParseInt(objectMeta.GetResourceVersion(), 10, 64)
-		if err == nil {
-			h.objects[objectMeta.GetUID()] = resourceVersion
-		}
-	}
-}
-
+// CacheSyncer is the interface for starting informers and waiting for cache sync.
 type CacheSyncer interface {
 	Start(stopCh <-chan struct{})
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 }
 
+// Option is a functional option for forceSyncEventHandler.
 type Option func(*forceSyncEventHandler)
 
+// WithResyncPeriod sets the resync period for the event handler registration.
 func WithResyncPeriod(resyncPeriod time.Duration) Option {
 	return func(handler *forceSyncEventHandler) {
 		handler.resyncPeriod = resyncPeriod
 	}
 }
 
-// ForceSyncFromInformer ensures that the EventHandler will synchronize data immediately after registration,
-// helping those plugins that need to build memory status through EventHandler to correctly synchronize data
-func ForceSyncFromInformer(stopCh <-chan struct{}, cacheSyncer CacheSyncer, informer cache.SharedInformer, handler cache.ResourceEventHandler, options ...Option) (cache.ResourceEventHandlerRegistration, error) {
-	syncEventHandler := newForceSyncEventHandler(handler, options...)
-	registration, err := informer.AddEventHandlerWithResyncPeriod(syncEventHandler, syncEventHandler.resyncPeriod)
-	if cacheSyncer != nil {
-		cacheSyncer.Start(stopCh)
-		cacheSyncer.WaitForCacheSync(stopCh)
+// ForceSyncFromInformer registers handler via standard AddEventHandler and collects
+// the registration for WaitForHandlersSync.
+// NOTE: The informer is NOT started here; it will be started later in startInformersAndWaitForSync.
+// Function signature is kept unchanged for backward compatibility.
+func ForceSyncFromInformer(stopCh <-chan struct{}, cacheSyncer CacheSyncer,
+	informer cache.SharedInformer, handler cache.ResourceEventHandler,
+	options ...Option) (cache.ResourceEventHandlerRegistration, error) {
+	cfg := &forceSyncEventHandler{}
+	for _, fn := range options {
+		fn(cfg)
 	}
-	allObjects := informer.GetStore().List()
-	for _, obj := range allObjects {
-		syncEventHandler.addDirectly(obj, true)
+	// Replace nil handler with a no-op handler to avoid panics when events are delivered.
+	if handler == nil {
+		handler = cache.ResourceEventHandlerFuncs{}
 	}
-	syncEventHandler.syncDone()
-	return registration, err
+	reg, err := informer.AddEventHandlerWithResyncPeriod(handler, cfg.resyncPeriod)
+	if err != nil {
+		return nil, err
+	}
+	// Avoid double-registration: forceSyncsharedIndexInformer.AddEventHandlerWithResyncPeriod
+	// already calls addRegistration internally, so skip it here to prevent duplicates
+	// in GetRegistrations() and redundant work in waitForKoordinatorHandlersSync.
+	if _, isWrapper := informer.(*forceSyncsharedIndexInformer); !isWrapper {
+		addRegistration(reg)
+	}
+	return reg, nil
 }
 
-func ForceSyncFromInformerWithReplace(stopCh <-chan struct{}, cacheSyncer CacheSyncer, informer cache.SharedInformer, handler cache.ResourceEventHandler, replaceHandler func([]interface{}) error, options ...Option) (cache.ResourceEventHandlerRegistration, error) {
-	syncEventHandler := newForceSyncEventHandler(handler, options...)
-	registration, err := informer.AddEventHandlerWithResyncPeriod(syncEventHandler, syncEventHandler.resyncPeriod)
-	if err != nil {
-		return nil, err
+// ForceSyncFromInformerWithReplace registers handler via ForceSyncFromInformer and, when
+// replaceHandler is non-nil, registers an AfterPluginInformersSynced startup hook that
+// invokes replaceHandler exactly once with a full snapshot of the informer's store. The
+// scheduler startup pipeline runs these hooks AFTER the plugin informer factories have
+// started and synced, but BEFORE the main informer factories (pods/nodes/etc.) deliver
+// events; this gives downstream event handlers a clean happens-before anchor on the
+// rebuilt plugin state. A non-nil error from replaceHandler aborts startup so the
+// scheduler can shut down gracefully.
+//
+// IMPORTANT (discouraged for new call sites): the whole-snapshot "replace" semantics is
+// a legacy shape kept for the ElasticQuota plugin. New plugins that need to initialize
+// from an initial list should either (a) register an AfterPluginInformersSynced hook
+// directly and pull the snapshot from a lister, or (b) use the plain ForceSyncFromInformer
+// path with idempotent OnAdd/OnUpdate handling, which does not require any cross-factory
+// startup ordering.
+func ForceSyncFromInformerWithReplace(stopCh <-chan struct{}, cacheSyncer CacheSyncer,
+	informer cache.SharedInformer, handler cache.ResourceEventHandler,
+	replaceHandler func([]interface{}) error,
+	options ...Option) (cache.ResourceEventHandlerRegistration, error) {
+	reg, err := ForceSyncFromInformer(stopCh, cacheSyncer, informer, handler, options...)
+	if err != nil || replaceHandler == nil {
+		return reg, err
 	}
+	// Register a startup hook that fires AFTER the hosting plugin informer factory has
+	// started and synced. At that point the registered handler has already consumed the
+	// initial list, so informer.GetStore().List() returns a complete snapshot. The hook
+	// runs synchronously relative to the startup pipeline, so its completion is totally
+	// ordered before any main informer begins delivering events.
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		if !cache.WaitForCacheSync(ctx.Done(), reg.HasSynced) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("ForceSyncFromInformerWithReplace: handler registration never synced")
+		}
+		return replaceHandler(informer.GetStore().List())
+	})
+	return reg, nil
+}
 
-	if cacheSyncer != nil {
-		cacheSyncer.Start(stopCh)
-		cacheSyncer.WaitForCacheSync(stopCh)
-	}
-
-	allObjects := informer.GetStore().List()
-	// record object uid.
-	for _, obj := range allObjects {
-		if metaAccessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
-			objectMeta := metaAccessor.GetObjectMeta()
-			resourceVersion, err := strconv.ParseInt(objectMeta.GetResourceVersion(), 10, 64)
-			if err == nil {
-				syncEventHandler.objects[objectMeta.GetUID()] = resourceVersion
+// WaitForHandlersSync waits until all collected handler registrations have synced.
+// It is intended for use in tests: call it after starting informer factories so that
+// all OnAdd events delivered by the initial list have been processed before assertions.
+func WaitForHandlersSync(ctx context.Context) error {
+	return wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		for _, reg := range GetRegistrations() {
+			if !reg.HasSynced() {
+				return false, nil
 			}
 		}
-	}
-	// replace objects
-	err = replaceHandler(allObjects)
-	if err != nil {
-		return nil, err
-	}
-	syncEventHandler.syncDone()
-	return registration, err
+		return true, nil
+	})
 }

--- a/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -50,22 +51,40 @@ func TestSyncedEventHandler(t *testing.T) {
 	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
 	addTimes := map[string]int{}
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(10)
+
+	// ForceSyncFromInformer only registers the handler; the informer must be
+	// started explicitly via factory.Start().
 	ForceSyncFromInformer(context.TODO().Done(), sharedInformerFactory, nodeInformer.Informer(), cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*corev1.Node)
+			mu.Lock()
 			addTimes[node.Name]++
+			mu.Unlock()
 			wg.Done()
 		},
 	})
+
+	// Start informers so that the registered handler receives initial list events.
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	sharedInformerFactory.Start(stopCh)
+
 	wg.Wait()
+
+	mu.Lock()
 	for _, v := range addTimes {
 		if v > 1 {
+			mu.Unlock()
 			t.Errorf("unexpected add times, want 1 but got %d", v)
-			break
+			return
 		}
 	}
+	mu.Unlock()
+
+	sharedInformerFactory.WaitForCacheSync(stopCh)
 	node, err := nodeInformer.Lister().Get("node-0")
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
@@ -82,7 +101,111 @@ func TestSyncedEventHandler(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestForceSyncFromInformerWithReplace_NilReplaceHandler ensures that passing a
+// nil replaceHandler is equivalent to the plain ForceSyncFromInformer path and
+// does NOT register a startup hook.
+func TestForceSyncFromInformerWithReplace_NilReplaceHandler(t *testing.T) {
+	ResetRegistrations()
+	defer ResetRegistrations()
+
+	fakeClientSet := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
+
+	_, err := ForceSyncFromInformerWithReplace(
+		context.TODO().Done(),
+		sharedInformerFactory,
+		nodeInformer.Informer(),
+		cache.ResourceEventHandlerFuncs{},
+		nil, // replaceHandler
+	)
+	assert.NoError(t, err)
+
+	// Running the startup phase must be a no-op: no hook was registered.
+	runCtx, runCancel := context.WithTimeout(context.Background(), time.Second)
+	defer runCancel()
+	assert.NoError(t, RunAfterPluginInformersSynced(runCtx))
+}
+
+// TestForceSyncFromInformerWithReplace_PropagatesError ensures a non-nil error
+// returned from replaceHandler is surfaced verbatim through
+// RunAfterPluginInformersSynced so the scheduler startup path can fail fast.
+func TestForceSyncFromInformerWithReplace_PropagatesError(t *testing.T) {
+	ResetRegistrations()
+	defer ResetRegistrations()
+
+	var objects []runtime.Object
+	for i := 0; i < 3; i++ {
+		objects = append(objects, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:             uuid.NewUUID(),
+				Name:            fmt.Sprintf("node-%d", i),
+				ResourceVersion: fmt.Sprintf("%d", i+1),
+			},
+		})
+	}
+	fakeClientSet := kubefake.NewSimpleClientset(objects...)
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
+
+	sentinel := errors.New("replace-failed")
+	_, err := ForceSyncFromInformerWithReplace(
+		context.TODO().Done(),
+		sharedInformerFactory,
+		nodeInformer.Informer(),
+		cache.ResourceEventHandlerFuncs{},
+		func(objs []interface{}) error { return sentinel },
+	)
+	assert.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	sharedInformerFactory.Start(stopCh)
+	sharedInformerFactory.WaitForCacheSync(stopCh)
+
+	runCtx, runCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer runCancel()
+	err = RunAfterPluginInformersSynced(runCtx)
+	assert.ErrorIs(t, err, sentinel, "replaceHandler error must propagate via the AfterPluginInformersSynced hook")
+}
+
+// TestForceSyncFromInformerWithReplace_CtxCanceledBeforeSync ensures that when
+// the startup ctx is canceled before the handler registration finishes syncing,
+// the hook surfaces ctx.Err() instead of silently succeeding.
+func TestForceSyncFromInformerWithReplace_CtxCanceledBeforeSync(t *testing.T) {
+	ResetRegistrations()
+	defer ResetRegistrations()
+
+	fakeClientSet := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
+
+	replaceCalled := false
+	_, err := ForceSyncFromInformerWithReplace(
+		context.TODO().Done(),
+		sharedInformerFactory,
+		nodeInformer.Informer(),
+		cache.ResourceEventHandlerFuncs{},
+		func(objs []interface{}) error {
+			replaceCalled = true
+			return nil
+		},
+	)
+	assert.NoError(t, err)
+
+	// Do NOT start the informer factory, so reg.HasSynced() never becomes true.
+	// Use an already-canceled ctx so cache.WaitForCacheSync returns immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = RunAfterPluginInformersSynced(ctx)
+	assert.ErrorIs(t, err, context.Canceled, "hook must surface ctx.Err() when cache.WaitForCacheSync fails due to cancellation")
+	assert.False(t, replaceCalled, "replaceHandler must not run when the underlying registration never synced")
+}
+
 func TestSyncedEventHandlerWithReplace(t *testing.T) {
+	ResetRegistrations()
+
 	var objects []runtime.Object
 	for i := 0; i < 10; i++ {
 		node := &corev1.Node{
@@ -98,23 +221,83 @@ func TestSyncedEventHandlerWithReplace(t *testing.T) {
 	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
 	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
 	addTimes := map[string]int{}
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(10)
-	ForceSyncFromInformerWithReplace(context.TODO().Done(), sharedInformerFactory, nodeInformer.Informer(), cache.ResourceEventHandlerFuncs{}, func(objs []interface{}) error {
-		for _, obj := range objs {
-			node := obj.(*corev1.Node)
-			addTimes[node.Name]++
-			wg.Done()
-		}
-		return nil
-	})
+
+	// replaceHandlerCalled is closed once replaceHandler has run.
+	replaceHandlerCalled := make(chan struct{})
+	var replacedObjs []interface{}
+	var replaceMu sync.Mutex
+
+	// ForceSyncFromInformerWithReplace registers handler via the regular path and
+	// stashes replaceHandler as an AfterPluginInformersSynced startup hook. The
+	// hook is dispatched by RunAfterPluginInformersSynced below, mirroring the
+	// production startup sequence in cmd/koord-scheduler/app/server.go.
+	ForceSyncFromInformerWithReplace(context.TODO().Done(), sharedInformerFactory, nodeInformer.Informer(),
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				node := obj.(*corev1.Node)
+				mu.Lock()
+				addTimes[node.Name]++
+				mu.Unlock()
+				wg.Done()
+			},
+		},
+		func(objs []interface{}) error {
+			replaceMu.Lock()
+			replacedObjs = objs
+			replaceMu.Unlock()
+			close(replaceHandlerCalled)
+			return nil
+		},
+	)
+
+	// Start informers so that the registered handler receives initial list events.
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	sharedInformerFactory.Start(stopCh)
+
 	wg.Wait()
+
+	mu.Lock()
 	for _, v := range addTimes {
 		if v > 1 {
+			mu.Unlock()
 			t.Errorf("unexpected add times, want 1 but got %d", v)
-			break
+			return
 		}
 	}
+	mu.Unlock()
+
+	// Dispatch startup hooks: this is where replaceHandler now runs, in the same
+	// phase the scheduler would trigger it in production.
+	runCtx, runCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer runCancel()
+	if err := RunAfterPluginInformersSynced(runCtx); err != nil {
+		t.Fatalf("RunAfterPluginInformersSynced failed: %v", err)
+	}
+
+	// replaceHandler must have been called by the time the hook run returns.
+	select {
+	case <-replaceHandlerCalled:
+	default:
+		t.Fatal("replaceHandler was not called by RunAfterPluginInformersSynced")
+	}
+
+	replaceMu.Lock()
+	assert.Equal(t, 10, len(replacedObjs), "replaceHandler should receive all 10 nodes")
+	replaceMu.Unlock()
+
+	// WaitForHandlersSync should return quickly now that the initial list has been
+	// fully delivered (registrations no longer gate on replaceHandler completion).
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer syncCancel()
+	if err := WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("WaitForHandlersSync timed out: %v", err)
+	}
+
+	sharedInformerFactory.WaitForCacheSync(stopCh)
 	node, err := nodeInformer.Lister().Get("node-0")
 	assert.NoError(t, err)
 	assert.NotNil(t, node)

--- a/pkg/scheduler/frameworkext/helper/forcesync_factory.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_factory.go
@@ -28,12 +28,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// NOTE(joseph): When the K8s Scheduler Framework starts, the thread that constructs NodeInfo
-// and the scheduling thread are not synchronized. In this way, when the Pod on a Node is not
-// filled in the NodeInfo, the Node is scheduled for a new Pod. This behavior is not expected.
-// The K8s community itself has also noticed this issue https://github.com/kubernetes/kubernetes/issues/116717,
-// but it was only fixed in the K8s v1.28 version https://github.com/kubernetes/kubernetes/pull /116729.
-// So we need to fix it ourselves.
+// forceSyncSharedInformerFactory wraps SharedInformerFactory so that every informer
+// obtained via InformerFor is wrapped with forceSyncsharedIndexInformer, which
+// intercepts AddEventHandler / AddEventHandlerWithResyncPeriod calls and collects
+// the returned ResourceEventHandlerRegistration for WaitForHandlersSync.
 
 var _ informers.SharedInformerFactory = &forceSyncSharedInformerFactory{}
 
@@ -54,7 +52,7 @@ func NewForceSyncSharedInformerFactory(factory informers.SharedInformerFactory) 
 
 func (f *forceSyncSharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	informer := f.SharedInformerFactory.InformerFor(obj, newFunc)
-	return newForceSyncSharedIndexInformer(informer, f.defaultResync, f.SharedInformerFactory)
+	return newForceSyncSharedIndexInformer(informer, f.defaultResync)
 }
 
 func (f *forceSyncSharedInformerFactory) Core() core.Interface {

--- a/pkg/scheduler/frameworkext/helper/forcesync_factory_test.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_factory_test.go
@@ -26,19 +26,53 @@ import (
 )
 
 func TestSharedInformerFactory(t *testing.T) {
+	// Reset registrations to avoid interference from other tests.
+	ResetRegistrations()
+
 	client := kubefake.NewSimpleClientset()
 	factory := scheduler.NewInformerFactory(client, 0)
 	factory = NewForceSyncSharedInformerFactory(factory)
 	assert.NotNil(t, factory.Storage())
 
 	informer := factory.Core().V1().Nodes().Informer()
-	assert.False(t, informer.HasSynced())
 	_, ok := informer.(*forceSyncsharedIndexInformer)
-	assert.True(t, ok)
+	assert.True(t, ok, "expected forceSyncsharedIndexInformer wrapper")
 
-	informer.AddEventHandler(&forceSyncEventHandler{})
-	assert.False(t, informer.HasSynced())
-
+	// AddEventHandler via the wrapper should collect the registration.
 	informer.AddEventHandler(&cache.ResourceEventHandlerFuncs{})
-	assert.True(t, informer.HasSynced())
+	regs := GetRegistrations()
+	assert.Len(t, regs, 1, "expected 1 registration after AddEventHandler")
+
+	// A second AddEventHandler should add another registration.
+	informer.AddEventHandler(&cache.ResourceEventHandlerFuncs{})
+	regs = GetRegistrations()
+	assert.Len(t, regs, 2, "expected 2 registrations after second AddEventHandler")
+}
+
+// TestForceSyncFromInformerNoDuplicateRegistration verifies that calling ForceSyncFromInformer
+// with a forceSyncsharedIndexInformer-wrapped informer does NOT double-count the registration.
+// The wrapper's AddEventHandlerWithResyncPeriod already calls addRegistration internally;
+// ForceSyncFromInformer must skip its own addRegistration in that case.
+func TestForceSyncFromInformerNoDuplicateRegistration(t *testing.T) {
+	// Reset registrations to avoid interference from other tests.
+	ResetRegistrations()
+
+	client := kubefake.NewSimpleClientset()
+	factory := scheduler.NewInformerFactory(client, 0)
+	wrappedFactory := NewForceSyncSharedInformerFactory(factory)
+
+	wrapperInformer := wrappedFactory.Core().V1().Nodes().Informer()
+	_, ok := wrapperInformer.(*forceSyncsharedIndexInformer)
+	assert.True(t, ok, "expected forceSyncsharedIndexInformer wrapper")
+
+	// Calling ForceSyncFromInformer on a wrapper informer should result in exactly
+	// one registration, not two.
+	ForceSyncFromInformer(nil, nil, wrapperInformer, &cache.ResourceEventHandlerFuncs{})
+	regs := GetRegistrations()
+	assert.Len(t, regs, 1, "ForceSyncFromInformer on wrapper informer must not double-count registration")
+
+	// Calling ForceSyncFromInformer again adds exactly one more (not two more).
+	ForceSyncFromInformer(nil, nil, wrapperInformer, &cache.ResourceEventHandlerFuncs{})
+	regs = GetRegistrations()
+	assert.Len(t, regs, 2, "second ForceSyncFromInformer on wrapper informer should add exactly one registration")
 }

--- a/pkg/scheduler/frameworkext/helper/forcesync_informer.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_informer.go
@@ -17,10 +17,8 @@ limitations under the License.
 package helper
 
 import (
-	"context"
 	"time"
 
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -29,14 +27,12 @@ var _ cache.SharedIndexInformer = &forceSyncsharedIndexInformer{}
 type forceSyncsharedIndexInformer struct {
 	cache.SharedIndexInformer
 	defaultResync time.Duration
-	factory       informers.SharedInformerFactory
 }
 
-func newForceSyncSharedIndexInformer(informer cache.SharedIndexInformer, defaultResync time.Duration, factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+func newForceSyncSharedIndexInformer(informer cache.SharedIndexInformer, defaultResync time.Duration) cache.SharedIndexInformer {
 	return &forceSyncsharedIndexInformer{
 		SharedIndexInformer: informer,
 		defaultResync:       defaultResync,
-		factory:             factory,
 	}
 }
 
@@ -45,8 +41,10 @@ func (s *forceSyncsharedIndexInformer) AddEventHandler(handler cache.ResourceEve
 }
 
 func (s *forceSyncsharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	if _, ok := handler.(*forceSyncEventHandler); ok {
-		return s.SharedIndexInformer.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+	reg, err := s.SharedIndexInformer.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+	if err != nil {
+		return nil, err
 	}
-	return ForceSyncFromInformer(context.Background().Done(), s.factory, s.SharedIndexInformer, handler, WithResyncPeriod(resyncPeriod))
+	addRegistration(reg)
+	return reg, nil
 }

--- a/pkg/scheduler/frameworkext/helper/startup_hooks.go
+++ b/pkg/scheduler/frameworkext/helper/startup_hooks.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"sync"
+)
+
+// AfterInformersSyncedHook is a function invoked at a well-defined phase of the
+// scheduler startup pipeline, after a set of informer factories has been started
+// and their caches have synced. Plugins register hooks to perform initialization
+// that must run at a specific point relative to informer readiness (for example,
+// rebuilding plugin internal state from an initial-list snapshot obtained from a
+// lister). A non-nil return value aborts the startup pipeline so the scheduler
+// can shut down gracefully.
+type AfterInformersSyncedHook func(ctx context.Context) error
+
+var (
+	startupHooksMu                  sync.Mutex
+	afterPluginInformersSyncedHooks []AfterInformersSyncedHook
+	afterAllInformersSyncedHooks    []AfterInformersSyncedHook
+)
+
+// RegisterAfterPluginInformersSynced registers a hook invoked by the scheduler
+// startup pipeline AFTER plugin-private informer factories (registered via
+// InformerFactoryProvider) have been started and their caches have synced, and
+// BEFORE the scheduler's main informer factories (pods/nodes/etc.) are started.
+//
+// This is the canonical place to rebuild plugin internal state from an
+// initial-list snapshot taken via a lister, so that downstream event handlers
+// on the main informers observe a fully initialized state when they start firing.
+// It supersedes the older "replaceHandler" pattern for plugins that need a
+// whole-snapshot initialization anchored to a specific startup phase.
+func RegisterAfterPluginInformersSynced(hook AfterInformersSyncedHook) {
+	if hook == nil {
+		return
+	}
+	startupHooksMu.Lock()
+	defer startupHooksMu.Unlock()
+	afterPluginInformersSyncedHooks = append(afterPluginInformersSyncedHooks, hook)
+}
+
+// RegisterAfterAllInformersSynced registers a hook invoked by the scheduler
+// startup pipeline AFTER all informer factories (plugin + main) have been
+// started and their caches and handler registrations have synced, but BEFORE
+// the scheduler begins dispatching pods. Typical uses: kicking off background
+// reconcilers that rely on fully populated caches.
+func RegisterAfterAllInformersSynced(hook AfterInformersSyncedHook) {
+	if hook == nil {
+		return
+	}
+	startupHooksMu.Lock()
+	defer startupHooksMu.Unlock()
+	afterAllInformersSyncedHooks = append(afterAllInformersSyncedHooks, hook)
+}
+
+// RunAfterPluginInformersSynced invokes all hooks registered via
+// RegisterAfterPluginInformersSynced in registration order. It aborts and
+// returns the first non-nil error so callers can fail fast on initialization
+// failure. ctx cancellation between hooks is surfaced as ctx.Err().
+func RunAfterPluginInformersSynced(ctx context.Context) error {
+	return runStartupHooks(ctx, snapshotHooks(&afterPluginInformersSyncedHooks))
+}
+
+// RunAfterAllInformersSynced invokes all hooks registered via
+// RegisterAfterAllInformersSynced in registration order, aborting on the first
+// non-nil error.
+func RunAfterAllInformersSynced(ctx context.Context) error {
+	return runStartupHooks(ctx, snapshotHooks(&afterAllInformersSyncedHooks))
+}
+
+func snapshotHooks(hooks *[]AfterInformersSyncedHook) []AfterInformersSyncedHook {
+	startupHooksMu.Lock()
+	defer startupHooksMu.Unlock()
+	out := make([]AfterInformersSyncedHook, len(*hooks))
+	copy(out, *hooks)
+	return out
+}
+
+func runStartupHooks(ctx context.Context, hooks []AfterInformersSyncedHook) error {
+	for _, h := range hooks {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := h(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ResetStartupHooks clears all registered startup hooks. Only for testing.
+func ResetStartupHooks() {
+	startupHooksMu.Lock()
+	afterPluginInformersSyncedHooks = nil
+	afterAllInformersSyncedHooks = nil
+	startupHooksMu.Unlock()
+}

--- a/pkg/scheduler/frameworkext/helper/startup_hooks_test.go
+++ b/pkg/scheduler/frameworkext/helper/startup_hooks_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Each test in this file mutates the package-global hook registries; they must
+// not run in parallel, and every test must start by calling ResetStartupHooks.
+
+func TestRegisterAfterPluginInformersSynced_NilHookIsIgnored(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	RegisterAfterPluginInformersSynced(nil)
+
+	called := false
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if err := RunAfterPluginInformersSynced(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.True(t, called, "non-nil hook should still run when a nil hook was filtered out")
+}
+
+func TestRegisterAfterAllInformersSynced_NilHookIsIgnored(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	RegisterAfterAllInformersSynced(nil)
+
+	called := false
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		called = true
+		return nil
+	})
+
+	if err := RunAfterAllInformersSynced(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.True(t, called, "non-nil hook should still run when a nil hook was filtered out")
+}
+
+func TestRunAfterPluginInformersSynced_PreservesRegistrationOrder(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	var order []int
+	for i := 0; i < 5; i++ {
+		i := i
+		RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+			order = append(order, i)
+			return nil
+		})
+	}
+
+	if err := RunAfterPluginInformersSynced(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Equal(t, []int{0, 1, 2, 3, 4}, order)
+}
+
+func TestRunAfterAllInformersSynced_PreservesRegistrationOrder(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	var order []int
+	for i := 0; i < 3; i++ {
+		i := i
+		RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+			order = append(order, i)
+			return nil
+		})
+	}
+
+	if err := RunAfterAllInformersSynced(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Equal(t, []int{0, 1, 2}, order)
+}
+
+func TestRunAfterPluginInformersSynced_ShortCircuitsOnFirstError(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	sentinel := errors.New("boom")
+
+	var callCount int
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return sentinel
+	})
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	err := RunAfterPluginInformersSynced(context.Background())
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 2, callCount, "subsequent hooks should be skipped after the first error")
+}
+
+func TestRunAfterAllInformersSynced_ShortCircuitsOnFirstError(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	sentinel := errors.New("boom")
+
+	var callCount int
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return sentinel
+	})
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	err := RunAfterAllInformersSynced(context.Background())
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, callCount, "subsequent hooks should be skipped after the first error")
+}
+
+func TestRunAfterPluginInformersSynced_AbortsOnCanceledContext(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var callCount int
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		callCount++
+		// Cancel from within the first hook so the next iteration sees ctx.Err().
+		cancel()
+		return nil
+	})
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	err := RunAfterPluginInformersSynced(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, callCount, "a canceled ctx must prevent the next hook from running")
+}
+
+func TestRunAfterAllInformersSynced_AbortsOnCanceledContext(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var callCount int
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		callCount++
+		cancel()
+		return nil
+	})
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	err := RunAfterAllInformersSynced(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestRunAfterInformersSynced_EmptyIsNoOp(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	assert.NoError(t, RunAfterPluginInformersSynced(context.Background()))
+	assert.NoError(t, RunAfterAllInformersSynced(context.Background()))
+}
+
+func TestResetStartupHooks_ClearsBothRegistries(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error { return errors.New("should-not-run") })
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error { return errors.New("should-not-run") })
+
+	ResetStartupHooks()
+
+	assert.NoError(t, RunAfterPluginInformersSynced(context.Background()))
+	assert.NoError(t, RunAfterAllInformersSynced(context.Background()))
+}
+
+func TestStartupHooks_AfterPluginAndAfterAllAreIndependent(t *testing.T) {
+	ResetStartupHooks()
+	defer ResetStartupHooks()
+
+	var seenPlugin, seenAll int
+	RegisterAfterPluginInformersSynced(func(ctx context.Context) error { seenPlugin++; return nil })
+	RegisterAfterAllInformersSynced(func(ctx context.Context) error { seenAll++; return nil })
+
+	// Run plugin phase only; AfterAll hooks must not fire.
+	assert.NoError(t, RunAfterPluginInformersSynced(context.Background()))
+	assert.Equal(t, 1, seenPlugin)
+	assert.Equal(t, 0, seenAll)
+
+	// Run all phase; AfterPlugin must not fire again.
+	assert.NoError(t, RunAfterAllInformersSynced(context.Background()))
+	assert.Equal(t, 1, seenPlugin)
+	assert.Equal(t, 1, seenAll)
+}

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -18,6 +18,7 @@ package frameworkext
 
 import (
 	"context"
+	"reflect"
 
 	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
 	corev1 "k8s.io/api/core/v1"
@@ -295,3 +296,25 @@ type NextPodPlugin interface {
 }
 
 type ForgetPodHandler func(pod *corev1.Pod)
+
+// SharedInformerFactory is a minimal interface for informer factories
+// that can be started and cache-synced.
+type SharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+// InformerFactoryProvider is implemented by plugins that create their own
+// informer factories (e.g. for third-party CRDs). The framework collects
+// these factories and starts them in the central startup flow, ensuring
+// all caches are synced before scheduling begins.
+//
+// NOTE: This interface is intended for plugin-private informer factories that
+// are NOT shared across plugins. For commonly shared informer factories
+// (e.g. used by multiple plugins), register them in ExtendedHandle instead
+// (like KoordinatorSharedInformerFactory or NodeResourceTopologyInformerFactory)
+// so that all plugins access the same factory instance and avoid duplicate
+// API server watches.
+type InformerFactoryProvider interface {
+	GetInformerFactories() []SharedInformerFactory
+}

--- a/pkg/scheduler/frameworkext/workloadauditor/event_handlers_test.go
+++ b/pkg/scheduler/frameworkext/workloadauditor/event_handlers_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadauditor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfeatures "k8s.io/client-go/features"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/scheduler"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/profile"
+
+	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
+	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
+)
+
+type eventHandlerMutableGates interface {
+	clientfeatures.Gates
+	Set(key clientfeatures.Feature, value bool) error
+}
+
+func init() {
+	schedulermetrics.Register()
+}
+
+// withWatchListClient sets the WatchListClient feature gate for the duration of
+// the current test and restores the previous value via t.Cleanup. This avoids
+// mutating a process-wide client-go feature gate from init(), which would leak
+// across tests and packages and cause hard-to-debug flakes.
+func withWatchListClient(t testing.TB, value bool) {
+	fg, ok := clientfeatures.FeatureGates().(eventHandlerMutableGates)
+	if !ok {
+		t.Skip("client-go feature gates are not mutable in this environment")
+		return
+	}
+	prev := fg.Enabled(clientfeatures.WatchListClient)
+	if err := fg.Set(clientfeatures.WatchListClient, value); err != nil {
+		t.Fatalf("failed to set WatchListClient feature gate: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = fg.Set(clientfeatures.WatchListClient, prev)
+	})
+}
+
+// mockWorkloadAuditor is a lightweight WorkloadAuditor used in event handler tests.
+type mockWorkloadAuditor struct {
+	enabled bool
+	added   []*corev1.Pod
+	deleted []*corev1.Pod
+}
+
+func newMockAuditor(enabled bool) *mockWorkloadAuditor {
+	return &mockWorkloadAuditor{enabled: enabled}
+}
+
+func (m *mockWorkloadAuditor) Enabled() bool { return m.enabled }
+func (m *mockWorkloadAuditor) AddPod(pod *corev1.Pod) {
+	m.added = append(m.added, pod)
+}
+func (m *mockWorkloadAuditor) DeletePod(pod *corev1.Pod) {
+	m.deleted = append(m.deleted, pod)
+}
+func (m *mockWorkloadAuditor) RecordPod(_ *corev1.Pod, _ RecordType, _ string)                 {}
+func (m *mockWorkloadAuditor) RecordPodGating(_ *corev1.Pod, _ bool)                           {}
+func (m *mockWorkloadAuditor) RecordAttemptPod(_ *corev1.Pod)                                  {}
+func (m *mockWorkloadAuditor) RecordPodScheduleResult(_ *corev1.Pod, _ RecordType, _ string)   {}
+func (m *mockWorkloadAuditor) AddGangGroup(_ string)                                           {}
+func (m *mockWorkloadAuditor) DeleteGangGroup(_ string)                                        {}
+func (m *mockWorkloadAuditor) RecordGangGroup(_ string, _ *corev1.Pod, _ RecordType, _ string) {}
+func (m *mockWorkloadAuditor) RecordGangGating(_ string, _ *corev1.Pod, _ bool)                {}
+func (m *mockWorkloadAuditor) RecordGangScheduleResult(_ string, _ RecordType, _ string)       {}
+func (m *mockWorkloadAuditor) RecordDiagnosis(_ *corev1.Pod, _ string, _ RecordType, _ string) {}
+
+// TestAddEventHandler_HandlerRegistrationAndSync verifies that AddEventHandler registers
+// the pod handler via ForceSyncFromInformer (so a registration is collected) and that
+// OnAdd events are delivered to the workloadAuditor after the informer starts.
+func TestAddEventHandler_HandlerRegistrationAndSync(t *testing.T) {
+	// Disable WatchListClient for this test (fake client compatibility) and
+	// restore the previous value on cleanup to avoid leaking across tests.
+	withWatchListClient(t, false)
+	// Reset registrations to isolate from other tests.
+	frameworkexthelper.ResetRegistrations()
+	defer frameworkexthelper.ResetRegistrations()
+
+	fakeClientSet := kubefake.NewSimpleClientset()
+	fakeKoordClientSet := koordfake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	koordInformerFactory := koordinatorinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
+
+	// Construct a minimal Scheduler with a Profiles map so that HandlesSchedulerName works.
+	sched := &scheduler.Scheduler{
+		Profiles: profile.Map{
+			corev1.DefaultSchedulerName: (framework.Framework)(nil),
+		},
+	}
+	auditor := newMockAuditor(true)
+
+	// Pre-create an unscheduled pod with default scheduler name; the filter inside
+	// AddEventHandler accepts pods where NodeName=="" and schedulerName is handled.
+	pendingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-pod",
+			Namespace: "default",
+			UID:       "uid-pending",
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: corev1.DefaultSchedulerName,
+			// NodeName intentionally empty: this pod passes the filter.
+		},
+	}
+	_, err := fakeClientSet.CoreV1().Pods(pendingPod.Namespace).Create(context.TODO(), pendingPod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// AddEventHandler calls ForceSyncFromInformer internally, which should collect registrations.
+	AddEventHandler(sched, auditor, sharedInformerFactory, koordInformerFactory)
+
+	// Verify that at least one registration was collected (the pod handler).
+	regs := frameworkexthelper.GetRegistrations()
+	assert.NotEmpty(t, regs, "expected at least one handler registration after AddEventHandler")
+
+	// Start informers so the registered handler receives the initial list (OnAdd events).
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	sharedInformerFactory.Start(stopCh)
+	koordInformerFactory.Start(stopCh)
+	sharedInformerFactory.WaitForCacheSync(stopCh)
+	koordInformerFactory.WaitForCacheSync(stopCh)
+
+	// Wait for all collected handler registrations to finish their initial list sync.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = frameworkexthelper.WaitForHandlersSync(ctx)
+	assert.NoError(t, err, "handlers did not sync within timeout")
+
+	// The pending pod (NodeName=="" and handled scheduler) must have been delivered via OnAdd.
+	assert.Len(t, auditor.added, 1, "expected pending pod to be added to the auditor")
+	if len(auditor.added) == 1 {
+		assert.Equal(t, pendingPod.Name, auditor.added[0].Name)
+	}
+}
+
+// TestAddEventHandler_DisabledAuditor verifies that AddEventHandler is a no-op when
+// the auditor is disabled, so no registrations are collected.
+func TestAddEventHandler_DisabledAuditor(t *testing.T) {
+	withWatchListClient(t, false)
+	frameworkexthelper.ResetRegistrations()
+	defer frameworkexthelper.ResetRegistrations()
+
+	fakeClientSet := kubefake.NewSimpleClientset()
+	fakeKoordClientSet := koordfake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	koordInformerFactory := koordinatorinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
+
+	sched := &scheduler.Scheduler{
+		Profiles: profile.Map{
+			corev1.DefaultSchedulerName: (framework.Framework)(nil),
+		},
+	}
+	// disabled auditor: AddEventHandler should return early without registering handlers.
+	auditor := newMockAuditor(false)
+
+	AddEventHandler(sched, auditor, sharedInformerFactory, koordInformerFactory)
+
+	regs := frameworkexthelper.GetRegistrations()
+	assert.Empty(t, regs, "expected no registrations when auditor is disabled")
+}

--- a/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
+++ b/pkg/scheduler/plugins/coscheduling/controller/podgroup_test.go
@@ -42,6 +42,7 @@ import (
 	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
 	koordinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/core"
 )
 
@@ -186,7 +187,7 @@ func Test_Run(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ctrl, kubeClient, pgClient := setUp(ctx, c.podNames, c.pgName, c.podPhase, c.minMember, c.previousPhase, c.podGroupCreateTime, nil)
+			ctrl, kubeClient, pgClient := setUp(t, ctx, c.podNames, c.pgName, c.podPhase, c.minMember, c.previousPhase, c.podGroupCreateTime, nil)
 			// 0 means not set
 			if len(c.podNextPhase) != 0 {
 				ps := makePods(c.podNames, c.pgName, c.podNextPhase, nil)
@@ -269,7 +270,7 @@ func TestFillGroupStatusOccupied(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ctrl, _, pgClient := setUp(ctx, c.podNames, c.pgName, c.podPhase, c.minMember, c.groupPhase, nil, c.podOwnerReference)
+			ctrl, _, pgClient := setUp(t, ctx, c.podNames, c.pgName, c.podPhase, c.minMember, c.groupPhase, nil, c.podOwnerReference)
 			ctrl.Start()
 			err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 1*time.Second, false, func(ctx context.Context) (done bool, err error) {
 				pg, err := pgClient.SchedulingV1alpha1().PodGroups("default").Get(ctx, c.pgName, metav1.GetOptions{})
@@ -290,7 +291,9 @@ func TestFillGroupStatusOccupied(t *testing.T) {
 	}
 }
 
-func setUp(ctx context.Context, podNames []string, pgName string, podPhase v1.PodPhase, minMember int32, groupPhase v1alpha1.PodGroupPhase, podGroupCreateTime *metav1.Time, podOwnerReference []metav1.OwnerReference) (*PodGroupController, *fake.Clientset, *pgfake.Clientset) {
+func setUp(t testing.TB, ctx context.Context, podNames []string, pgName string, podPhase v1.PodPhase, minMember int32, groupPhase v1alpha1.PodGroupPhase, podGroupCreateTime *metav1.Time, podOwnerReference []metav1.OwnerReference) (*PodGroupController, *fake.Clientset, *pgfake.Clientset) {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	var kubeClient *fake.Clientset
 	if len(podNames) == 0 {
 		kubeClient = fake.NewSimpleClientset()
@@ -318,6 +321,27 @@ func setUp(ctx context.Context, podNames []string, pgName string, podPhase v1.Po
 	args := &config.CoschedulingArgs{DefaultTimeout: metav1.Duration{Duration: time.Second}}
 	pgMgr := core.NewPodGroupManager(nil, args, pgClient, pgInformerFactory, informerFactory, koordInformerFactory)
 	ctrl := NewPodGroupController(pgInformer, podInformer, pgClient, pgMgr, 1)
+
+	// Start informer factories with a test-lifetime stop channel so that
+	// callers can keep mutating the client after setUp returns. Note: the
+	// incoming ctx may be context.TODO(), whose Done() is nil; using it as a
+	// stop channel would disable cancellation entirely.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	pgInformerFactory.Start(stopCh)
+	koordInformerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+	pgInformerFactory.WaitForCacheSync(stopCh)
+	koordInformerFactory.WaitForCacheSync(stopCh)
+	// Use a bounded context for handler sync so the test fails fast if a
+	// registration never reaches HasSynced instead of hanging indefinitely.
+	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer syncCancel()
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
+
 	return ctrl, kubeClient, pgClient
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -44,11 +44,12 @@ import (
 
 // Coscheduling is a plugin that schedules pods in a group.
 type Coscheduling struct {
-	args             *config.CoschedulingArgs
-	frameworkHandler fwktype.Handle
-	pgClient         pgclientset.Interface
-	pgInformer       schedinformers.PodGroupInformer
-	pgMgr            core.Manager
+	args              *config.CoschedulingArgs
+	frameworkHandler  fwktype.Handle
+	pgClient          pgclientset.Interface
+	pgInformerFactory pgformers.SharedInformerFactory
+	pgInformer        schedinformers.PodGroupInformer
+	pgMgr             core.Manager
 }
 
 var _ fwktype.PreEnqueuePlugin = &Coscheduling{}
@@ -67,6 +68,7 @@ var _ fwktype.PreBindPlugin = &Coscheduling{}
 var _ frameworkext.ReservationPreBindPlugin = &Coscheduling{}
 var _ fwktype.PostBindPlugin = &Coscheduling{}
 var _ fwktype.EnqueueExtensions = &Coscheduling{}
+var _ frameworkext.InformerFactoryProvider = &Coscheduling{}
 
 const (
 	// Name is the name of the plugin used in Registry and configurations.
@@ -97,11 +99,12 @@ func New(_ context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.
 	koordInformerFactory := extendedHandle.KoordinatorSharedInformerFactory()
 	pgMgr := core.NewPodGroupManager(handle, args, pgClient, pgInformerFactory, informerFactory, koordInformerFactory)
 	plugin := &Coscheduling{
-		args:             args,
-		frameworkHandler: handle,
-		pgClient:         pgClient,
-		pgInformer:       pgInformer,
-		pgMgr:            pgMgr,
+		args:              args,
+		frameworkHandler:  handle,
+		pgClient:          pgClient,
+		pgInformerFactory: pgInformerFactory,
+		pgInformer:        pgInformer,
+		pgMgr:             pgMgr,
 	}
 	return plugin, nil
 }
@@ -280,4 +283,9 @@ func (cs *Coscheduling) PreBindReservation(ctx context.Context, cycleState fwkty
 // PostBind is called after a pod is successfully bound. These plugins are used update PodGroup when pod is bound.
 func (cs *Coscheduling) PostBind(ctx context.Context, _ fwktype.CycleState, pod *v1.Pod, nodeName string) {
 	cs.pgMgr.PostBind(ctx, pod, nodeName)
+}
+
+// GetInformerFactories returns the PodGroup informer factory for central startup management.
+func (cs *Coscheduling) GetInformerFactories() []frameworkext.SharedInformerFactory {
+	return []frameworkext.SharedInformerFactory{cs.pgInformerFactory}
 }

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/util"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
@@ -188,6 +189,8 @@ type pluginTestSuit struct {
 }
 
 func newPluginTestSuit(t *testing.T, nodes []*corev1.Node, pgClientSet pgclientset.Interface, cs kubernetes.Interface) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	var v1args v1.CoschedulingArgs
 	v1.SetDefaults_CoschedulingArgs(&v1args)
 	var gangSchedulingArgs config.CoschedulingArgs
@@ -226,10 +229,34 @@ func newPluginTestSuit(t *testing.T, nodes []*corev1.Node, pgClientSet pgclients
 	}
 }
 
-func (p *pluginTestSuit) start() {
-	ctx := context.TODO()
-	p.Handle.SharedInformerFactory().Start(ctx.Done())
-	p.Handle.SharedInformerFactory().WaitForCacheSync(ctx.Done())
+func (p *pluginTestSuit) start(t testing.TB) {
+	// Use a test-lifetime stop channel so informers keep delivering events for
+	// objects created/updated by the test AFTER start() returns. A stop channel
+	// bound to a short-lived context would be closed the moment start() returns
+	// and silently stop the informer watchers, making later informer-driven
+	// assertions flaky.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	// Start the shared informer factory for k8s resources (pods, etc.)
+	p.Handle.SharedInformerFactory().Start(stopCh)
+	p.Handle.SharedInformerFactory().WaitForCacheSync(stopCh)
+	// Start the pg informer factory and koordinator informer factory via the plugin.
+	if gp, ok := p.plugin.(*Coscheduling); ok {
+		gp.pgInformerFactory.Start(stopCh)
+		gp.pgInformerFactory.WaitForCacheSync(stopCh)
+		if extHandle, ok := gp.frameworkHandler.(frameworkext.ExtendedHandle); ok {
+			extHandle.KoordinatorSharedInformerFactory().Start(stopCh)
+			extHandle.KoordinatorSharedInformerFactory().WaitForCacheSync(stopCh)
+		}
+	}
+	// Use a separate bounded context only for the handler-sync wait so a hang
+	// doesn't block the whole test; surface the failure via t.Fatalf so it is
+	// attributed to the offending test rather than panicking.
+	syncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
 }
 
 func NewPodInfo(t *testing.T, pod *corev1.Pod) *framework.PodInfo {
@@ -311,7 +338,7 @@ func TestPostFilter(t *testing.T) {
 
 			suit := newPluginTestSuit(t, nil, pgClientSet, cs)
 			gp := suit.plugin.(*Coscheduling)
-			suit.start()
+			suit.start(t)
 			gangId := util.GetId(tt.pod.Namespace, util.GetGangNameByPod(tt.pod))
 			if tt.resourceSatisfied {
 				gp.PostBind(context.TODO(), nil, tt.pod, "test")
@@ -482,7 +509,7 @@ func TestPermit(t *testing.T) {
 			cs.CoreV1().Pods(tt.pod.Namespace).Create(context.TODO(), tt.pod, metav1.CreateOptions{})
 
 			suit := newPluginTestSuit(t, nil, pgClientSet, cs)
-			suit.start()
+			suit.start(t)
 			gp := suit.plugin.(*Coscheduling)
 
 			// add assumed pods
@@ -585,7 +612,7 @@ func TestUnreserve(t *testing.T) {
 
 			suit := newPluginTestSuit(t, nil, pgClientSet, cs)
 			gp := suit.plugin.(*Coscheduling)
-			suit.start()
+			suit.start(t)
 
 			ctx := context.TODO()
 			cycleState := framework.NewCycleState()
@@ -724,7 +751,7 @@ func TestPreBind(t *testing.T) {
 			}
 
 			suit := newPluginTestSuit(t, nil, pgClientSet, cs)
-			suit.start()
+			suit.start(t)
 			gp := suit.plugin.(*Coscheduling)
 
 			ctx := context.TODO()
@@ -896,7 +923,7 @@ func TestPreBindReservation(t *testing.T) {
 			}
 
 			suit := newPluginTestSuit(t, nil, pgClientSet, cs)
-			suit.start()
+			suit.start(t)
 			gp := suit.plugin.(*Coscheduling)
 
 			ctx := context.TODO()

--- a/pkg/scheduler/plugins/coscheduling/plugin_service_test.go
+++ b/pkg/scheduler/plugins/coscheduling/plugin_service_test.go
@@ -25,10 +25,13 @@ import (
 	fakepgclientset "github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/generated/clientset/versioned/fake"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/core"
 )
 
 func newPluginTestSuitForGangAPI(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	var v1args v1.CoschedulingArgs
 	v1.SetDefaults_CoschedulingArgs(&v1args)
 	var gangSchedulingArgs config.CoschedulingArgs
@@ -81,8 +84,10 @@ func TestEndpointsQueryGangInfo(t *testing.T) {
 	p, err := suit.proxyNew(context.TODO(), suit.gangSchedulingArgs, suit.Handle)
 	assert.NotNil(t, p)
 	assert.Nil(t, err)
-	suit.start()
 	gp := p.(*Coscheduling)
+	// Assign the plugin so that suit.start() can access pgInformerFactory.
+	suit.plugin = p
+	suit.start(t)
 	gangExpected := core.GangSummary{
 		Name:                   "ganga_ns/ganga",
 		WaitTime:               time.Second * 600,

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 )
 
 var fakeH800DeviceCR = func() *schedulingv1alpha1.Device {
@@ -893,12 +895,18 @@ func TestAllocateByPartition(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice("test-node-1", false)
 			assert.NotNil(t, nodeDevice)
@@ -913,8 +921,8 @@ func TestAllocateByPartition(t *testing.T) {
 
 			podRequest[apiext.ResourceRDMA] = *resource.NewQuantity(1, resource.DecimalSI)
 
-			nodeDevice.lock.Lock()
-			defer nodeDevice.lock.Unlock()
+			nodeDevice.lock.RLock()
+			defer nodeDevice.lock.RUnlock()
 
 			pod := &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -1323,12 +1331,18 @@ func TestAllocateByTopology(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice("test-node-1", false)
 			assert.NotNil(t, nodeDevice)
@@ -1389,7 +1403,9 @@ func TestAllocateByTopology(t *testing.T) {
 				pod:        pod,
 			}
 
+			nodeDevice.lock.RLock()
 			allocations, status := allocator.Allocate(nil, nil, nil, nil)
+			nodeDevice.lock.RUnlock()
 			if !status.IsSuccess() != tt.wantErr {
 				t.Errorf("Allocate() error = %v, wantErr %v", status.AsError(), tt.wantErr)
 				return
@@ -1573,12 +1589,18 @@ func TestAllocateSharedGPU(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice("test-node-1", false)
 			assert.NotNil(t, nodeDevice)
@@ -1653,7 +1675,9 @@ func TestAllocateSharedGPU(t *testing.T) {
 				scorer:     scorer,
 			}
 
+			nodeDevice.lock.RLock()
 			allocations, status := allocator.Allocate(nil, nil, nil, nil)
+			nodeDevice.lock.RUnlock()
 			if !status.IsSuccess() != tt.wantErr {
 				t.Errorf("Allocate() error = %v, wantErr %v", status.AsError(), tt.wantErr)
 				return
@@ -1891,12 +1915,18 @@ func TestAllocateByTemplate(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice(tt.node.Name, false)
 			assert.NotNil(t, nodeDevice)
@@ -1935,7 +1965,9 @@ func TestAllocateByTemplate(t *testing.T) {
 				scorer:     scorer,
 			}
 
+			nodeDevice.lock.RLock()
 			allocations, status := allocator.Allocate(nil, nil, nil, nil)
+			nodeDevice.lock.RUnlock()
 			if !status.IsSuccess() != tt.wantErr {
 				t.Errorf("Allocate() error = %v, wantErr %v", status.AsError(), tt.wantErr)
 				return

--- a/pkg/scheduler/plugins/deviceshare/device_allocator_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_allocator_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ import (
 	koordfake "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned/fake"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 )
 
 var (
@@ -1194,12 +1196,18 @@ func TestAutopilotAllocator(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice("test-node-1", false)
 			assert.NotNil(t, nodeDevice)
@@ -1255,7 +1263,9 @@ func TestAutopilotAllocator(t *testing.T) {
 				pod:        pod,
 			}
 
+			nodeDevice.lock.RLock()
 			allocations, status := allocator.Allocate(nil, nil, nil, nil)
+			nodeDevice.lock.RUnlock()
 			if !status.IsSuccess() != tt.wantErr {
 				t.Errorf("Allocate() error = %v, wantErr %v", status.AsError(), tt.wantErr)
 				return
@@ -2006,12 +2016,18 @@ func TestAutopilotAllocatorWithExclusivePolicyAndRequiredScope(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			frameworkexthelper.ResetRegistrations()
 			deviceCache := newNodeDeviceCache()
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
 			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
-			sharedInformerFactory.Start(nil)
-			sharedInformerFactory.WaitForCacheSync(nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			sharedInformerFactory.Start(ctx.Done())
+			koordShareInformerFactory.Start(ctx.Done())
+			if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+				t.Fatalf("WaitForHandlersSync failed: %v", err)
+			}
 
 			nodeDevice := deviceCache.getNodeDevice("test-node-1", false)
 			assert.NotNil(t, nodeDevice)
@@ -2072,7 +2088,9 @@ func TestAutopilotAllocatorWithExclusivePolicyAndRequiredScope(t *testing.T) {
 				pod:        pod,
 			}
 
+			nodeDevice.lock.RLock()
 			allocations, status := allocator.Allocate(nil, nil, nil, nil)
+			nodeDevice.lock.RUnlock()
 			if !status.IsSuccess() != tt.wantErr {
 				t.Errorf("Allocate() error = %v, wantErr %v", status.AsError(), tt.wantErr)
 				return

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -591,8 +591,21 @@ func (n *nodeDeviceCache) getAllNodeDeviceSummary() map[string]*NodeDeviceSummar
 }
 
 func (n *nodeDeviceCache) gcNodeDevice(ctx context.Context, informerFactory informers.SharedInformerFactory, period time.Duration) {
-	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
-	frameworkexthelper.ForceSyncFromInformer(ctx.Done(), informerFactory, nodeInformer, nil)
+	// Wait for all koord plugin event handlers (pod / device / reservation /
+	// node, etc.) to finish processing their initial list before starting GC.
+	// A bare cache.WaitForCacheSync(nodeInformer.HasSynced) only guarantees the
+	// underlying store is populated; it does NOT guarantee that OnAdd callbacks
+	// (which build nodeDeviceInfos) have run to completion. Without this wait
+	// the first GC tick may operate on a half-populated nodeDeviceInfos map
+	// (or, worse, see a warm nodeDeviceInfos but an empty node lister) and
+	// mistakenly evict entries that are about to be recreated.
+	// WaitForHandlersSync defers on ResourceEventHandlerRegistration.HasSynced
+	// for every registration collected by ForceSyncFromInformer, which is the
+	// same signal the scheduler's Run() waits on before accepting scheduling
+	// cycles -- effectively delaying GC until "after scheduler Run".
+	if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+		return
+	}
 
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		nodeLister := informerFactory.Core().V1().Nodes().Lister()

--- a/pkg/scheduler/plugins/deviceshare/device_cache_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_test.go
@@ -138,6 +138,11 @@ func Test_gcNodeDevices(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
 	defer cancel()
+	// Initialize the node informer before starting the factory so that WaitForCacheSync waits for it.
+	informerFactory.Core().V1().Nodes().Informer()
+	// Start the informer factory so that ForceSyncFromInformer handlers receive data.
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 	cache.gcNodeDevice(ctx, informerFactory, defaultGCPeriod)
 	nodeNames := sets.StringKeySet(cache.nodeDeviceInfos)
 	assert.Equal(t, expectedNodeNames, nodeNames)

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -40,6 +40,7 @@ import (
 	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/validation"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/schedulingphase"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
@@ -772,7 +773,7 @@ func (p *Plugin) getAllNodeDeviceSummary() map[string]*NodeDeviceSummary {
 	return p.nodeDeviceCache.getAllNodeDeviceSummary()
 }
 
-func New(_ context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
+func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
 	args, ok := obj.(*schedulerconfig.DeviceShareArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type DeviceShareArgs, got %T", obj)
@@ -798,7 +799,16 @@ func New(_ context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.
 	registerDeviceEventHandler(deviceCache, extendedHandle.KoordinatorSharedInformerFactory())
 	registerPodEventHandler(deviceCache, handle.SharedInformerFactory(), extendedHandle.KoordinatorSharedInformerFactory())
 	extendedHandle.RegisterForgetPodHandler(deviceCache.deletePod)
-	go deviceCache.gcNodeDevice(context.TODO(), handle.SharedInformerFactory(), defaultGCPeriod)
+	// Register the node informer synchronously during New so that the registration
+	// is visible to the framework's WaitForHandlersSync. If we registered it inside
+	// the gcNodeDevice goroutine, the framework might start scheduling before the
+	// handler registration is collected. Using a no-op handler because gcNodeDevice
+	// only reads from the node lister.
+	nodeInformer := handle.SharedInformerFactory().Core().V1().Nodes().Informer()
+	if _, err := frameworkexthelper.ForceSyncFromInformer(ctx.Done(), handle.SharedInformerFactory(), nodeInformer, nil); err != nil {
+		return nil, err
+	}
+	go deviceCache.gcNodeDevice(ctx, handle.SharedInformerFactory(), defaultGCPeriod)
 
 	gpuSharedResourceTemplatesCache := newGPUSharedResourceTemplatesCache()
 	registerGPUSharedResourceTemplatesConfigMapEventHandler(gpuSharedResourceTemplatesCache,

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -60,6 +60,7 @@ import (
 	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	v1schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
@@ -160,6 +161,7 @@ type pluginTestSuit struct {
 }
 
 func newPluginTestSuit(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
+	frameworkexthelper.ResetRegistrations()
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
 	extenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
@@ -3228,6 +3230,14 @@ func Test_Plugin_FilterNominateReservation(t *testing.T) {
 	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)
+
+	// Start the informer factory and wait for cache sync so that the Node object is
+	// visible to the node lister used by gcNodeDevice. Without this, the GC goroutine
+	// may delete the device cache entry because the node is not found in the lister.
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	suit.Framework.SharedInformerFactory().Start(stopCh)
+	suit.Framework.SharedInformerFactory().WaitForCacheSync(stopCh)
 
 	cycleState := framework.NewCycleState()
 	pod := &corev1.Pod{

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -38,10 +38,18 @@ import (
 )
 
 func Test_Plugin_ReservationRestore(t *testing.T) {
-	suit := newPluginTestSuit(t, nil)
+	suit := newPluginTestSuit(t, []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}},
+	})
 	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)
+
+	// Start informer factory to prevent gcNodeDevice goroutine from deleting device cache entries.
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	suit.Framework.SharedInformerFactory().Start(stopCh)
+	suit.Framework.SharedInformerFactory().WaitForCacheSync(stopCh)
 
 	cycleState := framework.NewCycleState()
 	pod := &corev1.Pod{
@@ -225,10 +233,18 @@ func Test_Plugin_ReservationRestore(t *testing.T) {
 }
 
 func Test_Plugin_RestoreReservationPreAllocation(t *testing.T) {
-	suit := newPluginTestSuit(t, nil)
+	suit := newPluginTestSuit(t, []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}},
+	})
 	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 	pl := p.(*Plugin)
+
+	// Start informer factory to prevent gcNodeDevice goroutine from deleting device cache entries.
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	suit.Framework.SharedInformerFactory().Start(stopCh)
+	suit.Framework.SharedInformerFactory().WaitForCacheSync(stopCh)
 
 	cycleState := framework.NewCycleState()
 	reservation := &schedulingv1alpha1.Reservation{
@@ -1255,10 +1271,20 @@ func Test_allocateWithNominated(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Each subtest gets its own isolated plugin instance, device cache, and rInfo
 			// to avoid any shared-state races between subtests or background goroutines.
-			suit := newPluginTestSuit(t, nil)
+			// Pass node so that the fake client's node lister includes "test-node",
+			// preventing gcNodeDevice from GC-ing it once the informer syncs.
+			suit := newPluginTestSuit(t, []*corev1.Node{node})
 			p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
+
+			// Start and sync the informer factory so the node lister is warm.
+			// gcNodeDevice waits for the informer to sync before starting GC;
+			// since "test-node" is in the node lister, GC will not remove it.
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			suit.Framework.SharedInformerFactory().Start(stopCh)
+			suit.Framework.SharedInformerFactory().WaitForCacheSync(stopCh)
 
 			pl.nodeDeviceCache.updateNodeDevice("test-node", newDevice())
 

--- a/pkg/scheduler/plugins/elasticquota/controller_test.go
+++ b/pkg/scheduler/plugins/elasticquota/controller_test.go
@@ -178,11 +178,10 @@ func TestController_Run(t *testing.T) {
 			for _, p := range c.pods {
 				suit.Handle.ClientSet().CoreV1().Pods(p.Namespace).Create(ctx, p, metav1.CreateOptions{})
 			}
-			plugin, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			p := plugin.(*Plugin)
+			p := suit.createPlugin(t).(*Plugin)
 			ctrl := NewElasticQuotaController(p)
 			ctrl.syncElasticQuotaStatusWorker()
+			var err error
 			for _, v := range c.want {
 				eq, _ := suit.client.SchedulingV1alpha1().ElasticQuotas(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
 				assert.NotNil(t, eq)

--- a/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/hook_plugin_test.go
@@ -227,9 +227,7 @@ func TestReplaceQuotasWithHookPlugins(t *testing.T) {
 				},
 			}
 		})
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	// prepare test quotas
 	quotas := []interface{}{
@@ -241,7 +239,7 @@ func TestReplaceQuotasWithHookPlugins(t *testing.T) {
 	// ReplaceQuotas will conflict with QuotaEventHandler. sleep 1 seconds to avoid it.
 	time.Sleep(time.Second)
 	// call ReplaceQuotas which should trigger ResetQuotasForHookPlugins
-	err = plugin.ReplaceQuotas(quotas)
+	err := plugin.ReplaceQuotas(quotas)
 	assert.Nil(t, err)
 
 	// verify hook plugins were called
@@ -277,9 +275,7 @@ func initPluginSuit(t *testing.T) (*pluginTestSuit, *Plugin) {
 				},
 			}
 		})
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	return suit, plugin
 }
 

--- a/pkg/scheduler/plugins/elasticquota/node_handler_test.go
+++ b/pkg/scheduler/plugins/elasticquota/node_handler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package elasticquota
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -77,10 +76,7 @@ func TestPlugin_OnNodeAdd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.NotNil(t, p)
-			assert.Nil(t, err)
-			plugin := p.(*Plugin)
+			plugin := suit.createPlugin(t).(*Plugin)
 
 			time.Sleep(100 * time.Millisecond)
 			for _, node := range tt.nodes {
@@ -210,9 +206,7 @@ func TestPlugin_OnNodeUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			plugin := p.(*Plugin)
+			plugin := suit.createPlugin(t).(*Plugin)
 
 			for _, node := range nodes {
 				plugin.OnNodeAdd(node)
@@ -266,9 +260,7 @@ func TestPlugin_OnNodeDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			plugin := p.(*Plugin)
+			plugin := suit.createPlugin(t).(*Plugin)
 
 			for _, node := range nodes {
 				plugin.OnNodeAdd(node)

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -76,15 +76,16 @@ func (p *PostFilterState) Clone() fwktype.StateData {
 }
 
 type Plugin struct {
-	handle            fwktype.Handle
-	client            versioned.Interface
-	pluginArgs        *config.ElasticQuotaArgs
-	quotaLister       v1alpha1.ElasticQuotaLister
-	quotaInformer     cache.SharedIndexInformer
-	podLister         v1.PodLister
-	pdbLister         policylisters.PodDisruptionBudgetLister
-	nodeLister        v1.NodeLister
-	groupQuotaManager *core.GroupQuotaManager
+	handle                    fwktype.Handle
+	client                    versioned.Interface
+	pluginArgs                *config.ElasticQuotaArgs
+	scheSharedInformerFactory externalversions.SharedInformerFactory
+	quotaLister               v1alpha1.ElasticQuotaLister
+	quotaInformer             cache.SharedIndexInformer
+	podLister                 v1.PodLister
+	pdbLister                 policylisters.PodDisruptionBudgetLister
+	nodeLister                v1.NodeLister
+	groupQuotaManager         *core.GroupQuotaManager
 
 	quotaManagerLock sync.RWMutex
 	// groupQuotaManagersForQuotaTree store the GroupQuotaManager of all quota trees. The key is the quota tree id
@@ -108,13 +109,14 @@ type Plugin struct {
 }
 
 var (
-	_ fwktype.EnqueueExtensions = &Plugin{}
-	_ fwktype.PreFilterPlugin   = &Plugin{}
-	_ fwktype.PostFilterPlugin  = &Plugin{}
-	_ fwktype.ReservePlugin     = &Plugin{}
+	_ fwktype.EnqueueExtensions            = &Plugin{}
+	_ fwktype.PreFilterPlugin              = &Plugin{}
+	_ fwktype.PostFilterPlugin             = &Plugin{}
+	_ fwktype.ReservePlugin                = &Plugin{}
+	_ frameworkext.InformerFactoryProvider = &Plugin{}
 )
 
-func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
 	pluginArgs, ok := args.(*config.ElasticQuotaArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type ElasticQuotaArgs, got %T", args)
@@ -154,6 +156,7 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 		handle:                         handle,
 		client:                         client,
 		pluginArgs:                     pluginArgs,
+		scheSharedInformerFactory:      scheSharedInformerFactory,
 		podLister:                      handle.SharedInformerFactory().Core().V1().Pods().Lister(),
 		quotaInformer:                  informer,
 		quotaLister:                    elasticQuotaInformer.Lister(),
@@ -174,8 +177,6 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 	elasticQuota.quotaToTreeMap[extension.DefaultQuotaName] = ""
 	elasticQuota.quotaToTreeMap[extension.SystemQuotaName] = ""
 
-	ctx := context.TODO()
-
 	elasticQuota.createRootQuotaIfNotPresent()
 	elasticQuota.createSystemQuotaIfNotPresent()
 	elasticQuota.createDefaultQuotaIfNotPresent()
@@ -187,7 +188,6 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 	if err != nil {
 		return nil, err
 	}
-
 	nodeInformer := handle.SharedInformerFactory().Core().V1().Nodes().Informer()
 	frameworkexthelper.ForceSyncFromInformer(ctx.Done(), handle.SharedInformerFactory(), nodeInformer, cache.ResourceEventHandlerFuncs{
 		AddFunc:    elasticQuota.OnNodeAdd,
@@ -573,6 +573,11 @@ func (g *Plugin) Unreserve(ctx context.Context, state fwktype.CycleState, p *cor
 
 func (g *Plugin) GetQuotaInformer() cache.SharedIndexInformer { // expose for extensions
 	return g.quotaInformer
+}
+
+// GetInformerFactories returns the ElasticQuota informer factory for central startup management.
+func (g *Plugin) GetInformerFactories() []frameworkext.SharedInformerFactory {
+	return []frameworkext.SharedInformerFactory{g.scheSharedInformerFactory}
 }
 
 // updateQuotaSnapshot periodically updates quota snapshot for all quota trees

--- a/pkg/scheduler/plugins/elasticquota/plugin_helper_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_helper_test.go
@@ -93,10 +93,7 @@ func TestGetQuotaName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.NotNil(t, p)
-			assert.Nil(t, err)
-			eQP := p.(*Plugin)
+			eQP := suit.createPlugin(t).(*Plugin)
 			for _, eq := range tt.elasticQuotas {
 				_, err := eQP.client.SchedulingV1alpha1().ElasticQuotas(eq.Namespace).Create(context.TODO(), eq, metav1.CreateOptions{})
 				assert.NoError(t, err)

--- a/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package elasticquota
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,11 +37,8 @@ import (
 
 func TestEndpointsQueryQuotaInfo(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.NotNil(t, p)
-	assert.Nil(t, err)
-
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
+	var err error
 	quota := CreateQuota2("test1", "", 100, 100, 10, 10, 20, 20, false, "")
 	plugin.OnQuotaAdd(quota)
 

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core"
 	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
@@ -136,6 +137,8 @@ var (
 type PluginTestOption func(elasticQuotaArgs *config.ElasticQuotaArgs)
 
 func newPluginTestSuit(t *testing.T, nodes []*corev1.Node, pluginTestOpts ...PluginTestOption) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	setLoglevel("5")
 	var v1args v1.ElasticQuotaArgs
 	v1.SetDefaults_ElasticQuotaArgs(&v1args)
@@ -210,6 +213,8 @@ func newPluginTestSuit(t *testing.T, nodes []*corev1.Node, pluginTestOpts ...Plu
 }
 
 func newPluginTestSuitWithPod(t *testing.T, nodes []*corev1.Node, pods []*corev1.Pod) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	setLoglevel("5")
 	var v1args v1.ElasticQuotaArgs
 	v1.SetDefaults_ElasticQuotaArgs(&v1args)
@@ -354,13 +359,105 @@ type pluginTestSuit struct {
 	proxyNew                         runtime.PluginFactory
 	elasticQuotaArgs                 *config.ElasticQuotaArgs
 	client                           *pgfake.Clientset
+	// plugin holds a reference to the created plugin instance so that start() can
+	// discover and start any additional informer factories owned by the plugin.
+	plugin fwktype.Plugin
+}
+
+// createPlugin creates the plugin via proxyNew, stores it in s.plugin, and starts its informer
+// factories so that informer-backed listers and event handlers are operational immediately.
+//
+// Startup order matters: plugin-owned factories (e.g. scheSharedInformerFactory for quota CRD)
+// must be fully synced before pod/node informers start delivering OnAdd events, because pod
+// handlers call GetQuotaName which reads from the quota lister.
+func (s *pluginTestSuit) createPlugin(t testing.TB) fwktype.Plugin {
+	// Reset global handler registrations so WaitForHandlersSync only tracks handlers from this
+	// plugin instance (the framework may have created an internal instance during NewFramework).
+	frameworkexthelper.ResetRegistrations()
+	p, err := s.proxyNew(context.TODO(), s.elasticQuotaArgs, s.Handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+	s.plugin = p
+	// Use a background stop channel so all informers remain running for the whole test.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer syncCancel()
+
+	// Step 1: start and sync plugin-owned informer factories first (e.g. quota CRD informer).
+	// This ensures the quota lister is populated before pod/node OnAdd events fire.
+	if provider, ok := p.(frameworkext.InformerFactoryProvider); ok {
+		for _, f := range provider.GetInformerFactories() {
+			f.Start(stopCh)
+			f.WaitForCacheSync(syncCtx.Done())
+		}
+	}
+
+	// Step 1b: run AfterPluginInformersSynced hooks (e.g. ElasticQuota's ReplaceQuotas)
+	// BEFORE starting pod/node informers. Otherwise the rebuild races with pod/node
+	// OnAdd handlers that read the same plugin state.
+	//
+	// This mirrors the production startup sequence in cmd/koord-scheduler/app/server.go.
+	if err := frameworkexthelper.RunAfterPluginInformersSynced(syncCtx); err != nil {
+		t.Fatalf("AfterPluginInformersSynced hook failed: %v", err)
+	}
+
+	// Step 2: start and sync the shared informer factories (pod, node, etc.).
+	s.Handle.SharedInformerFactory().Start(stopCh)
+	s.koordinatorSharedInformerFactory.Start(stopCh)
+	s.Handle.SharedInformerFactory().WaitForCacheSync(syncCtx.Done())
+	s.koordinatorSharedInformerFactory.WaitForCacheSync(syncCtx.Done())
+
+	// Step 3: wait for all handler registrations to have processed their initial list.
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
+	return p
+}
+
+// start starts all informer factories and waits for caches and handler registrations to sync.
+// Call this after creating the plugin so that ForceSyncFromInformer handlers receive OnAdd events.
+// If s.plugin is set and implements InformerFactoryProvider, its extra factories are also started.
+func (s *pluginTestSuit) start(t testing.TB) {
+	// Start informer factories with a background stop channel so they remain running after start() returns.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+
+	s.Handle.SharedInformerFactory().Start(stopCh)
+	s.koordinatorSharedInformerFactory.Start(stopCh)
+
+	// Start plugin informer factories (e.g. scheSharedInformerFactory for ElasticQuota CRD).
+	if provider, ok := s.plugin.(frameworkext.InformerFactoryProvider); ok {
+		for _, f := range provider.GetInformerFactories() {
+			f.Start(stopCh)
+		}
+	}
+
+	// Wait for cache sync and handler sync with a bounded timeout.
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer syncCancel()
+
+	s.Handle.SharedInformerFactory().WaitForCacheSync(syncCtx.Done())
+	s.koordinatorSharedInformerFactory.WaitForCacheSync(syncCtx.Done())
+
+	// WaitForCacheSync for plugin informer factories.
+	if provider, ok := s.plugin.(frameworkext.InformerFactoryProvider); ok {
+		for _, f := range provider.GetInformerFactories() {
+			f.WaitForCacheSync(syncCtx.Done())
+		}
+	}
+
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
 }
 
 func TestNew(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
+	p := suit.createPlugin(t)
 	assert.NotNil(t, p)
-	assert.Nil(t, err)
 	assert.Equal(t, Name, p.Name())
 }
 
@@ -398,9 +495,7 @@ func createResourceList(cpu, mem int64) corev1.ResourceList {
 
 func TestPlugin_OnQuotaAdd(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	pl := p.(*Plugin)
+	pl := suit.createPlugin(t).(*Plugin)
 	pl.groupQuotaManager.UpdateClusterTotalResource(createResourceList(501952056, 0))
 	gqm := pl.groupQuotaManager
 	quota := suit.AddQuota("1", "", 0, 0, 0, 0, 0, 0, false, "")
@@ -474,9 +569,7 @@ func CreateQuota2(name string, parentName string, maxCpu, maxMem int64, minCpu, 
 
 func TestPlugin_OnQuotaUpdate(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	gqm := plugin.groupQuotaManager
 	// test2 Max[96, 160]  Min[100,160] request[20,40]
 	//   `-- test2-a Max[96, 160]  Min[50,80] request[20,40]
@@ -570,9 +663,7 @@ func TestPlugin_OnQuotaUpdate(t *testing.T) {
 
 func TestPlugin_OnPodAdd_Update_Delete(t *testing.T) {
 	suit := newPluginTestSuitWithPod(t, nil, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	gqm := plugin.groupQuotaManager
 	plugin.addQuota("test1", extension.RootQuotaName, 96, 160, 100, 160, 96, 160, true, "", "")
 	plugin.addQuota("test2", extension.RootQuotaName, 96, 160, 100, 160, 96, 160, true, "", "")
@@ -698,9 +789,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			gp.pluginArgs.EnableRuntimeQuota = !tt.disableRuntimeQuota
 			qi := gp.groupQuotaManager.GetQuotaInfoByName(tt.quotaInfo.Name)
 			qi.Lock()
@@ -761,9 +850,7 @@ func TestPlugin_PreFilter_CheckParent(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			gp.pluginArgs.EnableCheckParentQuota = true
 			gp.OnQuotaAdd(tt.parQuotaInfo)
 			gp.OnQuotaAdd(tt.quotaInfo)
@@ -869,8 +956,7 @@ func TestPlugin_Prefilter_QuotaNonPreempt(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, _ := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			gp.groupQuotaManager.UpdateClusterTotalResource(tt.totalResource)
 			for _, qis := range tt.quotaInfos {
 				gp.OnQuotaAdd(qis)
@@ -913,9 +999,7 @@ func TestPlugin_Reserve(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			pod := makePod2("pod", tt.quotaInfo.CalculateInfo.Used)
 			gp.OnPodAdd(pod)
 			gp.OnPodAdd(tt.pod)
@@ -950,9 +1034,7 @@ func TestPlugin_Unreserve(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			ctx := context.TODO()
 			gp.OnPodAdd(tt.pod)
 			gp.Reserve(ctx, framework.NewCycleState(), tt.pod, "")
@@ -994,9 +1076,7 @@ func TestPlugin_AddPod(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			pod := makePod2("test", tt.quotaInfo.CalculateInfo.Used)
 			gp.OnPodAdd(pod)
 			if tt.shouldAdd {
@@ -1045,9 +1125,7 @@ func TestPlugin_RemovePod(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			pod := makePod2("pod", tt.quotaInfo.CalculateInfo.Used)
 			gp.OnPodAdd(pod)
 			if tt.shouldAdd {
@@ -1256,10 +1334,7 @@ func TestPlugin_Recover(t *testing.T) {
 		suit.Handle.ClientSet().CoreV1().Pods("").Create(context.TODO(), pod, metav1.CreateOptions{})
 	}
 	time.Sleep(100 * time.Millisecond)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	pl := p.(*Plugin)
-	time.Sleep(100 * time.Millisecond)
+	pl := suit.createPlugin(t).(*Plugin)
 	assert.Equal(t, pl.groupQuotaManager.GetQuotaInfoByName("test1").GetRequest(), createResourceList(40, 40))
 	assert.Equal(t, pl.groupQuotaManager.GetQuotaInfoByName("test1").GetUsed(), createResourceList(40, 40))
 	assert.True(t, quotav1.IsZero(pl.groupQuotaManager.GetQuotaInfoByName(extension.DefaultQuotaName).GetRequest()))
@@ -1268,9 +1343,7 @@ func TestPlugin_Recover(t *testing.T) {
 
 func TestPlugin_migrateDefaultQuotaGroupsPod(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	gqm := plugin.groupQuotaManager
 	plugin.addQuota("test2", extension.RootQuotaName, 96, 160, 100, 160, 96, 160, true, "", "")
 	pods := []*corev1.Pod{
@@ -1910,9 +1983,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterQuotaChanged(t *testing.T) {
 			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.MultiQuotaTree, true)()
 
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			gp.pluginArgs.EnableCheckParentQuota = tt.enableCheckParent
 
 			// Add quota infos - add parent quota first if it exists
@@ -1971,9 +2042,7 @@ func TestPlugin_EventsToRegister(t *testing.T) {
 			suit := newPluginTestSuit(t, nil, func(args *config.ElasticQuotaArgs) {
 				args.EnableQueueHint = tt.enableQueueHint
 			})
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 
 			events, err := gp.EventsToRegister(context.TODO())
 			assert.NoError(t, err)
@@ -2274,9 +2343,7 @@ func TestPlugin_QueueingHint_IsSchedulableAfterPodDeletion(t *testing.T) {
 			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.MultiQuotaTree, true)()
 
 			suit := newPluginTestSuit(t, nil)
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 			gp.pluginArgs.EnableCheckParentQuota = tt.enableCheckParent
 
 			// Add quota infos - add parent quota first if it exists
@@ -2373,9 +2440,7 @@ func TestPlugin_updateQuotaSnapshot(t *testing.T) {
 			suit := newPluginTestSuit(t, nil, func(args *config.ElasticQuotaArgs) {
 				args.EnableQueueHint = true
 			})
-			p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-			assert.Nil(t, err)
-			gp := p.(*Plugin)
+			gp := suit.createPlugin(t).(*Plugin)
 
 			// Setup quotas
 			quotas := tt.setupQuotas(gp)

--- a/pkg/scheduler/plugins/elasticquota/pod_handler_test.go
+++ b/pkg/scheduler/plugins/elasticquota/pod_handler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package elasticquota
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -37,9 +36,7 @@ func TestPlugin_OnPodAddAndDeleteWhenDisableDefault(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.DisableDefaultQuota, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	suit.AddQuota("test", "", 10, 40, 10, 40, 10, 40, false, "")
 
@@ -76,9 +73,7 @@ func TestPlugin_OnPodUpdateWhenDisableDefault(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.DisableDefaultQuota, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	suit.AddQuota("test1", "", 10, 40, 10, 40, 10, 40, false, "")
 	suit.AddQuota("test2", "", 10, 40, 10, 40, 10, 40, false, "")
@@ -119,9 +114,7 @@ func TestPlugin_OnPodUpdateWhenDisableDefaultAndRootTree(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	plugin.addRootQuota("test1", "", 10, 40, 10, 40, 10, 40, false, "", "tree1")
 	plugin.addRootQuota("test2", "", 10, 40, 10, 40, 10, 40, false, "", "tree2")
@@ -180,9 +173,7 @@ func TestPlugin_OnPodDelete(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.DisableDefaultQuota, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	suit.AddQuota("test", "", 10, 40, 10, 40, 10, 40, false, "")
 

--- a/pkg/scheduler/plugins/elasticquota/quota_handler_test.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_handler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package elasticquota
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -37,9 +36,7 @@ func TestPlugin_OnQuotaAddWithTreeID(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	plugin.groupQuotaManager.UpdateClusterTotalResource(createResourceList(501952056, 0))
 	gqm := plugin.groupQuotaManager
@@ -74,9 +71,7 @@ func TestPlugin_OnQuotaUpdateAndDeleteWithTreeID(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	// tree-b:
 	// test2 Max[100, 200]  Min[100,160] request[20,40]
@@ -238,9 +233,7 @@ func TestPlugin_OnRootQuotaAddAndUpdate(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	// tree-cn-hangzhou-a:
 	// cn-hangzhou-a Max[100, 200]  Min[100,200] request[90,190]
@@ -306,9 +299,7 @@ func TestPlugin_HandlerQuotaWhenRoot(t *testing.T) {
 
 	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, koordfeatures.MultiQuotaTree, true)()
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	for _, node := range nodes {
 		plugin.OnNodeAdd(node)
@@ -343,9 +334,7 @@ func TestPlugin_ReplaceQuotas(t *testing.T) {
 	}
 
 	suit := newPluginTestSuit(t, nil)
-	p, err := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	assert.Nil(t, err)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 
 	// ReplaceQuotas will conflict with QuotaEventHandler. sleep 1 seconds to avoid it.
 	time.Sleep(time.Second)

--- a/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_overuse_revoke_test.go
@@ -31,8 +31,7 @@ import (
 
 func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, _ := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	pg := p.(*Plugin)
+	pg := suit.createPlugin(t).(*Plugin)
 	pg.groupQuotaManager.UpdateClusterTotalResource(MakeResourceList().CPU(100).Mem(100).GPU(100).Obj())
 	suit.AddQuota("test1", extension.RootQuotaName, 4797411900, 0, 1085006000, 0, 4797411900, 0, true, "extended")
 	gqm := pg.groupQuotaManager
@@ -95,8 +94,7 @@ func TestQuotaOverUsedGroupMonitor_Monitor(t *testing.T) {
 
 func TestQuotaOverUsedRevokeController_GetToRevokePodList(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, _ := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	gqm := plugin.groupQuotaManager
 	suit.AddQuota("test1", extension.RootQuotaName, 4797411900, 0, 1085006000, 0, 4797411900, 0, false, "extended")
 	time.Sleep(10 * time.Millisecond)
@@ -142,8 +140,7 @@ func TestQuotaOverUsedRevokeController_GetToRevokePodList(t *testing.T) {
 
 func TestQuotaOverUsedRevokeController_GetToMonitorQuotas(t *testing.T) {
 	suit := newPluginTestSuit(t, nil)
-	p, _ := suit.proxyNew(context.TODO(), suit.elasticQuotaArgs, suit.Handle)
-	plugin := p.(*Plugin)
+	plugin := suit.createPlugin(t).(*Plugin)
 	plugin.pluginArgs.DelayEvictTime.Duration = 0 * time.Second
 	plugin.pluginArgs.MonitorAllQuotas = true
 

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
 	topologylister "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,13 +79,13 @@ var (
 )
 
 type Plugin struct {
-	handle          frameworkext.ExtendedHandle
-	pluginArgs      *schedulingconfig.NodeNUMAResourceArgs
-	nrtLister       topologylister.NodeResourceTopologyLister
-	scorer          *resourceAllocationScorer
-	numaScorer      *resourceAllocationScorer
-	resourceManager ResourceManager
-
+	handle                 frameworkext.ExtendedHandle
+	pluginArgs             *schedulingconfig.NodeNUMAResourceArgs
+	nrtInformerFactory     nrtinformers.SharedInformerFactory
+	nrtLister              topologylister.NodeResourceTopologyLister
+	scorer                 *resourceAllocationScorer
+	numaScorer             *resourceAllocationScorer
+	resourceManager        ResourceManager
 	topologyOptionsManager TopologyOptionsManager
 }
 
@@ -157,6 +158,7 @@ func NewWithOptions(args runtime.Object, handle fwktype.Handle, opts ...Option) 
 	return &Plugin{
 		handle:                 handle.(frameworkext.ExtendedHandle),
 		pluginArgs:             pluginArgs,
+		nrtInformerFactory:     nrtInformerFactory,
 		nrtLister:              nrtLister,
 		scorer:                 scorer,
 		numaScorer:             numaScorer,

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	nrtfake "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,7 @@ import (
 	_ "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/scheme"
 	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
@@ -177,9 +179,12 @@ type pluginTestSuit struct {
 	KoordClientSet       *koordfake.Clientset
 	proxyNew             runtime.PluginFactory
 	nodeNUMAResourceArgs *schedulingconfig.NodeNUMAResourceArgs
+	plugin               fwktype.Plugin
 }
 
 func newPluginTestSuit(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	var v1args v1.NodeNUMAResourceArgs
 	v1.SetDefaults_NodeNUMAResourceArgs(&v1args)
 	var nodeNUMAResourceArgs schedulingconfig.NodeNUMAResourceArgs
@@ -227,7 +232,7 @@ func newPluginTestSuit(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *
 
 	extender := extenderFactory.NewFrameworkExtender(fh)
 
-	return &pluginTestSuit{
+	suit := &pluginTestSuit{
 		Handle:               fh,
 		ExtenderFactory:      extenderFactory,
 		Extender:             extender,
@@ -236,12 +241,41 @@ func newPluginTestSuit(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *
 		proxyNew:             proxyNew,
 		nodeNUMAResourceArgs: &nodeNUMAResourceArgs,
 	}
+	// Wrap proxyNew so that the created plugin is saved for start() to access.
+	originalProxyNew := suit.proxyNew
+	suit.proxyNew = func(ctx context.Context, configuration apiruntime.Object, f fwktype.Handle) (fwktype.Plugin, error) {
+		pl, err := originalProxyNew(ctx, configuration, f)
+		if err == nil {
+			suit.plugin = pl
+		}
+		return pl, err
+	}
+	return suit
 }
 
-func (p *pluginTestSuit) start() {
-	ctx := context.TODO()
-	p.Handle.SharedInformerFactory().Start(ctx.Done())
-	p.Handle.SharedInformerFactory().WaitForCacheSync(ctx.Done())
+func (p *pluginTestSuit) start(t testing.TB) {
+	// Use a test-lifetime stop channel so informers keep delivering events for
+	// objects created/updated by the test AFTER start() returns. A stop channel
+	// bound to a short-lived context would be closed the moment start() returns
+	// and silently stop the informer watchers.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	p.Handle.SharedInformerFactory().Start(stopCh)
+	p.ExtenderFactory.KoordinatorSharedInformerFactory().Start(stopCh)
+	p.Handle.SharedInformerFactory().WaitForCacheSync(stopCh)
+	p.ExtenderFactory.KoordinatorSharedInformerFactory().WaitForCacheSync(stopCh)
+	// Start the NRT informer factory if the plugin has been created.
+	if np, ok := p.plugin.(*Plugin); ok && np.nrtInformerFactory != nil {
+		np.nrtInformerFactory.Start(stopCh)
+		np.nrtInformerFactory.WaitForCacheSync(stopCh)
+	}
+	// Use a separate bounded context only for the handler-sync wait so a hang
+	// doesn't block the whole test.
+	syncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
 }
 
 func TestNew(t *testing.T) {
@@ -606,7 +640,7 @@ func TestPlugin_PreFilter(t *testing.T) {
 			assert.NotNil(t, p)
 			assert.Nil(t, err)
 
-			suit.start()
+			suit.start(t)
 			cycleState := framework.NewCycleState()
 
 			if tt.pod.Annotations != nil && tt.pod.Annotations[extension.AnnotationSchedulingHint] != "" {
@@ -1076,7 +1110,7 @@ func TestPlugin_Filter(t *testing.T) {
 				manager.nodeAllocations[tt.allocationState.nodeName] = tt.allocationState
 			}
 
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			if tt.state != nil {
@@ -1179,7 +1213,7 @@ func TestFilterWithAmplifiedCPUs(t *testing.T) {
 
 			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
 			assert.NoError(t, err)
-			suit.start()
+			suit.start(t)
 			pl := p.(*Plugin)
 
 			if tt.nodeHasNRT {
@@ -1687,7 +1721,7 @@ func TestPlugin_Reserve(t *testing.T) {
 			cpuManager := plg.resourceManager.(*resourceManager)
 			cpuManager.nodeAllocations[nodeAllocation.nodeName] = nodeAllocation
 
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			if tt.state != nil {
@@ -1810,7 +1844,7 @@ func TestPlugin_PreBind(t *testing.T) {
 	_, status := suit.Handle.ClientSet().CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
 	assert.Nil(t, status)
 
-	suit.start()
+	suit.start(t)
 
 	plg := p.(*Plugin)
 
@@ -1857,7 +1891,7 @@ func TestPlugin_PreBindWithCPUBindPolicyNone(t *testing.T) {
 	_, status := suit.Handle.ClientSet().CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
 	assert.Nil(t, status)
 
-	suit.start()
+	suit.start(t)
 
 	plg := p.(*Plugin)
 
@@ -1911,7 +1945,7 @@ func TestPlugin_PreBindReservation(t *testing.T) {
 	_, status := suit.KoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
 	assert.Nil(t, status)
 
-	suit.start()
+	suit.start(t)
 
 	plg := p.(*Plugin)
 

--- a/pkg/scheduler/plugins/nodenumaresource/reservation_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation_test.go
@@ -134,7 +134,7 @@ func TestPlugin_RestoreReservationPreAllocation(t *testing.T) {
 			assert.NotNil(t, p)
 
 			pl := p.(*Plugin)
-			suit.start()
+			suit.start(t)
 
 			// Setup CPU topology
 			pl.topologyOptionsManager.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {
@@ -285,7 +285,7 @@ func TestPlugin_AllocateReservationPreAllocationFromPreAllocatablePods(t *testin
 	assert.NotNil(t, p)
 
 	pl := p.(*Plugin)
-	suit.start()
+	suit.start(t)
 
 	// Setup CPU topology: 1 NUMA node, 2 sockets, 4 cores per socket, 2 threads per core
 	// Total: 16 logical CPUs (0-15)
@@ -507,7 +507,7 @@ func TestPlugin_PreAllocationWithMultiplePreAllocatablePods(t *testing.T) {
 	assert.NotNil(t, p)
 
 	pl := p.(*Plugin)
-	suit.start()
+	suit.start(t)
 
 	// Setup CPU topology
 	pl.topologyOptionsManager.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {
@@ -660,7 +660,7 @@ func TestPlugin_FilterNominateReservationPreAllocation(t *testing.T) {
 	assert.NotNil(t, p)
 
 	pl := p.(*Plugin)
-	suit.start()
+	suit.start(t)
 
 	// Setup CPU topology
 	pl.topologyOptionsManager.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {
@@ -802,7 +802,7 @@ func TestPlugin_GetNominatedReusableAlloc(t *testing.T) {
 	assert.NotNil(t, p)
 
 	pl := p.(*Plugin)
-	suit.start()
+	suit.start(t)
 
 	// Setup CPU topology
 	pl.topologyOptionsManager.UpdateTopologyOptions("test-node", func(options *TopologyOptions) {

--- a/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
@@ -526,7 +526,7 @@ func TestPlugin_Score(t *testing.T) {
 			cpuManager := plg.resourceManager.(*resourceManager)
 			cpuManager.nodeAllocations[allocateState.nodeName] = allocateState
 
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			if tt.state != nil {
@@ -784,7 +784,7 @@ func TestScoreWithAmplifiedCPUs(t *testing.T) {
 			suit.nodeNUMAResourceArgs.ScoringStrategy = tt.args.ScoringStrategy
 			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
 			assert.NoError(t, err)
-			suit.start()
+			suit.start(t)
 
 			pl := p.(*Plugin)
 

--- a/pkg/scheduler/plugins/nodenumaresource/topology_options_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/topology_options_test.go
@@ -30,11 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
 func TestTopologyOptionsManager(t *testing.T) {
 	suit := newPluginTestSuit(t, nil, nil)
+
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 
 	expectCPUTopology := buildCPUTopologyForTest(2, 1, 4, 2)
 
@@ -139,7 +143,23 @@ func TestTopologyOptionsManager(t *testing.T) {
 	err = registerNodeResourceTopologyEventHandler(nrtInformerFactory, topologyOptionsManager)
 	assert.NoError(t, err)
 
-	suit.start()
+	// Start the NRT informer factory so that ForceSyncFromInformer handlers receive OnAdd events.
+	// Use a test-lifetime stop channel (closed via t.Cleanup) instead of
+	// context.TODO().Done(), which would be nil and could hang the test
+	// indefinitely if cache sync never completes, leaking goroutines across tests.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	nrtInformerFactory.Start(stopCh)
+	nrtInformerFactory.WaitForCacheSync(stopCh)
+
+	suit.start(t)
+
+	// Wait for all ForceSyncFromInformer handler registrations to sync.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
 
 	topologyOptions := topologyOptionsManager.GetTopologyOptions(nodeName)
 	assert.NotNil(t, topologyOptions.CPUTopology)

--- a/pkg/scheduler/plugins/reservation/controller/controller_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/controller_test.go
@@ -48,6 +48,7 @@ import (
 	koordinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
 	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
@@ -1049,4 +1050,71 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.expectedGCInterval, controller.gcInterval)
 		})
 	}
+}
+
+// TestControllerStart verifies that controller.Start() registers a pod event handler
+// via ForceSyncFromInformer and that the handler receives OnAdd events after informers start.
+func TestControllerStart(t *testing.T) {
+	// Reset registrations before the test to avoid cross-test pollution.
+	frameworkexthelper.ResetRegistrations()
+	defer frameworkexthelper.ResetRegistrations()
+
+	fakeClientSet := kubefake.NewSimpleClientset()
+	fakeKoordClientSet := koordfake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
+
+	// Pre-create a pod assigned to a reservation so the OnAdd handler will store it in
+	// the controller's internal cache.
+	testReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "res-uid-start-test",
+			Name: "test-reservation-start",
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationAvailable,
+		},
+	}
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "pod-uid-start-test",
+			Name:      "test-pod-start",
+			Namespace: "default",
+			Annotations: map[string]string{
+				apiext.AnnotationReservationAllocated: `{"name":"test-reservation-start","uid":"res-uid-start-test"}`,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	_, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), testReservation, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeClientSet.CoreV1().Pods(testPod.Namespace).Create(context.TODO(), testPod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create controller with GC and resync disabled to keep the test focused.
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet,
+		&config.ReservationArgs{DisableGarbageCollection: true, ResyncIntervalSeconds: 0})
+
+	// Start() calls ForceSyncFromInformer for the pod informer, which should add a registration.
+	controller.Start()
+
+	// After Start(), at least one registration must have been collected (the pod handler).
+	regs := frameworkexthelper.GetRegistrations()
+	assert.NotEmpty(t, regs, "expected at least one handler registration after controller.Start()")
+
+	// Wait for all registered handlers to finish their initial list sync so that
+	// OnAdd events have been delivered before we inspect controller state.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = frameworkexthelper.WaitForHandlersSync(ctx)
+	assert.NoError(t, err, "handlers did not sync within timeout")
+
+	// The pod handler's OnAdd must have stored the pod in the controller's internal cache.
+	podsOnNode := controller.getPodsOnNode("test-node")
+	assert.Len(t, podsOnNode, 1, "expected test pod to be recorded in controller cache after OnAdd")
+
+	podsOnReservation := controller.getPodsOnReservation("res-uid-start-test")
+	assert.Len(t, podsOnReservation, 1, "expected test pod to be indexed by reservation UID")
 }

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -688,6 +688,7 @@ func TestMultiReservationsOnSameNode(t *testing.T) {
 
 	p, err := suit.pluginFactory()
 	assert.NoError(t, err)
+	suit.start(t)
 	pl := p.(*Plugin)
 
 	nominatedReservationCount := map[types.UID]int{}
@@ -749,6 +750,7 @@ func TestReservationsNominator(t *testing.T) {
 
 	p, err := suit.pluginFactory()
 	assert.NoError(t, err)
+	suit.start(t)
 	pl := p.(*Plugin)
 
 	nominatorImpl := pl.handle.(frameworkext.FrameworkExtender).GetReservationNominator()

--- a/pkg/scheduler/plugins/reservation/plugin_benchmark_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_benchmark_test.go
@@ -1536,7 +1536,7 @@ func Benchmark_filterWithReservations(b *testing.B) {
 			assert.NoError(b, err)
 			pl := p.(*Plugin)
 			pl.enableSkipReservationFitsNode = tt.enableSkipReservationFitsNode
-			suit.start()
+			suit.start(b)
 			cycleState := framework.NewCycleState()
 			if tt.stateData.podRequestsResources == nil {
 				tt.stateData.podRequestsResources = framework.NewResource(tt.stateData.podRequests)

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	v1 "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
@@ -156,6 +157,8 @@ type pluginTestSuit struct {
 }
 
 func newPluginTestSuitWith(t testing.TB, pods []*corev1.Pod, nodes []*corev1.Node, setArgs ...func(*config.ReservationArgs)) *pluginTestSuit {
+	// Reset registrations to avoid cross-test interference via package-level state.
+	frameworkexthelper.ResetRegistrations()
 	var v1args v1.ReservationArgs
 	v1.SetDefaults_ReservationArgs(&v1args)
 	var reservationArgs config.ReservationArgs
@@ -218,11 +221,24 @@ func newPluginTestSuit(t testing.TB) *pluginTestSuit {
 	return newPluginTestSuitWith(t, nil, nil)
 }
 
-func (s *pluginTestSuit) start() {
-	s.fw.SharedInformerFactory().Start(nil)
-	s.extenderFactory.KoordinatorSharedInformerFactory().Start(nil)
-	s.fw.SharedInformerFactory().WaitForCacheSync(nil)
-	s.extenderFactory.KoordinatorSharedInformerFactory().WaitForCacheSync(nil)
+func (s *pluginTestSuit) start(t testing.TB) {
+	// Use a test-lifetime stop channel so informers keep delivering events for
+	// objects created/updated by the test AFTER start() returns. A stop channel
+	// bound to a short-lived context would be closed the moment start() returns
+	// and silently stop the informer watchers.
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	s.fw.SharedInformerFactory().Start(stopCh)
+	s.extenderFactory.KoordinatorSharedInformerFactory().Start(stopCh)
+	s.fw.SharedInformerFactory().WaitForCacheSync(stopCh)
+	s.extenderFactory.KoordinatorSharedInformerFactory().WaitForCacheSync(stopCh)
+	// Use a separate bounded context only for the handler-sync wait so a hang
+	// doesn't block the whole test.
+	syncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := frameworkexthelper.WaitForHandlersSync(syncCtx); err != nil {
+		t.Fatalf("timed out waiting for handler registrations to sync: %v", err)
+	}
 }
 
 func TestNew(t *testing.T) {
@@ -409,9 +425,9 @@ func TestPreFilter(t *testing.T) {
 			}
 
 			p, err := suit.pluginFactory()
-
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
+			suit.start(t)
 
 			reservationAffinity, err := reservationutil.GetRequiredReservationAffinity(tt.pod)
 			assert.NoError(t, err)
@@ -959,7 +975,7 @@ func TestFilter(t *testing.T) {
 				tt.stateData.podResourceNames = quotav1.ResourceNames(tt.stateData.podRequests)
 				cycleState.Write(stateKey, tt.stateData)
 			}
-			suit.start()
+			suit.start(t)
 
 			got := pl.Filter(context.TODO(), cycleState, tt.pod, tt.nodeInfo)
 			assert.Equal(t, tt.want, got)
@@ -2511,7 +2527,7 @@ func Test_filterWithReservations(t *testing.T) {
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
 			pl.enableSkipReservationFitsNode = tt.enableSkipReservationFitsNode
-			suit.start()
+			suit.start(t)
 			cycleState := framework.NewCycleState()
 			if tt.stateData.podRequestsResources == nil {
 				tt.stateData.podRequestsResources = framework.NewResource(tt.stateData.podRequests)
@@ -3059,7 +3075,7 @@ func Test_filterWithPreAllocatablePods(t *testing.T) {
 			p, err := suit.pluginFactory()
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
-			suit.start()
+			suit.start(t)
 			cycleState := framework.NewCycleState()
 			cycleState.Write(stateKey, tt.stateData)
 			nodeInfo := framework.NewNodeInfo()
@@ -3225,7 +3241,7 @@ func TestPreFilterExtensionAddPod(t *testing.T) {
 			p, err := suit.pluginFactory()
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
-			suit.start()
+			suit.start(t)
 			cycleState := framework.NewCycleState()
 			cycleState.Write(stateKey, tt.state)
 			if tt.withR {
@@ -4314,6 +4330,7 @@ func TestReserve(t *testing.T) {
 			p, err := suit.pluginFactory()
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
+			suit.start(t)
 			state := &stateData{}
 			cycleState := framework.NewCycleState()
 			cycleState.Write(stateKey, state)
@@ -4446,6 +4463,7 @@ func TestUnreserve(t *testing.T) {
 			p, err := suit.pluginFactory()
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
+			suit.start(t)
 			state := &stateData{}
 			cycleState := framework.NewCycleState()
 			cycleState.Write(stateKey, state)
@@ -4578,7 +4596,7 @@ func TestPreBind(t *testing.T) {
 
 			pl := p.(*Plugin)
 
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			var assumedRInfo *frameworkext.ReservationInfo
@@ -4709,7 +4727,7 @@ func TestBind(t *testing.T) {
 			p, err := suit.pluginFactory()
 			assert.NoError(t, err)
 			pl := p.(*Plugin)
-			suit.start()
+			suit.start(t)
 
 			if tt.fakeClient != nil {
 				pl.client = tt.fakeClient.SchedulingV1alpha1()
@@ -6097,6 +6115,7 @@ func TestPreAllocation(t *testing.T) {
 		p, err := suit.pluginFactory()
 		assert.NoError(t, err)
 		pl := p.(*Plugin)
+		suit.start(t)
 
 		reservePod := reservationutil.NewReservePod(reservation)
 		cycleState := framework.NewCycleState()
@@ -6514,7 +6533,7 @@ func testPreAllocationMode(t *testing.T, tt preAllocationTestCase, node *corev1.
 		assert.NoError(t, err)
 	}
 
-	suit.start()
+	suit.start(t)
 
 	// Wait for pre-allocatable pods to be cached
 	ctx := context.TODO()

--- a/pkg/scheduler/plugins/reservation/preemption_test.go
+++ b/pkg/scheduler/plugins/reservation/preemption_test.go
@@ -256,7 +256,7 @@ func TestPostFilterWithPreemption(t *testing.T) {
 				_, err = pl.handle.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			if tt.args.hasStateData {
@@ -467,7 +467,7 @@ func TestPreemptionMgrSelectVictimsOnNode(t *testing.T) {
 				_, err = pl.handle.KoordinatorClientSet().SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
-			suit.start()
+			suit.start(t)
 
 			got, got1, got2 := pl.preemptionMgr.SelectVictimsOnNode(context.TODO(), tt.args.state, tt.args.pod, tt.args.nodeInfo, tt.args.pdbs)
 			assert.Equal(t, tt.want, got)

--- a/pkg/scheduler/plugins/reservation/scoring_test.go
+++ b/pkg/scheduler/plugins/reservation/scoring_test.go
@@ -274,7 +274,7 @@ func TestScore(t *testing.T) {
 			cycleState.Write(stateKey, state)
 
 			// the usage of the lister requires the informers started
-			suit.start()
+			suit.start(t)
 
 			nodeInfoForScore := framework.NewNodeInfo()
 			nodeInfoForScore.SetNode(node)
@@ -412,7 +412,7 @@ func TestScoreWithOrder(t *testing.T) {
 		cycleState.Write(stateKey, state)
 
 		// the usage of the lister requires the informers started
-		suit.start()
+		suit.start(t)
 		// verify if the cache synced
 		podLister := suit.fw.SharedInformerFactory().Core().V1().Pods().Lister()
 		assert.NotNil(t, podLister)
@@ -867,7 +867,7 @@ func TestPreScoreWithNominateReservation(t *testing.T) {
 			cycleState.Write(stateKey, state)
 
 			// the usage of the lister requires the informers started
-			suit.start()
+			suit.start(t)
 
 			nodeInfos := make([]fwktype.NodeInfo, 0, len(nodes))
 			for _, n := range nodes {

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -1438,7 +1438,7 @@ func TestBeforePreFilterForReservePod(t *testing.T) {
 			pl.reservationCache.updateReservation(availableReservation)
 			err = pl.reservationCache.assumePod(availableReservation.UID, testAssignedPod)
 			assert.NoError(t, err)
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, tt.pod)
@@ -1988,7 +1988,7 @@ func TestBeforePreFilterForReservationPreAllocation(t *testing.T) {
 			pl.reservationCache.updateReservation(availableReservation)
 			err = pl.reservationCache.assumePod(availableReservation.UID, testAssignedPod)
 			assert.NoError(t, err)
-			suit.start()
+			suit.start(t)
 
 			cycleState := framework.NewCycleState()
 			_, restored, status := pl.BeforePreFilter(context.TODO(), cycleState, tt.pod)
@@ -2339,7 +2339,7 @@ func TestAfterPreFilter_RestoresPreAllocatablePods(t *testing.T) {
 	_, err = suit.fw.ClientSet().CoreV1().Pods(testPreAllocatablePod.Namespace).Create(context.TODO(), testPreAllocatablePod, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	suit.start()
+	suit.start(t)
 
 	cycleState := framework.NewCycleState()
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: This change revises the ForceSyncFromInformer mechanism to eliminate the following side effects:

- Inconsistent Startup Order: Previously, ForceSyncFromInformer started the informer factory before the Scheduler’s Run() method. This caused inconsistency between koord-scheduler and the vanilla kube-scheduler.
- High Startup Latency: To ensure event handlers were invoked synchronously, the previous implementation serially processed all stored events for each registered handler. This introduced non-negligible overhead to scheduler startup latency.

We now leverage the upstream Kubernetes solution (https://github.com/kubernetes/kubernetes/issues/113763, https://github.com/kubernetes/kubernetes/pull/116729) to replace this workaround.

With this patch, plugin event handlers are registered earlier in the lifecycle. While this aligns koord-scheduler with the standard boot procedure used by most scheduler plugins, existing koord plugins that depend on a specific startup order between event handlers and the scheduler's `Run()` method may require adaptation.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
