### PR TITLE
scheduler: add benchmarks for NodeNUMAResource and DeviceShare plugins

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin_benchmark_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_benchmark_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/utils/ptr"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+// BenchmarkPreFilter measures the cost of PreFilter for a pod requesting a whole GPU.
+func BenchmarkPreFilter(b *testing.B) {
+	const numNodes = 256
+	nodes := makeGPUNodes(numNodes, 8)
+	suit := newPluginTestSuit(b, nodes)
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i := 0; i < numNodes; i++ {
+		pl.nodeDeviceCache.updateNodeDevice(fmt.Sprintf("node-%d", i), makeGPUDevice(fmt.Sprintf("node-%d", i), 8))
+	}
+
+	pod := makeGPUPod(1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		_, status := pl.PreFilter(context.TODO(), cycleState, pod, nil)
+		if !status.IsSuccess() && !status.IsSkip() {
+			b.Fatalf("PreFilter failed: %v", status)
+		}
+	}
+}
+
+// BenchmarkFilter_GPU measures the cost of Filter for a pod requesting a whole GPU
+// against a node with 8 available GPUs.
+func BenchmarkFilter_GPU(b *testing.B) {
+	const numNodes = 256
+	nodes := makeGPUNodes(numNodes, 8)
+	suit := newPluginTestSuit(b, nodes)
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i := 0; i < numNodes; i++ {
+		pl.nodeDeviceCache.updateNodeDevice(fmt.Sprintf("node-%d", i), makeGPUDevice(fmt.Sprintf("node-%d", i), 8))
+	}
+
+	pod := makeGPUPod(1)
+	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
+	assert.NoError(b, err)
+
+	_, prefilterStatus := pl.PreFilter(context.TODO(), framework.NewCycleState(), pod, nil)
+	assert.True(b, prefilterStatus.IsSuccess())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+		assert.True(b, status.IsSuccess())
+		cycleState.Write(stateKey, state)
+		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		if !filterStatus.IsSuccess() {
+			b.Fatalf("Filter failed: %v", filterStatus)
+		}
+	}
+}
+
+// BenchmarkFilter_GPUShare measures the cost of Filter for a pod requesting a shared GPU slice (50 cores).
+func BenchmarkFilter_GPUShare(b *testing.B) {
+	const numNodes = 256
+	nodes := makeGPUNodes(numNodes, 8)
+	suit := newPluginTestSuit(b, nodes)
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i := 0; i < numNodes; i++ {
+		pl.nodeDeviceCache.updateNodeDevice(fmt.Sprintf("node-%d", i), makeGPUDevice(fmt.Sprintf("node-%d", i), 8))
+	}
+
+	pod := makeGPUSharePod(50, 50)
+	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+		assert.True(b, status.IsSuccess())
+		cycleState.Write(stateKey, state)
+		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		if !filterStatus.IsSuccess() {
+			b.Fatalf("Filter failed: %v", filterStatus)
+		}
+	}
+}
+
+// BenchmarkFilter_LargeCluster benchmarks Filter across a large cluster (1024 nodes, 8 GPUs each).
+func BenchmarkFilter_LargeCluster(b *testing.B) {
+	const numNodes = 1024
+	nodes := makeGPUNodes(numNodes, 8)
+	suit := newPluginTestSuit(b, nodes)
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i := 0; i < numNodes; i++ {
+		pl.nodeDeviceCache.updateNodeDevice(fmt.Sprintf("node-%d", i), makeGPUDevice(fmt.Sprintf("node-%d", i), 8))
+	}
+
+	pod := makeGPUPod(1)
+	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+		assert.True(b, status.IsSuccess())
+		cycleState.Write(stateKey, state)
+		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		if !filterStatus.IsSuccess() {
+			b.Fatalf("Filter failed: %v", filterStatus)
+		}
+	}
+}
+
+func makeGPUNodes(n, gpusPerNode int) []*corev1.Node {
+	nodes := make([]*corev1.Node, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("96"),
+					corev1.ResourceMemory: resource.MustParse("512Gi"),
+					apiext.ResourceGPU:    *resource.NewQuantity(int64(gpusPerNode*100), resource.DecimalSI),
+				},
+			},
+		}
+	}
+	return nodes
+}
+
+func makeGPUDevice(nodeName string, gpuCount int) *schedulingv1alpha1.Device {
+	devices := make([]schedulingv1alpha1.DeviceInfo, gpuCount)
+	for i := 0; i < gpuCount; i++ {
+		devices[i] = schedulingv1alpha1.DeviceInfo{
+			Type:   schedulingv1alpha1.GPU,
+			Minor:  ptr.To(int32(i)),
+			Health: true,
+			UUID:   fmt.Sprintf("%s-gpu-%d", nodeName, i),
+			Resources: corev1.ResourceList{
+				apiext.ResourceGPUCore:        resource.MustParse("100"),
+				apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+			},
+		}
+	}
+	return &schedulingv1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: devices,
+		},
+	}
+}
+
+func makeGPUPod(gpuCount int) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bench-gpu-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "bench-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							apiext.ResourceGPU: *resource.NewQuantity(int64(gpuCount*100), resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeGPUSharePod(corePercent, memRatioPercent int) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bench-gpushare-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "bench-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							apiext.ResourceGPUCore:        *resource.NewQuantity(int64(corePercent), resource.DecimalSI),
+							apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(int64(memRatioPercent), resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin_benchmark_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_benchmark_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,8 +36,12 @@ func BenchmarkPreFilter(b *testing.B) {
 	const numNodes = 256
 	nodes := makeGPUNodes(numNodes, 8)
 	suit := newPluginTestSuit(b, nodes)
-	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
-	assert.NoError(b, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	p, err := suit.proxyNew(ctx, getDefaultArgs(), suit.Framework)
+	if err != nil {
+		b.Fatalf("failed to create plugin: %v", err)
+	}
 	pl := p.(*Plugin)
 
 	for i := 0; i < numNodes; i++ {
@@ -50,7 +53,7 @@ func BenchmarkPreFilter(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cycleState := framework.NewCycleState()
-		_, status := pl.PreFilter(context.TODO(), cycleState, pod, nil)
+		_, status := pl.PreFilter(ctx, cycleState, pod, nil)
 		if !status.IsSuccess() && !status.IsSkip() {
 			b.Fatalf("PreFilter failed: %v", status)
 		}
@@ -63,8 +66,12 @@ func BenchmarkFilter_GPU(b *testing.B) {
 	const numNodes = 256
 	nodes := makeGPUNodes(numNodes, 8)
 	suit := newPluginTestSuit(b, nodes)
-	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
-	assert.NoError(b, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	p, err := suit.proxyNew(ctx, getDefaultArgs(), suit.Framework)
+	if err != nil {
+		b.Fatalf("failed to create plugin: %v", err)
+	}
 	pl := p.(*Plugin)
 
 	for i := 0; i < numNodes; i++ {
@@ -73,18 +80,20 @@ func BenchmarkFilter_GPU(b *testing.B) {
 
 	pod := makeGPUPod(1)
 	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
-	assert.NoError(b, err)
+	if err != nil {
+		b.Fatalf("failed to get node info: %v", err)
+	}
 
-	_, prefilterStatus := pl.PreFilter(context.TODO(), framework.NewCycleState(), pod, nil)
-	assert.True(b, prefilterStatus.IsSuccess())
+	baseState, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+	if !status.IsSuccess() {
+		b.Fatalf("preparePod failed: %v", status)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cycleState := framework.NewCycleState()
-		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
-		assert.True(b, status.IsSuccess())
-		cycleState.Write(stateKey, state)
-		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		cycleState.Write(stateKey, baseState.Clone())
+		filterStatus := pl.Filter(ctx, cycleState, pod, nodeInfo)
 		if !filterStatus.IsSuccess() {
 			b.Fatalf("Filter failed: %v", filterStatus)
 		}
@@ -96,8 +105,12 @@ func BenchmarkFilter_GPUShare(b *testing.B) {
 	const numNodes = 256
 	nodes := makeGPUNodes(numNodes, 8)
 	suit := newPluginTestSuit(b, nodes)
-	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
-	assert.NoError(b, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	p, err := suit.proxyNew(ctx, getDefaultArgs(), suit.Framework)
+	if err != nil {
+		b.Fatalf("failed to create plugin: %v", err)
+	}
 	pl := p.(*Plugin)
 
 	for i := 0; i < numNodes; i++ {
@@ -106,15 +119,20 @@ func BenchmarkFilter_GPUShare(b *testing.B) {
 
 	pod := makeGPUSharePod(50, 50)
 	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
-	assert.NoError(b, err)
+	if err != nil {
+		b.Fatalf("failed to get node info: %v", err)
+	}
+
+	baseState, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+	if !status.IsSuccess() {
+		b.Fatalf("preparePod failed: %v", status)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cycleState := framework.NewCycleState()
-		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
-		assert.True(b, status.IsSuccess())
-		cycleState.Write(stateKey, state)
-		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		cycleState.Write(stateKey, baseState.Clone())
+		filterStatus := pl.Filter(ctx, cycleState, pod, nodeInfo)
 		if !filterStatus.IsSuccess() {
 			b.Fatalf("Filter failed: %v", filterStatus)
 		}
@@ -126,8 +144,12 @@ func BenchmarkFilter_LargeCluster(b *testing.B) {
 	const numNodes = 1024
 	nodes := makeGPUNodes(numNodes, 8)
 	suit := newPluginTestSuit(b, nodes)
-	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
-	assert.NoError(b, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	p, err := suit.proxyNew(ctx, getDefaultArgs(), suit.Framework)
+	if err != nil {
+		b.Fatalf("failed to create plugin: %v", err)
+	}
 	pl := p.(*Plugin)
 
 	for i := 0; i < numNodes; i++ {
@@ -136,15 +158,20 @@ func BenchmarkFilter_LargeCluster(b *testing.B) {
 
 	pod := makeGPUPod(1)
 	nodeInfo, err := suit.Framework.SnapshotSharedLister().NodeInfos().Get("node-0")
-	assert.NoError(b, err)
+	if err != nil {
+		b.Fatalf("failed to get node info: %v", err)
+	}
+
+	baseState, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
+	if !status.IsSuccess() {
+		b.Fatalf("preparePod failed: %v", status)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cycleState := framework.NewCycleState()
-		state, status := preparePod(pod, pl.gpuSharedResourceTemplatesCache, pl.gpuSharedResourceTemplatesMatchedResources)
-		assert.True(b, status.IsSuccess())
-		cycleState.Write(stateKey, state)
-		filterStatus := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		cycleState.Write(stateKey, baseState.Clone())
+		filterStatus := pl.Filter(ctx, cycleState, pod, nodeInfo)
 		if !filterStatus.IsSuccess() {
 			b.Fatalf("Filter failed: %v", filterStatus)
 		}

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -160,7 +160,7 @@ type pluginTestSuit struct {
 	proxyNew                         runtime.PluginFactory
 }
 
-func newPluginTestSuit(t *testing.T, nodes []*corev1.Node) *pluginTestSuit {
+func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
 	frameworkexthelper.ResetRegistrations()
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_benchmark_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_benchmark_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingconfig "github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
+)
+
+// BenchmarkPreFilter measures the cost of the PreFilter phase for a CPU-bind pod
+// (QoS=LSR, FullPCPUs bind policy) across a 256-node cluster.
+func BenchmarkPreFilter(b *testing.B) {
+	const numNodes = 256
+	nodes := makeNUMANodes(numNodes)
+	suit := newPluginTestSuit(b, nil, nodes)
+	p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	for i := 0; i < numNodes; i++ {
+		topo := buildCPUTopologyForTest(2, 1, 4, 2)
+		pl.topologyOptionsManager.UpdateTopologyOptions(fmt.Sprintf("node-%d", i), func(opts *TopologyOptions) {
+			opts.CPUTopology = topo
+			for node := 0; node < topo.NumNodes; node++ {
+				opts.NUMANodeResources = append(opts.NUMANodeResources, NUMANodeResource{
+					Node: node,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+					},
+				})
+			}
+		})
+	}
+
+	suit.start(b)
+
+	pod := makeCPUBindPod(4)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		topologymanager.InitStore(cycleState)
+		_, status := pl.PreFilter(context.TODO(), cycleState, pod, nil)
+		if !status.IsSuccess() && !status.IsSkip() {
+			b.Fatalf("PreFilter failed: %v", status)
+		}
+	}
+}
+
+// BenchmarkFilter_CPUBind measures the cost of the Filter phase for a CPU-bind pod
+// on a node with a populated CPUTopology.
+func BenchmarkFilter_CPUBind(b *testing.B) {
+	const numNodes = 256
+	nodes := makeNUMANodes(numNodes)
+	suit := newPluginTestSuit(b, nil, nodes)
+	p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	topo := buildCPUTopologyForTest(2, 1, 4, 2)
+	for i := 0; i < numNodes; i++ {
+		nodeName := fmt.Sprintf("node-%d", i)
+		alloc := NewNodeAllocation(nodeName)
+		pl.topologyOptionsManager.UpdateTopologyOptions(nodeName, func(opts *TopologyOptions) {
+			opts.CPUTopology = topo
+			for node := 0; node < topo.NumNodes; node++ {
+				opts.NUMANodeResources = append(opts.NUMANodeResources, NUMANodeResource{
+					Node: node,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+					},
+				})
+			}
+		})
+		manager := pl.resourceManager.(*resourceManager)
+		manager.nodeAllocations[nodeName] = alloc
+	}
+
+	suit.start(b)
+
+	nodeInfo, err := suit.Handle.SnapshotSharedLister().NodeInfos().Get("node-0")
+	assert.NoError(b, err)
+
+	pod := makeCPUBindPod(4)
+	state := &preFilterState{
+		requestCPUBind:         true,
+		preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+		numCPUsNeeded:          4,
+		requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("4"),
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		cycleState.Write(stateKey, state.Clone().(*preFilterState))
+		topologymanager.InitStore(cycleState)
+		status := pl.Filter(context.TODO(), cycleState, pod, nodeInfo)
+		if !status.IsSuccess() {
+			b.Fatalf("Filter failed: %v", status)
+		}
+	}
+}
+
+// BenchmarkScore_CPUBind measures the cost of the Score phase for a CPU-bind pod.
+func BenchmarkScore_CPUBind(b *testing.B) {
+	const numNodes = 256
+	nodes := makeNUMANodes(numNodes)
+
+	suit := newPluginTestSuit(b, nil, nodes)
+	suit.nodeNUMAResourceArgs.ScoringStrategy = &schedulingconfig.ScoringStrategy{
+		Type: schedulingconfig.LeastAllocated,
+		Resources: []config.ResourceSpec{
+			{Name: string(corev1.ResourceCPU), Weight: 1},
+			{Name: string(corev1.ResourceMemory), Weight: 1},
+		},
+	}
+	p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	topo := buildCPUTopologyForTest(2, 1, 4, 2)
+	for i := 0; i < numNodes; i++ {
+		nodeName := fmt.Sprintf("node-%d", i)
+		alloc := NewNodeAllocation(nodeName)
+		pl.topologyOptionsManager.UpdateTopologyOptions(nodeName, func(opts *TopologyOptions) {
+			opts.CPUTopology = topo
+		})
+		manager := pl.resourceManager.(*resourceManager)
+		manager.nodeAllocations[nodeName] = alloc
+	}
+
+	suit.start(b)
+
+	nodeInfo, err := suit.Handle.SnapshotSharedLister().NodeInfos().Get("node-0")
+	assert.NoError(b, err)
+
+	pod := makeCPUBindPod(4)
+	state := &preFilterState{
+		requestCPUBind:         true,
+		preferredCPUBindPolicy: schedulingconfig.CPUBindPolicyFullPCPUs,
+		numCPUsNeeded:          4,
+		requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("4"),
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		cycleState.Write(stateKey, state.Clone().(*preFilterState))
+		topologymanager.InitStore(cycleState)
+		_, status := pl.Score(context.TODO(), cycleState, pod, nodeInfo)
+		if !status.IsSuccess() {
+			b.Fatalf("Score failed: %v", status)
+		}
+	}
+}
+
+// BenchmarkPreFilter_LargeCluster measures PreFilter at scale: 1024 nodes.
+func BenchmarkPreFilter_LargeCluster(b *testing.B) {
+	const numNodes = 1024
+	nodes := makeNUMANodes(numNodes)
+	suit := newPluginTestSuit(b, nil, nodes)
+	p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+	assert.NoError(b, err)
+	pl := p.(*Plugin)
+
+	topo := buildCPUTopologyForTest(2, 2, 8, 2)
+	for i := 0; i < numNodes; i++ {
+		nodeName := fmt.Sprintf("node-%d", i)
+		pl.topologyOptionsManager.UpdateTopologyOptions(nodeName, func(opts *TopologyOptions) {
+			opts.CPUTopology = topo
+			for node := 0; node < topo.NumNodes; node++ {
+				opts.NUMANodeResources = append(opts.NUMANodeResources, NUMANodeResource{
+					Node: node,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("32"),
+						corev1.ResourceMemory: resource.MustParse("64Gi"),
+					},
+				})
+			}
+		})
+	}
+
+	suit.start(b)
+
+	pod := makeCPUBindPod(8)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cycleState := framework.NewCycleState()
+		topologymanager.InitStore(cycleState)
+		_, status := pl.PreFilter(context.TODO(), cycleState, pod, nil)
+		if !status.IsSuccess() && !status.IsSkip() {
+			b.Fatalf("PreFilter failed: %v", status)
+		}
+	}
+}
+
+func makeNUMANodes(n int) []*corev1.Node {
+	nodes := make([]*corev1.Node, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+				Labels: map[string]string{
+					extension.LabelNUMATopologyPolicy: string(extension.NUMATopologyPolicySingleNUMANode),
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("96"),
+					corev1.ResourceMemory: resource.MustParse("512Gi"),
+				},
+			},
+		}
+	}
+	return nodes
+}
+
+func makeCPUBindPod(cpus int) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bench-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				extension.LabelPodQoS: string(extension.QoSLSR),
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "bench-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    *resource.NewQuantity(int64(cpus), resource.DecimalSI),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -182,7 +182,7 @@ type pluginTestSuit struct {
 	plugin               fwktype.Plugin
 }
 
-func newPluginTestSuit(t *testing.T, pods []*corev1.Pod, nodes []*corev1.Node) *pluginTestSuit {
+func newPluginTestSuit(t testing.TB, pods []*corev1.Pod, nodes []*corev1.Node) *pluginTestSuit {
 	// Reset registrations to avoid cross-test interference via package-level state.
 	frameworkexthelper.ResetRegistrations()
 	var v1args v1.NodeNUMAResourceArgs


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Add benchmark tests for the `NodeNUMAResource` and `DeviceShare` scheduler plugins.

- **NodeNUMAResource**: benchmarks for `PreFilter`, `Filter` (CPU-bind), and `Score` phases at both 256-node and 1024-node cluster scales.
- **DeviceShare**: benchmarks for `PreFilter` and `Filter` phases covering full-GPU allocation, GPU sharing (partial core), and large-cluster (1024 nodes × 8 GPUs) scenarios.
- Also generalizes `newPluginTestSuit()` in both packages to accept `testing.TB` instead of `*testing.T` so the helper is reusable by benchmark functions.

The `Reservation` plugin already had benchmarks (`plugin_benchmark_test.go`, `transformer_benchmark_test.go`) and required no changes.

### Ⅱ. Does this pull request fix one issue?

fixes part of #2374

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

- No production code is changed; all new files are `_test.go`.
- The only change to existing test files is widening `newPluginTestSuit(t *testing.T, ...)` → `newPluginTestSuit(t testing.TB, ...)` in `plugin_test.go` for both packages — fully backward-compatible.
- Benchmark data sizes (256 / 1024 nodes) match the scale used in the existing Reservation benchmarks for consistency.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
