### PR TITLE
koordlet: move resctrl group constants from qos plugin to util/system

### DIFF
--- a/pkg/koordlet/metricsadvisor/collectors/resctrl/resctrl_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/resctrl/resctrl_collector.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
@@ -91,9 +90,9 @@ func (r *resctrlCollector) collectQoSResctrlStat() {
 	resctrlMetrics := make([]metriccache.MetricSample, 0)
 	collectTime := time.Now()
 	for _, qos := range []string{
-		string(extension.QoSLSR),
-		string(extension.QoSLS),
-		string(extension.QoSBE)} {
+		system.LSRResctrlGroup,
+		system.LSResctrlGroup,
+		system.BEResctrlGroup} {
 		l3Map, err := r.resctrlReader.ReadResctrlL3Stat(qos)
 		if err != nil {
 			klog.V(4).Infof("collect QoS %s resctrl llc data error: %v", qos, err)

--- a/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile.go
+++ b/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile.go
@@ -43,15 +43,6 @@ import (
 const (
 	ResctrlReconcileName = "ResctrlReconcile"
 
-	// LSRResctrlGroup is the name of LSR resctrl group
-	LSRResctrlGroup = "LSR"
-	// LSResctrlGroup is the name of LS resctrl group
-	LSResctrlGroup = "LS"
-	// BEResctrlGroup is the name of BE resctrl group
-	BEResctrlGroup = "BE"
-	// UnknownResctrlGroup is the resctrl group which is unknown to reconcile
-	UnknownResctrlGroup = "Unknown"
-
 	// Max memory bandwidth for AMD CPU, Gb/s, since the extreme limit is hard to reach, we set a discount by 0.8
 	// TODO The max memory bandwidth varies across SKU, so koordlet should be aware of the maximum automatically,
 	// or support an configuration list.
@@ -65,7 +56,7 @@ const (
 
 var (
 	// resctrlGroupList is the list of resctrl groups to be reconcile
-	resctrlGroupList = []string{LSRResctrlGroup, LSResctrlGroup, BEResctrlGroup}
+	resctrlGroupList = []string{system.LSRResctrlGroup, system.LSResctrlGroup, system.BEResctrlGroup}
 )
 
 var _ framework.QOSStrategy = &resctrlReconcile{}
@@ -110,15 +101,15 @@ func getPodResctrlGroup(pod *corev1.Pod) string {
 	podQoS := extension.GetPodQoSClassWithDefault(pod)
 	switch podQoS {
 	case extension.QoSLSE:
-		return LSRResctrlGroup
+		return system.LSRResctrlGroup
 	case extension.QoSLSR:
-		return LSRResctrlGroup
+		return system.LSRResctrlGroup
 	case extension.QoSLS:
-		return LSResctrlGroup
+		return system.LSResctrlGroup
 	case extension.QoSBE:
-		return BEResctrlGroup
+		return system.BEResctrlGroup
 	}
-	return UnknownResctrlGroup
+	return system.UnknownResctrlGroup
 }
 
 func getResourceQOSForResctrlGroup(strategy *slov1alpha1.ResourceQOSStrategy, group string) *slov1alpha1.ResourceQOS {
@@ -126,11 +117,11 @@ func getResourceQOSForResctrlGroup(strategy *slov1alpha1.ResourceQOSStrategy, gr
 		return nil
 	}
 	switch group {
-	case LSRResctrlGroup:
+	case system.LSRResctrlGroup:
 		return strategy.LSRClass
-	case LSResctrlGroup:
+	case system.LSResctrlGroup:
 		return strategy.LSClass
-	case BEResctrlGroup:
+	case system.BEResctrlGroup:
 		return strategy.BEClass
 	}
 	return nil
@@ -477,7 +468,7 @@ func (r *resctrlReconcile) reconcileResctrlGroups(qosStrategy *slov1alpha1.Resou
 		}
 
 		// TODO https://github.com/koordinator-sh/koordinator/pull/94#discussion_r858779795
-		if group := getPodResctrlGroup(pod); group != UnknownResctrlGroup {
+		if group := getPodResctrlGroup(pod); group != system.UnknownResctrlGroup {
 			ids := r.getPodCgroupNewTaskIds(podMeta, curTaskMaps[group])
 			taskIds[group] = append(taskIds[group], ids...)
 			klog.V(6).Infof("pod %v apply to group %s with %v tasks", util.GetPodKey(pod), group, len(ids))

--- a/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile_test.go
+++ b/pkg/koordlet/qosmanager/plugins/resctrl/resctrl_reconcile_test.go
@@ -80,7 +80,7 @@ func testingPrepareResctrlL3CatGroups(t *testing.T, cbmStr, rootSchemataStr stri
 	if len(schemataData) >= 1 {
 		beSchemataData = []byte(schemataData[0])
 	}
-	beSchemataDir := filepath.Join(resctrlDir, BEResctrlGroup)
+	beSchemataDir := filepath.Join(resctrlDir, system.BEResctrlGroup)
 	err := os.MkdirAll(beSchemataDir, 0700)
 	assert.NoError(t, err)
 	beSchemataPath := filepath.Join(beSchemataDir, system.ResctrlSchemataName)
@@ -94,7 +94,7 @@ func testingPrepareResctrlL3CatGroups(t *testing.T, cbmStr, rootSchemataStr stri
 	if len(schemataData) >= 2 {
 		lsSchemataData = []byte(schemataData[1])
 	}
-	lsSchemataDir := filepath.Join(resctrlDir, LSResctrlGroup)
+	lsSchemataDir := filepath.Join(resctrlDir, system.LSResctrlGroup)
 	err = os.MkdirAll(lsSchemataDir, 0700)
 	assert.NoError(t, err)
 	lsSchemataPath := filepath.Join(lsSchemataDir, system.ResctrlSchemataName)
@@ -108,7 +108,7 @@ func testingPrepareResctrlL3CatGroups(t *testing.T, cbmStr, rootSchemataStr stri
 	if len(schemataData) >= 3 {
 		lsrSchemataData = []byte(schemataData[2])
 	}
-	lsrSchemataDir := filepath.Join(resctrlDir, LSRResctrlGroup)
+	lsrSchemataDir := filepath.Join(resctrlDir, system.LSRResctrlGroup)
 	err = os.MkdirAll(lsrSchemataDir, 0700)
 	assert.NoError(t, err)
 	lsrSchemataPath := filepath.Join(lsrSchemataDir, system.ResctrlSchemataName)
@@ -272,8 +272,8 @@ func Test_initCatResctrl(t *testing.T) {
 		assert.NoError(t, err)
 
 		resctrlDirPath = filepath.Join(system.Conf.SysFSRootDir, system.ResctrlDir)
-		beResctrlGroupPath := filepath.Join(resctrlDirPath, BEResctrlGroup)
-		lsResctrlGroupPath := filepath.Join(resctrlDirPath, LSResctrlGroup)
+		beResctrlGroupPath := filepath.Join(resctrlDirPath, system.BEResctrlGroup)
+		lsResctrlGroupPath := filepath.Join(resctrlDirPath, system.LSResctrlGroup)
 		_, err = os.Stat(beResctrlGroupPath)
 		assert.NoError(t, err)
 		_, err = os.Stat(lsResctrlGroupPath)
@@ -549,7 +549,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "throw an error for write on invalid path",
 			args: args{
-				group: LSResctrlGroup,
+				group: system.LSResctrlGroup,
 				cbm:   0xf,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -570,7 +570,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "warning to empty policy",
 			args: args{
-				group: LSResctrlGroup,
+				group: system.LSResctrlGroup,
 				cbm:   0xf,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -590,7 +590,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "throw an error for calculating schemata failed",
 			args: args{
-				group: LSResctrlGroup,
+				group: system.LSResctrlGroup,
 				cbm:   0x4,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -610,7 +610,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "apply policy correctly",
 			args: args{
-				group: LSResctrlGroup,
+				group: system.LSResctrlGroup,
 				cbm:   0xf,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -633,7 +633,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "apply policy correctly 1",
 			args: args{
-				group: LSResctrlGroup,
+				group: system.LSResctrlGroup,
 				cbm:   0x7ff,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -664,7 +664,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "apply policy correctly 2",
 			args: args{
-				group: LSRResctrlGroup,
+				group: system.LSRResctrlGroup,
 				cbm:   0x7ff,
 				l3Num: 2,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -695,7 +695,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3PolicyForGroup(t *testing.T) {
 		{
 			name: "calculate the policy but no need to update",
 			args: args{
-				group: BEResctrlGroup,
+				group: system.BEResctrlGroup,
 				cbm:   0x7ff,
 				l3Num: 1,
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -803,7 +803,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 		{
 			name: "throw an error for write on invalid path",
 			args: args{
-				group:        LSResctrlGroup,
+				group:        system.LSResctrlGroup,
 				l3Num:        2,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -823,7 +823,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 		{
 			name: "warning to empty policy",
 			args: args{
-				group:        LSResctrlGroup,
+				group:        system.LSResctrlGroup,
 				l3Num:        2,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -842,7 +842,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 		{
 			name: "apply policy correctly on intel",
 			args: args{
-				group:        LSResctrlGroup,
+				group:        system.LSResctrlGroup,
 				l3Num:        2,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -868,7 +868,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 				mockSchemata: "    L3:0=f;1=f;2=f;3=f\n    MB:0=2048;1=2048;2=2048;3=2048",
 			},
 			args: args{
-				group:        BEResctrlGroup,
+				group:        system.BEResctrlGroup,
 				l3Num:        4,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -892,7 +892,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 				mockSchemata: "    L3:0=f;1=f;2=f;3=f\n    MB:0=2048;1=2048;2=2048;3=2048",
 			},
 			args: args{
-				group:        BEResctrlGroup,
+				group:        system.BEResctrlGroup,
 				l3Num:        4,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: system.AMD_VENDOR_ID},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -911,7 +911,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 		{
 			name: "calculate the policy but no need to update",
 			args: args{
-				group:        BEResctrlGroup,
+				group:        system.BEResctrlGroup,
 				l3Num:        2,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -942,7 +942,7 @@ func TestResctrlReconcile_calculateAndApplyRDTMbPolicyForGroup(t *testing.T) {
 		{
 			name: "calculate the policy but no need to update 1",
 			args: args{
-				group:        BEResctrlGroup,
+				group:        system.BEResctrlGroup,
 				l3Num:        1,
 				basicCPUInfo: extension.CPUBasicInfo{VendorID: "GenuineIntel"},
 				qosStrategy: &slov1alpha1.ResourceQOSStrategy{
@@ -1034,14 +1034,14 @@ func TestResctrlReconcile_calculateAndApplyRDTL3GroupTasks(t *testing.T) {
 	}{
 		{
 			name:    "write nothing",
-			args:    args{group: LSResctrlGroup},
+			args:    args{group: system.LSResctrlGroup},
 			want:    "",
 			wantErr: false,
 		},
 		{
 			name: "abort writing for invalid path",
 			args: args{
-				group:   LSResctrlGroup,
+				group:   system.LSResctrlGroup,
 				taskIds: []int32{0, 1, 2, 5, 7, 9},
 			},
 			fields: fields{
@@ -1053,7 +1053,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3GroupTasks(t *testing.T) {
 		{
 			name: "write successfully",
 			args: args{
-				group:   BEResctrlGroup,
+				group:   system.BEResctrlGroup,
 				taskIds: []int32{0, 1, 2, 5, 7, 9},
 			},
 			want:    "012579", // the real content of resctrl tasks file would be "0\n\1\n2\n..."
@@ -1062,7 +1062,7 @@ func TestResctrlReconcile_calculateAndApplyRDTL3GroupTasks(t *testing.T) {
 		{
 			name: "write successfully 1",
 			args: args{
-				group:   BEResctrlGroup,
+				group:   system.BEResctrlGroup,
 				taskIds: []int32{0, 1, 2, 4, 5, 6},
 			},
 			want:    "012456", // the real content of resctrl tasks file would be "0\n\1\n2\n..."
@@ -1172,18 +1172,18 @@ func TestResctrlReconcile_reconcileRDTResctrlPolicy(t *testing.T) {
 		// reconcile and check if the result is correct
 		r.reconcileRDTResctrlPolicy(nodeSLO.Spec.ResourceQOSStrategy)
 
-		beSchemataPath := filepath.Join(resctrlDirPath, BEResctrlGroup, system.ResctrlSchemataName)
+		beSchemataPath := filepath.Join(resctrlDirPath, system.BEResctrlGroup, system.ResctrlSchemataName)
 		expectBESchemataStr := "L3:0=3f;1=3f;\n"
 		got, _ := os.ReadFile(beSchemataPath)
 		assert.Equal(t, expectBESchemataStr, string(got))
 
-		lsSchemataPath := filepath.Join(resctrlDirPath, LSResctrlGroup, system.ResctrlSchemataName)
+		lsSchemataPath := filepath.Join(resctrlDirPath, system.LSResctrlGroup, system.ResctrlSchemataName)
 		expectLSSchemataStr := "MB:0=90;1=90;\n"
 		got, _ = os.ReadFile(lsSchemataPath)
 		assert.Equal(t, expectLSSchemataStr, string(got))
 
 		// log error for invalid be resctrl path
-		err = os.RemoveAll(filepath.Join(resctrlDirPath, BEResctrlGroup))
+		err = os.RemoveAll(filepath.Join(resctrlDirPath, system.BEResctrlGroup))
 		assert.NoError(t, err)
 		r.reconcileRDTResctrlPolicy(nodeSLO.Spec.ResourceQOSStrategy)
 
@@ -1320,15 +1320,15 @@ func TestResctrlReconcile_reconcileResctrlGroups(t *testing.T) {
 		r.reconcileResctrlGroups(testQOSStrategy)
 
 		// check if the reconciliation is a success
-		out, err := os.ReadFile(system.ResctrlTasks.Path(BEResctrlGroup))
+		out, err := os.ReadFile(system.ResctrlTasks.Path(system.BEResctrlGroup))
 		assert.NoError(t, err)
 		assert.Equal(t, wantResctrlBETaskStr, string(out))
 
-		out, err = os.ReadFile(system.ResctrlTasks.Path(LSRResctrlGroup))
+		out, err = os.ReadFile(system.ResctrlTasks.Path(system.LSRResctrlGroup))
 		assert.NoError(t, err)
 		assert.Equal(t, wantResctrlLSRTaskStr, string(out))
 
-		beTasksPath := filepath.Join(system.ResctrlTasks.Path(BEResctrlGroup))
+		beTasksPath := filepath.Join(system.ResctrlTasks.Path(system.BEResctrlGroup))
 		err = os.WriteFile(beTasksPath, []byte(testingBEResctrlTasksStr), 0666)
 		assert.NoError(t, err)
 
@@ -1336,7 +1336,7 @@ func TestResctrlReconcile_reconcileResctrlGroups(t *testing.T) {
 		r.reconcileResctrlGroups(testQOSStrategy)
 
 		// check if the reconciliation is a success
-		out, err = os.ReadFile(system.ResctrlTasks.Path(BEResctrlGroup))
+		out, err = os.ReadFile(system.ResctrlTasks.Path(system.BEResctrlGroup))
 		assert.NoError(t, err)
 		assert.Equal(t, wantResctrlBETaskStr, string(out))
 	})

--- a/pkg/koordlet/util/system/resctrl.go
+++ b/pkg/koordlet/util/system/resctrl.go
@@ -59,6 +59,15 @@ const (
 	// other cpu vendor like "GenuineIntel"
 	AMD_VENDOR_ID   = "AuthenticAMD"
 	INTEL_VENDOR_ID = "GenuineIntel"
+
+	// LSRResctrlGroup is the name of LSR resctrl group
+	LSRResctrlGroup = "LSR"
+	// LSResctrlGroup is the name of LS resctrl group
+	LSResctrlGroup = "LS"
+	// BEResctrlGroup is the name of BE resctrl group
+	BEResctrlGroup = "BE"
+	// UnknownResctrlGroup is the resctrl group which is unknown to reconcile
+	UnknownResctrlGroup = "Unknown"
 )
 
 var (


### PR DESCRIPTION
## Summary
- Move resctrl group constants (LSRResctrlGroup, LSResctrlGroup, BEResctrlGroup, UnknownResctrlGroup) from `pkg/koordlet/qosmanager/plugins/resctrl` to `pkg/koordlet/util/system`
- Update the resctrl collector to use the shared constants instead of `extension.QoS*`, removing the `apis/extension` import
- Update the qos plugin and its tests to reference the constants via the `system` package

Fixes #2411

## Test plan
- [ ] Verify `go build ./pkg/koordlet/...` passes
- [ ] Verify `go vet ./pkg/koordlet/util/system/ ./pkg/koordlet/qosmanager/plugins/resctrl/ ./pkg/koordlet/metricsadvisor/collectors/resctrl/` passes
- [ ] Verify existing unit tests pass for affected packages