### PR TITLE
webhook: Optimize UpdateQuotaStatus when conflict

### DIFF
--- a/cmd/koord-manager/main.go
+++ b/cmd/koord-manager/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/util/sloconfig"
 	"github.com/koordinator-sh/koordinator/pkg/webhook"
 	podvalidating "github.com/koordinator-sh/koordinator/pkg/webhook/pod/validating"
+	"github.com/koordinator-sh/koordinator/pkg/webhook/quotaevaluate"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -83,6 +84,7 @@ func main() {
 	opts.InitFlags(flag.CommandLine)
 	sloconfig.InitFlags(flag.CommandLine)
 	podvalidating.InitFlags(flag.CommandLine)
+	quotaevaluate.InitFlags(flag.CommandLine)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 	klog.InitFlags(nil)
 	// Opt into the new klog behavior so that -stderrthreshold is honored even

--- a/pkg/webhook/pod/validating/evaluate_quota_test.go
+++ b/pkg/webhook/pod/validating/evaluate_quota_test.go
@@ -397,7 +397,7 @@ func TestEvaluateQuota(t *testing.T) {
 				Client:  client,
 				Decoder: decoder,
 			}
-			quotaAccessor := quotaevaluate.NewQuotaAccessor(h.Client)
+			quotaAccessor := quotaevaluate.NewQuotaAccessor(h.Client, h.Client)
 			h.QuotaEvaluator = quotaevaluate.NewQuotaEvaluator(quotaAccessor, 16, make(chan struct{}))
 
 			var objRawExt, oldObjRawExt runtime.RawExtension

--- a/pkg/webhook/pod/validating/webhooks.go
+++ b/pkg/webhook/pod/validating/webhooks.go
@@ -50,7 +50,7 @@ func (b *podValidateBuilder) Build() admission.Handler {
 		Client:  b.mgr.GetClient(),
 		Decoder: admission.NewDecoder(b.mgr.GetScheme()),
 	}
-	quotaAccessor := quotaevaluate.NewQuotaAccessor(h.Client)
+	quotaAccessor := quotaevaluate.NewQuotaAccessor(h.Client, b.mgr.GetAPIReader())
 	h.QuotaEvaluator = quotaevaluate.NewQuotaEvaluator(quotaAccessor, 16, make(chan struct{}))
 	h.PodEnhancedValidator = NewPodEnhancedValidator(b.mgr.GetClient())
 

--- a/pkg/webhook/quotaevaluate/evaluator.go
+++ b/pkg/webhook/quotaevaluate/evaluator.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 // podResources are the set of resources managed by quota associated with pods.
@@ -79,10 +80,10 @@ const (
 	defaultQuotaUpdateMaxRetries = 10
 
 	// defaultQuotaUpdateRetryJitter is the per-retry decorrelation upper bound.
-	// Actual sleep is in [jitter/2, jitter). 100ms is large enough to decorrelate
+	// Actual sleep is in [jitter/2, jitter). 50ms is large enough to decorrelate
 	// peer webhook pods given typical apiserver RTT (< 20ms) yet small enough
 	// to amortize across many retries within the total budget.
-	defaultQuotaUpdateRetryJitter = 20 * time.Millisecond
+	defaultQuotaUpdateRetryJitter = 50 * time.Millisecond
 	// defaultQuotaUpdateMaxTotalJitter bounds cumulative jitter per batch so
 	// Evaluate()'s 10s timeout never gets consumed by jitter alone.
 	defaultQuotaUpdateMaxTotalJitter = 1 * time.Second
@@ -171,18 +172,6 @@ type quotaCheckContext struct {
 	// calls. Persists across recursive checkQuota calls; capped at
 	// QuotaUpdateMaxTotalJitter so jitter cannot exhaust Evaluate()'s timeout.
 	totalJitterSpent time.Duration
-}
-
-// addResourceList adds the resources in newList to list.
-func addResourceList(list, newList corev1.ResourceList) {
-	for name, quantity := range newList {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-		} else {
-			value.Add(quantity)
-			list[name] = value
-		}
-	}
 }
 
 // maskResourceList removes entries from resources that are not in nameSet or have zero values.
@@ -518,7 +507,7 @@ func (e *quotaEvaluator) checkRequest(quota *v1alpha1.ElasticQuota, a *Attribute
 
 	// Accumulate delta and update cached usage for next iteration
 	ctx.used = newUsage
-	addResourceList(ctx.delta, requestedUsage)
+	util.AddResourceList(ctx.delta, requestedUsage)
 
 	return nil
 }

--- a/pkg/webhook/quotaevaluate/evaluator.go
+++ b/pkg/webhook/quotaevaluate/evaluator.go
@@ -76,41 +76,53 @@ const (
 	// per batch, matching the original hardcoded value so small batches keep the
 	// previous behavior exactly.
 	quotaUpdateMinRetries = 3
-	// defaultQuotaUpdateMaxRetries caps the worst-case latency of a batch.
-	defaultQuotaUpdateMaxRetries = 10
-
-	// defaultQuotaUpdateRetryJitter is the per-retry decorrelation upper bound.
-	// Actual sleep is in [jitter/2, jitter). 50ms is large enough to decorrelate
-	// peer webhook pods given typical apiserver RTT (< 20ms) yet small enough
-	// to amortize across many retries within the total budget.
-	defaultQuotaUpdateRetryJitter = 50 * time.Millisecond
-	// defaultQuotaUpdateMaxTotalJitter bounds cumulative jitter per batch so
-	// Evaluate()'s 10s timeout never gets consumed by jitter alone.
-	defaultQuotaUpdateMaxTotalJitter = 1 * time.Second
 )
 
 // QuotaUpdateMaxRetries is the upper bound of UpdateQuotaStatus retries per batch.
-// Bound the worst-case latency of a heavily-contended batch.
-var QuotaUpdateMaxRetries = defaultQuotaUpdateMaxRetries
+// Default 3 matches pre-optimization behavior. Recommended 10 for high-contention
+// multi-replica deployments to allow dynamic retry scaling with batch size
+// (retries grow by 1 per doubling of batch size, capped at this value).
+var QuotaUpdateMaxRetries = quotaUpdateMinRetries
 
 // QuotaUpdateRetryJitter is the per-retry decorrelation sleep upper bound for
-// UpdateQuotaStatus. Set <= 0 to disable jitter entirely.
-var QuotaUpdateRetryJitter = defaultQuotaUpdateRetryJitter
+// UpdateQuotaStatus conflicts. Actual sleep per retry is drawn from [jitter/2, jitter).
+// Default 0 (disabled) matches pre-optimization behavior. Recommended 50ms for
+// multi-replica webhook deployments to reduce conflict storms between peers.
+var QuotaUpdateRetryJitter time.Duration
 
-// QuotaUpdateMaxTotalJitter is the per-batch cumulative jitter cap.
-// Set <= 0 to disable jitter entirely.
-var QuotaUpdateMaxTotalJitter = defaultQuotaUpdateMaxTotalJitter
+// QuotaUpdateMaxTotalJitter bounds cumulative jitter per batch so Evaluate()'s
+// 10s evaluation timeout never gets consumed by jitter alone.
+// Default 1s is a safe upper bound for most scenarios (10% of the 10s timeout).
+// Jitter is only effective when --quota-update-retry-jitter > 0.
+var QuotaUpdateMaxTotalJitter = 1 * time.Second
+
+// QuotaUpdateConflictFreshGet controls whether UpdateQuotaStatus uses a non-cached
+// (apiReader) read on conflict to refresh the local cache, so the next retry
+// sees the latest ResourceVersion and avoids repeated conflicts.
+// Default false matches pre-optimization behavior. Recommended true for
+// environments where the cached client frequently returns stale ResourceVersions.
+var QuotaUpdateConflictFreshGet bool
 
 func InitFlags(fs *flag.FlagSet) {
 	fs.IntVar(&QuotaUpdateMaxRetries, "quota-update-max-retries",
 		QuotaUpdateMaxRetries,
-		"Maximum number of UpdateQuotaStatus retries per batch. Caps worst-case latency.")
+		"Maximum number of UpdateQuotaStatus retries per batch (default 3). "+
+			"Recommended 10 for high-contention multi-replica deployments "+
+			"to allow dynamic retry scaling with batch size.")
 	fs.DurationVar(&QuotaUpdateRetryJitter, "quota-update-retry-jitter",
 		QuotaUpdateRetryJitter,
-		"Per-retry decorrelation sleep upper bound for UpdateQuotaStatus conflicts. Set <= 0 to disable jitter.")
+		"Per-retry decorrelation sleep upper bound for UpdateQuotaStatus conflicts (default 0, disabled). "+
+			"Recommended 50ms for multi-replica webhook deployments to reduce conflict storms. "+
+			"Actual sleep is in [jitter/2, jitter).")
 	fs.DurationVar(&QuotaUpdateMaxTotalJitter, "quota-update-max-total-jitter",
 		QuotaUpdateMaxTotalJitter,
-		"Per-batch cumulative jitter cap for UpdateQuotaStatus retries. Set <= 0 to disable jitter.")
+		"Per-batch cumulative jitter cap for UpdateQuotaStatus retries (default 1s). "+
+			"Bounds worst-case jitter overhead within Evaluate()'s 10s evaluation timeout. "+
+			"Only effective when --quota-update-retry-jitter > 0.")
+	fs.BoolVar(&QuotaUpdateConflictFreshGet, "quota-update-conflict-fresh-get",
+		QuotaUpdateConflictFreshGet,
+		"Use non-cached apiReader on update conflict to refresh local cache (default false). "+
+			"Recommended true to reduce repeat conflicts caused by stale cached ResourceVersions.")
 }
 
 // retriesForBatch returns the retry budget for a batch in which n pods have
@@ -138,11 +150,11 @@ func retriesForBatch(n int) int {
 
 // jitterForNextUpdate decides how much jitter to grant the upcoming
 // UpdateQuotaStatus call. Returns 0 when:
-//   - either jitter knob is non-positive (feature disabled), or
+//   - jitter is non-positive (feature disabled), or
 //   - no retry would happen after this update (remainingRetries <= 0), or
 //   - granting more would exceed QuotaUpdateMaxTotalJitter for this batch.
 func (e *quotaEvaluator) jitterForNextUpdate(ctx *quotaCheckContext, remainingRetries int) time.Duration {
-	if QuotaUpdateRetryJitter <= 0 || QuotaUpdateMaxTotalJitter <= 0 {
+	if QuotaUpdateRetryJitter <= 0 {
 		return 0
 	}
 	if remainingRetries <= 0 {

--- a/pkg/webhook/quotaevaluate/evaluator.go
+++ b/pkg/webhook/quotaevaluate/evaluator.go
@@ -309,7 +309,11 @@ func (e *quotaEvaluator) checkAttributes(key string, admissionAttributes []*admi
 		return
 	}
 
-	e.checkQuota(quota, admissionAttributes, QuotaUpdateMaxRetries, nil)
+	startRetries := QuotaUpdateMaxRetries
+	if startRetries < quotaUpdateMinRetries {
+		startRetries = quotaUpdateMinRetries
+	}
+	e.checkQuota(quota, admissionAttributes, startRetries, nil)
 }
 
 func (e *quotaEvaluator) checkQuota(quota *v1alpha1.ElasticQuota, admissionAttributes []*admissionWaiter, remainingRetries int, ctx *quotaCheckContext) {

--- a/pkg/webhook/quotaevaluate/evaluator.go
+++ b/pkg/webhook/quotaevaluate/evaluator.go
@@ -18,7 +18,9 @@ package quotaevaluate
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -27,6 +29,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,6 +65,133 @@ var podResources = []corev1.ResourceName{
 	extension.ResourceNvidiaGPU,
 	extension.ResourceGPUShared,
 	extension.ResourceGPUMemoryRatio,
+}
+
+// podResourcesSet is a pre-computed set of podResources for O(1) lookup.
+var podResourcesSet = sets.New(podResources...)
+
+const (
+	// quotaUpdateMinRetries is the fixed lower bound of UpdateQuotaStatus retries
+	// per batch, matching the original hardcoded value so small batches keep the
+	// previous behavior exactly.
+	quotaUpdateMinRetries = 3
+	// defaultQuotaUpdateMaxRetries caps the worst-case latency of a batch.
+	defaultQuotaUpdateMaxRetries = 10
+
+	// defaultQuotaUpdateRetryJitter is the per-retry decorrelation upper bound.
+	// Actual sleep is in [jitter/2, jitter). 100ms is large enough to decorrelate
+	// peer webhook pods given typical apiserver RTT (< 20ms) yet small enough
+	// to amortize across many retries within the total budget.
+	defaultQuotaUpdateRetryJitter = 20 * time.Millisecond
+	// defaultQuotaUpdateMaxTotalJitter bounds cumulative jitter per batch so
+	// Evaluate()'s 10s timeout never gets consumed by jitter alone.
+	defaultQuotaUpdateMaxTotalJitter = 1 * time.Second
+)
+
+// QuotaUpdateMaxRetries is the upper bound of UpdateQuotaStatus retries per batch.
+// Bound the worst-case latency of a heavily-contended batch.
+var QuotaUpdateMaxRetries = defaultQuotaUpdateMaxRetries
+
+// QuotaUpdateRetryJitter is the per-retry decorrelation sleep upper bound for
+// UpdateQuotaStatus. Set <= 0 to disable jitter entirely.
+var QuotaUpdateRetryJitter = defaultQuotaUpdateRetryJitter
+
+// QuotaUpdateMaxTotalJitter is the per-batch cumulative jitter cap.
+// Set <= 0 to disable jitter entirely.
+var QuotaUpdateMaxTotalJitter = defaultQuotaUpdateMaxTotalJitter
+
+func InitFlags(fs *flag.FlagSet) {
+	fs.IntVar(&QuotaUpdateMaxRetries, "quota-update-max-retries",
+		QuotaUpdateMaxRetries,
+		"Maximum number of UpdateQuotaStatus retries per batch. Caps worst-case latency.")
+	fs.DurationVar(&QuotaUpdateRetryJitter, "quota-update-retry-jitter",
+		QuotaUpdateRetryJitter,
+		"Per-retry decorrelation sleep upper bound for UpdateQuotaStatus conflicts. Set <= 0 to disable jitter.")
+	fs.DurationVar(&QuotaUpdateMaxTotalJitter, "quota-update-max-total-jitter",
+		QuotaUpdateMaxTotalJitter,
+		"Per-batch cumulative jitter cap for UpdateQuotaStatus retries. Set <= 0 to disable jitter.")
+}
+
+// retriesForBatch returns the retry budget for a batch in which n pods have
+// contributed a non-zero delta. Equivalent to the legacy hardcoded value when
+// n <= 1, and grows by 1 with every doubling of n, capped at QuotaUpdateMaxRetries.
+//
+// Why: expected failed admissions per batch is ~ n * p^k. Holding k constant lets
+// that error term scale linearly with n. Bumping k by log2(n) keeps it roughly
+// constant. Extra attempts only run on failure (with probability p^k), so the
+// marginal cost decays exponentially and steady-state throughput is unaffected.
+func retriesForBatch(n int) int {
+	maxK := QuotaUpdateMaxRetries
+	if maxK < quotaUpdateMinRetries {
+		maxK = quotaUpdateMinRetries
+	}
+	if n <= 1 {
+		return quotaUpdateMinRetries
+	}
+	k := quotaUpdateMinRetries + int(math.Floor(math.Log2(float64(n))))
+	if k > maxK {
+		return maxK
+	}
+	return k
+}
+
+// jitterForNextUpdate decides how much jitter to grant the upcoming
+// UpdateQuotaStatus call. Returns 0 when:
+//   - either jitter knob is non-positive (feature disabled), or
+//   - no retry would happen after this update (remainingRetries <= 0), or
+//   - granting more would exceed QuotaUpdateMaxTotalJitter for this batch.
+func (e *quotaEvaluator) jitterForNextUpdate(ctx *quotaCheckContext, remainingRetries int) time.Duration {
+	if QuotaUpdateRetryJitter <= 0 || QuotaUpdateMaxTotalJitter <= 0 {
+		return 0
+	}
+	if remainingRetries <= 0 {
+		return 0
+	}
+	if ctx.totalJitterSpent+QuotaUpdateRetryJitter > QuotaUpdateMaxTotalJitter {
+		return 0
+	}
+	return QuotaUpdateRetryJitter
+}
+
+// quotaCheckContext holds accumulated state across checkQuota invocations for performance
+// optimization and retry fast-path support.
+type quotaCheckContext struct {
+	admission corev1.ResourceList
+	fatal     error
+
+	// used caches the most recently computed childRequest to avoid
+	// repeated marshal/unmarshal round-trips within the batch loop.
+	used corev1.ResourceList
+	// delta is the sum of all successfully admitted Pod deltas in this batch.
+	// Used for optimistic fast-path validation on retry.
+	delta corev1.ResourceList
+	names sets.Set[corev1.ResourceName]
+
+	// totalJitterSpent accumulates per-batch jitter allocated to UpdateQuotaStatus
+	// calls. Persists across recursive checkQuota calls; capped at
+	// QuotaUpdateMaxTotalJitter so jitter cannot exhaust Evaluate()'s timeout.
+	totalJitterSpent time.Duration
+}
+
+// addResourceList adds the resources in newList to list.
+func addResourceList(list, newList corev1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// maskResourceList removes entries from resources that are not in nameSet or have zero values.
+func maskResourceList(resources corev1.ResourceList, nameSet sets.Set[corev1.ResourceName]) {
+	for key, value := range resources {
+		if !nameSet.Has(key) || value.IsZero() {
+			delete(resources, key)
+		}
+	}
 }
 
 type Attributes struct {
@@ -190,51 +320,72 @@ func (e *quotaEvaluator) checkAttributes(key string, admissionAttributes []*admi
 		return
 	}
 
-	e.checkQuota(quota, admissionAttributes, 3)
+	e.checkQuota(quota, admissionAttributes, QuotaUpdateMaxRetries, nil)
 }
 
-func (e *quotaEvaluator) checkQuota(quota *v1alpha1.ElasticQuota, admissionAttributes []*admissionWaiter, remainingRetries int) {
-	// yet another copy to compare against originals to see if we actually have deltas
-	originalQuota := quota.DeepCopy()
-	originChildRequest, err := extension.GetChildRequest(originalQuota)
-	if err != nil {
-		klog.Warningf("failed go get child request %v/%v, err: %v", quota.Namespace, quota.Name, err)
-	}
-	childRequest, err := extension.GetChildRequest(quota)
-	if err != nil {
-		klog.Warningf("failed go get child request %v/%v, err: %v", quota.Namespace, quota.Name, err)
-	}
+func (e *quotaEvaluator) checkQuota(quota *v1alpha1.ElasticQuota, admissionAttributes []*admissionWaiter, remainingRetries int, ctx *quotaCheckContext) {
+	ctx = e.initCtx(ctx, quota)
 
-	changed := false
-	for i := range admissionAttributes {
-		admissionAttribute := admissionAttributes[i]
-		newQuota, err := e.checkRequest(quota, admissionAttribute.attributes)
-		if err != nil {
-			admissionAttribute.result = err
-			continue
-		}
+	fastPathOK := false
+	// fast retry only happens when quota is changed in last round and resource names keep unchanged
+	if ctx.fatal == nil && len(ctx.delta) > 0 {
+		newUsage := quotav1.Add(ctx.used, ctx.delta)
+		maskResourceList(newUsage, ctx.names)
 
-		newChildRequest, err := extension.GetChildRequest(newQuota)
-		if err != nil {
-			klog.Warningf("failed go get child request %v/%v, err: %v", quota.Namespace, quota.Name, err)
-		}
-		if !quotav1.Equals(childRequest, newChildRequest) {
-			changed = true
+		if allowed, _ := quotav1.LessThanOrEqual(newUsage, ctx.admission); !allowed {
+			// cached delta is no longer admissible; drop it and rebuild via slow path
+			ctx.delta = corev1.ResourceList{}
 		} else {
-			admissionAttribute.result = nil
+			fastPathOK = true
+			ctx.used = newUsage
+		}
+	}
+
+	if !fastPathOK {
+		changed := 0
+		for i := range admissionAttributes {
+			admissionAttribute := admissionAttributes[i]
+			if !IsDefaultDeny(admissionAttribute.result) {
+				continue
+			}
+			oldUsed := ctx.used.DeepCopy()
+			err := e.checkRequest(quota, admissionAttribute.attributes, ctx)
+			if err != nil {
+				admissionAttribute.result = err
+				continue
+			}
+
+			if !quotav1.Equals(oldUsed, ctx.used) {
+				changed++
+			} else {
+				admissionAttribute.result = nil
+			}
 		}
 
-		childRequest = newChildRequest
-		quota = newQuota
+		if changed <= 0 {
+			return
+		}
+		// Narrow the retry budget to what this batch's real workload warrants.
+		// remainingRetries is decremented on every recursion, so the min here
+		// can only ratchet it further down -- a batch that shrinks across
+		// retries gets a tighter budget but never a looser one.
+		if retries := retriesForBatch(changed); retries < remainingRetries {
+			remainingRetries = retries
+		}
 	}
 
-	if !changed {
-		return
-	}
-
-	var updateErr error
-	if !quotav1.Equals(originChildRequest, childRequest) {
-		updateErr = e.quotaAccessor.UpdateQuotaStatus(quota)
+	data, updateErr := json.Marshal(ctx.used)
+	if updateErr == nil {
+		newQuota := quota.DeepCopy()
+		if newQuota.Annotations == nil {
+			newQuota.Annotations = make(map[string]string)
+		}
+		newQuota.Annotations[extension.AnnotationChildRequest] = string(data)
+		jitter := e.jitterForNextUpdate(ctx, remainingRetries)
+		if jitter > 0 {
+			ctx.totalJitterSpent += jitter
+		}
+		updateErr = e.quotaAccessor.UpdateQuotaStatus(newQuota, jitter)
 	}
 
 	if updateErr == nil {
@@ -267,7 +418,29 @@ func (e *quotaEvaluator) checkQuota(quota *v1alpha1.ElasticQuota, admissionAttri
 		return
 	}
 
-	e.checkQuota(newQuota, admissionAttributes, remainingRetries-1)
+	// Pass ctx to enable fast-path in next recursion
+	e.checkQuota(newQuota, admissionAttributes, remainingRetries-1, ctx)
+}
+
+func (e *quotaEvaluator) initCtx(ctx *quotaCheckContext, quota *v1alpha1.ElasticQuota) *quotaCheckContext {
+	if ctx == nil {
+		ctx = &quotaCheckContext{}
+	}
+	childRequest, childRequestErr := extension.GetChildRequest(quota)
+	admission, admissionErr := GetQuotaAdmission(quota)
+	ctx.admission = admission
+	ctx.fatal = utilerrors.NewAggregate([]error{childRequestErr, admissionErr})
+	if childRequest != nil {
+		ctx.used = childRequest.DeepCopy()
+	} else {
+		ctx.used = corev1.ResourceList{}
+	}
+	names := sets.KeySet(quota.Spec.Max)
+	// clean up when resource names changed
+	if ctx.names.Len() == 0 || !names.Equal(ctx.names) {
+		ctx.names, ctx.delta = names, corev1.ResourceList{}
+	}
+	return ctx
 }
 
 func (e *quotaEvaluator) Handles(a *Attributes) bool {
@@ -302,42 +475,33 @@ func PodUsageFunc(pod *corev1.Pod, clock clock.Clock) (corev1.ResourceList, erro
 	return requests, nil
 }
 
-func (e *quotaEvaluator) checkRequest(quota *v1alpha1.ElasticQuota, a *Attributes) (*v1alpha1.ElasticQuota, error) {
+func (e *quotaEvaluator) checkRequest(quota *v1alpha1.ElasticQuota, a *Attributes, ctx *quotaCheckContext) error {
 	if !e.Handles(a) {
-		return quota, nil
+		return nil
 	}
 
-	if len(quotav1.Intersection(quotav1.ResourceNames(quota.Spec.Max), podResources)) == 0 {
-		return quota, nil
+	if ctx.fatal != nil {
+		return ctx.fatal
 	}
 
-	deltaUsage, err := PodUsageFunc(a.Pod, clock.RealClock{})
+	if ctx.names.Intersection(podResourcesSet).Len() == 0 {
+		return nil
+	}
+
+	requestedUsage, err := PodUsageFunc(a.Pod, clock.RealClock{})
 	if err != nil {
-		return quota, err
+		return err
 	}
 
-	deltaUsage = quotav1.RemoveZeros(deltaUsage)
-	if len(deltaUsage) == 0 {
-		return quota, nil
-	}
-
-	hardResources := quotav1.ResourceNames(quota.Spec.Max)
-	requestedUsage := quotav1.Mask(deltaUsage, hardResources)
-	requestedUsage = quotav1.RemoveZeros(requestedUsage)
+	// Filter requestedUsage to only include resources in quota.Spec.Max, removing zeros.
+	maskResourceList(requestedUsage, ctx.names)
 	if len(requestedUsage) == 0 {
-		return quota, nil
+		return nil
 	}
 
-	quotaCopy := quota.DeepCopy()
-	used, err := extension.GetChildRequest(quotaCopy)
-	if err != nil {
-		return nil, err
-	}
-	admission, err := GetQuotaAdmission(quotaCopy)
-	if err != nil {
-		return nil, err
-	}
+	used, admission := ctx.used, ctx.admission
 
+	// Use quotav1.Add (non-destructive) to preserve original 'used' for error messages
 	newUsage := quotav1.Add(used, requestedUsage)
 	maskedNewUsage := quotav1.Mask(newUsage, quotav1.ResourceNames(requestedUsage))
 
@@ -345,23 +509,18 @@ func (e *quotaEvaluator) checkRequest(quota *v1alpha1.ElasticQuota, a *Attribute
 		failedRequestedUsage := quotav1.Mask(requestedUsage, exceeded)
 		failedUsed := quotav1.Mask(used, exceeded)
 		failedHard := quotav1.Mask(admission, exceeded)
-		return quota, fmt.Errorf("exceeded quota: %s/%s, requested: %s, used: %s, limited: %s",
+		return fmt.Errorf("exceeded quota: %s/%s, requested: %s, used: %s, limited: %s",
 			quota.Namespace, quota.Name,
 			prettyPrint(failedRequestedUsage),
 			prettyPrint(failedUsed),
 			prettyPrint(failedHard))
 	}
 
-	data, err := json.Marshal(newUsage)
-	if err != nil {
-		return nil, err
-	}
-	if quotaCopy.Annotations == nil {
-		quotaCopy.Annotations = make(map[string]string)
-	}
-	quotaCopy.Annotations[extension.AnnotationChildRequest] = string(data)
+	// Accumulate delta and update cached usage for next iteration
+	ctx.used = newUsage
+	addResourceList(ctx.delta, requestedUsage)
 
-	return quotaCopy, nil
+	return nil
 }
 
 func (e *quotaEvaluator) Evaluate(a *Attributes) error {

--- a/pkg/webhook/quotaevaluate/evaluator_test.go
+++ b/pkg/webhook/quotaevaluate/evaluator_test.go
@@ -18,7 +18,9 @@ package quotaevaluate
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -26,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
@@ -34,6 +38,265 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/util"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/elasticquota"
 )
+
+// newTestEvaluator returns an Evaluator backed by a fake client preloaded with
+// the given quotas. The same fake client is reused as both the cached client
+// and the apiReader since the fake has no informer cache to skip.
+func newTestEvaluator(quotas ...*v1alpha1.ElasticQuota) (Evaluator, client.Client) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+	objs := make([]client.Object, 0, len(quotas))
+	for _, q := range quotas {
+		objs = append(objs, q)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return NewQuotaEvaluator(NewQuotaAccessor(c, c), 16, make(chan struct{})), c
+}
+
+func TestCheckRequest(t *testing.T) {
+	e := &quotaEvaluator{}
+
+	tests := []struct {
+		name        string
+		quota       *v1alpha1.ElasticQuota
+		ctx         *quotaCheckContext
+		attr        *Attributes
+		expectErr   bool
+		errContains string
+		expectUsed  corev1.ResourceList
+		expectDelta corev1.ResourceList
+	}{
+		{
+			name: "successful request updates used and delta",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("20"),
+					corev1.ResourceMemory: resource.MustParse("60Gi"),
+				}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{},
+				admission: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20"), corev1.ResourceMemory: resource.MustParse("60Gi")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(corev1.ResourceCPU, corev1.ResourceMemory),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Create,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					}).Obj(),
+			},
+			expectErr:   false,
+			expectUsed:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("4Gi")},
+			expectDelta: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("4Gi")},
+		},
+		{
+			name: "exceeded quota returns error",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+				admission: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(corev1.ResourceCPU),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Create,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					}).Obj(),
+			},
+			expectErr:   true,
+			errContains: "exceeded quota",
+			expectUsed:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+			expectDelta: corev1.ResourceList{},
+		},
+		{
+			name: "non-create operation is no-op",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{},
+				admission: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(corev1.ResourceCPU),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Update,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).Obj(),
+			},
+			expectErr:   false,
+			expectUsed:  corev1.ResourceList{},
+			expectDelta: corev1.ResourceList{},
+		},
+		{
+			name: "only quota-managed resources are counted",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					extension.ResourceNvidiaGPU: resource.MustParse("4"),
+				}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{},
+				admission: corev1.ResourceList{extension.ResourceNvidiaGPU: resource.MustParse("4")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(extension.ResourceNvidiaGPU),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Create,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{
+						corev1.ResourceCPU:          resource.MustParse("2"),
+						corev1.ResourceMemory:       resource.MustParse("4Gi"),
+						extension.ResourceNvidiaGPU: resource.MustParse("1"),
+					}).Obj(),
+			},
+			expectErr:   false,
+			expectUsed:  corev1.ResourceList{extension.ResourceNvidiaGPU: resource.MustParse("1")},
+			expectDelta: corev1.ResourceList{extension.ResourceNvidiaGPU: resource.MustParse("1")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := e.checkRequest(tt.quota, tt.attr, tt.ctx)
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectUsed, tt.ctx.used)
+			assert.Equal(t, tt.expectDelta, tt.ctx.delta)
+		})
+	}
+}
+
+// retryMockAccessor simulates update failure on first attempt then success on retry.
+type retryMockAccessor struct {
+	firstQuota  *v1alpha1.ElasticQuota
+	retryQuota  *v1alpha1.ElasticQuota
+	failFirst   bool
+	updateCalls int
+}
+
+func (m *retryMockAccessor) GetQuota(key string) (*v1alpha1.ElasticQuota, error) {
+	return m.retryQuota.DeepCopy(), nil
+}
+
+func (m *retryMockAccessor) UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota, _ time.Duration) error {
+	m.updateCalls++
+	if m.failFirst && m.updateCalls == 1 {
+		return fmt.Errorf("conflict")
+	}
+	return nil
+}
+
+func TestCheckQuotaFastRetry(t *testing.T) {
+	tests := []struct {
+		name             string
+		quota            *v1alpha1.ElasticQuota
+		retryQuota       *v1alpha1.ElasticQuota
+		attrs            []*Attributes
+		expectAllSuccess bool
+	}{
+		{
+			name: "fast retry succeeds when quota has capacity",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("20"),
+				}).ChildRequest(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("10"),
+				}).Obj(),
+			retryQuota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("20"),
+				}).ChildRequest(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("12"),
+				}).Obj(),
+			attrs: []*Attributes{
+				{
+					QuotaNamespace: "ns",
+					QuotaName:      "test",
+					Operation:      admissionv1.Create,
+					Pod: elasticquota.MakePod("ns", "pod1").Container(
+						corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).Obj(),
+				},
+				{
+					QuotaNamespace: "ns",
+					QuotaName:      "test",
+					Operation:      admissionv1.Create,
+					Pod: elasticquota.MakePod("ns", "pod2").Container(
+						corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}).Obj(),
+				},
+			},
+			expectAllSuccess: true,
+		},
+		{
+			name: "fast retry falls back to full evaluation when exceeds",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("20"),
+				}).ChildRequest(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("10"),
+				}).Obj(),
+			retryQuota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("20"),
+				}).ChildRequest(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("18"),
+				}).Obj(),
+			attrs: []*Attributes{
+				{
+					QuotaNamespace: "ns",
+					QuotaName:      "test",
+					Operation:      admissionv1.Create,
+					Pod: elasticquota.MakePod("ns", "pod1").Container(
+						corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5")}).Obj(),
+				},
+			},
+			expectAllSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor := &retryMockAccessor{
+				firstQuota: tt.quota,
+				retryQuota: tt.retryQuota,
+				failFirst:  true,
+			}
+			e := &quotaEvaluator{quotaAccessor: accessor}
+
+			waiters := make([]*admissionWaiter, len(tt.attrs))
+			for i, attr := range tt.attrs {
+				waiters[i] = newAdmissionWaiter(attr)
+			}
+
+			e.checkQuota(tt.quota, waiters, QuotaUpdateMaxRetries, nil)
+
+			allSuccess := true
+			for _, w := range waiters {
+				if w.result != nil {
+					allSuccess = false
+					break
+				}
+			}
+			assert.Equal(t, tt.expectAllSuccess, allSuccess)
+		})
+	}
+}
 
 func TestEvaluate(t *testing.T) {
 	testCases := []struct {
@@ -178,15 +441,7 @@ func TestEvaluate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			_ = v1alpha1.AddToScheme(scheme)
-			_ = clientgoscheme.AddToScheme(scheme)
-
-			client := fake.NewClientBuilder().WithScheme(scheme).
-				WithObjects(tc.quota).Build()
-
-			quotaAccessor := NewQuotaAccessor(client)
-			evaluator := NewQuotaEvaluator(quotaAccessor, 16, make(chan struct{}))
+			evaluator, c := newTestEvaluator(tc.quota)
 
 			err := evaluator.Evaluate(tc.attribute)
 			if tc.expectError {
@@ -197,7 +452,7 @@ func TestEvaluate(t *testing.T) {
 				assert.NoError(t, err)
 
 				newQuota := &v1alpha1.ElasticQuota{}
-				err = client.Get(context.TODO(), types.NamespacedName{
+				err = c.Get(context.TODO(), types.NamespacedName{
 					Namespace: tc.quota.Namespace,
 					Name:      tc.quota.Name,
 				}, newQuota)
@@ -207,6 +462,155 @@ func TestEvaluate(t *testing.T) {
 				t.Logf("expec %v, got %v", util.DumpJSON(tc.expectUsed), util.DumpJSON(newUsage))
 				assert.Equal(t, tc.expectUsed, newUsage)
 			}
+		})
+	}
+}
+
+func TestEvaluateSequential(t *testing.T) {
+	type step struct {
+		req         corev1.ResourceList
+		expectErr   string // substring; empty means success
+	}
+	tests := []struct {
+		name            string
+		quota           *v1alpha1.ElasticQuota
+		steps           []step
+		expectFinalUsed corev1.ResourceList
+	}{
+		{
+			name: "multiple pods accumulate usage",
+			quota: elasticquota.MakeQuota("test1").Namespace("ns1").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("20"),
+					corev1.ResourceMemory: resource.MustParse("60Gi"),
+				}).Obj(),
+			steps: []step{
+				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourceMemory: resource.MustParse("10Gi")}},
+				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourceMemory: resource.MustParse("10Gi")}},
+			},
+			expectFinalUsed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+		},
+		{
+			name: "second pod exceeds accumulated quota",
+			quota: elasticquota.MakeQuota("test1").Namespace("ns1").Max(
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")}).ChildRequest(
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).Obj(),
+			steps: []step{
+				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},                  // 8+1=9 <=10
+				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}, expectErr: "exceeded quota"}, // 9+3=12 >10
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluator, c := newTestEvaluator(tt.quota)
+
+			for i, s := range tt.steps {
+				err := evaluator.Evaluate(&Attributes{
+					QuotaNamespace: tt.quota.Namespace,
+					QuotaName:      tt.quota.Name,
+					Operation:      admissionv1.Create,
+					Pod:            elasticquota.MakePod(tt.quota.Namespace, fmt.Sprintf("pod%d", i+1)).Container(s.req).Obj(),
+				})
+				if s.expectErr != "" {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), s.expectErr)
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+
+			if tt.expectFinalUsed == nil {
+				return
+			}
+			got := &v1alpha1.ElasticQuota{}
+			assert.NoError(t, c.Get(context.TODO(), types.NamespacedName{
+				Namespace: tt.quota.Namespace,
+				Name:      tt.quota.Name,
+			}, got))
+			used, err := extension.GetChildRequest(got)
+			assert.NoError(t, err)
+			for k, v := range tt.expectFinalUsed {
+				assert.Equal(t, v, used[k], "resource %s", k)
+			}
+		})
+	}
+}
+
+func TestRetriesForBatch(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want int
+	}{
+		{"empty batch falls back to min", 0, quotaUpdateMinRetries},
+		{"single pod equals legacy hardcoded value", 1, quotaUpdateMinRetries},
+		{"two pods earn one extra retry", 2, quotaUpdateMinRetries + 1},
+		{"three pods still in log2=1 bucket", 3, quotaUpdateMinRetries + 1},
+		{"four pods earn two extra retries", 4, quotaUpdateMinRetries + 2},
+		{"eight pods earn three extra retries", 8, quotaUpdateMinRetries + 3},
+		{"capped at QuotaUpdateMaxRetries", 1 << 20, QuotaUpdateMaxRetries},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, retriesForBatch(tc.n))
+		})
+	}
+
+	t.Run("respects QuotaUpdateMaxRetries override", func(t *testing.T) {
+		orig := QuotaUpdateMaxRetries
+		t.Cleanup(func() { QuotaUpdateMaxRetries = orig })
+
+		QuotaUpdateMaxRetries = 5
+		assert.Equal(t, 5, retriesForBatch(1<<10))
+		assert.Equal(t, quotaUpdateMinRetries, retriesForBatch(1))
+
+		// max lower than min collapses to min
+		QuotaUpdateMaxRetries = 1
+		assert.Equal(t, quotaUpdateMinRetries, retriesForBatch(1<<10))
+	})
+}
+
+func TestJitterForNextUpdate(t *testing.T) {
+	const (
+		defR = defaultQuotaUpdateRetryJitter
+		defT = defaultQuotaUpdateMaxTotalJitter
+	)
+	tests := []struct {
+		name             string
+		retryJitter      time.Duration
+		maxTotalJitter   time.Duration
+		spent            time.Duration
+		remainingRetries int
+		want             time.Duration
+	}{
+		{"happy path", defR, defT, 0, 1, defR},
+		{"last attempt", defR, defT, 0, 0, 0},
+		{"budget exhausted", defR, defT, defT - defR + 1, 5, 0},
+		{"retry knob zero disables", 0, defT, 0, 5, 0},
+		{"retry knob negative disables", -time.Millisecond, defT, 0, 5, 0},
+		{"total knob zero disables", defR, 0, 0, 5, 0},
+		{"total knob negative disables", defR, -time.Second, 0, 5, 0},
+		{"custom fits", 50 * time.Millisecond, 75 * time.Millisecond, 0, 5, 50 * time.Millisecond},
+		{"custom overshoot", 50 * time.Millisecond, 75 * time.Millisecond, 50 * time.Millisecond, 5, 0},
+	}
+
+	e := &quotaEvaluator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origR, origT := QuotaUpdateRetryJitter, QuotaUpdateMaxTotalJitter
+			t.Cleanup(func() {
+				QuotaUpdateRetryJitter, QuotaUpdateMaxTotalJitter = origR, origT
+			})
+			QuotaUpdateRetryJitter = tt.retryJitter
+			QuotaUpdateMaxTotalJitter = tt.maxTotalJitter
+
+			ctx := &quotaCheckContext{totalJitterSpent: tt.spent}
+			assert.Equal(t, tt.want, e.jitterForNextUpdate(ctx, tt.remainingRetries))
 		})
 	}
 }

--- a/pkg/webhook/quotaevaluate/evaluator_test.go
+++ b/pkg/webhook/quotaevaluate/evaluator_test.go
@@ -542,6 +542,10 @@ func TestEvaluateSequential(t *testing.T) {
 }
 
 func TestRetriesForBatch(t *testing.T) {
+	orig := QuotaUpdateMaxRetries
+	t.Cleanup(func() { QuotaUpdateMaxRetries = orig })
+	QuotaUpdateMaxRetries = 10
+
 	tests := []struct {
 		name string
 		n    int
@@ -577,8 +581,8 @@ func TestRetriesForBatch(t *testing.T) {
 
 func TestJitterForNextUpdate(t *testing.T) {
 	const (
-		defR = defaultQuotaUpdateRetryJitter
-		defT = defaultQuotaUpdateMaxTotalJitter
+		testJitter  = 50 * time.Millisecond
+		maxTotalCap = 1 * time.Second
 	)
 	tests := []struct {
 		name             string
@@ -588,13 +592,13 @@ func TestJitterForNextUpdate(t *testing.T) {
 		remainingRetries int
 		want             time.Duration
 	}{
-		{"happy path", defR, defT, 0, 1, defR},
-		{"last attempt", defR, defT, 0, 0, 0},
-		{"budget exhausted", defR, defT, defT - defR + 1, 5, 0},
-		{"retry knob zero disables", 0, defT, 0, 5, 0},
-		{"retry knob negative disables", -time.Millisecond, defT, 0, 5, 0},
-		{"total knob zero disables", defR, 0, 0, 5, 0},
-		{"total knob negative disables", defR, -time.Second, 0, 5, 0},
+		{"happy path", testJitter, maxTotalCap, 0, 1, testJitter},
+		{"last attempt", testJitter, maxTotalCap, 0, 0, 0},
+		{"budget exhausted", testJitter, maxTotalCap, maxTotalCap - testJitter + 1, 5, 0},
+		{"retry knob zero disables", 0, maxTotalCap, 0, 5, 0},
+		{"retry knob negative disables", -time.Millisecond, maxTotalCap, 0, 5, 0},
+		{"total knob zero disables", testJitter, 0, 0, 5, 0},
+		{"total knob negative disables", testJitter, -time.Second, 0, 5, 0},
 		{"custom fits", 50 * time.Millisecond, 75 * time.Millisecond, 0, 5, 50 * time.Millisecond},
 		{"custom overshoot", 50 * time.Millisecond, 75 * time.Millisecond, 50 * time.Millisecond, 5, 0},
 	}

--- a/pkg/webhook/quotaevaluate/evaluator_test.go
+++ b/pkg/webhook/quotaevaluate/evaluator_test.go
@@ -468,8 +468,8 @@ func TestEvaluate(t *testing.T) {
 
 func TestEvaluateSequential(t *testing.T) {
 	type step struct {
-		req         corev1.ResourceList
-		expectErr   string // substring; empty means success
+		req       corev1.ResourceList
+		expectErr string // substring; empty means success
 	}
 	tests := []struct {
 		name            string
@@ -499,7 +499,7 @@ func TestEvaluateSequential(t *testing.T) {
 				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")}).ChildRequest(
 				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).Obj(),
 			steps: []step{
-				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},                  // 8+1=9 <=10
+				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},                              // 8+1=9 <=10
 				{req: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}, expectErr: "exceeded quota"}, // 9+3=12 >10
 			},
 		},

--- a/pkg/webhook/quotaevaluate/quota_accessor.go
+++ b/pkg/webhook/quotaevaluate/quota_accessor.go
@@ -18,14 +18,18 @@ package quotaevaluate
 
 import (
 	"context"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/lru"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 )
 
@@ -34,14 +38,20 @@ import (
 type QuotaAccessor interface {
 	// UpdateQuotaStatus is called to persist final status.  This method should write to persistent storage.
 	// An error indicates that write didn't complete successfully.
-	UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota) error
+	//
+	// jitter is the upper bound of an optional decorrelation sleep injected on
+	// conflict, before the fresh-quota read. Caller passes 0 to disable. Actual
+	// sleep is drawn from [jitter/2, jitter).
+	UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota, jitter time.Duration) error
 
 	// GetQuota gets the specificated elastic quota.
 	GetQuota(key string) (*v1alpha1.ElasticQuota, error)
 }
 
 type quotaAccessor struct {
-	client client.Client
+	client    client.Client
+	apiReader client.Reader // non-cached reader for conflict recovery
+
 	// updatedQuotas holds a cache of quotas that we've updated.  This is used to pull the "really latest" during back to
 	// back quota evaluations that touch the same quota doc.  This only works because we can compare etcd resourceVersions
 	// for the same resource as integers.  Before this change: 22 updates with 12 conflicts.  after this change: 15 updates with 0 conflicts
@@ -49,23 +59,42 @@ type quotaAccessor struct {
 }
 
 // NewQuotaAccessor creates an object that conforms to the QuotaAccessor interface to be used to retrieve quota objects.
-func NewQuotaAccessor(c client.Client) *quotaAccessor {
+func NewQuotaAccessor(c client.Client, apiReader client.Reader) *quotaAccessor {
 	updatedCache := lru.New(100)
 	return &quotaAccessor{
 		client:        c,
+		apiReader:     apiReader,
 		updatedQuotas: updatedCache,
 	}
 }
 
-func (q *quotaAccessor) UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota) error {
+func (q *quotaAccessor) UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota, jitter time.Duration) error {
 	err := q.client.Update(context.TODO(), newQuota)
-	if err != nil {
-		return err
-	}
 	key := newQuota.Namespace + "/" + newQuota.Name
+	if err != nil {
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		// Sleep BEFORE the fresh read so the cached freshQuota is the freshest
+		// possible; sleeping after would leave a stale ResourceVersion that
+		// guarantees another conflict on the next update.
+		if jitter > 0 {
+			time.Sleep(wait.Jitter(jitter/2, 1.0))
+		}
+		freshQuota := &v1alpha1.ElasticQuota{}
+		if getErr := q.apiReader.Get(context.TODO(), types.NamespacedName{
+			Namespace: newQuota.Namespace,
+			Name:      newQuota.Name,
+		}, freshQuota); getErr != nil {
+			klog.ErrorS(getErr, "Failed to get fresh quota on conflict", "key", key)
+			return err
+		}
+		newQuota = freshQuota
+	}
 	q.updatedQuotas.Add(key, newQuota)
-	klog.Infof("quota acessor update status for: %v, usage: %v", key, newQuota.Status.Used)
-	return nil
+	klog.V(4).InfoS("Quota accessor cache updated", "key", key, "resourceVersion", newQuota.ResourceVersion,
+		"usage", newQuota.Annotations[extension.AnnotationChildRequest], "updateErr", err)
+	return err
 }
 
 var etcdVersioner = storage.APIObjectVersioner{}

--- a/pkg/webhook/quotaevaluate/quota_accessor.go
+++ b/pkg/webhook/quotaevaluate/quota_accessor.go
@@ -81,6 +81,9 @@ func (q *quotaAccessor) UpdateQuotaStatus(newQuota *v1alpha1.ElasticQuota, jitte
 		if jitter > 0 {
 			time.Sleep(wait.Jitter(jitter/2, 1.0))
 		}
+		if !QuotaUpdateConflictFreshGet {
+			return err
+		}
 		freshQuota := &v1alpha1.ElasticQuota{}
 		if getErr := q.apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: newQuota.Namespace,

--- a/pkg/webhook/quotaevaluate/quota_accessor_test.go
+++ b/pkg/webhook/quotaevaluate/quota_accessor_test.go
@@ -103,6 +103,10 @@ func TestUpdateQuotaStatus(t *testing.T) {
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = clientgoscheme.AddToScheme(scheme)
 
+	origFreshGet := QuotaUpdateConflictFreshGet
+	QuotaUpdateConflictFreshGet = true
+	t.Cleanup(func() { QuotaUpdateConflictFreshGet = origFreshGet })
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			quota := &v1alpha1.ElasticQuota{

--- a/pkg/webhook/quotaevaluate/quota_accessor_test.go
+++ b/pkg/webhook/quotaevaluate/quota_accessor_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotaevaluate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+)
+
+type fakeClientWrapper struct {
+	client.Client
+	updateErr error
+}
+
+func (c *fakeClientWrapper) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.updateErr != nil {
+		return c.updateErr
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+type fakeReaderWrapper struct {
+	client.Reader
+	getErr error
+}
+
+func (r *fakeReaderWrapper) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	if r.getErr != nil {
+		return r.getErr
+	}
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func TestUpdateQuotaStatus(t *testing.T) {
+	conflictError := apierrors.NewConflict(schema.GroupResource{Group: "scheduling.sigs.k8s.io", Resource: "elasticquotas"}, "", fmt.Errorf("the object has been modified"))
+
+	testCases := []struct {
+		name            string
+		updateErr       error
+		getErr          error
+		expectError     bool
+		expectCached    bool
+		expectCachedCPU string
+	}{
+		{
+			name:            "update success",
+			expectError:     false,
+			expectCached:    true,
+			expectCachedCPU: "8",
+		},
+		{
+			name:            "conflict refreshes cache from apiReader",
+			updateErr:       conflictError,
+			expectError:     true,
+			expectCached:    true,
+			expectCachedCPU: "4",
+		},
+		{
+			name:         "conflict with apiReader failure skips cache",
+			updateErr:    conflictError,
+			getErr:       fmt.Errorf("api server unavailable"),
+			expectError:  true,
+			expectCached: false,
+		},
+		{
+			name:         "non-conflict error skips fetch and cache",
+			updateErr:    fmt.Errorf("internal server error"),
+			expectError:  true,
+			expectCached: false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			quota := &v1alpha1.ElasticQuota{
+				TypeMeta: metav1.TypeMeta{Kind: "ElasticQuota", APIVersion: "scheduling.sigs.k8s.io/v1alpha1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "quota1",
+				},
+				Status: v1alpha1.ElasticQuotaStatus{
+					Used: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(quota).Build()
+			cw := &fakeClientWrapper{Client: fakeClient, updateErr: tc.updateErr}
+			rw := &fakeReaderWrapper{Reader: fakeClient, getErr: tc.getErr}
+			accessor := NewQuotaAccessor(cw, rw)
+
+			got := &v1alpha1.ElasticQuota{}
+			err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: "ns1", Name: "quota1"}, got)
+			assert.NoError(t, err)
+
+			got.Status.Used = corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("8"),
+			}
+
+			err = accessor.UpdateQuotaStatus(got, 0)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			cached, ok := accessor.updatedQuotas.Get("ns1/quota1")
+			assert.Equal(t, tc.expectCached, ok)
+			if tc.expectCached {
+				cachedQuota := cached.(*v1alpha1.ElasticQuota)
+				assert.Equal(t, resource.MustParse(tc.expectCachedCPU), cachedQuota.Status.Used[corev1.ResourceCPU])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe what this PR does

  This PR optimizes the elastic quota admission webhook (`pkg/webhook/quotaevaluate`) to reduce `UpdateQuotaStatus` conflict failures observed in multi-replica deployments. The changes are layered and orthogonal —
  each can be reverted independently:

  1. **Conflict-aware quota refresh** (`quota_accessor.go`): on `UpdateQuotaStatus` conflict, the accessor fetches the latest object via a non-cached `apiReader` and pushes it into the LRU cache so the next
  `GetQuota` skips the lagging informer.

  2. **Per-batch context cache** (`quotaCheckContext`): accumulates `used` / `delta` / `admission` / `names` across the recursive `checkQuota` calls in the same batch, eliminating repeated marshal/unmarshal
  round-trips on retry.

  3. **Fast-path retry**: when a batch retries after a conflict, the cached delta is validated against the fresh admission in one shot; if it still fits, the per-pod `checkRequest` loop is skipped entirely.

  4. **Dynamic retry budget** (`retriesForBatch`): scales the retry count logarithmically with the number of pods that actually contributed a delta, from `k_min=3` up to `k_max` (configurable via
  `--quota-update-max-retries`, default 3, recommended 10). Single-pod batches keep the legacy `remainingRetries=3` behavior exactly; large batches earn more retries proportional to the work they carry.

  5. **Decorrelation jitter for retries** (`jitterForNextUpdate` + `UpdateQuotaStatus(jitter)`): before the conflict-refresh read inside `UpdateQuotaStatus`, an optional jitter sleep is injected. The evaluator
  decides whether to grant jitter based on three gates: feature must be enabled, more retries must still be available, and per-batch cumulative jitter budget must not be exceeded. Jitter is placed before
  `apiReader.Get` so the cached `freshQuota` is the freshest possible.

  ### Goal

  Improve elastic quota admission success rate in multi-replica webhook deployments, where concurrent `UpdateQuotaStatus` calls produce two distinct kinds of conflicts:

  - **Informer-lag conflicts ("stale read")** — one webhook pod reads a quota version that another pod has already advanced. Resolved by the `apiReader` refresh + LRU cache.
  - **Concurrent-write conflicts ("write race")** — peer pods hit the same `ResourceVersion` and only one wins. Resolved by decorrelation jitter, which staggers retry start times across replicas.

  ### New flags

  All defaults match pre-optimization behavior — no behavioral change without explicit opt-in.

  | Flag | Default | Recommended | Description |
  |------|---------|-------------|-------------|
  | `--quota-update-max-retries` | 3 | 10 | Maximum retries per batch. Scales dynamically with batch size via `retriesForBatch(n) = 3 + ⌊log₂ n⌋`, capped at this value. |
  | `--quota-update-retry-jitter` | 0 (disabled) | 50ms | Per-retry decorrelation sleep upper bound. Actual sleep is in `[jitter/2, jitter)`. |
  | `--quota-update-max-total-jitter` | 1s | 1s | Per-batch cumulative jitter cap. Bounds worst-case jitter overhead within `Evaluate()`'s 10s timeout. Only effective when `--quota-update-retry-jitter > 0`. |
  | `--quota-update-conflict-fresh-get` | false | true | On update conflict, use non-cached `apiReader` to refresh local LRU cache with the latest `ResourceVersion`. |

  To enable all optimizations:

  --quota-update-max-retries=10 --quota-update-retry-jitter=50ms --quota-update-conflict-fresh-get=true

  ### Quantitative targets

  - For a batch of `n` pods with per-attempt failure probability `p`, expected admission losses scale as `n · p^k`. The legacy fixed `k=3` is the default; setting `--quota-update-max-retries=10` enables dynamic
  scaling where `k(n) ≈ k_min + ⌊log₂ n⌋` keeps the loss term roughly constant. At `p=0.3`, a batch of 64 pods sees expected losses drop from ~1.73 to ~0.013 (≈130×).
  - Steady-state throughput `n·(1-p)/t` is independent of `k` because extra retries only run on failure (cost ~`p^k`, exponentially decaying). Larger batches earn more retries essentially for free.
  - Per-batch cumulative jitter is capped at 1s (default), well within `Evaluate()`'s 10s timeout — worst-case latency stays bounded.

  ### Non-goals

  - No schema change to `ElasticQuota` (still uses `Annotations[AnnotationChildRequest]`).
  - No change to the single-worker-per-quota concurrency model.
  - No client-side distributed locking — apiserver CAS remains the source of truth.