### PR TITLE
scheduler: relax node-level reservation restore

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -53,6 +53,11 @@ const (
 
 	// AnnotationReservationRestrictedOptions represent the Reservation Restricted options
 	AnnotationReservationRestrictedOptions = SchedulingDomainPrefix + "/reservation-restricted-options"
+
+	// LabelReservationLevel indicates the reservation level.
+	// "node" means node-level reservation (reserve whole-node resources for a tenant).
+	LabelReservationLevel = SchedulingDomainPrefix + "/reservation-level"
+	ReservationLevelNode  = "node"
 )
 
 type ReservationAllocated struct {
@@ -106,6 +111,14 @@ type ReservationRestrictedOptions struct {
 	// If the Reservation's AllocatePolicy is Restricted, and no resources configured,
 	// by default the resources equal all reserved resources by the Reservation.
 	Resources []corev1.ResourceName `json:"resources,omitempty"`
+}
+
+// IsNodeLevelReservation checks if the reservation is a node-level reservation.
+func IsNodeLevelReservation(obj metav1.Object) bool {
+	if obj == nil {
+		return false
+	}
+	return obj.GetLabels()[LabelReservationLevel] == ReservationLevelNode
 }
 
 func IsReservationIgnored(pod *corev1.Pod) bool {

--- a/apis/extension/reservation_test.go
+++ b/apis/extension/reservation_test.go
@@ -258,3 +258,66 @@ func TestExactMatchReservation(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNodeLevelReservation(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  metav1.Object
+		want bool
+	}{
+		{
+			name: "nil object",
+			obj:  nil,
+			want: false,
+		},
+		{
+			name: "object with no labels",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "object with empty labels",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-pod",
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "object with wrong label value",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						LabelReservationLevel: "cluster",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "object with node-level label",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						LabelReservationLevel: ReservationLevelNode,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNodeLevelReservation(tt.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -134,6 +134,13 @@ const (
 	// resource overcommitment caused by scheduling pods based on a stale cache from the
 	// previous leader's final moments.
 	SyncBarrier featuregate.Feature = "SyncBarrier"
+
+	// owner: @saintube
+	// alpha: v1.9
+	//
+	// NodeLevelReservationLightweight skips expensive nodeInfo restore for node-level reservations
+	// to eliminate per-cycle restore overhead and preserve snapshot incremental updates.
+	NodeLevelReservationLightweight featuregate.Feature = "NodeLevelReservationLightweight"
 )
 
 var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -162,6 +169,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},
 	SyncBarrier:                               {Default: false, PreRelease: featuregate.Alpha},
 	CrossSchedulerNomination:                  {Default: false, PreRelease: featuregate.Alpha},
+	NodeLevelReservationLightweight:           {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -446,6 +446,19 @@ func updateReservation(sched *scheduler.Scheduler, schedAdapter frameworkext.Sch
 	// Case 2: From unassigned to available (scheduling succeeded)
 	if oldActive && newAvailable {
 		addReservationToSchedulerCache(schedAdapter, newR)
+		// when a node-level reservation transitions to Available, remove the assumed fake pod
+		// from cache since it was added during the scheduling cycle.
+		if k8sfeature.DefaultFeatureGate.Enabled(features.NodeLevelReservationLightweight) &&
+			extension.IsNodeLevelReservation(newR) && newR.Status.NodeName != "" {
+			reservePod := reservationutil.NewReservePod(newR)
+			if err := schedAdapter.GetCache().RemovePod(klog.Background(), reservePod); err != nil {
+				klog.V(4).InfoS("Failed to remove assumed reserve pod from cache during Available transition (may already be removed)",
+					"reservation", klog.KObj(newR), "err", err)
+			} else {
+				klog.V(4).InfoS("Successfully removed assumed reserve pod from cache for node-level reservation",
+					"reservation", klog.KObj(newR))
+			}
+		}
 		if oldResponsible {
 			// Remove from scheduling queue since it's now scheduled
 			deleteReservationFromSchedulingQueue(sched, schedAdapter, oldR)
@@ -530,6 +543,15 @@ func addReservationToSchedulerCache(sched frameworkext.Scheduler, r *schedulingv
 	klog.V(3).InfoS("Try to add reservation into SchedulerCache", "reservation", klog.KObj(r), "reservationUID", r.UID, "node", reservationutil.GetReservationNodeName(r))
 	// update pod cache and trigger pod assigned event for scheduling queue
 	reservePod := reservationutil.NewReservePod(r)
+	// node-level reservation that is already Available should not have fake pod in cache.
+	// Resource visibility is handled by reservation cache + BeforeFilter unmatchedHold injection.
+	if k8sfeature.DefaultFeatureGate.Enabled(features.NodeLevelReservationLightweight) &&
+		extension.IsNodeLevelReservation(r) && r.Status.NodeName != "" {
+		klog.V(4).InfoS("Skip adding node-level reservation fake pod to SchedulerCache (lightweight)",
+			"reservation", klog.KObj(r), "reservationUID", r.UID, "node", r.Status.NodeName)
+		sched.GetSchedulingQueue().AssignedPodAdded(klog.Background(), reservePod)
+		return
+	}
 	if err := sched.GetCache().AddPod(klog.Background(), reservePod); err != nil {
 		klog.ErrorS(err, "Failed to add reservation into SchedulerCache", "reservation", klog.KObj(reservePod))
 	} else {
@@ -565,6 +587,14 @@ func updateReservationInSchedulerCache(sched frameworkext.Scheduler, oldR, newR 
 	}
 	oldReservePod := reservationutil.NewReservePod(oldR)
 	newReservePod := reservationutil.NewReservePod(newR)
+	// node-level reservation fake pod is not in cache, skip UpdatePod.
+	if k8sfeature.DefaultFeatureGate.Enabled(features.NodeLevelReservationLightweight) &&
+		extension.IsNodeLevelReservation(newR) && newR.Status.NodeName != "" {
+		klog.V(4).InfoS("Skip updating node-level reservation fake pod in SchedulerCache (lightweight)",
+			"reservation", klog.KObj(newR), "reservationUID", newR.UID)
+		sched.GetSchedulingQueue().AssignedPodUpdated(klog.Background(), oldReservePod, newReservePod, fwktype.ClusterEvent{})
+		return
+	}
 	if err := sched.GetCache().UpdatePod(klog.Background(), oldReservePod, newReservePod); err != nil {
 		klog.ErrorS(err, "Failed to update reservation into SchedulerCache", "reservation", klog.KObj(newR))
 	} else {
@@ -601,7 +631,15 @@ func deleteReservationFromSchedulerCache(sched frameworkext.Scheduler, r *schedu
 
 	reservePod := reservationutil.NewReservePod(r)
 	if _, err := sched.GetCache().GetPod(reservePod); err != nil {
-		klog.V(4).InfoS("Reservation not found in SchedulerCache, skipping deletion", "reservation", klog.KObj(r), "reservationUID", r.UID)
+		// for node-level Available reservations, fake pod is expected to not be in cache.
+		if k8sfeature.DefaultFeatureGate.Enabled(features.NodeLevelReservationLightweight) &&
+			extension.IsNodeLevelReservation(r) && r.Status.NodeName != "" {
+			klog.V(4).InfoS("Reserve pod not found in cache (expected for node-level lightweight)",
+				"reservation", klog.KObj(r), "reservationUID", r.UID)
+		} else {
+			klog.V(4).InfoS("Reservation not found in SchedulerCache, skipping deletion",
+				"reservation", klog.KObj(r), "reservationUID", r.UID)
+		}
 		return
 	}
 	// The ports allocated from the reservation by some owner pods should not be removed from the NodeInfo.

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -101,6 +101,8 @@ type frameworkExtenderImpl struct {
 	metricsRecorder *metrics.MetricAsyncRecorder
 
 	crossSchedulerNominator *CrossSchedulerPodNominator
+
+	postFilterNodeDecorators []PostFilterNodeDecorator // decorators for PostFilter
 }
 
 func NewFrameworkExtender(f *FrameworkExtenderFactory, fw framework.Framework) FrameworkExtender {
@@ -219,6 +221,10 @@ func (ext *frameworkExtenderImpl) updatePlugins(pl fwktype.Plugin) {
 		} else {
 			klog.Warningf("framework extender got multiple PreferNodesPlugin registered, using the first one with name: %s", ext.preferNodesPlugin.Name())
 		}
+	}
+	if decorator, ok := pl.(PostFilterNodeDecorator); ok {
+		ext.postFilterNodeDecorators = append(ext.postFilterNodeDecorators, decorator)
+		klog.V(4).InfoS("framework extender got PostFilterNodeDecorator registered", "profile", ext.ProfileName(), "plugin", pl.Name())
 	}
 }
 
@@ -450,9 +456,15 @@ func (ext *frameworkExtenderImpl) RunScorePlugins(ctx context.Context, state fwk
 	return pluginToNodeScores, status
 }
 
+// GetPostFilterNodeDecorators returns the registered PostFilterNodeDecorators.
+func (ext *frameworkExtenderImpl) GetPostFilterNodeDecorators() []PostFilterNodeDecorator {
+	return ext.postFilterNodeDecorators
+}
+
 func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) (_ *fwktype.PostFilterResult, status *fwktype.Status) {
 	schedulingphase.RecordPhase(state, schedulingphase.PostFilter)
 	defer func() { schedulingphase.RecordPhase(state, "") }()
+
 	defer func() {
 		for _, transformer := range ext.postFilterTransformersEnabled {
 			startTime := time.Now()

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
 	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing/framework"
@@ -2310,4 +2312,286 @@ func buildCrossSchedulerExtenderAndNodeInfo(t *testing.T, node *corev1.Node, cro
 	extender := extenderFactory.NewFrameworkExtender(fh)
 	extender.SetConfiguredPlugins(fh.ListPlugins())
 	return extender, nodeInfo
+}
+
+// --- PostFilter snapshot test helpers ---
+
+type pfTestHandle struct {
+	fwktype.Handle
+	snapshot fwktype.SharedLister
+}
+
+func (h *pfTestHandle) SnapshotSharedLister() fwktype.SharedLister {
+	return h.snapshot
+}
+
+type pfTestSharedLister struct {
+	nodeInfos   []fwktype.NodeInfo
+	nodeInfoMap map[string]fwktype.NodeInfo
+}
+
+func (l *pfTestSharedLister) NodeInfos() fwktype.NodeInfoLister {
+	return &pfTestNodeInfoLister{parent: l}
+}
+
+func (l *pfTestSharedLister) StorageInfos() fwktype.StorageInfoLister {
+	return nil
+}
+
+type pfTestNodeInfoLister struct {
+	parent *pfTestSharedLister
+}
+
+func (nl *pfTestNodeInfoLister) List() ([]fwktype.NodeInfo, error) {
+	return nl.parent.nodeInfos, nil
+}
+
+func (nl *pfTestNodeInfoLister) HavePodsWithAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (nl *pfTestNodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (nl *pfTestNodeInfoLister) Get(nodeName string) (fwktype.NodeInfo, error) {
+	ni, ok := nl.parent.nodeInfoMap[nodeName]
+	if !ok {
+		return nil, fmt.Errorf("node %s not found", nodeName)
+	}
+	return ni, nil
+}
+
+func pfMakeNodeInfo(name string, cpuAlloc int64) fwktype.NodeInfo {
+	ni := framework.NewNodeInfo()
+	ni.SetNode(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(cpuAlloc, resource.DecimalSI),
+			},
+		},
+	})
+	return ni
+}
+
+type pfTestPodInjector struct {
+	pod *corev1.Pod
+}
+
+func (d *pfTestPodInjector) DecorateNodeForPostFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) error {
+	podInfo, _ := framework.NewPodInfo(d.pod)
+	nodeInfo.AddPodInfo(podInfo)
+	return nil
+}
+
+type pfTestFailingDecorator struct{}
+
+func (d *pfTestFailingDecorator) DecorateNodeForPostFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) error {
+	return fmt.Errorf("decorator failed")
+}
+
+// --- PostFilter snapshot tests ---
+
+func TestNewPostFilterHandle_NoDecorators(t *testing.T) {
+	innerHandle := &pfTestHandle{}
+	result := NewPostFilterHandle(innerHandle, nil, context.Background(), nil, nil)
+	assert.Equal(t, innerHandle, result, "should return original handle when no decorators")
+}
+
+func TestNewPostFilterHandle_WithDecorators(t *testing.T) {
+	ni := pfMakeNodeInfo("node-1", 32000)
+	sl := &pfTestSharedLister{
+		nodeInfos:   []fwktype.NodeInfo{ni},
+		nodeInfoMap: map[string]fwktype.NodeInfo{"node-1": ni},
+	}
+	innerHandle := &pfTestHandle{snapshot: sl}
+
+	injector := &pfTestPodInjector{
+		pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "injected-pod"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	result := NewPostFilterHandle(innerHandle, []PostFilterNodeDecorator{injector}, context.Background(), nil, nil)
+	assert.NotEqual(t, innerHandle, result, "should return a different handle when decorators exist")
+
+	decoratedSnapshot := result.SnapshotSharedLister()
+	assert.NotNil(t, decoratedSnapshot)
+
+	nodeInfos, err := decoratedSnapshot.NodeInfos().List()
+	assert.NoError(t, err)
+	assert.Len(t, nodeInfos, 1)
+
+	decoratedNode := nodeInfos[0]
+	originalPodCount := len(ni.(*framework.NodeInfo).Pods)
+	decoratedPodCount := len(decoratedNode.(*framework.NodeInfo).Pods)
+	assert.Greater(t, decoratedPodCount, originalPodCount, "decorated nodeInfo should have more pods than original")
+}
+
+func TestPostFilterDecoratedSnapshot_GetDecoratesNode(t *testing.T) {
+	ni := pfMakeNodeInfo("node-1", 32000)
+	sl := &pfTestSharedLister{
+		nodeInfos:   []fwktype.NodeInfo{ni},
+		nodeInfoMap: map[string]fwktype.NodeInfo{"node-1": ni},
+	}
+	innerHandle := &pfTestHandle{snapshot: sl}
+
+	injector := &pfTestPodInjector{
+		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "injected-pod"}},
+	}
+
+	result := NewPostFilterHandle(innerHandle, []PostFilterNodeDecorator{injector}, context.Background(), nil, nil)
+
+	decoratedNode, err := result.SnapshotSharedLister().NodeInfos().Get("node-1")
+	assert.NoError(t, err)
+	assert.NotNil(t, decoratedNode)
+
+	originalPods := len(ni.(*framework.NodeInfo).Pods)
+	decoratedPods := len(decoratedNode.(*framework.NodeInfo).Pods)
+	assert.Equal(t, 0, originalPods, "original nodeInfo should not be mutated")
+	assert.Equal(t, 1, decoratedPods, "decorated nodeInfo should have the injected pod")
+}
+
+func TestPostFilterDecoratedSnapshot_DecoratorError(t *testing.T) {
+	ni := pfMakeNodeInfo("node-1", 32000)
+	sl := &pfTestSharedLister{
+		nodeInfos:   []fwktype.NodeInfo{ni},
+		nodeInfoMap: map[string]fwktype.NodeInfo{"node-1": ni},
+	}
+	innerHandle := &pfTestHandle{snapshot: sl}
+
+	result := NewPostFilterHandle(innerHandle, []PostFilterNodeDecorator{&pfTestFailingDecorator{}}, context.Background(), nil, nil)
+
+	_, err := result.SnapshotSharedLister().NodeInfos().List()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decorator failed")
+
+	_, err = result.SnapshotSharedLister().NodeInfos().Get("node-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decorator failed")
+}
+
+func TestPostFilterDecoratedSnapshot_StorageInfosPassthrough(t *testing.T) {
+	sl := &pfTestSharedLister{}
+	innerHandle := &pfTestHandle{snapshot: sl}
+
+	injector := &pfTestPodInjector{pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}}
+	result := NewPostFilterHandle(innerHandle, []PostFilterNodeDecorator{injector}, context.Background(), nil, nil)
+
+	decoratedSnapshot := result.SnapshotSharedLister()
+	assert.Nil(t, decoratedSnapshot.StorageInfos(), "StorageInfos should pass through to inner")
+}
+
+// --- WrapPreemptPodForReservation tests ---
+
+func TestWrapPreemptPodForReservation(t *testing.T) {
+	defaultPreemptCalled := false
+	defaultPreemptPod := func(ctx context.Context, c preemption.Candidate, preemptor, victim *corev1.Pod, pluginName string) error {
+		defaultPreemptCalled = true
+		return nil
+	}
+
+	koordClient := koordfake.NewSimpleClientset()
+
+	testReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-reservation"},
+	}
+	_, err := koordClient.SchedulingV1alpha1().Reservations().Create(context.Background(), testReservation, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	wrapped := WrapPreemptPodForReservation(defaultPreemptPod, koordClient)
+
+	reservePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "reserve-pod-1", Namespace: "default",
+			Annotations: map[string]string{
+				"scheduling.koordinator.sh/reserve-pod":      "true",
+				"scheduling.koordinator.sh/reservation-name": "test-reservation",
+			},
+		},
+	}
+	preemptorPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "preemptor", Namespace: "default"},
+	}
+
+	t.Run("reserve pod victim: delete reservation via API", func(t *testing.T) {
+		defaultPreemptCalled = false
+		err := wrapped(context.Background(), nil, preemptorPod, reservePod, "test-plugin")
+		assert.NoError(t, err)
+		assert.False(t, defaultPreemptCalled, "default PreemptPod should NOT be called for reserve pod")
+
+		_, getErr := koordClient.SchedulingV1alpha1().Reservations().Get(context.Background(), "test-reservation", metav1.GetOptions{})
+		assert.True(t, apierrors.IsNotFound(getErr), "reservation should be deleted")
+	})
+
+	t.Run("normal pod victim: delegate to default PreemptPod", func(t *testing.T) {
+		defaultPreemptCalled = false
+		normalPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "normal-victim", Namespace: "default"},
+		}
+		err := wrapped(context.Background(), nil, preemptorPod, normalPod, "test-plugin")
+		assert.NoError(t, err)
+		assert.True(t, defaultPreemptCalled, "default PreemptPod should be called for normal pod")
+	})
+
+	t.Run("reserve pod with empty reservation name: return error", func(t *testing.T) {
+		badReservePod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bad-reserve-pod",
+				Annotations: map[string]string{
+					"scheduling.koordinator.sh/reserve-pod": "true",
+				},
+			},
+		}
+		err := wrapped(context.Background(), nil, preemptorPod, badReservePod, "test-plugin")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get reservation name")
+	})
+
+	t.Run("reserve pod with already-deleted reservation: no error", func(t *testing.T) {
+		r2 := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: "already-deleted-r"},
+		}
+		_, err := koordClient.SchedulingV1alpha1().Reservations().Create(context.Background(), r2, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		err = koordClient.SchedulingV1alpha1().Reservations().Delete(context.Background(), "already-deleted-r", metav1.DeleteOptions{})
+		assert.NoError(t, err)
+
+		reservePod2 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "reserve-pod-2",
+				Annotations: map[string]string{
+					"scheduling.koordinator.sh/reserve-pod":      "true",
+					"scheduling.koordinator.sh/reservation-name": "already-deleted-r",
+				},
+			},
+		}
+		err = wrapped(context.Background(), nil, preemptorPod, reservePod2, "test-plugin")
+		assert.NoError(t, err, "should not error when reservation is already deleted (NotFound)")
+	})
+
+	t.Run("default PreemptPod error propagated for normal pod", func(t *testing.T) {
+		errWrapped := WrapPreemptPodForReservation(
+			func(ctx context.Context, c preemption.Candidate, preemptor, victim *corev1.Pod, pluginName string) error {
+				return fmt.Errorf("preempt failed")
+			},
+			koordClient,
+		)
+		normalPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "normal-victim-2", Namespace: "default"},
+		}
+		err := errWrapped(context.Background(), nil, preemptorPod, normalPod, "test-plugin")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "preempt failed")
+	})
 }

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -64,6 +64,9 @@ type ExtendedHandle interface {
 	// It returns nil when the feature is not enabled or not configured.
 	GetCrossSchedulerPodNominator() *CrossSchedulerPodNominator
 	GetWorkloadAuditor() workloadauditor.WorkloadAuditor
+	// GetPostFilterNodeDecorators returns the registered PostFilterNodeDecorators
+	// that inject additional preemptable pods into nodeInfo for preemption evaluation.
+	GetPostFilterNodeDecorators() []PostFilterNodeDecorator
 }
 
 // FrameworkExtender extends the K8s Scheduling Framework interface to provide more extension methods to support Koordinator.
@@ -150,6 +153,17 @@ type ScoreTransformer interface {
 type PostFilterTransformer interface {
 	SchedulingTransformer
 	AfterPostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader)
+}
+
+// PostFilterNodeDecorator allows plugins to inject additional preemptable pods
+// into nodeInfo before preemption evaluation. This is used by the reservation
+// plugin to make node-level reservation reserve pods visible to preemption
+// evaluators, even though they are not stored in the SchedulerCache.
+type PostFilterNodeDecorator interface {
+	// DecorateNodeForPostFilter injects reserve pods into the given nodeInfo
+	// snapshot for preemption visibility. Called per-node by the decorated snapshot.
+	DecorateNodeForPostFilter(ctx context.Context, cycleState fwktype.CycleState,
+		pod *corev1.Pod, nodeInfo fwktype.NodeInfo) error
 }
 
 // PluginToReservationRestoreStates declares a map from plugin name to its ReservationRestoreState.

--- a/pkg/scheduler/frameworkext/postfilter_snapshot.go
+++ b/pkg/scheduler/frameworkext/postfilter_snapshot.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+)
+
+// PostFilterHandleWrapper wraps a framework.Handle to override SnapshotSharedLister
+// with a decorated snapshot for preemption evaluation. This ensures the decoration
+// is scoped to a single evaluator call, avoiding global state mutation.
+type PostFilterHandleWrapper struct {
+	fwktype.Handle
+	decoratedSnapshot fwktype.SharedLister
+}
+
+func (h *PostFilterHandleWrapper) SnapshotSharedLister() fwktype.SharedLister {
+	return h.decoratedSnapshot
+}
+
+// NewPostFilterHandle creates a handle wrapper with reserve pods injected into the snapshot
+// for preemption visibility. This should be called in each PostFilter plugin's method
+// before creating a preemption.Evaluator.
+func NewPostFilterHandle(
+	handle fwktype.Handle,
+	decorators []PostFilterNodeDecorator,
+	ctx context.Context,
+	state fwktype.CycleState,
+	pod *corev1.Pod,
+) fwktype.Handle {
+	if len(decorators) == 0 {
+		return handle
+	}
+	originalSnapshot := handle.SnapshotSharedLister()
+	decoratedSnapshot := newPostFilterDecoratedSnapshot(
+		originalSnapshot, decorators, ctx, state, pod)
+	return &PostFilterHandleWrapper{
+		Handle:            handle,
+		decoratedSnapshot: decoratedSnapshot,
+	}
+}
+
+// postFilterDecoratedSnapshot wraps a SharedLister to inject reserve pods
+// into nodeInfo for preemption evaluation.
+type postFilterDecoratedSnapshot struct {
+	inner      fwktype.SharedLister
+	decorators []PostFilterNodeDecorator
+	ctx        context.Context
+	state      fwktype.CycleState
+	pod        *corev1.Pod
+}
+
+func newPostFilterDecoratedSnapshot(
+	inner fwktype.SharedLister,
+	decorators []PostFilterNodeDecorator,
+	ctx context.Context,
+	state fwktype.CycleState,
+	pod *corev1.Pod,
+) *postFilterDecoratedSnapshot {
+	return &postFilterDecoratedSnapshot{
+		inner:      inner,
+		decorators: decorators,
+		ctx:        ctx,
+		state:      state,
+		pod:        pod,
+	}
+}
+
+func (s *postFilterDecoratedSnapshot) NodeInfos() fwktype.NodeInfoLister {
+	return &postFilterDecoratedNodeInfoLister{
+		inner:      s.inner.NodeInfos(),
+		decorators: s.decorators,
+		ctx:        s.ctx,
+		state:      s.state,
+		pod:        s.pod,
+	}
+}
+
+func (s *postFilterDecoratedSnapshot) StorageInfos() fwktype.StorageInfoLister {
+	return s.inner.StorageInfos()
+}
+
+// postFilterDecoratedNodeInfoLister wraps a NodeInfoLister to inject
+// reserve pods per-node via PostFilterNodeDecorator.
+type postFilterDecoratedNodeInfoLister struct {
+	inner      fwktype.NodeInfoLister
+	decorators []PostFilterNodeDecorator
+	ctx        context.Context
+	state      fwktype.CycleState
+	pod        *corev1.Pod
+}
+
+func (l *postFilterDecoratedNodeInfoLister) List() ([]fwktype.NodeInfo, error) {
+	nodeInfos, err := l.inner.List()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]fwktype.NodeInfo, 0, len(nodeInfos))
+	for _, ni := range nodeInfos {
+		decorated, err := l.decorateNodeInfo(ni)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, decorated)
+	}
+	return result, nil
+}
+
+func (l *postFilterDecoratedNodeInfoLister) HavePodsWithAffinityList() ([]fwktype.NodeInfo, error) {
+	return l.inner.HavePodsWithAffinityList()
+}
+
+func (l *postFilterDecoratedNodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]fwktype.NodeInfo, error) {
+	return l.inner.HavePodsWithRequiredAntiAffinityList()
+}
+
+func (l *postFilterDecoratedNodeInfoLister) Get(nodeName string) (fwktype.NodeInfo, error) {
+	ni, err := l.inner.Get(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	return l.decorateNodeInfo(ni)
+}
+
+func (l *postFilterDecoratedNodeInfoLister) decorateNodeInfo(nodeInfo fwktype.NodeInfo) (fwktype.NodeInfo, error) {
+	// Snapshot (clone) the nodeInfo so we don't mutate the original
+	cloned := nodeInfo.Snapshot()
+	for _, decorator := range l.decorators {
+		if err := decorator.DecorateNodeForPostFilter(l.ctx, l.state, l.pod, cloned); err != nil {
+			klog.V(4).ErrorS(err, "Failed to decorate nodeInfo for PostFilter",
+				"node", nodeInfo.Node().Name)
+			return nil, err
+		}
+	}
+	return cloned, nil
+}

--- a/pkg/scheduler/frameworkext/preempt_reservation.go
+++ b/pkg/scheduler/frameworkext/preempt_reservation.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
+
+	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+)
+
+// WrapPreemptPodForReservation wraps the default PreemptPod function to support
+// preempting reservation reserve pods by deleting the Reservation object
+// instead of deleting the Pod (which may not exist for node-level reservations).
+func WrapPreemptPodForReservation(
+	defaultPreemptPod func(ctx context.Context, c preemption.Candidate, preemptor, victim *corev1.Pod, pluginName string) error,
+	koordinatorClient koordinatorclientset.Interface,
+) func(ctx context.Context, c preemption.Candidate, preemptor, victim *corev1.Pod, pluginName string) error {
+	return func(ctx context.Context, c preemption.Candidate, preemptor, victim *corev1.Pod, pluginName string) error {
+		if reservationutil.IsReservePod(victim) {
+			rName := reservationutil.GetReservationNameFromReservePod(victim)
+			if len(rName) == 0 {
+				return fmt.Errorf("failed to get reservation name from reserve pod %s", klog.KObj(victim))
+			}
+			if err := koordinatorClient.SchedulingV1alpha1().
+				Reservations().Delete(ctx, rName, metav1.DeleteOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				klog.V(4).InfoS("Reservation already deleted during preemption",
+					"reservation", rName, "preemptor", klog.KObj(preemptor))
+			}
+			return nil
+		}
+		// Normal pod: use default PreemptPod
+		return defaultPreemptPod(ctx, c, preemptor, victim, pluginName)
+	}
+}

--- a/pkg/scheduler/frameworkext/reservation_info.go
+++ b/pkg/scheduler/frameworkext/reservation_info.go
@@ -56,6 +56,7 @@ type ReservationInfo struct {
 	AllocatedPorts        fwktype.HostPortInfo
 	AssignedPods          map[types.UID]*PodRequirement
 	OwnerMatchers         []reservationutil.ReservationOwnerMatcher
+	IsNodeLevel           bool
 	ParseError            error
 }
 
@@ -127,6 +128,7 @@ func NewReservationInfo(r *schedulingv1alpha1.Reservation) *ReservationInfo {
 		AllocatablePorts: util.RequestedHostPorts(reservedPod),
 		AssignedPods:     map[types.UID]*PodRequirement{},
 		OwnerMatchers:    ownerMatchers,
+		IsNodeLevel:      apiext.IsNodeLevelReservation(r),
 		ParseError:       parseError,
 	}
 }
@@ -173,6 +175,7 @@ func NewReservationInfoFromPod(pod *corev1.Pod) *ReservationInfo {
 		AllocatablePorts: util.RequestedHostPorts(pod),
 		AssignedPods:     map[types.UID]*PodRequirement{},
 		OwnerMatchers:    ownerMatchers,
+		IsNodeLevel:      apiext.IsNodeLevelReservation(pod),
 		ParseError:       parseError,
 	}
 }
@@ -393,6 +396,7 @@ func (ri *ReservationInfo) Clone() *ReservationInfo {
 		AllocatedPorts:        util.CloneHostPorts(ri.AllocatedPorts),
 		AssignedPods:          assignedPods,
 		OwnerMatchers:         ri.OwnerMatchers,
+		IsNodeLevel:           ri.IsNodeLevel,
 		ParseError:            ri.ParseError,
 	}
 }
@@ -416,6 +420,7 @@ func (ri *ReservationInfo) UpdateReservation(r *schedulingv1alpha1.Reservation) 
 
 	ri.Reservation = r
 	ri.Pod = reservationutil.NewReservePod(r)
+	ri.IsNodeLevel = apiext.IsNodeLevelReservation(r)
 	ri.AllocatablePorts = util.RequestedHostPorts(ri.Pod)
 	if ri.Allocated != nil {
 		ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
@@ -457,6 +462,7 @@ func (ri *ReservationInfo) UpdatePod(pod *corev1.Pod) {
 	ri.ResourceNames = resourceNames
 
 	ri.Pod = pod
+	ri.IsNodeLevel = apiext.IsNodeLevelReservation(pod)
 	ri.AllocatablePorts = util.RequestedHostPorts(pod)
 	ri.Allocated = quotav1.Mask(ri.Allocated, ri.ResourceNames)
 	reserved := util.GetNodeReservationFromAnnotation(pod.Annotations)

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -532,7 +532,22 @@ func (g *Plugin) PostFilter(ctx context.Context, state fwktype.CycleState, pod *
 		metrics.PreemptionAttempts.Inc()
 	}()
 
-	pe := preemption.NewEvaluator(Name, g.handle, g, false)
+	// Create a local handle with decorated snapshot for preemption visibility,
+	// scoped to this evaluator call to avoid global state mutation.
+	handle := g.handle
+	if extHandle, ok := g.handle.(frameworkext.ExtendedHandle); ok {
+		decorators := extHandle.GetPostFilterNodeDecorators()
+		if len(decorators) > 0 {
+			handle = frameworkext.NewPostFilterHandle(g.handle, decorators, ctx, state, pod)
+		}
+	}
+
+	pe := preemption.NewEvaluator(Name, handle, g, false)
+	// wrap PreemptPod to handle reserve pod deletion via Reservation API
+	if extHandle, ok := g.handle.(frameworkext.ExtendedHandle); ok {
+		pe.PreemptPod = frameworkext.WrapPreemptPodForReservation(
+			pe.PreemptPod, extHandle.KoordinatorClientSet())
+	}
 
 	result, status := pe.Preempt(ctx, state, pod, filteredNodeStatusMap)
 	if status.Message() != "" {

--- a/pkg/scheduler/plugins/reservation/cache.go
+++ b/pkg/scheduler/plugins/reservation/cache.go
@@ -503,6 +503,26 @@ func (cache *reservationCache) ForEachMatchableReservationOnNode(nodeName string
 	return nil
 }
 
+// ListMatchableReservationsOnNode returns all matchable reservations on the node as a list.
+// Compared to ForEachMatchableReservationOnNode, this reduces lock hold time by moving
+// matching logic outside the lock.
+func (cache *reservationCache) ListMatchableReservationsOnNode(nodeName string) []*frameworkext.ReservationInfo {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	rOnNode := cache.matchableOnNode[nodeName]
+	if len(rOnNode) == 0 {
+		return nil
+	}
+	result := make([]*frameworkext.ReservationInfo, 0, len(rOnNode))
+	for uid := range rOnNode {
+		rInfo := cache.reservationInfos[uid]
+		if rInfo != nil {
+			result = append(result, rInfo.Clone())
+		}
+	}
+	return result
+}
+
 func (cache *reservationCache) ListAvailableReservationInfosOnNode(nodeName string, listAll bool) []*frameworkext.ReservationInfo {
 	var result []*frameworkext.ReservationInfo
 	if !listAll {

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -91,6 +91,7 @@ var (
 
 	_ frameworkext.ControllerProvider      = &Plugin{}
 	_ frameworkext.PreFilterTransformer    = &Plugin{}
+	_ frameworkext.PostFilterNodeDecorator = &Plugin{}
 	_ frameworkext.ReservationCache        = &Plugin{}
 	_ frameworkext.ReservationNominator    = &Plugin{}
 	_ frameworkext.ReservationFilterPlugin = &Plugin{}
@@ -98,17 +99,18 @@ var (
 )
 
 type Plugin struct {
-	handle                         frameworkext.ExtendedHandle
-	args                           *config.ReservationArgs
-	rLister                        listerschedulingv1alpha1.ReservationLister
-	podLister                      listercorev1.PodLister
-	client                         clientschedulingv1alpha1.SchedulingV1alpha1Interface
-	reservationCache               *reservationCache
-	nominator                      *nominator
-	preemptionMgr                  *PreemptionMgr
-	enableLazyReservationRestore   bool
-	enableSkipReservationFitsNode  bool
-	enablePreAllocationClusterMode bool
+	handle                                frameworkext.ExtendedHandle
+	args                                  *config.ReservationArgs
+	rLister                               listerschedulingv1alpha1.ReservationLister
+	podLister                             listercorev1.PodLister
+	client                                clientschedulingv1alpha1.SchedulingV1alpha1Interface
+	reservationCache                      *reservationCache
+	nominator                             *nominator
+	preemptionMgr                         *PreemptionMgr
+	enableLazyReservationRestore          bool
+	enableNodeLevelReservationLightweight bool
+	enableSkipReservationFitsNode         bool
+	enablePreAllocationClusterMode        bool
 }
 
 func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
@@ -135,15 +137,16 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 	registerPodEventHandler(extendedHandle, cache, nm, sharedInformerFactory)
 
 	p := &Plugin{
-		handle:                        extendedHandle,
-		args:                          pluginArgs,
-		rLister:                       reservationLister,
-		podLister:                     podLister,
-		client:                        extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
-		reservationCache:              cache,
-		nominator:                     nm,
-		enableLazyReservationRestore:  k8sfeature.DefaultFeatureGate.Enabled(features.LazyReservationRestore),
-		enableSkipReservationFitsNode: k8sfeature.DefaultFeatureGate.Enabled(features.SkipReservationFitsNode),
+		handle:                                extendedHandle,
+		args:                                  pluginArgs,
+		rLister:                               reservationLister,
+		podLister:                             podLister,
+		client:                                extendedHandle.KoordinatorClientSet().SchedulingV1alpha1(),
+		reservationCache:                      cache,
+		nominator:                             nm,
+		enableLazyReservationRestore:          k8sfeature.DefaultFeatureGate.Enabled(features.LazyReservationRestore),
+		enableNodeLevelReservationLightweight: k8sfeature.DefaultFeatureGate.Enabled(features.NodeLevelReservationLightweight),
+		enableSkipReservationFitsNode:         k8sfeature.DefaultFeatureGate.Enabled(features.SkipReservationFitsNode),
 	}
 
 	if pluginArgs.EnablePreemption {
@@ -384,7 +387,22 @@ func (pl *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod
 				preemptible := state.preemptible[node.Name]
 				preemptibleResource := framework.NewResource(preemptible)
 				nodeAllocatable := nodeInfo.GetAllocatable().(*framework.Resource)
-				insufficientResources := fitsNode(state.podRequestsResources, nodeAllocatable, nodeRState.podRequested, nodeRState.rAllocated, nil, len(nodeRState.matchedOrIgnored), len(nodeInfo.GetPods()), preemptibleResource)
+				// Determine allPodsRequested and allRAllocated based on path
+				var allPodsRequested fwktype.Resource
+				var allRAllocated fwktype.Resource
+				if nodeRState.isNodeLevel {
+					// explicitly add unmatchedHold to requested (nodeInfo is NOT modified)
+					if nodeRState.unmatchedHold != nil {
+						allPodsRequested = addUnmatchedHoldToRequested(nodeInfo.GetRequested(), nodeRState.unmatchedHold)
+					} else {
+						allPodsRequested = nodeInfo.GetRequested()
+					}
+				} else {
+					// Baseline: use captured values
+					allPodsRequested = nodeRState.podRequested
+					allRAllocated = nodeRState.rAllocated
+				}
+				insufficientResources := fitsNode(state.podRequestsResources, nodeAllocatable, allPodsRequested, allRAllocated, nil, len(nodeRState.matchedOrIgnored), len(nodeInfo.GetPods()), preemptibleResource)
 				if len(insufficientResources) != 0 {
 					// Return Unschedulable (not UnschedulableAndUnresolvable) so that the preemption evaluator
 					// can consider this node as a potential preemption candidate via NodesForStatusCode(Unschedulable).
@@ -416,10 +434,43 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState fwktype
 	state := getStateData(cycleState)
 	nodeRState := state.nodeReservationStates[node.Name]
 
+	// Determine allPodsRequested and allRAllocated based on path
+	var allPodsRequested fwktype.Resource
+	var allRAllocated fwktype.Resource
+	if nodeRState.isNodeLevel {
+		// explicitly add unmatchedHold to requested (nodeInfo is NOT modified)
+		if nodeRState.unmatchedHold != nil {
+			allPodsRequested = addUnmatchedHoldToRequested(nodeInfo.GetRequested(), nodeRState.unmatchedHold)
+		} else {
+			allPodsRequested = nodeInfo.GetRequested()
+		}
+	} else {
+		// Baseline: use captured values
+		allPodsRequested = nodeRState.podRequested
+		allRAllocated = nodeRState.rAllocated
+	}
+
 	// For reservation-ignored pods, the transformer has already restored all reservation resources back to the node.
 	// NodeResourceFit plugin will validate if the node has sufficient resources for the pod.
-	// So we can skip the resource validation here and return success directly.
+	// For node-level path, check if unmatchedHold makes the node too full for the ignored pod.
 	if apiext.IsReservationIgnored(pod) {
+		if nodeRState.isNodeLevel && nodeRState.unmatchedHold != nil {
+			// Check: podRequest <= allocatable - (nodeInfo.Requested + unmatchedHold)
+			preemptible := dummyResource
+			state.preemptLock.RLock()
+			if state.preemptible[node.Name] != nil {
+				preemptible = framework.NewResource(state.preemptible[node.Name])
+			}
+			state.preemptLock.RUnlock()
+			insufficientResources := fitsNode(state.podRequestsResources, nodeInfo.GetAllocatable(), allPodsRequested, nil, nil, len(nodeRState.matchedOrIgnored), len(nodeInfo.GetPods()), preemptible)
+			if len(insufficientResources) > 0 {
+				failureReasons := make([]string, 0, len(insufficientResources))
+				for _, r := range insufficientResources {
+					failureReasons = append(failureReasons, fmt.Sprintf("Insufficient %s by node", r))
+				}
+				return fwktype.NewStatus(fwktype.Unschedulable, failureReasons...)
+			}
+		}
 		klog.V(5).InfoS("Skip duplicated filter for reservation-ignored pod", "pod", klog.KObj(pod), "node", node.Name, "matchedReservations", len(matchedReservations))
 		return nil
 	}
@@ -465,8 +516,8 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState fwktype
 		}
 		state.preemptLock.RUnlock()
 
-		insufficientResourcesByNode, insufficientResourceReasonsByReservation := fitsNodeAndReservation(state.podRequestsResources, nodeRState.podRequested,
-			nodeRState.rAllocated, preemptibleWithRR, rInfo.GetAvailable(), state.podRequests, preemptibleInRR, pod, rInfo, nodeInfo, len(nodeRState.matchedOrIgnored),
+		insufficientResourcesByNode, insufficientResourceReasonsByReservation := fitsNodeAndReservation(state.podRequestsResources, allPodsRequested,
+			allRAllocated, preemptibleWithRR, rInfo.GetAvailable(), state.podRequests, preemptibleInRR, pod, rInfo, nodeInfo, len(nodeRState.matchedOrIgnored),
 			requireDetailReasons, isFitsNodeSkipped)
 		allInsufficientResourcesByNode.Insert(insufficientResourcesByNode...)
 		allInsufficientResourceReasonsByReservation = append(allInsufficientResourceReasonsByReservation, insufficientResourceReasonsByReservation...)
@@ -511,7 +562,7 @@ func (pl *Plugin) filterWithReservations(ctx context.Context, cycleState fwktype
 			failureReasons = buildNodeFailureReasons(allInsufficientResourcesByNode.List())
 		} else {
 			// try to allocate from node alone
-			insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo.GetAllocatable(), nodeRState.podRequested, nodeRState.rAllocated, nil, len(nodeRState.matchedOrIgnored), len(nodeInfo.GetPods()), preemptible)
+			insufficientResourcesByNode := fitsNode(state.podRequestsResources, nodeInfo.GetAllocatable(), allPodsRequested, allRAllocated, nil, len(nodeRState.matchedOrIgnored), len(nodeInfo.GetPods()), preemptible)
 			failureReasons = buildNodeFailureReasons(insufficientResourcesByNode)
 		}
 		if len(failureReasons) > 0 {
@@ -849,6 +900,27 @@ func sortPreAllocatablePodsForDefaultMode(ctx context.Context, extender framewor
 }
 
 var dummyResource = framework.NewResource(nil)
+
+// addUnmatchedHoldToRequested creates a new Resource that sums the requested resources and unmatchedHold.
+// This is used in node-level path to explicitly account for unmatched reservations' held resources
+// without modifying nodeInfo.
+func addUnmatchedHoldToRequested(requested fwktype.Resource, unmatchedHold *framework.Resource) *framework.Resource {
+	r, ok := requested.(*framework.Resource)
+	if !ok {
+		return unmatchedHold.Clone()
+	}
+	result := r.Clone()
+	result.MilliCPU += unmatchedHold.MilliCPU
+	result.Memory += unmatchedHold.Memory
+	result.EphemeralStorage += unmatchedHold.EphemeralStorage
+	if result.ScalarResources == nil && len(unmatchedHold.ScalarResources) > 0 {
+		result.ScalarResources = map[corev1.ResourceName]int64{}
+	}
+	for rName, rQuant := range unmatchedHold.ScalarResources {
+		result.ScalarResources[rName] += rQuant
+	}
+	return result
+}
 
 func fitsNodeAndReservation(podRequestsResources, allPodsRequested, allRAllocated, preemptible, rRemained fwktype.Resource,
 	podRequests, preemptibleInRR corev1.ResourceList, pod *corev1.Pod, rInfo *frameworkext.ReservationInfo,

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -48,6 +48,8 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+
+	schedframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 var (
@@ -104,8 +106,19 @@ func (pm *PreemptionMgr) PostFilter(ctx context.Context, state fwktype.CycleStat
 		metrics.PreemptionAttempts.Inc()
 	}()
 
-	pe := preemption.NewEvaluator(Name, pm.fh, pm, false)
+	// Create a local handle with decorated snapshot for preemption visibility,
+	// scoped to this evaluator call to avoid global state mutation.
+	handle := fwktype.Handle(pm.fh)
+	decorators := pm.fh.GetPostFilterNodeDecorators()
+	if len(decorators) > 0 {
+		handle = frameworkext.NewPostFilterHandle(pm.fh, decorators, ctx, state, pod)
+	}
+
+	pe := preemption.NewEvaluator(Name, handle, pm, false)
 	pe.PodLister = newDelegatingPodLister(pm.podLister, pm.reservationLister, pod)
+	// wrap PreemptPod to handle reserve pod deletion via Reservation API
+	pe.PreemptPod = frameworkext.WrapPreemptPodForReservation(
+		pe.PreemptPod, pm.fh.KoordinatorClientSet())
 	klog.V(4).InfoS("Attempt to do reservation preemption in the PostFilter", "pod", klog.KObj(pod))
 
 	result, status := pe.Preempt(ctx, state, pod, m)
@@ -356,4 +369,29 @@ func getPreemptionArgs(pluginArgs *config.ReservationArgs) (*schedulerconfig.Def
 		MinCandidateNodesAbsolute:   pluginArgs.MinCandidateNodesAbsolute,
 	}
 	return preemptionArgs, nil
+}
+
+// DecorateNodeForPostFilter injects node-level reserve pods into nodeInfo
+// for preemption visibility.
+func (pl *Plugin) DecorateNodeForPostFilter(ctx context.Context, cycleState fwktype.CycleState,
+	pod *corev1.Pod, nodeInfo fwktype.NodeInfo) error {
+	if !pl.enableNodeLevelReservationLightweight {
+		return nil
+	}
+	nodeName := nodeInfo.Node().Name
+	rInfos := pl.reservationCache.ListMatchableReservationsOnNode(nodeName)
+	for _, rInfo := range rInfos {
+		if !rInfo.IsNodeLevel {
+			continue // Non-node-level reservations are still in NodeInfo (ledgered)
+		}
+		reservePod := rInfo.GetReservePod()
+		podInfo, err := schedframework.NewPodInfo(reservePod)
+		if err != nil {
+			klog.V(4).ErrorS(err, "Failed to create PodInfo for reserve pod",
+				"reservation", rInfo.GetName(), "node", nodeName)
+			continue
+		}
+		nodeInfo.AddPodInfo(podInfo)
+	}
+	return nil
 }

--- a/pkg/scheduler/plugins/reservation/preemption_test.go
+++ b/pkg/scheduler/plugins/reservation/preemption_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
@@ -753,4 +754,142 @@ func TestOrderedScoreFuncs(t *testing.T) {
 	// OrderedScoreFuncs should always return nil
 	result := pl.preemptionMgr.OrderedScoreFuncs(context.TODO(), nil)
 	assert.Nil(t, result)
+}
+
+func TestDecorateNodeForPostFilter(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	// node-level reservation
+	nodeLevelR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "node-level-r",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "tenant"}}},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("16"),
+								corev1.ResourceMemory: resource.MustParse("32Gi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	nodeLevelR.Status = schedulingv1alpha1.ReservationStatus{
+		Phase:    schedulingv1alpha1.ReservationAvailable,
+		NodeName: node.Name,
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("16"),
+			corev1.ResourceMemory: resource.MustParse("32Gi"),
+		},
+	}
+
+	// non-node-level reservation
+	nonNodeLevelR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "non-node-level-r",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "other"}}},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("4"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	nonNodeLevelR.Status = schedulingv1alpha1.ReservationStatus{
+		Phase:    schedulingv1alpha1.ReservationAvailable,
+		NodeName: node.Name,
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("4"),
+		},
+	}
+
+	t.Run("feature gate OFF: no-op", func(t *testing.T) {
+		suit := newPluginTestSuitWith(t, nil, []*corev1.Node{node}, func(args *config.ReservationArgs) {
+			args.EnablePreemption = true
+		})
+		p, err := suit.pluginFactory()
+		assert.NoError(t, err)
+		pl := p.(*Plugin)
+		pl.enableNodeLevelReservationLightweight = false
+		pl.reservationCache.updateReservation(nodeLevelR)
+
+		nodeInfo := framework.NewNodeInfo()
+		nodeInfo.SetNode(node)
+		podCountBefore := len(nodeInfo.Pods)
+
+		err = pl.DecorateNodeForPostFilter(context.Background(), nil, nil, nodeInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, podCountBefore, len(nodeInfo.Pods), "no pods should be added when FG is off")
+	})
+
+	t.Run("feature gate ON with node-level reservation: injects reserve pod", func(t *testing.T) {
+		suit := newPluginTestSuitWith(t, nil, []*corev1.Node{node}, func(args *config.ReservationArgs) {
+			args.EnablePreemption = true
+		})
+		p, err := suit.pluginFactory()
+		assert.NoError(t, err)
+		pl := p.(*Plugin)
+		pl.enableNodeLevelReservationLightweight = true
+		pl.reservationCache.updateReservation(nodeLevelR)
+
+		nodeInfo := framework.NewNodeInfo()
+		nodeInfo.SetNode(node)
+
+		err = pl.DecorateNodeForPostFilter(context.Background(), nil, nil, nodeInfo)
+		assert.NoError(t, err)
+		// Should have the reserve pod injected
+		assert.Equal(t, 1, len(nodeInfo.Pods), "reserve pod should be injected for node-level reservation")
+	})
+
+	t.Run("feature gate ON with non-node-level reservation: skips", func(t *testing.T) {
+		suit := newPluginTestSuitWith(t, nil, []*corev1.Node{node}, func(args *config.ReservationArgs) {
+			args.EnablePreemption = true
+		})
+		p, err := suit.pluginFactory()
+		assert.NoError(t, err)
+		pl := p.(*Plugin)
+		pl.enableNodeLevelReservationLightweight = true
+		pl.reservationCache.updateReservation(nonNodeLevelR)
+
+		nodeInfo := framework.NewNodeInfo()
+		nodeInfo.SetNode(node)
+		podCountBefore := len(nodeInfo.Pods)
+
+		err = pl.DecorateNodeForPostFilter(context.Background(), nil, nil, nodeInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, podCountBefore, len(nodeInfo.Pods), "non-node-level reservations should not be injected")
+	})
 }

--- a/pkg/scheduler/plugins/reservation/reservation_state.go
+++ b/pkg/scheduler/plugins/reservation/reservation_state.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 )
@@ -88,8 +89,15 @@ type nodeReservationState struct {
 	// selectedPreAllocatablePods represents the selected pre-allocated pods for the reservation.
 	selectedPreAllocatablePods []*corev1.Pod
 
+	isNodeLevel   bool // indicates node-level reservation lightweight path
 	preRestored   bool // restore in PreFilter or Filter
 	finalRestored bool // restore in Filter
+
+	// unmatchedHold is the total resources held by unmatched reservations on this node.
+	// node-level lightweight path: unmatchedHold = sum(R.Allocatable - R.Allocated) for each unmatched R.
+	// It is accounted for during Filter/filterWithReservations via addUnmatchedHoldToRequested(...)
+	// when evaluating requested resources, while leaving nodeInfo unchanged.
+	unmatchedHold *framework.Resource
 }
 
 type nodeDiagnosisState struct {

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -146,7 +146,8 @@ func (pl *Plugin) prepareMatchReservationStateForNormalPod(ctx context.Context, 
 	requiredNodeAffinity := nodeaffinity.GetRequiredNodeAffinity(pod)
 	podRequests := resourceapi.PodRequests(pod, resourceapi.PodResourcesOptions{})
 	// check if the node-level preRestore is required for all nodes in the BeforePreFilter
-	isNodePreRestoreRequired := isPodAllNodesPreRestoreRequired(pod)
+	// If NodeLevelReservationLightweight is enabled, we skip the preRestore since the reservations should not have any pod affinities.
+	isNodePreRestoreRequired := !pl.enableNodeLevelReservationLightweight && isPodAllNodesPreRestoreRequired(pod)
 
 	extender, _ := pl.handle.(frameworkext.FrameworkExtender)
 	if extender != nil { // global preRestore
@@ -206,23 +207,14 @@ func (pl *Plugin) prepareMatchReservationStateForNormalPod(ctx context.Context, 
 			taintsUnmatchedReasons:   map[string]int{},
 		}
 
-		status := pl.reservationCache.ForEachMatchableReservationOnNode(nodeName, func(rInfo *frameworkext.ReservationInfo) (bool, *fwktype.Status) {
-			// check if the reservation matches or can be ignored by the pod
+		rInfos := pl.reservationCache.ListMatchableReservationsOnNode(nodeName)
+		for _, rInfo := range rInfos {
 			isMatchedOrIgnored := checkReservationMatchedOrIgnored(pod, rInfo, diagnosisState, node, podRequests, reservationAffinity, exactMatchReservationSpec, affinityReservationName, isReservationIgnored)
-
-			if isMatchedOrIgnored { // reservation is matched or ignored for the pod
-				matchedOrIgnored = append(matchedOrIgnored, rInfo.Clone())
-			} else if rInfo.GetAllocatedPods() > 0 { // reservation is unmatched and not ignored
-				unmatched = append(unmatched, rInfo.Clone())
+			if isMatchedOrIgnored {
+				matchedOrIgnored = append(matchedOrIgnored, rInfo)
+			} else if rInfo.GetAllocatedPods() > 0 {
+				unmatched = append(unmatched, rInfo)
 			}
-
-			return true, nil
-		})
-		if !status.IsSuccess() {
-			err = status.AsError()
-			klog.ErrorS(err, "Failed to forEach reservations on node", "pod", klog.KObj(pod), "node", nodeName)
-			errCh.SendErrorWithCancel(err, cancel)
-			return
 		}
 
 		if diagnosisState.ignored > 0 || diagnosisState.ownerMatched > 0 {
@@ -247,25 +239,49 @@ func (pl *Plugin) prepareMatchReservationStateForNormalPod(ctx context.Context, 
 			unmatched:        unmatched,
 		}
 
-		// LazyReservationRestore indicates whether to restore reserved resources for the scheduling pod lazily.
-		// If it is disabled, the reserved resources are ensured to restore in BeforePreFilter/PreFilter phase, where all
-		// nodes related to reservations will restore reserved resources and refresh node snapshots in the next cycle.
-		// If it is enabled, the reserved resources are delayed to restore in Filter phase when the pod does not specify
-		// any pod affinity/anti-affinity or topologySpreadConstraints, it can reduce resource restoration overhead
-		// especially when there are a large scale of reservations. However, it does not ensure the correctness of the
-		// existing pod affinities, so it is disabled by default.
-		if !pl.enableLazyReservationRestore {
-			_, status = restoreReservationResourcesForNode(ctx, cycleState, extender, pod, nil, nodeInfo, nodeRState, skipRestoreNodeInfo)
-			if !status.IsSuccess() {
-				err = status.AsError()
-				errCh.SendErrorWithCancel(err, cancel)
-				return
+		// Check if all reservations on this node are node-level for lightweight path
+		isNodeLevel := pl.enableNodeLevelReservationLightweight &&
+			allNodeLevelReservation(matchedOrIgnored, unmatched)
+		if isNodeLevel {
+			nodeRState.isNodeLevel = true
+			// compute unmatchedHold instead of restoring.
+			// No fake pods in cache, so no restore (RemovePod/InvalidNodeInfo) is needed.
+			// The unmatchedHold will be explicitly added in Reservation Filter.
+			nodeRState.unmatchedHold = computeUnmatchedHold(unmatched)
+			// Still run extension RestoreReservation for DeviceShare/NUMA independent caches.
+			if extender != nil {
+				_, extStatus := extender.RunReservationExtensionRestoreReservation(
+					ctx, cycleState, pod, matchedOrIgnored, unmatched, nodeInfo)
+				if !extStatus.IsSuccess() {
+					err = extStatus.AsError()
+					errCh.SendErrorWithCancel(err, cancel)
+					return
+				}
 			}
-		} else if isNodePreRestoreRequired { // the pre restoration is required in the BeforePreFilter
-			err = preRestoreReservationResourcesForNode(logger, extender, pod, nil, nodeInfo, nodeRState, skipRestoreNodeInfo)
-			if err != nil {
-				errCh.SendErrorWithCancel(err, cancel)
-				return
+			nodeRState.preRestored = true   // no restore needed, mark both phases as complete
+			nodeRState.finalRestored = true // no more restore needed
+		} else {
+			// Baseline path: restore reserved resources in BeforePreFilter or Filter.
+			// LazyReservationRestore indicates whether to restore reserved resources for the scheduling pod lazily.
+			// If it is disabled, the reserved resources are ensured to restore in BeforePreFilter/PreFilter phase, where all
+			// nodes related to reservations will restore reserved resources and refresh node snapshots in the next cycle.
+			// If it is enabled, the reserved resources are delayed to restore in Filter phase when the pod does not specify
+			// any pod affinity/anti-affinity or topologySpreadConstraints, it can reduce resource restoration overhead
+			// especially when there are a large scale of reservations. However, it does not ensure the correctness of the
+			// existing pod affinities, so it is disabled by default.
+			if !pl.enableLazyReservationRestore {
+				_, status := restoreReservationResourcesForNode(ctx, cycleState, extender, pod, nil, nodeInfo, nodeRState, skipRestoreNodeInfo)
+				if !status.IsSuccess() {
+					err = status.AsError()
+					errCh.SendErrorWithCancel(err, cancel)
+					return
+				}
+			} else if isNodePreRestoreRequired { // the pre restoration is required in the BeforePreFilter
+				err = preRestoreReservationResourcesForNode(logger, extender, pod, nil, nodeInfo, nodeRState, skipRestoreNodeInfo)
+				if err != nil {
+					errCh.SendErrorWithCancel(err, cancel)
+					return
+				}
 			}
 		}
 
@@ -939,11 +955,46 @@ func getDiagnosisTaintKey(taint *corev1.Taint) string {
 	return fmt.Sprintf("{%s: %s}", taint.Key, taint.Value)
 }
 
+// allNodeLevelReservation checks if all reservations are node-level.
+func allNodeLevelReservation(matchedOrIgnored, unmatched []*frameworkext.ReservationInfo) bool {
+	for _, rInfo := range matchedOrIgnored {
+		if !rInfo.IsNodeLevel {
+			return false
+		}
+	}
+	for _, rInfo := range unmatched {
+		if !rInfo.IsNodeLevel {
+			return false
+		}
+	}
+	return len(matchedOrIgnored) > 0 || len(unmatched) > 0
+}
+
+// computeUnmatchedHold calculates the total resources held by unmatched reservations.
+// unmatchedHold = sum(R.Allocatable - R.Allocated) for each unmatched reservation.
+// This represents the resources "reserved" by unmatched reservations that are not available
+// for scheduling pods. It is used in the node-level lightweight path.
+func computeUnmatchedHold(unmatched []*frameworkext.ReservationInfo) *framework.Resource {
+	if len(unmatched) == 0 {
+		return nil
+	}
+	hold := &framework.Resource{}
+	for _, rInfo := range unmatched {
+		// hold += max(Allocatable - Allocated, 0) per resource
+		diff := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, rInfo.Allocated)
+		hold.Add(diff)
+	}
+	return hold
+}
+
 func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) (*corev1.Pod, fwktype.NodeInfo, bool, *fwktype.Status) {
+	nodeName := nodeInfo.Node().Name
+
 	// Both the reserve pod or the normal pod should consider the nominated reserve pods.
-	nominatedReservationInfos := pl.nominator.NominatedReservePodForNode(nodeInfo.Node().Name)
+	nominatedReservationInfos := pl.nominator.NominatedReservePodForNode(nodeName)
+
 	if len(nominatedReservationInfos) == 0 {
-		return pod, nodeInfo, false, nil
+		return pod, nodeInfo, false, nil // Zero overhead fast path
 	}
 
 	if nodeInfo.Node() == nil {
@@ -951,10 +1002,12 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState fwktype.CycleStat
 		return pod, nodeInfo, false, nil
 	}
 
+	// Create snapshot only when needed
 	nodeInfoOut := nodeInfo.Snapshot()
 	// Ignore the nominated reservations of the same job
 	podsOfSameJob := frameworkext.GetNominatedPodsOfTheSameJob(cycleState)
 
+	// Existing: add nominated reserve pods.
 	for _, rInfo := range nominatedReservationInfos {
 		if schedulingcorev1.PodPriority(rInfo.Pod) >= schedulingcorev1.PodPriority(pod) && rInfo.Pod.UID != pod.UID &&
 			(podsOfSameJob == nil || !podsOfSameJob.Has(string(rInfo.Pod.UID))) {

--- a/pkg/scheduler/plugins/reservation/transformer_test.go
+++ b/pkg/scheduler/plugins/reservation/transformer_test.go
@@ -34,9 +34,13 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/hinter"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 func TestRestoreReservation(t *testing.T) {
@@ -2500,6 +2504,948 @@ func TestAfterPreFilter_WithSchedulingHint(t *testing.T) {
 			for _, nodeName := range tt.expectedNodes {
 				_, exists := state.nodeReservationStates[nodeName]
 				assert.True(t, exists, "node %s should be processed", nodeName)
+			}
+		})
+	}
+}
+
+func Test_allNodeLevelReservation(t *testing.T) {
+	makeRI := func(isNodeLevel bool) *frameworkext.ReservationInfo {
+		return &frameworkext.ReservationInfo{IsNodeLevel: isNodeLevel}
+	}
+
+	tests := []struct {
+		name             string
+		matchedOrIgnored []*frameworkext.ReservationInfo
+		unmatched        []*frameworkext.ReservationInfo
+		want             bool
+	}{
+		{
+			name:             "both empty => false",
+			matchedOrIgnored: nil,
+			unmatched:        nil,
+			want:             false,
+		},
+		{
+			name:             "all node-level in matchedOrIgnored only",
+			matchedOrIgnored: []*frameworkext.ReservationInfo{makeRI(true), makeRI(true)},
+			unmatched:        nil,
+			want:             true,
+		},
+		{
+			name:             "all node-level in unmatched only",
+			matchedOrIgnored: nil,
+			unmatched:        []*frameworkext.ReservationInfo{makeRI(true)},
+			want:             true,
+		},
+		{
+			name:             "all node-level across both slices",
+			matchedOrIgnored: []*frameworkext.ReservationInfo{makeRI(true)},
+			unmatched:        []*frameworkext.ReservationInfo{makeRI(true)},
+			want:             true,
+		},
+		{
+			name:             "one non-node-level in matchedOrIgnored",
+			matchedOrIgnored: []*frameworkext.ReservationInfo{makeRI(true), makeRI(false)},
+			unmatched:        []*frameworkext.ReservationInfo{makeRI(true)},
+			want:             false,
+		},
+		{
+			name:             "one non-node-level in unmatched",
+			matchedOrIgnored: []*frameworkext.ReservationInfo{makeRI(true)},
+			unmatched:        []*frameworkext.ReservationInfo{makeRI(false)},
+			want:             false,
+		},
+		{
+			name:             "single non-node-level in matchedOrIgnored",
+			matchedOrIgnored: []*frameworkext.ReservationInfo{makeRI(false)},
+			unmatched:        nil,
+			want:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allNodeLevelReservation(tt.matchedOrIgnored, tt.unmatched)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestBeforePreFilter_NodeLevelReservationLightweight verifies that when
+// NodeLevelReservationLightweight is enabled and ALL reservations on a node are
+// node-level, BeforePreFilter:
+//  1. marks nodeRState.isNodeLevel = true
+//  2. skips the eager restore (skipRestoreNodeInfo || isNodeLevel path)
+func TestBeforePreFilter_NodeLevelReservationLightweight(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	// node-level reservation that has an allocated pod
+	nodeLevelReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "node-level-r",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("8"),
+									corev1.ResourceMemory: resource.MustParse("16Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	nodeLevelReservation.Status = schedulingv1alpha1.ReservationStatus{
+		Phase:    schedulingv1alpha1.ReservationAvailable,
+		NodeName: node.Name,
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("16Gi"),
+		},
+	}
+
+	// a pod that was assigned to the node-level reservation
+	allocatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(), Name: "allocated-pod", Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Containers: []corev1.Container{
+				{Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				}},
+			},
+		},
+	}
+
+	allPods := []*corev1.Pod{reservationutil.NewReservePod(nodeLevelReservation), allocatedPod}
+
+	tests := []struct {
+		name              string
+		enableFeatureGate bool
+		wantIsNodeLevel   bool
+		// should NOT be pre-restored when FG is on (restore is deferred to BeforeFilter)
+		wantPreRestored bool
+	}{
+		{
+			name:              "feature gate ON: isNodeLevel=true, skip nodeInfo restore",
+			enableFeatureGate: true,
+			wantIsNodeLevel:   true,
+			wantPreRestored:   true, // preRestore runs but skips nodeInfo (lightweight path)
+		},
+		{
+			name:              "feature gate OFF: isNodeLevel=false, eager restore happens",
+			enableFeatureGate: false,
+			wantIsNodeLevel:   false,
+			wantPreRestored:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.NodeLevelReservationLightweight, tt.enableFeatureGate)()
+
+			suit := newPluginTestSuitWith(t, allPods, []*corev1.Node{node})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+			pl.enableNodeLevelReservationLightweight = tt.enableFeatureGate
+			pl.enableLazyReservationRestore = false // eager mode
+
+			pl.reservationCache.updateReservation(nodeLevelReservation)
+			pl.reservationCache.addPod(nodeLevelReservation.UID, allocatedPod)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				}}},
+			}
+
+			nodeInfoBefore, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+			assert.NoError(t, err)
+			beforeCPU := nodeInfoBefore.(*framework.NodeInfo).Requested.MilliCPU
+
+			cycleState := framework.NewCycleState()
+			_, _, status := pl.BeforePreFilter(context.TODO(), cycleState, pod)
+			assert.True(t, status.IsSuccess())
+
+			state := getStateData(cycleState)
+			nodeRState := state.nodeReservationStates[node.Name]
+			assert.NotNil(t, nodeRState)
+			assert.Equal(t, tt.wantIsNodeLevel, nodeRState.isNodeLevel)
+			assert.Equal(t, tt.wantPreRestored, nodeRState.preRestored)
+
+			if tt.enableFeatureGate {
+				// nodeInfo should NOT be modified in eager mode when isNodeLevel=true
+				nodeInfoAfter, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+				assert.NoError(t, err)
+				assert.Equal(t, beforeCPU, nodeInfoAfter.(*framework.NodeInfo).Requested.MilliCPU,
+					"nodeInfo should not be modified for node-level reservation in BeforePreFilter")
+			}
+		})
+	}
+}
+
+// TestBeforeFilter_NodeLevelRestore verifies that BeforeFilter in node-level path
+// does NOT modify nodeInfo. The unmatchedHold accounting is moved to Reservation Filter.
+//   - no fake reserve pods in cache/nodeInfo, only real pods
+//   - BeforeFilter no longer injects unmatchedHold; it only handles nominated reserve pods
+func TestBeforeFilter_NodeLevelRestore(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	// ---- matched node-level reservation (8C16Gi) ----
+	matchedR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "matched-node-level",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				}}}},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationAvailable, NodeName: node.Name,
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	}
+
+	// ---- unmatched node-level reservation (12C24Gi) with 4C8Gi allocated pod ----
+	unmatchedR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "unmatched-node-level",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("12"),
+						corev1.ResourceMemory: resource.MustParse("24Gi"),
+					},
+				}}}},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationAvailable, NodeName: node.Name,
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("12"),
+				corev1.ResourceMemory: resource.MustParse("24Gi"),
+			},
+		},
+	}
+
+	unmatchedAllocatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: uuid.NewUUID(), Name: "unmatched-alloc-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			}}},
+		},
+	}
+
+	// snapshot contains only real pods, no fake reserve pods
+	allPods := []*corev1.Pod{
+		unmatchedAllocatedPod,
+	}
+
+	suit := newPluginTestSuitWith(t, allPods, []*corev1.Node{node})
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	pl.enableNodeLevelReservationLightweight = true
+	pl.enableLazyReservationRestore = false
+
+	pl.reservationCache.updateReservation(matchedR)
+	pl.reservationCache.updateReservation(unmatchedR)
+	pl.reservationCache.addPod(unmatchedR.UID, unmatchedAllocatedPod)
+
+	// Confirm both rInfos are marked node-level
+	matchedRInfo := pl.reservationCache.getReservationInfoByUID(matchedR.UID)
+	assert.NotNil(t, matchedRInfo)
+	assert.True(t, matchedRInfo.IsNodeLevel)
+	unmatchedRInfo := pl.reservationCache.getReservationInfoByUID(unmatchedR.UID)
+	assert.NotNil(t, unmatchedRInfo)
+	assert.True(t, unmatchedRInfo.IsNodeLevel)
+
+	// ---- Run BeforePreFilter to build state ----
+	schedulingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		}}},
+	}
+	cycleState := framework.NewCycleState()
+	_, _, status := pl.BeforePreFilter(context.TODO(), cycleState, schedulingPod)
+	assert.True(t, status.IsSuccess())
+
+	state := getStateData(cycleState)
+	nodeRState := state.nodeReservationStates[node.Name]
+	assert.NotNil(t, nodeRState)
+	assert.True(t, nodeRState.isNodeLevel, "nodeRState should be node-level")
+	assert.True(t, nodeRState.preRestored, "node-level path marks preRestored=true")
+
+	// ---- Snapshot BEFORE BeforeFilter: contains only real pods ----
+	nodeInfoBefore, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+	assert.NoError(t, err)
+	// total CPU = unmatchedAllocatedPod(4) = 4C (no fake reserve pods)
+	assert.Equal(t, int64(4000), nodeInfoBefore.(*framework.NodeInfo).Requested.MilliCPU)
+
+	// ---- Run BeforeFilter ----
+	_, nodeInfoOut, modified, filterStatus := pl.BeforeFilter(context.TODO(), cycleState, schedulingPod, nodeInfoBefore)
+	assert.True(t, filterStatus.IsSuccess())
+	// BeforeFilter no longer modifies nodeInfo for unmatchedHold injection.
+	// Without nominated reserve pods, modified should be false.
+	assert.False(t, modified, "BeforeFilter should NOT modify nodeInfo (unmatchedHold moved to Filter)")
+
+	// nodeInfoOut should be the same as nodeInfoBefore (not modified)
+	outNI, ok := nodeInfoOut.(*framework.NodeInfo)
+	assert.True(t, ok)
+
+	// snapshot Requested remains unchanged (only real pods: 4C)
+	assert.Equal(t, int64(4000), outNI.Requested.MilliCPU,
+		"BeforeFilter should NOT inject unmatchedHold into snapshot Requested")
+}
+
+// TestBeforeFilter_NodeLevelRestore_FGDisabled verifies that when the feature gate is
+// disabled, BeforeFilter does NOT perform the V2 node-level restore (isNodeLevel stays false).
+func TestBeforeFilter_NodeLevelRestore_FGDisabled(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	nodeLevelR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(), Name: "r1",
+			Labels: map[string]string{apiext.LabelReservationLevel: apiext.ReservationLevelNode},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners:       []schedulingv1alpha1.ReservationOwner{{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}}},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+					},
+				}}},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationAvailable, NodeName: node.Name,
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+		},
+	}
+
+	suit := newPluginTestSuitWith(t, []*corev1.Pod{reservationutil.NewReservePod(nodeLevelR)}, []*corev1.Node{node})
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	pl.enableNodeLevelReservationLightweight = false // FG disabled
+	pl.enableLazyReservationRestore = false
+
+	pl.reservationCache.updateReservation(nodeLevelR)
+
+	schedulingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		}}},
+	}
+	cycleState := framework.NewCycleState()
+	_, _, status := pl.BeforePreFilter(context.TODO(), cycleState, schedulingPod)
+	assert.True(t, status.IsSuccess())
+
+	// FG=off => isNodeLevel must be false regardless of reservation labels
+	state := getStateData(cycleState)
+	nodeRState := state.nodeReservationStates[node.Name]
+	assert.NotNil(t, nodeRState)
+	assert.False(t, nodeRState.isNodeLevel, "isNodeLevel must be false when feature gate is disabled")
+
+	nodeInfo, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+	assert.NoError(t, err)
+
+	// With FG off, no node-level restore in BeforeFilter; nominated infos empty => returns false
+	_, _, modified, filterStatus := pl.BeforeFilter(context.TODO(), cycleState, schedulingPod, nodeInfo)
+	assert.True(t, filterStatus.IsSuccess())
+	assert.False(t, modified, "no modification expected when FG is disabled")
+}
+
+func Test_computeUnmatchedHold(t *testing.T) {
+	tests := []struct {
+		name      string
+		unmatched []*frameworkext.ReservationInfo
+		wantNil   bool
+		wantCPU   int64
+		wantMem   int64
+		wantGPU   int64
+	}{
+		{
+			name:      "empty unmatched list returns nil",
+			unmatched: nil,
+			wantNil:   true,
+		},
+		{
+			name: "single unmatched with no allocated pods (full hold)",
+			unmatched: []*frameworkext.ReservationInfo{
+				{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("0"),
+						corev1.ResourceMemory: resource.MustParse("0"),
+					},
+				},
+			},
+			wantCPU: 8000,
+			wantMem: 16 * 1024 * 1024 * 1024,
+		},
+		{
+			name: "single unmatched with partial allocated",
+			unmatched: []*frameworkext.ReservationInfo{
+				{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+			},
+			wantCPU: 5000,
+			wantMem: 8 * 1024 * 1024 * 1024,
+		},
+		{
+			name: "multiple unmatched with scalar resources (GPU)",
+			unmatched: []*frameworkext.ReservationInfo{
+				{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("4"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+					},
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("2"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					},
+				},
+				{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("4"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
+					},
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("4"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+					},
+				},
+			},
+			wantCPU: 2000, // (4-2) + (4-4) = 2
+			wantGPU: 3,    // (2-1) + (4-2) = 3
+		},
+		{
+			name: "allocated exceeds allocatable (clamped to zero)",
+			unmatched: []*frameworkext.ReservationInfo{
+				{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("5"),
+					},
+				},
+			},
+			wantCPU: 0, // max(2-5, 0) = 0
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeUnmatchedHold(tt.unmatched)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.wantCPU, got.MilliCPU, "MilliCPU mismatch")
+			if tt.wantMem > 0 {
+				assert.Equal(t, tt.wantMem, got.Memory, "Memory mismatch")
+			}
+			if tt.wantGPU > 0 {
+				gpuQuant := got.ScalarResources[corev1.ResourceName("nvidia.com/gpu")]
+				assert.Equal(t, tt.wantGPU, gpuQuant, "GPU scalar mismatch")
+			}
+		})
+	}
+}
+
+func Test_addUnmatchedHoldToRequested(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested fwktype.Resource
+		hold      *framework.Resource
+		wantCPU   int64
+		wantMem   int64
+		wantGPU   int64
+	}{
+		{
+			name: "normal framework.Resource addition",
+			requested: &framework.Resource{
+				MilliCPU: 4000,
+				Memory:   8 * 1024 * 1024 * 1024,
+			},
+			hold: &framework.Resource{
+				MilliCPU: 2000,
+				Memory:   4 * 1024 * 1024 * 1024,
+			},
+			wantCPU: 6000,
+			wantMem: 12 * 1024 * 1024 * 1024,
+		},
+		{
+			name:      "non-Resource type falls back to clone of hold",
+			requested: dummyResource,
+			hold: &framework.Resource{
+				MilliCPU: 3000,
+				Memory:   2 * 1024 * 1024 * 1024,
+			},
+			wantCPU: 3000,
+			wantMem: 2 * 1024 * 1024 * 1024,
+		},
+		{
+			name: "scalar resources (GPU) merged correctly",
+			requested: &framework.Resource{
+				MilliCPU:        2000,
+				ScalarResources: map[corev1.ResourceName]int64{"nvidia.com/gpu": 1},
+			},
+			hold: &framework.Resource{
+				MilliCPU:        1000,
+				ScalarResources: map[corev1.ResourceName]int64{"nvidia.com/gpu": 3},
+			},
+			wantCPU: 3000,
+			wantGPU: 4,
+		},
+		{
+			name: "hold has scalar resources but requested does not",
+			requested: &framework.Resource{
+				MilliCPU: 2000,
+			},
+			hold: &framework.Resource{
+				MilliCPU:        1000,
+				ScalarResources: map[corev1.ResourceName]int64{"nvidia.com/gpu": 2},
+			},
+			wantCPU: 3000,
+			wantGPU: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addUnmatchedHoldToRequested(tt.requested, tt.hold)
+			assert.Equal(t, tt.wantCPU, got.MilliCPU)
+			if tt.wantMem > 0 {
+				assert.Equal(t, tt.wantMem, got.Memory)
+			}
+			if tt.wantGPU > 0 {
+				assert.Equal(t, tt.wantGPU, got.ScalarResources[corev1.ResourceName("nvidia.com/gpu")])
+			}
+		})
+	}
+}
+
+func TestNodeLevelLightweight_FilterResourceAccounting(t *testing.T) {
+	// This test validates the end-to-end resource accounting correctness for the
+	// node-level lightweight path across key scheduling scenarios:
+	// (a) matched pod uses reservation resources without over-commit
+	// (b) unmatched pod is correctly blocked by unmatchedHold
+	// (c) existing allocated pods are counted properly
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	// Node-level reservation: 16C 32Gi, with an allocated pod using 8C 16Gi
+	nodeLevelR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "node-level-r",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "tenant-a"},
+					},
+				},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("16"),
+									corev1.ResourceMemory: resource.MustParse("32Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	nodeLevelR.Status = schedulingv1alpha1.ReservationStatus{
+		Phase:    schedulingv1alpha1.ReservationAvailable,
+		NodeName: node.Name,
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("16"),
+			corev1.ResourceMemory: resource.MustParse("32Gi"),
+		},
+	}
+
+	// allocated pod inside the reservation
+	allocatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(), Name: "allocated-pod", Namespace: "default",
+			Labels: map[string]string{"app": "tenant-a"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Containers: []corev1.Container{
+				{Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				}},
+			},
+		},
+	}
+
+	// regular pod NOT matching the reservation
+	regularPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(), Name: "regular-pod", Namespace: "default",
+			Labels: map[string]string{"app": "other"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Containers: []corev1.Container{
+				{Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				}},
+			},
+		},
+	}
+
+	// In the lightweight path, the reserve pod is NOT in the scheduler cache.
+	// Only regular pods and allocated pods are in the cache.
+	allPods := []*corev1.Pod{allocatedPod, regularPod}
+
+	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.NodeLevelReservationLightweight, true)()
+
+	suit := newPluginTestSuitWith(t, allPods, []*corev1.Node{node})
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	pl.enableNodeLevelReservationLightweight = true
+	pl.enableLazyReservationRestore = false
+
+	pl.reservationCache.updateReservation(nodeLevelR)
+	pl.reservationCache.addPod(nodeLevelR.UID, allocatedPod)
+
+	// Verify: unmatchedHold = Allocatable - Allocated = (16C-8C, 32Gi-16Gi) = (8C, 16Gi)
+	rInfos := pl.reservationCache.ListMatchableReservationsOnNode(node.Name)
+	assert.Len(t, rInfos, 1)
+	rInfo := rInfos[0]
+
+	unmatchedHold := computeUnmatchedHold([]*frameworkext.ReservationInfo{rInfo})
+	assert.NotNil(t, unmatchedHold)
+	expectedHoldCPU := quotav1.SubtractWithNonNegativeResult(rInfo.Allocatable, rInfo.Allocated)
+	assert.Equal(t, expectedHoldCPU.Cpu().MilliValue(), unmatchedHold.MilliCPU)
+
+	// Verify: the holds sum up correctly with regular pod requests
+	// nodeInfo.Requested (without fake pod) should include allocatedPod + regularPod
+	// The formula: available = nodeAlloc - (nodeInfo.Requested + unmatchedHold)
+	// = 32C - (8C + 4C + 8C) = 12C for regular pods to use from non-reserved portion
+	nodeInfo, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+	assert.NoError(t, err)
+
+	requestedWithHold := addUnmatchedHoldToRequested(nodeInfo.GetRequested(), unmatchedHold)
+	// nodeInfo.Requested should NOT include the reserve pod (lightweight path)
+	// It should include: allocatedPod(8C) + regularPod(4C) = 12C
+	// With unmatchedHold(8C): total = 20C
+	// Available = 32C - 20C = 12C (this is the non-reserved capacity)
+	nodeAllocCPU := nodeInfo.GetAllocatable().(*framework.Resource).MilliCPU
+	availableCPU := nodeAllocCPU - requestedWithHold.MilliCPU
+	assert.Equal(t, int64(12000), availableCPU, "available CPU for non-reserved pods should be 12C")
+}
+
+// TestNodeLevelLightweight_FilterScenarios validates the Filter phase correctness
+// for the node-level lightweight path across key scheduling scenarios:
+// (a) matched pod uses reservation resources without over-commit
+// (b) unmatched pod correctly blocked when node is full considering unmatchedHold
+// (c) pod requesting too much for the reservation fails filter
+func TestNodeLevelLightweight_FilterScenarios(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("100"),
+				corev1.ResourceCPU:    resource.MustParse("32"),
+				corev1.ResourceMemory: resource.MustParse("64Gi"),
+			},
+		},
+	}
+
+	// Node-level reservation: 16C 32Gi, with 8C 16Gi already allocated
+	nodeLevelR := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "node-level-r",
+			Labels: map[string]string{
+				apiext.LabelReservationLevel: apiext.ReservationLevelNode,
+			},
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			AllocateOnce: ptr.To[bool](false),
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "tenant-a"}}},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("16"),
+								corev1.ResourceMemory: resource.MustParse("32Gi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	nodeLevelR.Status = schedulingv1alpha1.ReservationStatus{
+		Phase:    schedulingv1alpha1.ReservationAvailable,
+		NodeName: node.Name,
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("16"),
+			corev1.ResourceMemory: resource.MustParse("32Gi"),
+		},
+	}
+
+	allocatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(), Name: "allocated-pod", Namespace: "default",
+			Labels: map[string]string{"app": "tenant-a"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		wantSuccess bool
+	}{
+		{
+			name: "matched pod within reservation available: passes",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "tenant-a"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("8Gi"),
+							},
+						},
+					}},
+				},
+			},
+			wantSuccess: true, // 4C <= 8C (remaining in reservation)
+		},
+		{
+			name: "matched pod uses reservation resources correctly",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "tenant-a"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("8"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+						},
+					}},
+				},
+			},
+			wantSuccess: true, // 8C == 8C (exactly fills reservation)
+		},
+		{
+			name: "unmatched pod with no affinity: passes (NodeResourceFit handles accounting)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "other-app"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+						},
+					}},
+				},
+			},
+			wantSuccess: true, // no matched reservations => Filter returns nil (NodeResourceFit handles full check)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.NodeLevelReservationLightweight, true)()
+
+			// In lightweight path, reserve pod is NOT in cache
+			allPods := []*corev1.Pod{allocatedPod}
+
+			suit := newPluginTestSuitWith(t, allPods, []*corev1.Node{node})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+			pl.enableNodeLevelReservationLightweight = true
+			pl.enableLazyReservationRestore = false
+
+			pl.reservationCache.updateReservation(nodeLevelR)
+			pl.reservationCache.addPod(nodeLevelR.UID, allocatedPod)
+
+			cycleState := framework.NewCycleState()
+
+			// Run BeforePreFilter
+			_, _, preFilterStatus := pl.BeforePreFilter(context.TODO(), cycleState, tt.pod)
+			assert.True(t, preFilterStatus.IsSuccess(), "BeforePreFilter should succeed")
+
+			// Run BeforeFilter
+			nodeInfo, err := suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+			assert.NoError(t, err)
+			_, _, _, beforeFilterStatus := pl.BeforeFilter(context.TODO(), cycleState, tt.pod, nodeInfo)
+			assert.True(t, beforeFilterStatus.IsSuccess(), "BeforeFilter should succeed")
+
+			// Re-fetch nodeInfo after BeforeFilter (may have been snapshotted)
+			nodeInfo, err = suit.fw.SnapshotSharedLister().NodeInfos().Get(node.Name)
+			assert.NoError(t, err)
+
+			// Run Filter
+			filterStatus := pl.Filter(context.TODO(), cycleState, tt.pod, nodeInfo)
+			if tt.wantSuccess {
+				assert.True(t, filterStatus.IsSuccess(), "Filter should pass, got: %v", filterStatus.Message())
+			} else {
+				assert.False(t, filterStatus.IsSuccess(), "Filter should fail")
 			}
 		})
 	}

--- a/pkg/util/reservation/reservation.go
+++ b/pkg/util/reservation/reservation.go
@@ -580,13 +580,16 @@ func (s *RequiredReservationAffinity) MatchAffinity(node *corev1.Node) bool {
 	if s == nil {
 		return true
 	}
+	// try the lightweight nodeSelector match first
+	if s.nodeSelector != nil {
+		if !s.nodeSelector.Match(node) {
+			return false
+		}
+	}
 	if s.labelSelector != nil {
 		if !s.labelSelector.Matches(labels.Set(node.Labels)) {
 			return false
 		}
-	}
-	if s.nodeSelector != nil {
-		return s.nodeSelector.Match(node)
 	}
 	return true
 }

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -1171,3 +1171,135 @@ func TestTolerateUnschedulable(t *testing.T) {
 		})
 	}
 }
+
+// TestMatchAffinity_NodeSelectorShortCircuit verifies that nodeSelector is evaluated
+// BEFORE labelSelector, so an early mismatch short-circuits and avoids unnecessary
+// labelSelector matching.
+func TestMatchAffinity_NodeSelectorShortCircuit(t *testing.T) {
+	makePodWithAffinity := func(affinity *apiext.ReservationAffinity) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-pod",
+				Annotations: map[string]string{},
+			},
+		}
+		if affinity != nil {
+			_ = apiext.SetReservationAffinity(pod, affinity)
+		}
+		return pod
+	}
+
+	nodeA := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"zone": "a", "res-label": "v1"},
+		},
+	}
+	nodeB := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-b",
+			Labels: map[string]string{"zone": "b", "res-label": "v1"},
+		},
+	}
+
+	// affinity with both nodeSelector (zone=a) and labelSelector (res-label=v1)
+	affinityBoth := &apiext.ReservationAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &apiext.ReservationAffinitySelector{
+			ReservationSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"a"},
+						},
+					},
+				},
+			},
+		},
+		ReservationSelector: map[string]string{"res-label": "v1"},
+	}
+
+	// affinity with only labelSelector (res-label=v1)
+	affinityLabelOnly := &apiext.ReservationAffinity{
+		ReservationSelector: map[string]string{"res-label": "v1"},
+	}
+
+	// affinity with only nodeSelector (zone=a)
+	affinityNodeOnly := &apiext.ReservationAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &apiext.ReservationAffinitySelector{
+			ReservationSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"a"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		node      *corev1.Node
+		wantMatch bool
+	}{
+		{
+			name:      "nodeSelector match, labelSelector match => true",
+			pod:       makePodWithAffinity(affinityBoth),
+			node:      nodeA,
+			wantMatch: true,
+		},
+		{
+			name:      "nodeSelector mismatch (short-circuit) => false",
+			pod:       makePodWithAffinity(affinityBoth),
+			node:      nodeB,
+			wantMatch: false,
+		},
+		{
+			name:      "labelSelector only, match => true",
+			pod:       makePodWithAffinity(affinityLabelOnly),
+			node:      nodeA,
+			wantMatch: true,
+		},
+		{
+			name: "labelSelector only, mismatch => false",
+			pod:  makePodWithAffinity(affinityLabelOnly),
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-x", Labels: map[string]string{"res-label": "v2"}},
+			},
+			wantMatch: false,
+		},
+		{
+			name:      "nodeSelector only, match => true",
+			pod:       makePodWithAffinity(affinityNodeOnly),
+			node:      nodeA,
+			wantMatch: true,
+		},
+		{
+			name:      "nodeSelector only, mismatch => false",
+			pod:       makePodWithAffinity(affinityNodeOnly),
+			node:      nodeB,
+			wantMatch: false,
+		},
+		{
+			name:      "no affinity => always true",
+			pod:       makePodWithAffinity(nil),
+			node:      nodeA,
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ra, err := GetRequiredReservationAffinity(tt.pod)
+			assert.NoError(t, err)
+			got := ra.MatchAffinity(tt.node)
+			assert.Equal(t, tt.wantMatch, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: For reservations targeting the node-level (i.e. no more reservations co-exist on the same node), relax the resource restoration of reserved resources to improve scheduling throughput.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

For the PostFilter plugins that expect to preempt reservations, the node-level reservations are not stored in the nodeInfo anymore. Thus, we introduce a helper named `PostFilterHandlerWrapper` to decorate the snapshotLister for add/remove reserve pods.

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
