### PR TITLE
scheduler: fix networktopology preemption for reservations

### DIFF
--- a/pkg/scheduler/frameworkext/job_nominated_pods.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods.go
@@ -49,7 +49,7 @@ func MakeNominatedPodsOfTheSameJob(cycleState fwktype.CycleState, uids []string)
 	})
 }
 
-func getNominatedPodsOfTheSameJob(cycleState fwktype.CycleState) sets.Set[string] {
+func GetNominatedPodsOfTheSameJob(cycleState fwktype.CycleState) sets.Set[string] {
 	s, err := cycleState.Read(nominatedPodsOfTheSameJob)
 	if err != nil || s == nil {
 		return nil
@@ -75,7 +75,7 @@ func (ext *frameworkExtenderImpl) runFilterPluginsWithNominatedPods(
 	pod *corev1.Pod,
 	info fwktype.NodeInfo,
 ) *fwktype.Status {
-	podsOfSameJob := getNominatedPodsOfTheSameJob(state)
+	podsOfSameJob := GetNominatedPodsOfTheSameJob(state)
 	singlePass := k8sfeature.DefaultFeatureGate.Enabled(features.SkipFilterWithNominatedPods)
 
 	var status *fwktype.Status

--- a/pkg/scheduler/frameworkext/job_nominated_pods_test.go
+++ b/pkg/scheduler/frameworkext/job_nominated_pods_test.go
@@ -698,3 +698,34 @@ func Test_addMergedNominatedPods(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeAndGetNominatedPodsOfTheSameJob(t *testing.T) {
+	t.Run("set and get", func(t *testing.T) {
+		state := framework.NewCycleState()
+		uids := []string{"uid-1", "uid-2", "uid-3"}
+		MakeNominatedPodsOfTheSameJob(state, uids)
+
+		result := GetNominatedPodsOfTheSameJob(state)
+		assert.NotNil(t, result, "should return non-nil set when data exists")
+		assert.Equal(t, 3, result.Len())
+		for _, uid := range uids {
+			assert.True(t, result.Has(uid), "set should contain uid %s", uid)
+		}
+		assert.False(t, result.Has("uid-not-exist"))
+	})
+
+	t.Run("not set returns nil", func(t *testing.T) {
+		state := framework.NewCycleState()
+		result := GetNominatedPodsOfTheSameJob(state)
+		assert.Nil(t, result, "should return nil when no data stored")
+	})
+
+	t.Run("empty list returns empty set", func(t *testing.T) {
+		state := framework.NewCycleState()
+		MakeNominatedPodsOfTheSameJob(state, []string{})
+
+		result := GetNominatedPodsOfTheSameJob(state)
+		assert.NotNil(t, result, "should return non-nil set even for empty list")
+		assert.Equal(t, 0, result.Len())
+	})
+}

--- a/pkg/scheduler/plugins/reservation/nominator_test.go
+++ b/pkg/scheduler/plugins/reservation/nominator_test.go
@@ -770,4 +770,55 @@ func TestReservationsNominator(t *testing.T) {
 	assert.True(t, update)
 	assert.True(t, status.IsSuccess())
 	assert.Equal(t, 2, len(nodeInfoOut.GetPods()))
+
+	// Test gang scenario: same-job nominated reserve pods should be excluded from BeforeFilter.
+	t.Run("gang same-job exclusion", func(t *testing.T) {
+		gangPod0 := pods[0] // nominated on node-1
+		gangPod1 := pods[1] // nominated on node-1
+
+		// Mark gangPod0 as a same-job pod (gang-mate of gangPod1).
+		gangState := framework.NewCycleState()
+		frameworkext.MakeNominatedPodsOfTheSameJob(gangState, []string{string(gangPod0.UID)})
+
+		// Scheduling gangPod1: gangPod0 (same-job) should be excluded;
+		// gangPod1 itself is excluded by UID check (rInfo.Pod.UID != pod.UID).
+		// Result: 0 pods added.
+		_, nodeInfoOut, update, status := pl.BeforeFilter(ctx, gangState, gangPod1, nodeInfo)
+		assert.True(t, update)
+		assert.True(t, status.IsSuccess())
+		assert.Equal(t, 0, len(nodeInfoOut.GetPods()),
+			"gang-mate nominated pod should be excluded from BeforeFilter")
+
+		// Without same-job marking, gangPod0 should be included.
+		noGangState := framework.NewCycleState()
+		_, nodeInfoOut2, update2, status2 := pl.BeforeFilter(ctx, noGangState, gangPod1, nodeInfo)
+		assert.True(t, update2)
+		assert.True(t, status2.IsSuccess())
+		assert.Equal(t, 1, len(nodeInfoOut2.GetPods()),
+			"without same-job marking, nominated pod should be included")
+
+		// Mixed nomination: verify only same-job pods are excluded, others are included.
+		// pods[2] is scheduling; pods[0] is same-job; pods[1] is not.
+		// Result: pods[1] included, pods[0] excluded.
+		mixedState := framework.NewCycleState()
+		frameworkext.MakeNominatedPodsOfTheSameJob(mixedState, []string{string(gangPod0.UID)})
+		_, nodeInfoOut3, update3, status3 := pl.BeforeFilter(ctx, mixedState, pods[2], nodeInfo)
+		assert.True(t, update3)
+		assert.True(t, status3.IsSuccess())
+		assert.Equal(t, 1, len(nodeInfoOut3.GetPods()),
+			"mixed: non-same-job nominated pod should still be included")
+		// Verify the included pod is pods[1] (non-same-job), not pods[0] (same-job).
+		podUIDs := make([]string, len(nodeInfoOut3.GetPods()))
+		for i, p := range nodeInfoOut3.GetPods() {
+			podUIDs[i] = string(p.GetPod().UID)
+		}
+		assert.Contains(t, podUIDs, string(gangPod1.UID),
+			"mixed: non-same-job nominated pod should be included")
+		assert.NotContains(t, podUIDs, string(gangPod0.UID),
+			"mixed: same-job nominated pod should be excluded")
+
+		// Clean up nominated pods.
+		nominatorImpl.DeleteNominatedReservePod(gangPod0)
+		nominatorImpl.DeleteNominatedReservePod(gangPod1)
+	})
 }

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -952,9 +952,12 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState fwktype.CycleStat
 	}
 
 	nodeInfoOut := nodeInfo.Snapshot()
+	// Ignore the nominated reservations of the same job
+	podsOfSameJob := frameworkext.GetNominatedPodsOfTheSameJob(cycleState)
 
 	for _, rInfo := range nominatedReservationInfos {
-		if schedulingcorev1.PodPriority(rInfo.Pod) >= schedulingcorev1.PodPriority(pod) && rInfo.Pod.UID != pod.UID {
+		if schedulingcorev1.PodPriority(rInfo.Pod) >= schedulingcorev1.PodPriority(pod) && rInfo.Pod.UID != pod.UID &&
+			(podsOfSameJob == nil || !podsOfSameJob.Has(string(rInfo.Pod.UID))) {
 			pInfo, _ := framework.NewPodInfo(rInfo.Pod)
 			nodeInfoOut.AddPodInfo(pInfo)
 			status := pl.handle.RunPreFilterExtensionAddPod(ctx, cycleState, pod, pInfo, nodeInfoOut)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: Support network-topology-aware preemption with reservations.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fix a bug where the nominated reservations (reserve pods) are double-accounting during the FindOneNode phase of the networktopology scheduling.

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
