### PR TITLE
scheduler: integrate NominatedNodeNameForExpectation with reservation preemption 

### DIFF
--- a/pkg/scheduler/plugins/reservation/pod_eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler.go
@@ -93,6 +93,15 @@ func (h *podEventHandler) updatePod(oldPod, newPod *corev1.Pod) {
 	}
 
 	if !assignedPod(newPod) {
+		// When NominatedNodeName is cleared for an unassigned pod (e.g., by the k8s
+		// preemption's clearNominatedNodeName), sync the ReservationNominator to prevent
+		// stale nominations. With the NominatedNodeNameForExpectation feature gate (k8s 1.35+,
+		// Beta by default), NNN is also set during the binding cycle for pods awaiting
+		// WaitOnPermit or PreBind, so more pods will now have NNN set and may be subject
+		// to clearing by a concurrent preemption cycle.
+		if oldPod != nil && oldPod.Status.NominatedNodeName != "" && newPod.Status.NominatedNodeName == "" {
+			h.nominator.DeleteNominatedReservePodOrReservation(newPod)
+		}
 		return
 	}
 

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -425,6 +425,176 @@ func TestPodEventHandler_PreAllocatableCacheSync(t *testing.T) {
 	}
 }
 
+// TestPodEventHandler_NominatedNodeNameClearing tests that when an unassigned pod's
+// NominatedNodeName is cleared (e.g., by preemption's clearNominatedNodeName, or after a
+// binding-cycle failure with the NominatedNodeNameForExpectation feature), the
+// ReservationNominator is updated to prevent stale nominations from causing scheduling conflicts.
+func TestPodEventHandler_NominatedNodeNameClearing(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFunc   func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
+		oldPod      func(pod *corev1.Pod) *corev1.Pod
+		newPod      func(pod *corev1.Pod) *corev1.Pod
+		verifyFunc  func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
+		isReserve   bool
+	}{
+		{
+			name: "reserve pod NNN cleared while unassigned removes reservation nomination",
+			setupFunc: func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				handler.nominator.AddNominatedReservePod(podInfo, "test-node-1")
+			},
+			oldPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "test-node-1"
+				return p
+			},
+			newPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "" // NNN cleared by preemption or binding failure
+				return p
+			},
+			verifyFunc: func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// Nomination should be cleared after NNN is cleared for unassigned reserve pod
+				assert.Equal(t, "", handler.nominator.nominatedReservePodToNode[pod.UID],
+					"nominatedReservePodToNode should be cleared")
+				assert.Empty(t, handler.nominator.nominatedReservePod["test-node-1"],
+					"nominatedReservePod should be empty for the node")
+			},
+			isReserve: true,
+		},
+		{
+			name: "reserve pod NNN unchanged while unassigned keeps nomination",
+			setupFunc: func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				handler.nominator.AddNominatedReservePod(podInfo, "test-node-1")
+			},
+			oldPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "test-node-1"
+				return p
+			},
+			newPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "test-node-1" // NNN unchanged
+				return p
+			},
+			verifyFunc: func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// Nomination should remain when NNN is not cleared
+				assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[pod.UID],
+					"nominatedReservePodToNode should remain")
+				assert.NotEmpty(t, handler.nominator.nominatedReservePod["test-node-1"],
+					"nominatedReservePod should remain for the node")
+			},
+			isReserve: true,
+		},
+		{
+			name: "reserve pod NNN set from empty while unassigned does not affect nomination",
+			setupFunc: func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// no initial nomination
+			},
+			oldPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = ""
+				return p
+			},
+			newPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "test-node-1" // NNN set by expectation mechanism
+				return p
+			},
+			verifyFunc: func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// No nomination was set up, nothing should change
+				assert.Empty(t, handler.nominator.nominatedReservePodToNode,
+					"nominatedReservePodToNode should be empty")
+			},
+			isReserve: true,
+		},
+		{
+			name: "regular pod NNN cleared while unassigned removes pod reservation nomination",
+			setupFunc: func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				rUID := types.UID("test-reservation-uid")
+				nodeToReservation := map[string]types.UID{"test-node-1": rUID}
+				handler.nominator.nominatedPodToNode[pod.UID] = nodeToReservation
+			},
+			oldPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "test-node-1"
+				return p
+			},
+			newPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "" // NNN cleared
+				return p
+			},
+			verifyFunc: func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// Pod's reservation nomination should be cleared
+				assert.Empty(t, handler.nominator.nominatedPodToNode[pod.UID],
+					"nominatedPodToNode should be cleared for the pod")
+			},
+			isReserve: false,
+		},
+		{
+			name: "nil oldPod NNN cleared does not panic",
+			setupFunc: func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				handler.nominator.AddNominatedReservePod(podInfo, "test-node-1")
+			},
+			oldPod: func(pod *corev1.Pod) *corev1.Pod {
+				return nil // no old pod (e.g. first add event)
+			},
+			newPod: func(pod *corev1.Pod) *corev1.Pod {
+				p := pod.DeepCopy()
+				p.Status.NominatedNodeName = "" // unassigned pod with no NNN
+				return p
+			},
+			verifyFunc: func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo) {
+				// Nomination should remain - nil oldPod means NNN was not "cleared"
+				assert.Equal(t, "test-node-1", handler.nominator.nominatedReservePodToNode[pod.UID],
+					"nomination should remain when oldPod is nil")
+			},
+			isReserve: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &podEventHandler{
+				cache:     newReservationCache(nil),
+				nominator: newNominator(nil, nil),
+			}
+
+			var pod *corev1.Pod
+			if tt.isReserve {
+				reservation := &schedulingv1alpha1.Reservation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-reservation",
+						UID:  uuid.NewUUID(),
+					},
+					Spec: schedulingv1alpha1.ReservationSpec{
+						Template: &corev1.PodTemplateSpec{},
+					},
+				}
+				pod = reservationutil.NewReservePod(reservation)
+			} else {
+				pod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						UID:       uuid.NewUUID(),
+					},
+				}
+			}
+
+			podInfo, _ := framework.NewPodInfo(pod)
+			tt.setupFunc(handler, pod, podInfo)
+
+			oldPod := tt.oldPod(pod)
+			newPod := tt.newPod(pod)
+			handler.updatePod(oldPod, newPod)
+
+			tt.verifyFunc(t, handler, pod, podInfo)
+		})
+	}
+}
+
 // Helper functions for test pod creation
 
 func createPodWithLabels(uid, nodeName string, labels map[string]string) *corev1.Pod {

--- a/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/pod_eventhandler_test.go
@@ -431,12 +431,12 @@ func TestPodEventHandler_PreAllocatableCacheSync(t *testing.T) {
 // ReservationNominator is updated to prevent stale nominations from causing scheduling conflicts.
 func TestPodEventHandler_NominatedNodeNameClearing(t *testing.T) {
 	tests := []struct {
-		name        string
-		setupFunc   func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
-		oldPod      func(pod *corev1.Pod) *corev1.Pod
-		newPod      func(pod *corev1.Pod) *corev1.Pod
-		verifyFunc  func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
-		isReserve   bool
+		name       string
+		setupFunc  func(handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
+		oldPod     func(pod *corev1.Pod) *corev1.Pod
+		newPod     func(pod *corev1.Pod) *corev1.Pod
+		verifyFunc func(t *testing.T, handler *podEventHandler, pod *corev1.Pod, podInfo *framework.PodInfo)
+		isReserve  bool
 	}{
 		{
 			name: "reserve pod NNN cleared while unassigned removes reservation nomination",

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -109,10 +109,40 @@ func (pm *PreemptionMgr) PostFilter(ctx context.Context, state fwktype.CycleStat
 	klog.V(4).InfoS("Attempt to do reservation preemption in the PostFilter", "pod", klog.KObj(pod))
 
 	result, status := pe.Preempt(ctx, state, pod, m)
+	if status.IsSuccess() && result != nil && result.NominatingInfo != nil {
+		// Synchronously clear ReservationNominator entries for lower-priority reserve pods
+		// on the preempted node. The k8s preemption calls clearNominatedNodeName for them,
+		// but informer propagation is async. With the NominatedNodeNameForExpectation feature
+		// (k8s 1.35+ Beta), NNN is also set during the binding cycle, so more pods may have
+		// stale nominations that need immediate clearing to avoid scheduling conflicts.
+		pm.clearLowerPriorityReservePodNominations(pod, result.NominatingInfo.NominatedNodeName)
+	}
 	if status.Message() != "" {
 		return result, fwktype.NewStatus(status.Code(), "preemption: "+status.Message())
 	}
 	return result, status
+}
+
+// clearLowerPriorityReservePodNominations removes stale ReservationNominator entries for
+// lower-priority reserve pods on the given node immediately after preemption. This prevents
+// race conditions where a subsequent scheduling cycle uses the stale nomination state before
+// the async informer events from clearNominatedNodeName propagate.
+func (pm *PreemptionMgr) clearLowerPriorityReservePodNominations(pod *corev1.Pod, nodeName string) {
+	if nodeName == "" {
+		return
+	}
+	reservationNominator := pm.fh.GetReservationNominator()
+	if reservationNominator == nil {
+		return
+	}
+	podPriority := corev1helpers.PodPriority(pod)
+	for _, pi := range reservationNominator.NominatedReservePodForNode(nodeName) {
+		if corev1helpers.PodPriority(pi.GetPod()) < podPriority {
+			klog.V(4).InfoS("Clearing stale reservation nomination for lower-priority reserve pod after preemption",
+				"preemptor", klog.KObj(pod), "reservePod", klog.KObj(pi.GetPod()), "node", nodeName)
+			reservationNominator.DeleteNominatedReservePodOrReservation(pi.GetPod())
+		}
+	}
 }
 
 // SelectVictimsOnNode finds minimum set of pods on the given node that should be preempted in order to make enough room

--- a/pkg/scheduler/plugins/reservation/preemption_test.go
+++ b/pkg/scheduler/plugins/reservation/preemption_test.go
@@ -741,6 +741,127 @@ func TestFilterPodsWithPDBViolation(t *testing.T) {
 	}
 }
 
+// TestClearLowerPriorityReservePodNominations verifies that after successful preemption,
+// lower-priority reserve pod nominations are synchronously cleared from the ReservationNominator.
+// This prevents stale nominations from causing scheduling conflicts in subsequent cycles,
+// especially with the NominatedNodeNameForExpectation feature (k8s 1.35+ Beta) where NNN
+// is also set during the binding cycle.
+func TestClearLowerPriorityReservePodNominations(t *testing.T) {
+	preemptionPolicyLowerPriority := corev1.PreemptLowerPriority
+	const targetNode = "test-node-0"
+
+	makeReservePod := func(name string, priority int32) *corev1.Pod {
+		r := &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				UID:  uuid.NewUUID(),
+			},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Priority:         &priority,
+						PreemptionPolicy: &preemptionPolicyLowerPriority,
+					},
+				},
+			},
+		}
+		return reservationutil.NewReservePod(r)
+	}
+
+	tests := []struct {
+		name          string
+		preemptorPod  *corev1.Pod
+		reservePods   []*corev1.Pod
+		callNodeName  string // the node name passed to clearLowerPriorityReservePodNominations
+		wantRemaining []string
+	}{
+		{
+			name: "lower-priority reserve pods are removed, higher-priority kept",
+			preemptorPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "high-priority-preemptor", Namespace: "default", UID: uuid.NewUUID()},
+				Spec:       corev1.PodSpec{Priority: ptr.To[int32](200), PreemptionPolicy: &preemptionPolicyLowerPriority},
+			},
+			reservePods: []*corev1.Pod{
+				makeReservePod("low-prio-reserve", 50),
+				makeReservePod("high-prio-reserve", 300),
+			},
+			callNodeName:  targetNode,
+			wantRemaining: []string{"high-prio-reserve"},
+		},
+		{
+			name: "all reserve pods are lower-priority, all removed",
+			preemptorPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "highest-priority-preemptor", Namespace: "default", UID: uuid.NewUUID()},
+				Spec:       corev1.PodSpec{Priority: ptr.To[int32](1000), PreemptionPolicy: &preemptionPolicyLowerPriority},
+			},
+			reservePods: []*corev1.Pod{
+				makeReservePod("reserve-a", 100),
+				makeReservePod("reserve-b", 200),
+			},
+			callNodeName:  targetNode,
+			wantRemaining: []string{},
+		},
+		{
+			name: "no nominations on target node, nothing to clear",
+			preemptorPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "preemptor", Namespace: "default", UID: uuid.NewUUID()},
+				Spec:       corev1.PodSpec{Priority: ptr.To[int32](200), PreemptionPolicy: &preemptionPolicyLowerPriority},
+			},
+			reservePods:   []*corev1.Pod{},
+			callNodeName:  targetNode,
+			wantRemaining: []string{},
+		},
+		{
+			name: "empty nodeName is a no-op",
+			preemptorPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "preemptor", Namespace: "default", UID: uuid.NewUUID()},
+				Spec:       corev1.PodSpec{Priority: ptr.To[int32](200), PreemptionPolicy: &preemptionPolicyLowerPriority},
+			},
+			reservePods: []*corev1.Pod{
+				makeReservePod("low-reserve", 50),
+			},
+			callNodeName:  "", // empty node name - should be a no-op
+			wantRemaining: []string{"low-reserve"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
+				args.EnablePreemption = true
+			})
+			p, err := suit.pluginFactory()
+			assert.NoError(t, err)
+			pl, ok := p.(*Plugin)
+			assert.True(t, ok)
+			assert.NotNil(t, pl.preemptionMgr)
+
+			// Directly populate the nominator's internal maps to bypass lister validation.
+			// This is intentional in unit tests: we are testing clearLowerPriorityReservePodNominations,
+			// not the nomination admission logic.
+			for _, rp := range tt.reservePods {
+				pi, _ := framework.NewPodInfo(rp)
+				pl.nominator.nominatedReservePodToNode[rp.UID] = targetNode
+				pl.nominator.nominatedReservePod[targetNode] = append(
+					pl.nominator.nominatedReservePod[targetNode], pi)
+			}
+
+			// Call the function under test
+			pl.preemptionMgr.clearLowerPriorityReservePodNominations(tt.preemptorPod, tt.callNodeName)
+
+			// Verify remaining nominations
+			remaining := pl.nominator.NominatedReservePodForNode(targetNode)
+			remainingNames := make([]string, 0, len(remaining))
+			for _, pi := range remaining {
+				remainingNames = append(remainingNames, reservationutil.GetReservationNameFromReservePod(pi.GetPod()))
+			}
+
+			assert.ElementsMatch(t, tt.wantRemaining, remainingNames,
+				"unexpected reserve pod nominations remaining after clearLowerPriorityReservePodNominations")
+		})
+	}
+}
+
 func TestOrderedScoreFuncs(t *testing.T) {
 	suit := newPluginTestSuitWith(t, nil, nil, func(args *config.ReservationArgs) {
 		args.EnablePreemption = true


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Kubernetes 1.35 introduces `NominatedNodeNameForExpectation` (Beta, default on), which sets
`NominatedNodeName` (NNN) during the **binding cycle** for pods awaiting `WaitOnPermit` or
`PreBind` — not just during preemption. This creates two race conditions in Koordinator's
reservation preemption:

**Race 1 — stale ReservationNominator on NNN clearing:**
When k8s preemption's `clearNominatedNodeName` patches a lower-priority pod's NNN to `""`,
the informer fires a pod update event. But `pod_eventhandler.updatePod` returns early for
unassigned pods (`Spec.NodeName == ""`), leaving `ReservationNominator` with stale entries
that can block subsequent scheduling decisions.

**Race 2 — async informer lag after preemption:**
After a successful preemption cycle, the NNN-clearing informer event may not propagate
before the next scheduling cycle reads `ReservationNominator`, causing stale reserve pod
nominations to interfere.

**Fix 1 — `pod_eventhandler.go`:**
When an unassigned pod's NNN transitions from non-empty → empty, call
`DeleteNominatedReservePodOrReservation` to immediately sync the nominator instead of
returning early.

**Fix 2 — `preemption.go`:**
After `pe.Preempt` succeeds, synchronously clear `ReservationNominator` entries for
lower-priority reserve pods on the nominated node via a new
`clearLowerPriorityReservePodNominations` helper — providing immediate consistency without
waiting for informer propagation.

### Ⅱ. Does this pull request fix one issue?

fixes #2858

### Ⅲ. Describe how to verify it

1. Run the new unit tests
2. Run the full reservation plugin test suite to confirm no regressions

