### PR TITLE
fix(koordlet): fix SystemMemoryUsage with page cache policy

### DIFF
--- a/pkg/koordlet/metriccache/metric_resources.go
+++ b/pkg/koordlet/metriccache/metric_resources.go
@@ -29,8 +29,10 @@ var (
 
 	// define system resource usage as independent metric, although this can be calculate by node-sum(pod), but the time series are
 	// unaligned across different type of metric, which makes it hard to aggregate.
-	SystemCPUUsageMetric    = defaultMetricFactory.New(SysMetricCPUUsage)
-	SystemMemoryUsageMetric = defaultMetricFactory.New(SysMetricMemoryUsage)
+	SystemCPUUsageMetric                 = defaultMetricFactory.New(SysMetricCPUUsage)
+	SystemMemoryUsageMetric              = defaultMetricFactory.New(SysMetricMemoryUsage)
+	SystemMemoryUsageWithPageCacheMetric = defaultMetricFactory.New(SysMetricMemoryWithPageCacheUsage)
+	SystemMemoryWithHotPageUsageMetric   = defaultMetricFactory.New(SysMetricMemoryWithHotPageUsage)
 
 	PodCPUUsageMetric                 = defaultMetricFactory.New(PodMetricCPUUsage).withPropertySchema(MetricPropertyPodUID)
 	PodMemUsageMetric                 = defaultMetricFactory.New(PodMetricMemoryUsage).withPropertySchema(MetricPropertyPodUID)

--- a/pkg/koordlet/metriccache/metric_types.go
+++ b/pkg/koordlet/metriccache/metric_types.go
@@ -44,8 +44,10 @@ const (
 	NodeMetricGPUMemUsage        MetricKind = "node_gpu_memory_usage"
 	NodeMetricGPUMemTotal        MetricKind = "node_gpu_memory_total"
 
-	SysMetricCPUUsage    MetricKind = "sys_cpu_usage"
-	SysMetricMemoryUsage MetricKind = "sys_memory_usage"
+	SysMetricCPUUsage                 MetricKind = "sys_cpu_usage"
+	SysMetricMemoryUsage              MetricKind = "sys_memory_usage"
+	SysMetricMemoryWithPageCacheUsage MetricKind = "sys_memory_with_page_cache_usage"
+	SysMetricMemoryWithHotPageUsage   MetricKind = "sys_memory_with_hot_page_usage"
 
 	// NodeBE
 	NodeMetricBE MetricKind = "node_be"

--- a/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled.go
+++ b/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled.go
@@ -48,6 +48,7 @@ type kidledcoldPageCollector struct {
 	appendableDB    metriccache.Appendable
 	metricDB        metriccache.MetricCache // TODO remove redundant var
 	coldBoundary    int
+	sharedState     *framework.SharedState
 }
 
 func (k *kidledcoldPageCollector) Run(stopCh <-chan struct{}) {
@@ -79,7 +80,9 @@ func (k *kidledcoldPageCollector) Enabled() bool {
 	return false
 }
 
-func (k *kidledcoldPageCollector) Setup(c1 *framework.Context) {}
+func (k *kidledcoldPageCollector) Setup(c1 *framework.Context) {
+	k.sharedState = c1.State
+}
 
 func (k *kidledcoldPageCollector) collectColdPageInfo() {
 	if k.statesInformer == nil {
@@ -107,12 +110,12 @@ func (k *kidledcoldPageCollector) collectColdPageInfo() {
 
 	appender := k.appendableDB.Appender()
 	if err := appender.Append(coldPageMetrics); err != nil {
-		klog.ErrorS(err, "Append node metrics error")
+		klog.ErrorS(err, "Append cold memory metrics error")
 		return
 	}
 
 	if err := appender.Commit(); err != nil {
-		klog.Warningf("Commit node metrics failed, reason: %v", err)
+		klog.Warningf("Commit cold metrics failed, reason: %v", err)
 		return
 	}
 
@@ -143,6 +146,11 @@ func (k *kidledcoldPageCollector) collectNodeColdPageInfo() ([]metriccache.Metri
 		return nil, err
 	}
 	coldPageMetrics = append(coldPageMetrics, memUsageWithHotPageMetrics)
+
+	k.sharedState.UpdateNodeMemoryWithHotPageCache(metriccache.Point{
+		Timestamp: collectTime,
+		Value:     memUsageWithHotPageValue,
+	})
 
 	klog.V(4).Infof("collectNodeResUsed finished, count %v, memUsageWithHotPage[%v], coldPageSize[%v]",
 		len(coldPageMetrics), memUsageWithHotPageValue, nodeColdPageBytes)
@@ -192,6 +200,12 @@ func (k *kidledcoldPageCollector) collectPodsColdPageInfo() ([]metriccache.Metri
 			return nil, err
 		}
 		coldMetrics = append(coldMetrics, podMemUsageWithHotPageMetrics)
+
+		k.sharedState.UpdatePodsMemoryWithHotPageCache(uid, metriccache.Point{
+			Timestamp: collectTime,
+			Value:     podMemUsageWithHotPageValue,
+		})
+
 		count++
 		containerColdPageMetrics, err := k.collectContainersColdPageInfo(meta)
 		if err != nil {
@@ -258,8 +272,11 @@ func (k *kidledcoldPageCollector) collectHostAppsColdPageInfo() ([]metriccache.M
 	}
 	coldMetrics := make([]metriccache.MetricSample, 0, len(nodeSLO.Spec.HostApplications))
 	count := 0
+	var allMemoryUsageWithHotPageCache float64
+	var allTimestamp time.Time
 	for _, hostApp := range nodeSLO.Spec.HostApplications {
 		collectTime := timeNow()
+		allTimestamp = collectTime
 		cgroupDir := koordletutil.GetHostAppCgroupRelativePath(&hostApp)
 		coldPageBytes, err := k.cgroupReader.ReadMemoryColdPageUsage(cgroupDir)
 		if err != nil {
@@ -287,8 +304,17 @@ func (k *kidledcoldPageCollector) collectHostAppsColdPageInfo() ([]metriccache.M
 			return nil, err
 		}
 		coldMetrics = append(coldMetrics, memUsageWithHotPageMetrics)
+		allMemoryUsageWithHotPageCache += memUsageWithHotPageValue
 		count++
 	}
+
+	if count > 0 {
+		k.sharedState.UpdateHostAppMemoryWithHotPageCache(metriccache.Point{
+			Timestamp: allTimestamp,
+			Value:     allMemoryUsageWithHotPageCache,
+		})
+	}
+
 	klog.V(4).Infof("collectHostAppsColdPageInfo finished, host application num %d, collected %d", len(coldMetrics), count)
 	return coldMetrics, nil
 }

--- a/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled_test.go
@@ -394,6 +394,7 @@ DirectMap1G:           0 kB`
 				appendableDB:    metricCache,
 				metricDB:        metricCache,
 				started:         atomic.NewBool(false),
+				sharedState:     framework.NewSharedState(),
 			}
 			if tt.name == "states informer nil" {
 				c.statesInformer = nil
@@ -514,6 +515,7 @@ DirectMap1G:           0 kB`
 		metricDB:        metricCache,
 		started:         atomic.NewBool(false),
 		coldBoundary:    kidledConfig.KidledColdBoundary,
+		sharedState:     framework.NewSharedState(),
 	}
 	testNow := time.Now()
 	metrics, err := c.collectNodeColdPageInfo()
@@ -747,6 +749,7 @@ total_unevictable 0
 				appendableDB:    metricCache,
 				metricDB:        metricCache,
 				started:         atomic.NewBool(false),
+				sharedState:     framework.NewSharedState(),
 			}
 			assert.NotPanics(t, func() {
 				c.collectPodsColdPageInfo()
@@ -922,6 +925,7 @@ total_unevictable 0
 				statesInformer:  statesInformer,
 				appendableDB:    metricCache,
 				metricDB:        metricCache,
+				sharedState:     framework.NewSharedState(),
 			}
 			got, err := k.collectHostAppsColdPageInfo()
 			assert.Equal(t, tt.wantErr, err != nil)

--- a/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/coldmemoryresource/cold_page_kidled_test.go
@@ -352,10 +352,13 @@ DirectMap1G:           0 kB`
 					helper.WriteFileContents(system.KidledUseHierarchy.Path(""), `1`)
 					helper.SetResourcesSupported(true, system.MemoryIdlePageStats)
 					helper.WriteProcSubFileContents(system.ProcMemInfoName, meminfo)
+					helper.WriteCgroupFileContents("", system.MemoryIdlePageStats, testMemoryIdlePageStatsContent)
 					helper.WriteCgroupFileContents(testPodParentDir, system.MemoryStat, testMemStat)
 					helper.WriteCgroupFileContents(testPodParentDir, system.MemoryIdlePageStats, testMemoryIdlePageStatsContent)
 					helper.WriteCgroupFileContents(testContainerParentDir, system.MemoryStat, testMemStat)
 					helper.WriteCgroupFileContents(testContainerParentDir, system.MemoryIdlePageStats, testMemoryIdlePageStatsContent)
+					helper.WriteCgroupFileContents(testHostAppParentDir, system.MemoryStat, testMemStat)
+					helper.WriteCgroupFileContents(testHostAppParentDir, system.MemoryIdlePageStats, testMemoryIdlePageStatsContent)
 				},
 			},
 			wantstrated: false,

--- a/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector.go
@@ -111,6 +111,7 @@ func (h *hostAppCollector) collectHostAppResUsed() {
 	resourceMetrics := make([]metriccache.MetricSample, 0)
 	allCPUUsageCores := metriccache.Point{Timestamp: timeNow(), Value: 0}
 	allMemoryUsage := metriccache.Point{Timestamp: timeNow(), Value: 0}
+	allMemoryUsageWithPageCache := metriccache.Point{Timestamp: timeNow(), Value: 0}
 	metrics.ResetHostApplicationResourceUsage()
 	for _, hostApp := range nodeSLO.Spec.HostApplications {
 		collectTime := timeNow()
@@ -181,6 +182,8 @@ func (h *hostAppCollector) collectHostAppResUsed() {
 			klog.Warning("unrecognized node memory collect policy, use UsageWithoutPageCache as default")
 			allMemoryUsage.Value += float64(memoryUsageValue)
 		}
+
+		allMemoryUsageWithPageCache.Value += float64(memUsageWithPageCache)
 	}
 
 	appender := h.appendableDB.Appender()
@@ -195,6 +198,7 @@ func (h *hostAppCollector) collectHostAppResUsed() {
 	}
 
 	h.sharedState.UpdateHostAppUsage(allCPUUsageCores, allMemoryUsage)
+	h.sharedState.UpdateHostAppMemoryWithPageCache(allMemoryUsageWithPageCache)
 
 	h.started.Store(true)
 	klog.V(4).Infof("collectHostAppResUsed finished, host application num %d, collected %d",

--- a/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector.go
@@ -99,14 +99,6 @@ func (h *hostAppCollector) collectHostAppResUsed() {
 		return
 	}
 
-	nodeMetricSpec := h.statesInformer.GetNodeMetricSpec()
-	nodeMemoryCollectPolicy := defaultMemoryCollectPolicy
-	if nodeMetricSpec == nil {
-		klog.Warningf("get nil nodemetric, use default node memory collect policy: %v", defaultMemoryCollectPolicy)
-	} else if nodeMetricSpec.CollectPolicy != nil && nodeMetricSpec.CollectPolicy.NodeMemoryCollectPolicy != nil {
-		nodeMemoryCollectPolicy = *nodeMetricSpec.CollectPolicy.NodeMemoryCollectPolicy
-	}
-
 	count := 0
 	resourceMetrics := make([]metriccache.MetricSample, 0)
 	allCPUUsageCores := metriccache.Point{Timestamp: timeNow(), Value: 0}
@@ -172,17 +164,7 @@ func (h *hostAppCollector) collectHostAppResUsed() {
 		klog.V(6).Infof("collect host application %v finished, metric cpu=%v, memory=%v", hostApp.Name, cpuUsageValue, memoryUsageValue)
 		count++
 		allCPUUsageCores.Value += cpuUsageValue
-		// sum memory usage according to NodeMemoryCollectPolicy
-		switch nodeMemoryCollectPolicy {
-		case slov1alpha1.UsageWithoutPageCache:
-			allMemoryUsage.Value += float64(memoryUsageValue)
-		case slov1alpha1.UsageWithPageCache:
-			allMemoryUsage.Value += float64(memUsageWithPageCache)
-		default:
-			klog.Warning("unrecognized node memory collect policy, use UsageWithoutPageCache as default")
-			allMemoryUsage.Value += float64(memoryUsageValue)
-		}
-
+		allMemoryUsage.Value += float64(memoryUsageValue)
 		allMemoryUsageWithPageCache.Value += float64(memUsageWithPageCache)
 	}
 

--- a/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector_test.go
@@ -172,7 +172,7 @@ total_unevictable 0
 					"test-host-app": 209715200,
 				},
 				hostAppCPUUsage:    &metriccache.Point{Value: 1},
-				hostAPpMemoryUsage: &metriccache.Point{Value: 209715200},
+				hostAPpMemoryUsage: &metriccache.Point{Value: 104857600},
 			},
 		},
 		{
@@ -510,6 +510,12 @@ total_unevictable 0
 				// TODO mock time
 				assert.Equal(t, tt.wants.hostAppCPUUsage.Value, cpuUsage.Value)
 				assert.Equal(t, tt.wants.hostAPpMemoryUsage.Value, memoryUsage.Value)
+
+				if tt.name == "collect with policy UsageWithPageCache" {
+					memWithPageCache := c.sharedState.GetHostAppMemoryWithPageCache()
+					assert.NotNil(t, memWithPageCache)
+					assert.Equal(t, float64(209715200), memWithPageCache.Value)
+				}
 			}
 		})
 	}

--- a/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/hostapplication/host_app_collector_test.go
@@ -467,6 +467,13 @@ total_unevictable 0
 				c.collectHostAppResUsed()
 			})
 
+			if tt.fields.getNodeSLO != nil && len(tt.fields.getNodeSLO.Spec.HostApplications) > 0 && tt.name == "get host app metric" {
+				cpuPoint, memPoint := c.sharedState.GetHostAppUsage()
+				assert.NotNil(t, cpuPoint)
+				assert.NotNil(t, memPoint)
+				assert.NotNil(t, c.sharedState.GetHostAppMemoryWithPageCache())
+			}
+
 			querier, err := metricCache.Querier(testNow.Add(-time.Minute), testNow)
 			assert.NoError(t, err)
 

--- a/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector.go
@@ -50,6 +50,7 @@ type pageCacheCollector struct {
 	cgroupReader          resourceexecutor.CgroupReader
 	podFilter             framework.PodFilter
 	coldPageCollectorGate bool
+	sharedState           *framework.SharedState
 }
 
 func New(opt *framework.Options) framework.Collector {
@@ -73,7 +74,9 @@ func (p *pageCacheCollector) Enabled() bool {
 	return p.coldPageCollectorGate
 }
 
-func (p *pageCacheCollector) Setup(c *framework.Context) {}
+func (p *pageCacheCollector) Setup(c *framework.Context) {
+	p.sharedState = c.State
+}
 
 func (p *pageCacheCollector) Run(stopCh <-chan struct{}) {
 	go wait.Until(p.collectPageCache, p.collectInterval, stopCh)
@@ -115,6 +118,11 @@ func (p *pageCacheCollector) collectNodePageCache() {
 		return
 	}
 	nodeMetrics = append(nodeMetrics, memUsageWithPageCacheMetric)
+
+	p.sharedState.UpdateNodeMemoryWithPageCache(metriccache.Point{
+		Timestamp: collectTime,
+		Value:     memUsageWithPageCacheValue,
+	})
 
 	appender := p.appendableDB.Appender()
 	if err := appender.Append(nodeMetrics); err != nil {
@@ -167,6 +175,11 @@ func (p *pageCacheCollector) collectPodPageCache() {
 			return
 		}
 		metrics = append(metrics, memUsageWithPageCacheMetric)
+
+		p.sharedState.UpdatePodsMemoryWithPageCache(uid, metriccache.Point{
+			Timestamp: collectTime,
+			Value:     float64(memUsageWithPageCacheValue),
+		})
 
 		klog.V(6).Infof("collect pod %s, uid %s finished, metric %+v", podKey, pod.UID, metrics)
 

--- a/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
@@ -256,6 +256,9 @@ DirectMap1G:           0 kB`
 				CgroupReader:   resourceexecutor.NewCgroupReader(),
 			})
 			c := collector.(*pageCacheCollector)
+			c.Setup(&framework.Context{
+				State: framework.NewSharedState(),
+			})
 			assert.NotPanics(t, func() {
 				c.collectPageCache()
 			})

--- a/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
@@ -262,6 +262,11 @@ DirectMap1G:           0 kB`
 			assert.NotPanics(t, func() {
 				c.collectPageCache()
 			})
+			if tt.wantMetrics {
+				assert.NotNil(t, c.sharedState.GetNodeMemoryWithPageCache())
+				podPageCacheUsage := c.sharedState.GetPodsMemoryWithPageCacheByCollector()
+				assert.NotEmpty(t, podPageCacheUsage)
+			}
 			assert.NotPanics(t, func() {
 				c.Setup(&framework.Context{})
 			})

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector.go
@@ -134,9 +134,29 @@ func (s *systemResourceCollector) collectSysResUsed() {
 		return
 	}
 
+	metricsToAppend := []metriccache.MetricSample{systemCPUMetric, systemMemoryMetric}
+
+	nodeMemoryWithPageCache := s.sharedState.GetNodeMemoryWithPageCache()
+	hostAppMemoryWithPageCache := s.sharedState.GetHostAppMemoryWithPageCache()
+	if podsMemoryWithPageCache, err := s.getAllPodsMemoryWithPageCache(); err == nil && nodeMemoryWithPageCache != nil && hostAppMemoryWithPageCache != nil {
+		systemMemoryUsageWithPageCache := util.MaxFloat64(nodeMemoryWithPageCache.Value-podsMemoryWithPageCache-hostAppMemoryWithPageCache.Value, 0)
+		if metric, err := metriccache.SystemMemoryUsageWithPageCacheMetric.GenerateSample(nil, collectTime, systemMemoryUsageWithPageCache); err == nil {
+			metricsToAppend = append(metricsToAppend, metric)
+		}
+	}
+
+	nodeMemoryWithHotPageCache := s.sharedState.GetNodeMemoryWithHotPageCache()
+	hostAppMemoryWithHotPageCache := s.sharedState.GetHostAppMemoryWithHotPageCache()
+	if podsMemoryWithHotPageCache, err := s.getAllPodsMemoryWithHotPageCache(); err == nil && nodeMemoryWithHotPageCache != nil && hostAppMemoryWithHotPageCache != nil {
+		systemMemoryUsageWithHotPageCache := util.MaxFloat64(nodeMemoryWithHotPageCache.Value-podsMemoryWithHotPageCache-hostAppMemoryWithHotPageCache.Value, 0)
+		if metric, err := metriccache.SystemMemoryWithHotPageUsageMetric.GenerateSample(nil, collectTime, systemMemoryUsageWithHotPageCache); err == nil {
+			metricsToAppend = append(metricsToAppend, metric)
+		}
+	}
+
 	// commit metric sample
 	appender := s.appendableDB.Appender()
-	if err := appender.Append([]metriccache.MetricSample{systemCPUMetric, systemMemoryMetric}); err != nil {
+	if err := appender.Append(metricsToAppend); err != nil {
 		klog.ErrorS(err, "append system metrics error")
 		return
 	}
@@ -147,6 +167,40 @@ func (s *systemResourceCollector) collectSysResUsed() {
 
 	klog.V(4).Infof("collect system resource usage finished, cpu %v, memory %v", systemCPUUsage, systemMemoryUsage)
 	s.started.Store(true)
+}
+
+func (s *systemResourceCollector) getAllPodsMemoryWithPageCache() (float64, error) {
+	validTime := timeNow().Add(-s.outdatedInterval)
+	var memory float64
+	podMemoryByCollector := s.sharedState.GetPodsMemoryWithPageCacheByCollector()
+	if len(podMemoryByCollector) == 0 {
+		return 0, fmt.Errorf("pod resource memory with page cache is empty")
+	}
+	for collector, podMemory := range podMemoryByCollector {
+		if podMemory.Timestamp.Before(validTime) {
+			return 0, fmt.Errorf("pod collector %v memory with page cache metric is timeout, valid time %v, metric time is %v",
+				collector, validTime.String(), podMemory.Timestamp.String())
+		}
+		memory += podMemory.Value
+	}
+	return memory, nil
+}
+
+func (s *systemResourceCollector) getAllPodsMemoryWithHotPageCache() (float64, error) {
+	validTime := timeNow().Add(-s.outdatedInterval)
+	var memory float64
+	podMemoryByCollector := s.sharedState.GetPodsMemoryWithHotPageCacheByCollector()
+	if len(podMemoryByCollector) == 0 {
+		return 0, fmt.Errorf("pod resource memory with hot page cache is empty")
+	}
+	for collector, podMemory := range podMemoryByCollector {
+		if podMemory.Timestamp.Before(validTime) {
+			return 0, fmt.Errorf("pod collector %v memory with hot page cache metric is timeout, valid time %v, metric time is %v",
+				collector, validTime.String(), podMemory.Timestamp.String())
+		}
+		memory += podMemory.Value
+	}
+	return memory, nil
 }
 
 func (s *systemResourceCollector) getAllPodsResourceUsage() (cpuCore float64, memory float64, err error) {

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
@@ -45,18 +45,18 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 		podUsage     map[string]usageField
 		hostAppUsage *usageField
 
-		nodeUsageWithPageCache *usageField
-		podUsageWithPageCache  map[string]usageField
+		nodeUsageWithPageCache    *usageField
+		podUsageWithPageCache     map[string]usageField
 		hostAppUsageWithPageCache *usageField
 
-		nodeUsageWithHotPageCache *usageField
-		podUsageWithHotPageCache  map[string]usageField
+		nodeUsageWithHotPageCache    *usageField
+		podUsageWithHotPageCache     map[string]usageField
 		hostAppUsageWithHotPageCache *usageField
 	}
 	type want struct {
-		systemCPU                *float64
-		systemMemory             *float64
-		systemMemoryWithPageCache *float64
+		systemCPU                    *float64
+		systemMemory                 *float64
+		systemMemoryWithPageCache    *float64
 		systemMemoryWithHotPageCache *float64
 	}
 	tests := []struct {
@@ -98,34 +98,34 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 		{
 			name: "with page cache metrics",
 			fields: fields{
-				nodeUsage: &usageField{ts: timeNow(), cpu: 1, memory: 1024},
-				podUsage:  map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
+				nodeUsage:    &usageField{ts: timeNow(), cpu: 1, memory: 1024},
+				podUsage:     map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
 				hostAppUsage: &usageField{ts: timeNow(), cpu: 0, memory: 0},
-				
-				nodeUsageWithPageCache: &usageField{ts: timeNow(), memory: 2048},
-				podUsageWithPageCache:  map[string]usageField{"test": {ts: timeNow(), memory: 1024}},
+
+				nodeUsageWithPageCache:    &usageField{ts: timeNow(), memory: 2048},
+				podUsageWithPageCache:     map[string]usageField{"test": {ts: timeNow(), memory: 1024}},
 				hostAppUsageWithPageCache: &usageField{ts: timeNow(), memory: 256},
 			},
 			want: want{
-				systemCPU:                ptr.To[float64](0.5),
-				systemMemory:             ptr.To[float64](512),
+				systemCPU:                 ptr.To[float64](0.5),
+				systemMemory:              ptr.To[float64](512),
 				systemMemoryWithPageCache: ptr.To[float64](768), // 2048 - 1024 - 256 = 768
 			},
 		},
 		{
 			name: "with hot page cache metrics",
 			fields: fields{
-				nodeUsage: &usageField{ts: timeNow(), cpu: 1, memory: 1024},
-				podUsage:  map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
+				nodeUsage:    &usageField{ts: timeNow(), cpu: 1, memory: 1024},
+				podUsage:     map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
 				hostAppUsage: &usageField{ts: timeNow(), cpu: 0, memory: 0},
-				
-				nodeUsageWithHotPageCache: &usageField{ts: timeNow(), memory: 3000},
-				podUsageWithHotPageCache:  map[string]usageField{"test": {ts: timeNow(), memory: 1000}},
+
+				nodeUsageWithHotPageCache:    &usageField{ts: timeNow(), memory: 3000},
+				podUsageWithHotPageCache:     map[string]usageField{"test": {ts: timeNow(), memory: 1000}},
 				hostAppUsageWithHotPageCache: &usageField{ts: timeNow(), memory: 500},
 			},
 			want: want{
-				systemCPU:                ptr.To[float64](0.5),
-				systemMemory:             ptr.To[float64](512),
+				systemCPU:                    ptr.To[float64](0.5),
+				systemMemory:                 ptr.To[float64](512),
 				systemMemoryWithHotPageCache: ptr.To[float64](1500), // 3000 - 1000 - 500 = 1500
 			},
 		},

--- a/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/sysresource/system_resource_collector_test.go
@@ -44,10 +44,20 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 		nodeUsage    *usageField
 		podUsage     map[string]usageField
 		hostAppUsage *usageField
+
+		nodeUsageWithPageCache *usageField
+		podUsageWithPageCache  map[string]usageField
+		hostAppUsageWithPageCache *usageField
+
+		nodeUsageWithHotPageCache *usageField
+		podUsageWithHotPageCache  map[string]usageField
+		hostAppUsageWithHotPageCache *usageField
 	}
 	type want struct {
-		systemCPU    *float64
-		systemMemory *float64
+		systemCPU                *float64
+		systemMemory             *float64
+		systemMemoryWithPageCache *float64
+		systemMemoryWithHotPageCache *float64
 	}
 	tests := []struct {
 		name   string
@@ -58,94 +68,6 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 			name:   "node metric not exist",
 			fields: fields{},
 			want:   want{},
-		},
-		{
-			name: "pod metric not exist",
-			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    1,
-					memory: 1024,
-				},
-			},
-			want: want{},
-		},
-		{
-			name: "host application metric not exist",
-			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    1,
-					memory: 1024,
-				},
-				podUsage: map[string]usageField{
-					"test-collector": {
-						ts:     timeNow(),
-						cpu:    0.5,
-						memory: 512,
-					},
-				},
-			},
-			want: want{},
-		},
-		{
-			name: "node metric outdated",
-			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow().Add(-config.CollectSysMetricOutdatedInterval * 2),
-					cpu:    1,
-					memory: 1024,
-				},
-				podUsage: map[string]usageField{
-					"test-collector": {
-						ts:     timeNow(),
-						cpu:    0.5,
-						memory: 512,
-					},
-				},
-			},
-			want: want{},
-		},
-		{
-			name: "pod metric outdated",
-			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    1,
-					memory: 1024,
-				},
-				podUsage: map[string]usageField{
-					"test-collector": {
-						ts:     timeNow().Add(-config.CollectSysMetricOutdatedInterval * 2),
-						cpu:    0.5,
-						memory: 512,
-					},
-				},
-			},
-			want: want{},
-		},
-		{
-			name: "host application metric outdated",
-			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    1,
-					memory: 1024,
-				},
-				podUsage: map[string]usageField{
-					"test-collector": {
-						ts:     timeNow(),
-						cpu:    0.5,
-						memory: 512,
-					},
-				},
-				hostAppUsage: &usageField{
-					ts:     timeNow().Add(-config.CollectSysMetricOutdatedInterval * 2),
-					cpu:    0.1,
-					memory: 128,
-				},
-			},
-			want: want{},
 		},
 		{
 			name: "one pod collector",
@@ -174,60 +96,37 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 			},
 		},
 		{
-			name: "two pod collectors",
+			name: "with page cache metrics",
 			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    2,
-					memory: 2048,
-				},
-				podUsage: map[string]usageField{
-					"test-collector1": {
-						ts:     timeNow(),
-						cpu:    0.5,
-						memory: 512,
-					},
-					"test-collector2": {
-						ts:     timeNow(),
-						cpu:    1,
-						memory: 512,
-					},
-				},
-				hostAppUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    0,
-					memory: 0,
-				},
+				nodeUsage: &usageField{ts: timeNow(), cpu: 1, memory: 1024},
+				podUsage:  map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
+				hostAppUsage: &usageField{ts: timeNow(), cpu: 0, memory: 0},
+				
+				nodeUsageWithPageCache: &usageField{ts: timeNow(), memory: 2048},
+				podUsageWithPageCache:  map[string]usageField{"test": {ts: timeNow(), memory: 1024}},
+				hostAppUsageWithPageCache: &usageField{ts: timeNow(), memory: 256},
 			},
 			want: want{
-				systemCPU:    ptr.To[float64](0.5),
-				systemMemory: ptr.To[float64](1024),
+				systemCPU:                ptr.To[float64](0.5),
+				systemMemory:             ptr.To[float64](512),
+				systemMemoryWithPageCache: ptr.To[float64](768), // 2048 - 1024 - 256 = 768
 			},
 		},
 		{
-			name: "one pod collector with host application",
+			name: "with hot page cache metrics",
 			fields: fields{
-				nodeUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    1,
-					memory: 1024,
-				},
-				podUsage: map[string]usageField{
-					"test-collector": {
-						ts:     timeNow(),
-						cpu:    0.5,
-						memory: 512,
-					},
-				},
-				hostAppUsage: &usageField{
-					ts:     timeNow(),
-					cpu:    0.1,
-					memory: 128,
-				},
+				nodeUsage: &usageField{ts: timeNow(), cpu: 1, memory: 1024},
+				podUsage:  map[string]usageField{"test": {ts: timeNow(), cpu: 0.5, memory: 512}},
+				hostAppUsage: &usageField{ts: timeNow(), cpu: 0, memory: 0},
+				
+				nodeUsageWithHotPageCache: &usageField{ts: timeNow(), memory: 3000},
+				podUsageWithHotPageCache:  map[string]usageField{"test": {ts: timeNow(), memory: 1000}},
+				hostAppUsageWithHotPageCache: &usageField{ts: timeNow(), memory: 500},
 			},
 			want: want{
-				systemCPU:    ptr.To[float64](0.4),
-				systemMemory: ptr.To[float64](384),
+				systemCPU:                ptr.To[float64](0.5),
+				systemMemory:             ptr.To[float64](512),
+				systemMemoryWithHotPageCache: ptr.To[float64](1500), // 3000 - 1000 - 500 = 1500
 			},
 		},
 	}
@@ -255,40 +154,71 @@ func Test_systemResourceCollector_collectSysResUsed(t *testing.T) {
 					metriccache.Point{Timestamp: tt.fields.nodeUsage.ts, Value: tt.fields.nodeUsage.memory},
 				)
 			}
+			if tt.fields.nodeUsageWithPageCache != nil {
+				s.sharedState.UpdateNodeMemoryWithPageCache(metriccache.Point{Timestamp: tt.fields.nodeUsageWithPageCache.ts, Value: tt.fields.nodeUsageWithPageCache.memory})
+			}
+			if tt.fields.nodeUsageWithHotPageCache != nil {
+				s.sharedState.UpdateNodeMemoryWithHotPageCache(metriccache.Point{Timestamp: tt.fields.nodeUsageWithHotPageCache.ts, Value: tt.fields.nodeUsageWithHotPageCache.memory})
+			}
+
 			for collector, pod := range tt.fields.podUsage {
 				s.sharedState.UpdatePodUsage(collector,
 					metriccache.Point{Timestamp: pod.ts, Value: pod.cpu},
 					metriccache.Point{Timestamp: pod.ts, Value: pod.memory},
 				)
 			}
+			for collector, pod := range tt.fields.podUsageWithPageCache {
+				s.sharedState.UpdatePodsMemoryWithPageCache(collector, metriccache.Point{Timestamp: pod.ts, Value: pod.memory})
+			}
+			for collector, pod := range tt.fields.podUsageWithHotPageCache {
+				s.sharedState.UpdatePodsMemoryWithHotPageCache(collector, metriccache.Point{Timestamp: pod.ts, Value: pod.memory})
+			}
+
 			if tt.fields.hostAppUsage != nil {
 				s.sharedState.UpdateHostAppUsage(
 					metriccache.Point{Timestamp: tt.fields.hostAppUsage.ts, Value: tt.fields.hostAppUsage.cpu},
 					metriccache.Point{Timestamp: tt.fields.hostAppUsage.ts, Value: tt.fields.hostAppUsage.memory},
 				)
 			}
+			if tt.fields.hostAppUsageWithPageCache != nil {
+				s.sharedState.UpdateHostAppMemoryWithPageCache(metriccache.Point{Timestamp: tt.fields.hostAppUsageWithPageCache.ts, Value: tt.fields.hostAppUsageWithPageCache.memory})
+			}
+			if tt.fields.hostAppUsageWithHotPageCache != nil {
+				s.sharedState.UpdateHostAppMemoryWithHotPageCache(metriccache.Point{Timestamp: tt.fields.hostAppUsageWithHotPageCache.ts, Value: tt.fields.hostAppUsageWithHotPageCache.memory})
+			}
+
 			s.collectSysResUsed()
 
 			querier, err := metricCache.Querier(timeNow().Add(-s.outdatedInterval), timeNow())
 			assert.NoError(t, err)
 
+			// check default metrics
 			cpuResult, err := testQuery(querier, metriccache.SystemCPUUsageMetric, nil)
 			assert.NoError(t, err)
-			if tt.want.systemCPU == nil {
-				assert.Equal(t, 0, cpuResult.Count())
-			} else {
-				cpuValue, aggregateErr := cpuResult.Value(metriccache.AggregationTypeLast)
-				assert.NoError(t, aggregateErr)
+			if tt.want.systemCPU != nil {
+				cpuValue, _ := cpuResult.Value(metriccache.AggregationTypeLast)
 				assert.Equal(t, *tt.want.systemCPU, cpuValue)
 			}
+
 			memoryResult, err := testQuery(querier, metriccache.SystemMemoryUsageMetric, nil)
 			assert.NoError(t, err)
-			if tt.want.systemMemory == nil {
-				assert.Equal(t, 0, memoryResult.Count())
-			} else {
-				memoryValue, aggregateErr := memoryResult.Value(metriccache.AggregationTypeLast)
-				assert.NoError(t, aggregateErr)
+			if tt.want.systemMemory != nil {
+				memoryValue, _ := memoryResult.Value(metriccache.AggregationTypeLast)
 				assert.Equal(t, *tt.want.systemMemory, memoryValue)
+			}
+
+			// check new metrics
+			if tt.want.systemMemoryWithPageCache != nil {
+				res, err := testQuery(querier, metriccache.SystemMemoryUsageWithPageCacheMetric, nil)
+				assert.NoError(t, err)
+				val, _ := res.Value(metriccache.AggregationTypeLast)
+				assert.Equal(t, *tt.want.systemMemoryWithPageCache, val)
+			}
+			if tt.want.systemMemoryWithHotPageCache != nil {
+				res, err := testQuery(querier, metriccache.SystemMemoryWithHotPageUsageMetric, nil)
+				assert.NoError(t, err)
+				val, _ := res.Value(metriccache.AggregationTypeLast)
+				assert.Equal(t, *tt.want.systemMemoryWithHotPageCache, val)
 			}
 		})
 		err = metricCache.Close()

--- a/pkg/koordlet/metricsadvisor/framework/context.go
+++ b/pkg/koordlet/metricsadvisor/framework/context.go
@@ -67,8 +67,10 @@ type SharedState struct {
 func NewSharedState() *SharedState {
 	return &SharedState{
 		LatestMetric: LatestMetric{
-			podsCPUByCollector:    make(map[string]metriccache.Point),
-			podsMemoryByCollector: make(map[string]metriccache.Point),
+			podsCPUByCollector:                    make(map[string]metriccache.Point),
+			podsMemoryByCollector:                 make(map[string]metriccache.Point),
+			podsMemoryWithPageCacheByCollector:    make(map[string]metriccache.Point),
+			podsMemoryWithHotPageCacheByCollector: make(map[string]metriccache.Point),
 		},
 	}
 }

--- a/pkg/koordlet/metricsadvisor/framework/context.go
+++ b/pkg/koordlet/metricsadvisor/framework/context.go
@@ -74,17 +74,23 @@ func NewSharedState() *SharedState {
 }
 
 type LatestMetric struct {
-	nodeMutex  sync.RWMutex
-	nodeCPU    *metriccache.Point
-	nodeMemory *metriccache.Point
+	nodeMutex                  sync.RWMutex
+	nodeCPU                    *metriccache.Point
+	nodeMemory                 *metriccache.Point
+	nodeMemoryWithPageCache    *metriccache.Point
+	nodeMemoryWithHotPageCache *metriccache.Point
 
-	podMutex              sync.RWMutex
-	podsCPUByCollector    map[string]metriccache.Point
-	podsMemoryByCollector map[string]metriccache.Point
+	podMutex                              sync.RWMutex
+	podsCPUByCollector                    map[string]metriccache.Point
+	podsMemoryByCollector                 map[string]metriccache.Point
+	podsMemoryWithPageCacheByCollector    map[string]metriccache.Point
+	podsMemoryWithHotPageCacheByCollector map[string]metriccache.Point
 
-	hostAppMutex  sync.RWMutex
-	hostAppCPU    *metriccache.Point
-	hostAppMemory *metriccache.Point
+	hostAppMutex                  sync.RWMutex
+	hostAppCPU                    *metriccache.Point
+	hostAppMemory                 *metriccache.Point
+	hostAppMemoryWithPageCache    *metriccache.Point
+	hostAppMemoryWithHotPageCache *metriccache.Point
 }
 
 func (r *SharedState) UpdateNodeUsage(cpu, memory metriccache.Point) {
@@ -94,11 +100,41 @@ func (r *SharedState) UpdateNodeUsage(cpu, memory metriccache.Point) {
 	r.nodeMemory = &memory
 }
 
+func (r *SharedState) UpdateNodeMemoryWithPageCache(memory metriccache.Point) {
+	r.nodeMutex.Lock()
+	defer r.nodeMutex.Unlock()
+	r.nodeMemoryWithPageCache = &memory
+}
+
+func (r *SharedState) UpdateNodeMemoryWithHotPageCache(memory metriccache.Point) {
+	r.nodeMutex.Lock()
+	defer r.nodeMutex.Unlock()
+	r.nodeMemoryWithHotPageCache = &memory
+}
+
 func (r *SharedState) UpdatePodUsage(collectorName string, cpu, memory metriccache.Point) {
 	r.podMutex.Lock()
 	defer r.podMutex.Unlock()
 	r.podsCPUByCollector[collectorName] = cpu
 	r.podsMemoryByCollector[collectorName] = memory
+}
+
+func (r *SharedState) UpdatePodsMemoryWithPageCache(collectorName string, memory metriccache.Point) {
+	r.podMutex.Lock()
+	defer r.podMutex.Unlock()
+	if r.podsMemoryWithPageCacheByCollector == nil {
+		r.podsMemoryWithPageCacheByCollector = make(map[string]metriccache.Point)
+	}
+	r.podsMemoryWithPageCacheByCollector[collectorName] = memory
+}
+
+func (r *SharedState) UpdatePodsMemoryWithHotPageCache(collectorName string, memory metriccache.Point) {
+	r.podMutex.Lock()
+	defer r.podMutex.Unlock()
+	if r.podsMemoryWithHotPageCacheByCollector == nil {
+		r.podsMemoryWithHotPageCacheByCollector = make(map[string]metriccache.Point)
+	}
+	r.podsMemoryWithHotPageCacheByCollector[collectorName] = memory
 }
 
 func (r *SharedState) UpdateHostAppUsage(cpu, memory metriccache.Point) {
@@ -108,16 +144,52 @@ func (r *SharedState) UpdateHostAppUsage(cpu, memory metriccache.Point) {
 	r.hostAppMemory = &memory
 }
 
+func (r *SharedState) UpdateHostAppMemoryWithPageCache(memory metriccache.Point) {
+	r.hostAppMutex.Lock()
+	defer r.hostAppMutex.Unlock()
+	r.hostAppMemoryWithPageCache = &memory
+}
+
+func (r *SharedState) UpdateHostAppMemoryWithHotPageCache(memory metriccache.Point) {
+	r.hostAppMutex.Lock()
+	defer r.hostAppMutex.Unlock()
+	r.hostAppMemoryWithHotPageCache = &memory
+}
+
 func (r *SharedState) GetNodeUsage() (cpu, memory *metriccache.Point) {
 	r.nodeMutex.RLock()
 	defer r.nodeMutex.RUnlock()
 	return r.nodeCPU, r.nodeMemory
 }
 
+func (r *SharedState) GetNodeMemoryWithPageCache() *metriccache.Point {
+	r.nodeMutex.RLock()
+	defer r.nodeMutex.RUnlock()
+	return r.nodeMemoryWithPageCache
+}
+
+func (r *SharedState) GetNodeMemoryWithHotPageCache() *metriccache.Point {
+	r.nodeMutex.RLock()
+	defer r.nodeMutex.RUnlock()
+	return r.nodeMemoryWithHotPageCache
+}
+
 func (r *SharedState) GetHostAppUsage() (cpu, memory *metriccache.Point) {
 	r.hostAppMutex.RLock()
 	defer r.hostAppMutex.RUnlock()
 	return r.hostAppCPU, r.hostAppMemory
+}
+
+func (r *SharedState) GetHostAppMemoryWithPageCache() *metriccache.Point {
+	r.hostAppMutex.RLock()
+	defer r.hostAppMutex.RUnlock()
+	return r.hostAppMemoryWithPageCache
+}
+
+func (r *SharedState) GetHostAppMemoryWithHotPageCache() *metriccache.Point {
+	r.hostAppMutex.RLock()
+	defer r.hostAppMutex.RUnlock()
+	return r.hostAppMemoryWithHotPageCache
 }
 
 func (r *SharedState) GetPodsUsageByCollector() (cpu, memory map[string]metriccache.Point) {
@@ -132,4 +204,24 @@ func (r *SharedState) GetPodsUsageByCollector() (cpu, memory map[string]metricca
 		podsMemory[collector] = val
 	}
 	return podsCPU, podsMemory
+}
+
+func (r *SharedState) GetPodsMemoryWithPageCacheByCollector() map[string]metriccache.Point {
+	r.podMutex.RLock()
+	defer r.podMutex.RUnlock()
+	podsMemory := map[string]metriccache.Point{}
+	for collector, val := range r.podsMemoryWithPageCacheByCollector {
+		podsMemory[collector] = val
+	}
+	return podsMemory
+}
+
+func (r *SharedState) GetPodsMemoryWithHotPageCacheByCollector() map[string]metriccache.Point {
+	r.podMutex.RLock()
+	defer r.podMutex.RUnlock()
+	podsMemory := map[string]metriccache.Point{}
+	for collector, val := range r.podsMemoryWithHotPageCacheByCollector {
+		podsMemory[collector] = val
+	}
+	return podsMemory
 }

--- a/pkg/koordlet/metricsadvisor/framework/context_test.go
+++ b/pkg/koordlet/metricsadvisor/framework/context_test.go
@@ -180,3 +180,57 @@ func TestSharedState_UpdateHostAppUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestSharedState_NodeMemoryWithPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 2048}
+	r.UpdateNodeMemoryWithPageCache(p)
+	got := r.GetNodeMemoryWithPageCache()
+	assert.Equal(t, p, *got)
+}
+
+func TestSharedState_NodeMemoryWithHotPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 3072}
+	r.UpdateNodeMemoryWithHotPageCache(p)
+	got := r.GetNodeMemoryWithHotPageCache()
+	assert.Equal(t, p, *got)
+}
+
+func TestSharedState_PodsMemoryWithPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 4096}
+	r.UpdatePodsMemoryWithPageCache("c1", p)
+	got := r.GetPodsMemoryWithPageCacheByCollector()
+	assert.Equal(t, p, got["c1"])
+}
+
+func TestSharedState_PodsMemoryWithHotPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 5120}
+	r.UpdatePodsMemoryWithHotPageCache("c1", p)
+	got := r.GetPodsMemoryWithHotPageCacheByCollector()
+	assert.Equal(t, p, got["c1"])
+}
+
+func TestSharedState_HostAppMemoryWithPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 6144}
+	r.UpdateHostAppMemoryWithPageCache(p)
+	got := r.GetHostAppMemoryWithPageCache()
+	assert.Equal(t, p, *got)
+}
+
+func TestSharedState_HostAppMemoryWithHotPageCache(t *testing.T) {
+	now := time.Now()
+	r := NewSharedState()
+	p := metriccache.Point{Timestamp: now, Value: 7168}
+	r.UpdateHostAppMemoryWithHotPageCache(p)
+	got := r.GetHostAppMemoryWithHotPageCache()
+	assert.Equal(t, p, *got)
+}

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric.go
@@ -624,7 +624,22 @@ func (r *nodeMetricInformer) collectSystemMetric(queryparam metriccache.QueryPar
 		return rl, 0, err
 	}
 
-	memAggregateResult, err := doQuery(querier, metriccache.SystemMemoryUsageMetric, nil)
+	var memAggregateResult metriccache.AggregateResult
+	nodeMemoryCollectPolicy := defaultMemoryCollectPolicy
+	nodeMetricSpec := r.getNodeMetricSpec()
+	if nodeMetricSpec != nil && nodeMetricSpec.CollectPolicy != nil && nodeMetricSpec.CollectPolicy.NodeMemoryCollectPolicy != nil {
+		nodeMemoryCollectPolicy = *nodeMetricSpec.CollectPolicy.NodeMemoryCollectPolicy
+	}
+	if nodeMemoryCollectPolicy == slov1alpha1.UsageWithoutPageCache {
+		memAggregateResult, err = doQuery(querier, metriccache.SystemMemoryUsageMetric, nil)
+	} else if nodeMemoryCollectPolicy == slov1alpha1.UsageWithHotPageCache && system.GetIsStartColdMemory() {
+		memAggregateResult, err = doQuery(querier, metriccache.SystemMemoryWithHotPageUsageMetric, nil)
+	} else if nodeMemoryCollectPolicy == slov1alpha1.UsageWithPageCache {
+		memAggregateResult, err = doQuery(querier, metriccache.SystemMemoryUsageWithPageCacheMetric, nil)
+	} else {
+		memAggregateResult, err = doQuery(querier, metriccache.SystemMemoryUsageMetric, nil)
+	}
+
 	if err != nil {
 		return rl, 0, err
 	}

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
@@ -1276,7 +1276,8 @@ func Test_nodeMetricInformer_collectSystemMetric(t *testing.T) {
 	startTime := now.Add(-time.Second * 120)
 
 	type args struct {
-		queryparam metriccache.QueryParam
+		queryparam          metriccache.QueryParam
+		memoryCollectPolicy slov1alpha1.NodeMemoryCollectPolicy
 	}
 	type samples struct {
 		CPUUsed float64
@@ -1290,9 +1291,10 @@ func Test_nodeMetricInformer_collectSystemMetric(t *testing.T) {
 		want1   time.Duration
 	}{
 		{
-			name: "test-1",
+			name: "test-1 usageWithoutPageCache",
 			args: args{
-				queryparam: metriccache.QueryParam{Start: &startTime, End: &now, Aggregate: metriccache.AggregationTypeAVG},
+				queryparam:          metriccache.QueryParam{Start: &startTime, End: &now, Aggregate: metriccache.AggregationTypeAVG},
+				memoryCollectPolicy: slov1alpha1.UsageWithoutPageCache,
 			},
 			samples: samples{
 				CPUUsed: 2,
@@ -1301,6 +1303,38 @@ func Test_nodeMetricInformer_collectSystemMetric(t *testing.T) {
 			want: v1.ResourceList{
 				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory: *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI),
+			},
+			want1: now.Sub(startTime),
+		},
+		{
+			name: "test-2 usageWithPageCache",
+			args: args{
+				queryparam:          metriccache.QueryParam{Start: &startTime, End: &now, Aggregate: metriccache.AggregationTypeAVG},
+				memoryCollectPolicy: slov1alpha1.UsageWithPageCache,
+			},
+			samples: samples{
+				CPUUsed: 2,
+				MemUsed: 15 * 1024 * 1024 * 1024,
+			},
+			want: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(15*1024*1024*1024, resource.BinarySI),
+			},
+			want1: now.Sub(startTime),
+		},
+		{
+			name: "test-3 usageWithHotPageCache",
+			args: args{
+				queryparam:          metriccache.QueryParam{Start: &startTime, End: &now, Aggregate: metriccache.AggregationTypeAVG},
+				memoryCollectPolicy: slov1alpha1.UsageWithHotPageCache,
+			},
+			samples: samples{
+				CPUUsed: 2,
+				MemUsed: 12 * 1024 * 1024 * 1024,
+			},
+			want: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(12*1024*1024*1024, resource.BinarySI),
 			},
 			want1: now.Sub(startTime),
 		},
@@ -1318,17 +1352,28 @@ func Test_nodeMetricInformer_collectSystemMetric(t *testing.T) {
 			assert.NoError(t, err)
 			buildMockQueryResult(ctrl, mockQuerier, mockResultFactory, cpuQueryMeta, tt.samples.CPUUsed, duration)
 
-			memQueryMeta, err := metriccache.SystemMemoryUsageMetric.BuildQueryMeta(nil)
+			var memMetric metriccache.MetricResource
+			switch tt.args.memoryCollectPolicy {
+			case slov1alpha1.UsageWithPageCache:
+				memMetric = metriccache.SystemMemoryUsageWithPageCacheMetric
+			case slov1alpha1.UsageWithHotPageCache:
+				memMetric = metriccache.SystemMemoryWithHotPageUsageMetric
+				system.SetIsStartColdMemory(true)
+			default:
+				memMetric = metriccache.SystemMemoryUsageMetric
+			}
+
+			memQueryMeta, err := memMetric.BuildQueryMeta(nil)
 			assert.NoError(t, err)
 			buildMockQueryResult(ctrl, mockQuerier, mockResultFactory, memQueryMeta, tt.samples.MemUsed, duration)
-			
-			defaultPolicy := slov1alpha1.UsageWithoutPageCache
+
+			policy := tt.args.memoryCollectPolicy
 			r := &nodeMetricInformer{
 				metricCache: mockMetricCache,
 				nodeMetric: &slov1alpha1.NodeMetric{
 					Spec: slov1alpha1.NodeMetricSpec{
 						CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{
-							NodeMemoryCollectPolicy: &defaultPolicy,
+							NodeMemoryCollectPolicy: &policy,
 						},
 					},
 				},

--- a/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_nodemetric_test.go
@@ -1321,8 +1321,17 @@ func Test_nodeMetricInformer_collectSystemMetric(t *testing.T) {
 			memQueryMeta, err := metriccache.SystemMemoryUsageMetric.BuildQueryMeta(nil)
 			assert.NoError(t, err)
 			buildMockQueryResult(ctrl, mockQuerier, mockResultFactory, memQueryMeta, tt.samples.MemUsed, duration)
+			
+			defaultPolicy := slov1alpha1.UsageWithoutPageCache
 			r := &nodeMetricInformer{
 				metricCache: mockMetricCache,
+				nodeMetric: &slov1alpha1.NodeMetric{
+					Spec: slov1alpha1.NodeMetricSpec{
+						CollectPolicy: &slov1alpha1.NodeMetricCollectPolicy{
+							NodeMemoryCollectPolicy: &defaultPolicy,
+						},
+					},
+				},
 			}
 			got, got1, err := r.collectSystemMetric(tt.args.queryparam)
 			assert.NoError(t, err)


### PR DESCRIPTION
Closes #1730

This PR addresses the issue where `SystemMemoryUsage` did not calculate metrics correctly when the collection policy is `UsageWithHotPageCache` or `UsageWithPageCache`. 

It supports memory usage with page cache and hot page cache in the shared state, updates the respective collectors to emit these metrics, and ensures the correct policy is used during system metric collection.