### PR TITLE
fix/dead logging branch in setChild map existence check

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -398,15 +398,18 @@ func (gang *Gang) setChild(pod *v1.Pod) {
 	defer gang.lock.Unlock()
 
 	podId := util.GetId(pod.Namespace, pod.Name)
+	_, existed := gang.Children[podId]
 	gang.Children[podId] = pod
-	if _, ok := gang.Children[podId]; !ok {
+
+	if !existed {
 		klog.V(6).Infof("SetChild, gangName: %v, childName: %v", gang.Name, podId)
 	} else {
 		klog.V(6).Infof("UpdateChild, gangName: %v, childName: %v", gang.Name, podId)
 	}
 	if pod.Spec.NodeName == "" && gang.WaitingForBindChildren[podId] == nil {
+		_, pendingExisted := gang.PendingChildren[podId]
 		gang.PendingChildren[podId] = pod
-		if _, ok := gang.PendingChildren[podId]; !ok {
+		if !pendingExisted {
 			klog.Infof("SetPendingChild, gangName: %v, childName: %v", gang.Name, podId)
 		} else {
 			klog.Infof("UpdatePendingChild, gangName: %v, childName: %v", gang.Name, podId)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a dead logging branch in setChild within pkg/scheduler/plugins/coscheduling/core/gang.go.
Since the key had already been inserted, the condition was always false. As a result:

* SetChild logs were never emitted
* UpdateChild logs were always emitted, even for newly added children

This PR changes the logic to check key existence before insertion so logs correctly distinguish between new child creation and child updates.

The same fix is also applied to PendingChildren.
### Ⅱ. Does this pull request fix one issue?
fixes #2904 
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
Create a new gang and add a child pod that does not already exist in gang.Children
Observe logs from setChild
Verify that:
newly inserted children emit SetChild
existing children emit UpdateChild

Example verification:

first insertion → SetChild
subsequent insertion/update → UpdateChild

### Ⅳ. Special notes for reviews
This PR only changes logging branch behavior and does not modify scheduling logic or gang state management behavior.
### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
