### PR TITLE
scheduler: fix tryAllocateFromNode

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -560,8 +560,18 @@ func (p *Plugin) FilterNominateReservation(ctx context.Context, cycleState fwkty
 		return nil
 	}
 
-	_, status = tryAllocateFromReusable(p.resourceManager, restoreState, resourceOptions, map[types.UID]reusableAlloc{reservationInfo.UID(): matchedReservationAlloc}, pod, node)
-	return status
+	result, status := tryAllocateFromReusable(p.resourceManager, restoreState, resourceOptions, map[types.UID]reusableAlloc{reservationInfo.UID(): matchedReservationAlloc}, pod, node)
+	if !status.IsSuccess() {
+		return status
+	}
+	if result == nil {
+		// tryAllocateFromReusable returned nil/nil ("no reservation satisfied, but fallback allowed").
+		// In the FilterNominateReservation context, this means the reservation's NUMA scope is
+		// incompatible with the current best topology hint; treat it as unschedulable so this
+		// reservation is excluded from the nominator candidate pool.
+		return fwktype.NewStatus(fwktype.Unschedulable, "reservation NUMA scope is incompatible with the best topology hint")
+	}
+	return nil
 }
 
 func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodeName string) *fwktype.Status {
@@ -813,7 +823,13 @@ func tryAllocateFromNode(
 		}()
 	} else {
 		resourceOptions.requiredResources = nil
-		resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed)
+		// Return both unmatched and matched reservation owner usage to eliminate double accounting.
+		// For each reservation, the fake reservation pod occupies R.Spec.Resources while its owner
+		// pods are independently accounted in the node cache. Only the second-layer owner usage
+		// (already consumed inside the reservation) should be returned here; R.Spec.Resources remain
+		// deducted as they are still reserved from the pod's perspective when going through the
+		// node-free path, so the pod cannot steal any reservation capacity.
+		resourceOptions.reusableResources = appendAllocated(nil, restoreState.mergedUnmatchedUsed, restoreState.mergedMatchedAllocated)
 		resourceOptions.preferredCPUs = cpuset.NewCPUSet()
 		resourceOptions.preemptibleCPUs = cpuset.NewCPUSet()
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -1258,6 +1258,8 @@ func TestPlugin_FilterNominateReservation(t *testing.T) {
 	testState.Write(stateKey, &preFilterState{
 		skip: false,
 	})
+	node0mask, _ := bitmask.NewBitMask(0)
+
 	type fields struct {
 		nodes []*corev1.Node
 	}
@@ -1268,11 +1270,19 @@ func TestPlugin_FilterNominateReservation(t *testing.T) {
 		nodeName        string
 	}
 	tests := []struct {
-		name   string
+		name string
+		// fields/args are used by the simple early-return cases that bypass full construction.
 		fields fields
 		args   args
-		want   *fwktype.Status
+		// The following fields drive full NUMA-aware construction (used when state != nil).
+		state                     *preFilterState
+		rAlloc                    *reusableAlloc
+		reservationAllocatePolicy schedulingv1alpha1.ReservationAllocatePolicy
+		cpuTopology               *CPUTopology
+		numaAffinity              bitmask.BitMask
+		want                      *fwktype.Status
 	}{
+		// ---- early-return cases (no node / state issues) ----
 		{
 			name: "missing preFilterState",
 			args: args{
@@ -1295,15 +1305,188 @@ func TestPlugin_FilterNominateReservation(t *testing.T) {
 			},
 			want: fwktype.NewStatus(fwktype.Error, `getting nil node "test-node" from Snapshot`),
 		},
+		// ---- NUMA compatibility cases ----
+		{
+			// BestHint=NUMA0, R's remained is entirely on NUMA0.
+			// The second tryAllocateFromReusable Allocate call uses requiredResources={NUMA0:...}
+			// which is compatible with hint=NUMA0 → allocation succeeds → result != nil → pass.
+			name: "NUMA-compatible R passes filter (no reservation-affinity)",
+			state: &preFilterState{
+				podNUMATopologyPolicy: extension.NUMATopologyPolicyRestricted,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			rAlloc: &reusableAlloc{
+				allocatable: map[int]corev1.ResourceList{
+					0: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+				remained: map[int]corev1.ResourceList{
+					0: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			numaAffinity:              node0mask,
+			want:                      nil,
+		},
+		{
+			// Regression: before the fix, FilterNominateReservation returned nil (pass) when the
+			// reservation's NUMA scope was incompatible with the pod's BestHint but
+			// requiredFromReservation was false (no reservation-affinity). This caused the nominator
+			// to include the mismatched reservation as a candidate; when selected by scoring, Reserve
+			// then failed at hint-vs-nominated-NUMA validation.
+			//
+			// Root cause: tryAllocateFromReusable returned (nil, nil) on the fallback path
+			// (requiredFromReservation=false), which FilterNominateReservation previously treated as
+			// "pass". After the fix, result==nil is treated as Unschedulable.
+			name: "NUMA-incompatible R blocked from nominator without reservation-affinity (regression fix)",
+			state: &preFilterState{
+				podNUMATopologyPolicy: extension.NUMATopologyPolicyRestricted,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				// hasReservationAffinity=false (zero value) → requiredFromReservation=false
+			},
+			rAlloc: &reusableAlloc{
+				allocatable: map[int]corev1.ResourceList{
+					1: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+				remained: map[int]corev1.ResourceList{
+					1: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			numaAffinity:              node0mask,
+			want:                      fwktype.NewStatus(fwktype.Unschedulable, "reservation NUMA scope is incompatible with the best topology hint"),
+		},
+		{
+			// Baseline: with reservation-affinity, requiredFromReservation=true, so
+			// tryAllocateFromReusable already returned Unschedulable before the fix. Verify this
+			// path still works correctly after the fix.
+			name: "NUMA-incompatible R blocked from nominator with reservation-affinity (baseline)",
+			state: &preFilterState{
+				podNUMATopologyPolicy: extension.NUMATopologyPolicyRestricted,
+				requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				hasReservationAffinity: true, // requiredFromReservation=true
+			},
+			rAlloc: &reusableAlloc{
+				allocatable: map[int]corev1.ResourceList{
+					1: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+				remained: map[int]corev1.ResourceList{
+					1: {corev1.ResourceCPU: resource.MustParse("8")},
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			numaAffinity:              node0mask,
+			want:                      fwktype.NewStatus(fwktype.Unschedulable, "Reservation(s) Insufficient NUMA cpu"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			suit := newPluginTestSuit(t, nil, tt.fields.nodes)
+			const numaNodeName = "test-node-1"
+			nodeName := numaNodeName
+
+			var nodes []*corev1.Node
+			var cycleState fwktype.CycleState
+			var rInfo *frameworkext.ReservationInfo
+			var pod *corev1.Pod
+
+			if tt.state != nil {
+				// NUMA-aware cases: build a real node so the snapshot lookup succeeds.
+				nodes = []*corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   numaNodeName,
+							Labels: map[string]string{},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("96"),
+								corev1.ResourceMemory: resource.MustParse("512Gi"),
+							},
+						},
+					},
+				}
+			} else {
+				// Early-return cases: use fields.nodes and override nodeName if set.
+				nodes = tt.fields.nodes
+				if tt.args.nodeName != "" {
+					nodeName = tt.args.nodeName
+				}
+			}
+
+			suit := newPluginTestSuit(t, nil, nodes)
 			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
 			assert.NotNil(t, p)
 			assert.Nil(t, err)
 			pl := p.(*Plugin)
-			got := pl.FilterNominateReservation(context.TODO(), tt.args.cycleState, tt.args.pod, tt.args.reservationInfo, tt.args.nodeName)
+
+			if tt.cpuTopology != nil {
+				pl.topologyOptionsManager.UpdateTopologyOptions(numaNodeName, func(options *TopologyOptions) {
+					options.CPUTopology = tt.cpuTopology
+					for i := 0; i < tt.cpuTopology.NumNodes; i++ {
+						options.NUMANodeResources = append(options.NUMANodeResources, NUMANodeResource{
+							Node: i,
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(int64(tt.cpuTopology.CPUsPerNode()), resource.DecimalSI),
+							},
+						})
+					}
+				})
+			}
+
+			suit.start(t)
+
+			if tt.state != nil {
+				cycleState = framework.NewCycleState()
+				cycleState.Write(stateKey, tt.state)
+
+				// Construct the reservation and register it as the single matched alloc.
+				reservationUID := uuid.NewUUID()
+				reservation := &schedulingv1alpha1.Reservation{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:  reservationUID,
+						Name: "test-reservation",
+					},
+					Spec: schedulingv1alpha1.ReservationSpec{
+						AllocatePolicy: tt.reservationAllocatePolicy,
+					},
+				}
+				alloc := *tt.rAlloc
+				alloc.rInfo = frameworkext.NewReservationInfo(reservation)
+				rInfo = alloc.rInfo
+
+				cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+					nodeToState: frameworkext.NodeReservationRestoreStates{
+						numaNodeName: &nodeReservationRestoreStateData{
+							matched: map[types.UID]reusableAlloc{reservationUID: alloc},
+						},
+					},
+				})
+
+				if tt.numaAffinity != nil {
+					topologymanager.InitStore(cycleState)
+					store := topologymanager.GetStore(cycleState)
+					store.SetAffinity(numaNodeName, topologymanager.NUMATopologyHint{NUMANodeAffinity: tt.numaAffinity})
+				}
+
+				pod = &corev1.Pod{}
+			} else {
+				cycleState = tt.args.cycleState
+				rInfo = tt.args.reservationInfo
+				pod = tt.args.pod
+				if pod == nil {
+					pod = &corev1.Pod{}
+				}
+			}
+
+			got := pl.FilterNominateReservation(context.TODO(), cycleState, pod, rInfo, nodeName)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -1322,9 +1505,19 @@ func TestPlugin_Reserve(t *testing.T) {
 		numaAffinity              bitmask.BitMask
 		cpuTopology               *CPUTopology
 		allocatedCPUs             []int
-		want                      *fwktype.Status
-		wantCPUSet                cpuset.CPUSet
-		wantNUMAResource          []NUMANodeResource
+		// skipNominate skips AddNominatedReservation so the pod falls back to tryAllocateFromNode.
+		skipNominate bool
+		// extraNUMAAllocations is injected into nodeAllocation to simulate matched R owners' NUMA
+		// usage double-counted on the node NUMA account (alongside the R fake pod allocation).
+		extraNUMAAllocations []NUMANodeResource
+		// mergedMatchedAllocatable/mergedMatchedAllocated are injected into restoreState; the former
+		// is not consumed by tryAllocateFromNode directly but matches production restore semantics,
+		// while the latter is what the fix must pass to reusableResources to offset double-count.
+		mergedMatchedAllocatable map[int]corev1.ResourceList
+		mergedMatchedAllocated   map[int]corev1.ResourceList
+		want                     *fwktype.Status
+		wantCPUSet               cpuset.CPUSet
+		wantNUMAResource         []NUMANodeResource
 	}{
 		{
 			name: "error with missing preFilterState",
@@ -1622,6 +1815,218 @@ func TestPlugin_Reserve(t *testing.T) {
 			wantCPUSet:                cpuset.NewCPUSet(),
 		},
 		{
+			// Regression for the tryAllocateFromNode double-accounting bug:
+			// node NUMA0 total=8 cpu; matched R.Spec.Resources (allocatable) = 7 cpu on NUMA0 and
+			// R owner has already consumed 4 cpu on NUMA0; in production they are both recorded
+			// on the node NUMA account, making the account 7+4=11 cpu on NUMA0 (exceeding total 8).
+			// We simulate this by injecting a single extraNUMAAllocations of 11 cpu on NUMA0
+			// (the test helper's addCPUs/addPodAllocation path cannot accumulate R's NUMA cpu when
+			// R.remainedCPUs is empty because addCPUs pre-registers the UID in allocatedPods).
+			// The pod has no reservation-affinity and is not nominated, so Reserve falls back to
+			// tryAllocateFromNode which must return mergedMatchedAllocated (=4) so that
+			// available = max(0, 8 - max(0, 11-4)) = max(0, 8-7) = 1 cpu, allowing a 1-cpu pod.
+			// Without the fix, reusableResources omits mergedMatchedAllocated so available=0 and
+			// the pod would be rejected with Insufficient NUMA cpu.
+			name: "fallback tryAllocateFromNode: return mergedMatchedAllocated to offset matched R owner double-count",
+			state: &preFilterState{
+				numCPUsNeeded:          1,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("7")},
+					},
+					remained: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+			},
+			skipNominate: true,
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("11")}},
+			},
+			mergedMatchedAllocatable: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("7")},
+			},
+			mergedMatchedAllocated: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      nil,
+			wantCPUSet:                cpuset.CPUSet{},
+			wantNUMAResource: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			},
+		},
+		{
+			// Boundary: same topology/accounts as the regression case above; pod requests 2 cpu.
+			// Even after the fix returns mergedMatchedAllocated=4, available is clamped to
+			// max(0, 8 - max(0, 11-4)) = 1 cpu, i.e. only the node free part outside R.allocatable.
+			// The pod requesting 2 cpu must be rejected; this proves the fix does NOT let a pod
+			// without reservation-affinity steal matched R capacity (R.allocatable stays reserved).
+			name: "fallback tryAllocateFromNode: do not steal matched reservation capacity beyond node free",
+			state: &preFilterState{
+				numCPUsNeeded:          2,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("7")},
+					},
+					remained: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+			},
+			skipNominate: true,
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("11")}},
+			},
+			mergedMatchedAllocatable: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("7")},
+			},
+			mergedMatchedAllocated: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      fwktype.NewStatus(fwktype.Unschedulable, "Insufficient NUMA cpu"),
+			wantCPUSet:                cpuset.NewCPUSet(),
+		},
+		{
+			// Regression for the tryAllocateFromNode double-accounting bug:
+			// node NUMA0 total=8 cpu; matched R.Spec.Resources (allocatable) = 7 cpu on NUMA0 and
+			// R owner has already consumed 4 cpu on NUMA0; in production they are both recorded
+			// on the node NUMA account, making the account 7+4=11 cpu on NUMA0 (exceeding total 8).
+			// We simulate this by injecting a single extraNUMAAllocations of 11 cpu on NUMA0
+			// (the test helper's addCPUs/addPodAllocation path cannot accumulate R's NUMA cpu when
+			// R.remainedCPUs is empty because addCPUs pre-registers the UID in allocatedPods).
+			// The pod has no reservation-affinity and is not nominated, so Reserve falls back to
+			// tryAllocateFromNode which must return mergedMatchedAllocated (=4) so that
+			// available = max(0, 8 - max(0, 11-4)) = max(0, 8-7) = 1 cpu, allowing a 1-cpu pod.
+			// Without the fix, reusableResources omits mergedMatchedAllocated so available=0 and
+			// the pod would be rejected with Insufficient NUMA cpu.
+			name: "fallback tryAllocateFromNode: return mergedMatchedAllocated to offset matched R owner double-count",
+			state: &preFilterState{
+				numCPUsNeeded:          1,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("7")},
+					},
+					remained: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+			},
+			skipNominate: true,
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("11")}},
+			},
+			mergedMatchedAllocatable: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("7")},
+			},
+			mergedMatchedAllocated: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      nil,
+			wantCPUSet:                cpuset.CPUSet{},
+			wantNUMAResource: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			},
+		},
+		{
+			// Boundary: same topology/accounts as the regression case above; pod requests 2 cpu.
+			// Even after the fix returns mergedMatchedAllocated=4, available is clamped to
+			// max(0, 8 - max(0, 11-4)) = 1 cpu, i.e. only the node free part outside R.allocatable.
+			// The pod requesting 2 cpu must be rejected; this proves the fix does NOT let a pod
+			// without reservation-affinity steal matched R capacity (R.allocatable stays reserved).
+			name: "fallback tryAllocateFromNode: do not steal matched reservation capacity beyond node free",
+			state: &preFilterState{
+				numCPUsNeeded:          2,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("7")},
+					},
+					remained: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+			},
+			skipNominate: true,
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("11")}},
+			},
+			mergedMatchedAllocatable: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("7")},
+			},
+			mergedMatchedAllocated: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      fwktype.NewStatus(fwktype.Unschedulable, "Insufficient NUMA cpu"),
+			wantCPUSet:                cpuset.NewCPUSet(),
+		},
+		{
+			// allocateWithNominated defense-in-depth: pod has a nominated R on NUMA1 but BestHint=NUMA0,
+			// and no reservation-affinity (requiredFromReservation=false). tryAllocateFromReusable returns
+			// (nil, nil) because Restricted second-Allocate fails (R resources not in hint), but the
+			// fallback is refused since the pod has a concrete nominated reservation. Without this
+			// check the pod would silently bypass the reservation via tryAllocateFromNode.
+			name: "nominated R NUMA-incompatible without affinity: allocateWithNominated refuses fallback",
+			state: &preFilterState{
+				numCPUsNeeded:          4,
+				requests:               corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+				// hasReservationAffinity=false (zero value) → requiredFromReservation=false
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						1: {corev1.ResourceCPU: resource.MustParse("8")},
+					},
+					remained: map[int]corev1.ResourceList{
+						1: {corev1.ResourceCPU: resource.MustParse("8")},
+					},
+					remainedCPUs: cpuset.NewCPUSet(8, 9, 10, 11, 12, 13, 14, 15),
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      fwktype.NewStatus(fwktype.Unschedulable, "pod has a nominated reservation but cannot be allocated within its NUMA scope"),
+			wantCPUSet:                cpuset.NewCPUSet(),
+		},
+		{
 			name: "succeed allocate for a reservation-ignored pod",
 			state: &preFilterState{
 				requestCPUBind:         true,
@@ -1716,6 +2121,14 @@ func TestPlugin_Reserve(t *testing.T) {
 						}, tt.cpuTopology)
 					}
 				}
+				// Simulate owner pod NUMA usage already recorded on node NUMA account, which
+				// together with the R fake pod allocation above produces the double-count.
+				if len(tt.extraNUMAAllocations) > 0 {
+					nodeAllocation.addPodAllocation(&PodAllocation{
+						UID:               uuid.NewUUID(),
+						NUMANodeResources: tt.extraNUMAAllocations,
+					}, tt.cpuTopology)
+				}
 			}
 
 			cpuManager := plg.resourceManager.(*resourceManager)
@@ -1739,12 +2152,18 @@ func TestPlugin_Reserve(t *testing.T) {
 						}
 						alloc.rInfo = frameworkext.NewReservationInfo(reservation)
 						tt.matched[reservationUID] = alloc
-						rInfo := frameworkext.NewReservationInfo(reservation)
-						plg.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node-1", rInfo)
+						if !tt.skipNominate {
+							rInfo := frameworkext.NewReservationInfo(reservation)
+							plg.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node-1", rInfo)
+						}
 					}
 					cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
 						nodeToState: frameworkext.NodeReservationRestoreStates{
-							"test-node-1": &nodeReservationRestoreStateData{matched: tt.matched},
+							"test-node-1": &nodeReservationRestoreStateData{
+								matched:                  tt.matched,
+								mergedMatchedAllocatable: tt.mergedMatchedAllocatable,
+								mergedMatchedAllocated:   tt.mergedMatchedAllocated,
+							},
 						},
 					})
 				}

--- a/pkg/scheduler/plugins/nodenumaresource/reservation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/reservation.go
@@ -609,7 +609,29 @@ func (p *Plugin) allocateWithNominated(
 	if !status.IsSuccess() {
 		return nil, status
 	}
-	return tryAllocateFromReusable(p.resourceManager, restoreState, resourceOptions, nominatedReusableAllocMap, pod, node)
+
+	result, status := tryAllocateFromReusable(p.resourceManager, restoreState, resourceOptions, nominatedReusableAllocMap, pod, node)
+	if !status.IsSuccess() {
+		return nil, status
+	}
+	// When the pod has a concrete nominated reservation but tryAllocateFromReusable
+	// did not produce an allocation (e.g. Restricted alloc failed in both probe and
+	// formal Allocate), refuse to fall back to tryAllocateFromNode. Falling back
+	// here would let the pod silently bypass the reservation and steal node
+	// capacity that is still reserved for the nominated R, and would desynchronize
+	// with the reservation plugin which will still write annotation
+	// scheduling.koordinator.sh/reservation-allocated = <nominated R> in PreBind,
+	// resulting in an annotation/cpuset mismatch.
+	if result == nil && len(nominatedReusableAllocMap) > 0 {
+		if klog.V(5).Enabled() {
+			klog.InfoS("allocateWithNominated: refuse fallback, reservation nominated but no allocation produced",
+				"pod", klog.KObj(pod), "node", node.Name,
+				"nominatedCount", len(nominatedReusableAllocMap))
+		}
+		return nil, fwktype.NewStatus(fwktype.Unschedulable,
+			"pod has a nominated reservation but cannot be allocated within its NUMA scope")
+	}
+	return result, nil
 }
 
 func (p *Plugin) getPodNominatedReservationInfo(pod *corev1.Pod, nodeName string) *frameworkext.ReservationInfo {

--- a/pkg/scheduler/plugins/nodenumaresource/scoring.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring.go
@@ -108,12 +108,20 @@ func (p *Plugin) Score(ctx context.Context, cycleState fwktype.CycleState, pod *
 	restoreState := reservationRestoreState.getNodeState(nodeName)
 	podAllocation, status := p.allocateWithNominated(restoreState, resourceOptions, pod, node)
 	if !status.IsSuccess() {
-		return 0, status
+		// Score-layer contract: the pod has already passed Filter on this node, so returning a
+		// non-Success status here would be upgraded to framework.Error by the scheduling framework
+		// and surface as SchedulerError on the Pod condition. Degrade to score=0 with nil status
+		// so the scheduler can continue selecting other candidates naturally, and record a warning
+		// for later investigation (it implies a mismatch between Filter and Score strictness).
+		klog.Warningf("Score: allocateWithNominated failed after Filter passed, degrading to score=0; pod=%s node=%s reason=%s", klog.KObj(pod), node.Name, status.Message())
+		return 0, nil
 	}
 	if podAllocation == nil {
 		podAllocation, status = tryAllocateFromNode(p.resourceManager, nil, restoreState, resourceOptions, pod, node)
 		if !status.IsSuccess() {
-			return 0, status
+			// Same reasoning as above: degrade to score=0 instead of propagating Unschedulable/Error.
+			klog.Warningf("Score: tryAllocateFromNode failed after Filter passed, degrading to score=0; pod=%s node=%s reason=%s", klog.KObj(pod), node.Name, status.Message())
+			return 0, nil
 		}
 	}
 

--- a/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/scoring_test.go
@@ -26,6 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	apiresource "k8s.io/component-helpers/resource"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -34,7 +36,11 @@ import (
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	schedulerconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
+	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
 	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
 )
 
@@ -331,14 +337,22 @@ func TestNUMANodeScore(t *testing.T) {
 }
 
 func TestPlugin_Score(t *testing.T) {
+	node0, _ := bitmask.NewBitMask(0)
 	tests := []struct {
-		name        string
-		nodeLabels  map[string]string
-		state       *preFilterState
-		pod         *corev1.Pod
-		cpuTopology *CPUTopology
-		want        *fwktype.Status
-		wantScore   int64
+		name                      string
+		nodeLabels                map[string]string
+		state                     *preFilterState
+		pod                       *corev1.Pod
+		cpuTopology               *CPUTopology
+		allocatedCPUs             []int
+		matched                   map[types.UID]reusableAlloc
+		reservationAllocatePolicy schedulingv1alpha1.ReservationAllocatePolicy
+		numaAffinity              bitmask.BitMask
+		skipNominate              bool
+		mergedMatchedAllocated    map[int]corev1.ResourceList
+		extraNUMAAllocations      []NUMANodeResource
+		want                      *fwktype.Status
+		wantScore                 int64
 	}{
 		{
 			name: "error with missing preFilterState",
@@ -476,6 +490,93 @@ func TestPlugin_Score(t *testing.T) {
 			want:        nil,
 			wantScore:   50,
 		},
+		// ---- Score degradation: allocateWithNominated fails → (0, nil) ----
+		{
+			// Pod has a nominated Restricted R on NUMA1 but BestHint=NUMA0, no reservation-affinity.
+			// tryAllocateFromReusable returns (nil, nil); allocateWithNominated returns Unschedulable.
+			// Score degrades to (0, nil) instead of propagating the error (which would cause
+			// the framework to upgrade it to SchedulerError on the Pod condition).
+			name: "Score degrades to (0,nil) when allocateWithNominated fails",
+			state: &preFilterState{
+				numCPUsNeeded:          4,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulerconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						1: {corev1.ResourceCPU: resource.MustParse("8")},
+					},
+					remained: map[int]corev1.ResourceList{
+						1: {corev1.ResourceCPU: resource.MustParse("8")},
+					},
+					remainedCPUs: cpuset.NewCPUSet(8, 9, 10, 11, 12, 13, 14, 15),
+				},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      nil,
+			wantScore:                 0,
+		},
+		// ---- Score degradation: tryAllocateFromNode fails → (0, nil) ----
+		{
+			// No nominated R; tryAllocateFromNode returns Insufficient NUMA cpu because
+			// all 8 cpu on hinted NUMA0 are fully allocated. Score degrades to (0, nil).
+			name: "Score degrades to (0,nil) when tryAllocateFromNode fails",
+			state: &preFilterState{
+				numCPUsNeeded:          4,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulerconfig.CPUBindPolicyFullPCPUs,
+			},
+			cpuTopology: buildCPUTopologyForTest(2, 1, 4, 2),
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}},
+			},
+			pod:          &corev1.Pod{},
+			numaAffinity: node0,
+			want:         nil,
+			wantScore:    0,
+		},
+		// ---- Score: tryAllocateFromNode mergedMatchedAllocated fix ----
+		{
+			// Pod has no reservation-affinity, not nominated, falls back to tryAllocateFromNode.
+			// Node NUMA0 has 8 cpu total; matched R allocatable=7, owner allocated=4, double-count
+			// makes the NUMA account 11 cpu. With mergedMatchedAllocated=4, available=
+			// max(0,8-max(0,11-4))=1 cpu, so a 1-cpu pod can be scored.
+			// Before the tryAllocateFromNode fix, reusableResources omitted mergedMatchedAllocated
+			// so available=0 and Score returned Unschedulable (now degraded to 0,nil).
+			name: "Score succeeds with mergedMatchedAllocated offsetting double-count",
+			state: &preFilterState{
+				numCPUsNeeded:          1,
+				podNUMATopologyPolicy:  extension.NUMATopologyPolicyRestricted,
+				preferredCPUBindPolicy: schedulerconfig.CPUBindPolicyFullPCPUs,
+			},
+			matched: map[types.UID]reusableAlloc{
+				uuid.NewUUID(): {
+					allocatable: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("7")},
+					},
+					remained: map[int]corev1.ResourceList{
+						0: {corev1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+			},
+			skipNominate: true,
+			extraNUMAAllocations: []NUMANodeResource{
+				{Node: 0, Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("11")}},
+			},
+			mergedMatchedAllocated: map[int]corev1.ResourceList{
+				0: {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			reservationAllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyDefault,
+			cpuTopology:               buildCPUTopologyForTest(2, 1, 4, 2),
+			pod:                       &corev1.Pod{},
+			numaAffinity:              node0,
+			want:                      nil,
+			wantScore:                 100, // MostAllocated: requested(14)=allocated(18)-reusable(4) on NUMA0 / allocatable(8) → clamped to 100
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -520,7 +621,42 @@ func TestPlugin_Score(t *testing.T) {
 			if tt.cpuTopology != nil {
 				plg.topologyOptionsManager.UpdateTopologyOptions(allocateState.nodeName, func(options *TopologyOptions) {
 					options.CPUTopology = tt.cpuTopology
+					for i := 0; i < tt.cpuTopology.NumNodes; i++ {
+						options.NUMANodeResources = append(options.NUMANodeResources, NUMANodeResource{
+							Node: i,
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(int64(tt.cpuTopology.CPUsPerNode()), resource.DecimalSI),
+							},
+						})
+					}
 				})
+				if len(tt.allocatedCPUs) > 0 {
+					allocateState.addCPUs(tt.cpuTopology, uuid.NewUUID(), cpuset.NewCPUSet(tt.allocatedCPUs...), schedulerconfig.CPUExclusivePolicyNone)
+				}
+				if len(tt.matched) > 0 {
+					for reservationUID, alloc := range tt.matched {
+						allocateState.addCPUs(tt.cpuTopology, reservationUID, alloc.remainedCPUs, schedulerconfig.CPUExclusivePolicyNone)
+						var numaResources []NUMANodeResource
+						for i, allocatable := range alloc.allocatable {
+							numaResources = append(numaResources, NUMANodeResource{
+								Node:      i,
+								Resources: allocatable,
+							})
+						}
+						allocateState.addPodAllocation(&PodAllocation{
+							UID:                reservationUID,
+							CPUSet:             alloc.remainedCPUs,
+							CPUExclusivePolicy: schedulerconfig.CPUExclusivePolicyNone,
+							NUMANodeResources:  numaResources,
+						}, tt.cpuTopology)
+					}
+				}
+				if len(tt.extraNUMAAllocations) > 0 {
+					allocateState.addPodAllocation(&PodAllocation{
+						UID:               uuid.NewUUID(),
+						NUMANodeResources: tt.extraNUMAAllocations,
+					}, tt.cpuTopology)
+				}
 			}
 
 			cpuManager := plg.resourceManager.(*resourceManager)
@@ -536,6 +672,39 @@ func TestPlugin_Score(t *testing.T) {
 					}
 				}
 				cycleState.Write(stateKey, tt.state)
+				if len(tt.matched) > 0 {
+					for reservationUID, alloc := range tt.matched {
+						reservation := &schedulingv1alpha1.Reservation{
+							ObjectMeta: metav1.ObjectMeta{
+								UID:  reservationUID,
+								Name: "test-reservation",
+							},
+							Spec: schedulingv1alpha1.ReservationSpec{
+								AllocatePolicy: tt.reservationAllocatePolicy,
+							},
+						}
+						alloc.rInfo = frameworkext.NewReservationInfo(reservation)
+						tt.matched[reservationUID] = alloc
+						if !tt.skipNominate {
+							rInfo := frameworkext.NewReservationInfo(reservation)
+							plg.handle.GetReservationNominator().AddNominatedReservation(tt.pod, "test-node-1", rInfo)
+						}
+					}
+					cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+						nodeToState: frameworkext.NodeReservationRestoreStates{
+							"test-node-1": &nodeReservationRestoreStateData{
+								matched:                tt.matched,
+								mergedMatchedAllocated: tt.mergedMatchedAllocated,
+							},
+						},
+					})
+				}
+			}
+
+			if tt.numaAffinity != nil {
+				topologymanager.InitStore(cycleState)
+				store := topologymanager.GetStore(cycleState)
+				store.SetAffinity("test-node-1", topologymanager.NUMATopologyHint{NUMANodeAffinity: tt.numaAffinity})
 			}
 
 			nodeInfo, err := suit.Handle.SnapshotSharedLister().NodeInfos().Get("test-node-1")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: Fix a bug when the pod without the reservation-affinity fails to allocate NUMA CPU resources from the node unreserved part. Revise the DeviceShare logic to avoid the same kind of error.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
