### PR TITLE
koord-scheduler: fix integer rounding fragmentation in ElasticQuota runtime redistribution

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator.go
+++ b/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package core
 
 import (
+	"math/bits"
+	"sort"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -148,15 +150,21 @@ func (qt *quotaTree) redistribution(totalResource int64) {
 }
 
 func (qt *quotaTree) iterationForRedistribution(totalRes, totalSharedWeight int64, nodes []*quotaNode) {
-	if totalSharedWeight <= 0 {
+	if totalSharedWeight <= 0 || totalRes <= 0 || len(nodes) == 0 {
 		// if totalSharedWeight is not larger than 0, no need to iterate anymore.
 		return
 	}
+
+	// Use the largest remainder (Hamilton) method so that the integer residual left
+	// by per-node rounding is redistributed deterministically, guaranteeing that the
+	// sum of deltas equals totalRes (no resources lost or double-allocated due to
+	// fractional rounding).
+	deltas := computeHamiltonDeltas(totalRes, totalSharedWeight, nodes)
+
 	needAdjustQuotaNodes := make([]*quotaNode, 0)
 	toPartitionResource, needAdjustTotalSharedWeight := int64(0), int64(0)
-	for _, node := range nodes {
-		runtimeQuotaDelta := int64(float64(node.sharedWeight)*float64(totalRes)/float64(totalSharedWeight) + 0.5)
-		node.runtimeQuota += runtimeQuotaDelta
+	for i, node := range nodes {
+		node.runtimeQuota += deltas[i]
 		if node.runtimeQuota < node.request {
 			// if node's runtime is still less than request, the node still need to iterate.
 			needAdjustQuotaNodes = append(needAdjustQuotaNodes, node)
@@ -170,6 +178,70 @@ func (qt *quotaTree) iterationForRedistribution(totalRes, totalSharedWeight int6
 	if toPartitionResource > 0 && len(needAdjustQuotaNodes) > 0 {
 		qt.iterationForRedistribution(toPartitionResource, needAdjustTotalSharedWeight, needAdjustQuotaNodes)
 	}
+}
+
+// computeHamiltonDeltas splits totalRes into per-node integer deltas proportional
+// to node.sharedWeight using the largest-remainder method:
+//  1. base_i      = w_i * totalRes / totalSharedWeight       (integer division via 128-bit)
+//  2. remainder_i = w_i * totalRes mod totalSharedWeight
+//  3. residual    = totalRes - Σ base_i                       (provably >= 0)
+//  4. nodes with the largest remainders get +1 until residual == 0;
+//     ties broken by quotaName for determinism.
+//
+// 128-bit arithmetic (math/bits.Mul64 + Div64) avoids float64 precision loss
+// for large operands (e.g. memory in bytes where w*T can exceed 2^53),
+// guaranteeing Σ(deltas) == totalRes exactly.
+func computeHamiltonDeltas(totalRes, totalSharedWeight int64, nodes []*quotaNode) []int64 {
+	deltas := make([]int64, len(nodes))
+	if totalSharedWeight <= 0 || totalRes <= 0 || len(nodes) == 0 {
+		return deltas
+	}
+
+	type remainderEntry struct {
+		index     int
+		remainder uint64
+		name      string
+	}
+	remainders := make([]remainderEntry, 0, len(nodes))
+
+	uT := uint64(totalRes)
+	uW := uint64(totalSharedWeight)
+
+	distributed := int64(0)
+	for i, node := range nodes {
+		if node.sharedWeight <= 0 {
+			continue
+		}
+		hi, lo := bits.Mul64(uint64(node.sharedWeight), uT)
+		q, r := bits.Div64(hi, lo, uW)
+		base := int64(q)
+
+		deltas[i] = base
+		distributed += base
+		remainders = append(remainders, remainderEntry{
+			index:     i,
+			remainder: r,
+			name:      node.quotaName,
+		})
+	}
+
+	residual := totalRes - distributed
+	if residual <= 0 || len(remainders) == 0 {
+		return deltas
+	}
+
+	sort.SliceStable(remainders, func(a, b int) bool {
+		if remainders[a].remainder != remainders[b].remainder {
+			return remainders[a].remainder > remainders[b].remainder
+		}
+		return remainders[a].name < remainders[b].name
+	})
+
+	for i := 0; i < len(remainders) && residual > 0; i++ {
+		deltas[remainders[i].index]++
+		residual--
+	}
+	return deltas
 }
 
 type quotaResMapType map[string]v1.ResourceList

--- a/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/runtime_quota_calculator_test.go
@@ -266,6 +266,84 @@ func TestRuntimeQuotaCalculator_IterationAdjustQuota(t *testing.T) {
 	}
 }
 
+// TestRuntimeQuotaCalculator_IterationAdjustQuota_IntegerDistribution verifies
+// that integer-typed resources (e.g. GPU) are fully distributed to child quotas
+// without being lost due to per-node rounding. Previously the redistribution
+// step used `int64(w*t/W + 0.5)` independently per node, which could round every
+// child's share down to zero when many siblings shared a small residual (common
+// for GPU), making sum(children.runtime) strictly less than parent.runtime.
+func TestRuntimeQuotaCalculator_IterationAdjustQuota_IntegerDistribution(t *testing.T) {
+	const gpu = corev1.ResourceName("nvidia.com/gpu")
+
+	// Scenario reproducing the observed "3 GPU missing" case:
+	// - parent totalResource = 81 (== sum of mins, fully partitioned by min)
+	// - one donor child has request<min, allow-lent=true (contributes 3 to pool)
+	// - ten borrower children each have request>min, equal weights
+	// With the old rounding each borrower got 0 extra (3/10 + 0.5 = 0),
+	// losing all 3 GPUs.
+	type nodeSpec struct {
+		name         string
+		sharedWeight int64
+		request      int64
+		min          int64
+		allowLent    bool
+	}
+
+	var nodes []nodeSpec
+	nodes = append(nodes, nodeSpec{
+		name: "donor", sharedWeight: 1, request: 0, min: 3, allowLent: true,
+	})
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, nodeSpec{
+			name:         fmt.Sprintf("borrower-%02d", i),
+			sharedWeight: 1, request: 100, min: 78 / 10, allowLent: true,
+			// each borrower's min is 7 (or 8 for the first few) so that
+			// sum(min) = 3 + 78 = 81.
+		})
+	}
+	// Set each borrower's min explicitly so borrowers total 78; with the donor's
+	// min of 3, the overall sum(min) is 81.
+	perBorrowerMin := []int64{8, 8, 8, 8, 8, 8, 8, 8, 7, 7} // sums to 78
+	for i := 0; i < 10; i++ {
+		nodes[i+1].min = perBorrowerMin[i]
+	}
+
+	total := int64(0)
+	for _, n := range nodes {
+		total += n.min
+	}
+	assert.Equal(t, int64(81), total, "test setup: sum(min) must equal parent total (81)")
+
+	qtw := NewRuntimeQuotaCalculator("test-tree-integer-redistribution")
+	qtw.updateResourceKeys(map[corev1.ResourceName]struct{}{gpu: {}})
+	qtw.totalResource = corev1.ResourceList{
+		gpu: *resource.NewQuantity(81, resource.DecimalSI),
+	}
+	for _, n := range nodes {
+		qtw.quotaTree[gpu].insert(n.name, n.sharedWeight, n.request, n.min, 0, n.allowLent)
+	}
+
+	qtw.calculateRuntimeNoLock()
+
+	sum := int64(0)
+	for _, n := range nodes {
+		sum += qtw.quotaTree[gpu].quotaNodes[n.name].runtimeQuota
+	}
+	assert.Equal(t, int64(81), sum,
+		"sum of children runtime must equal parent total (no resources lost to rounding)")
+
+	// Donor's runtime must be clamped to its request (0), not inflated.
+	assert.Equal(t, int64(0), qtw.quotaTree[gpu].quotaNodes["donor"].runtimeQuota)
+
+	// Every borrower must at least get its min (guarantee).
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("borrower-%02d", i)
+		got := qtw.quotaTree[gpu].quotaNodes[name].runtimeQuota
+		assert.GreaterOrEqual(t, got, perBorrowerMin[i],
+			"borrower %s must receive at least its min", name)
+	}
+}
+
 func createQuotaInfoWithRes(name string, max, min corev1.ResourceList) *QuotaInfo {
 	quotaInfo := NewQuotaInfo(true, true, name, "")
 	quotaInfo.CalculateInfo.Max = max.DeepCopy()


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fix an integer rounding bug in `ElasticQuota` runtime redistribution.

In `iterationForRedistribution`, each child's share of the lendable pool is
rounded independently with `int64(float64(...) + 0.5)`. For integer-only
resources like `nvidia.com/gpu`, the rounded shares can sum to less than the
parent's total, leaving capacity stranded — `parent.runtime > Σ(child.runtime)`.

This PR replaces the per-node rounding with the Largest-Remainder (Hamilton)
method (new helper `computeHamiltonDeltas`):

- base = `floor(weight * totalRes / totalSharedWeight)`
- distribute the leftover units to the nodes with the largest fractional parts

This guarantees `Σ(delta) == totalRes` exactly.

## Ⅱ. Does this pull request fix one issue?

Fixes a GPU fragmentation issue observed in production:
parent quota with `max=81` GPUs, children's runtime sum only reached 78,
so 3 GPUs were permanently stranded and pending Pods could not be scheduled.
No linked issue.

## Ⅲ. Describe how to verify it

A regression test is added:

```bash
go test ./pkg/scheduler/plugins/elasticquota/core/... \
    -run TestRuntimeQuotaCalculator_IterationAdjustQuota_IntegerDistribution -v