### PR TITLE
fix(webhook): avoid health checker panics and add tests

### DIFF
--- a/pkg/webhook/util/health/checker.go
+++ b/pkg/webhook/util/health/checker.go
@@ -17,9 +17,11 @@ limitations under the License.
 package health
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -37,6 +39,11 @@ var (
 	onceWatch sync.Once
 	lock      sync.Mutex
 	client    *http.Client
+	// newWatcher is a variable so tests can override fsnotify.NewWatcher.
+	newWatcher = fsnotify.NewWatcher
+	// watchCancel/watchDone allow tests to stop watcher goroutines safely.
+	watchCancel context.CancelFunc
+	watchDone   chan struct{}
 )
 
 func loadHTTPClientWithCACert() error {
@@ -58,9 +65,11 @@ func loadHTTPClientWithCACert() error {
 	return nil
 }
 
-func watchCACert(watcher *fsnotify.Watcher) {
+func watchCACert(ctx context.Context, watcher *fsnotify.Watcher) {
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case event, ok := <-watcher.Events:
 			// Channel is closed.
 			if !ok {
@@ -110,16 +119,34 @@ func isRemove(event fsnotify.Event) bool {
 func Checker(_ *http.Request) error {
 	onceWatch.Do(func() {
 		if err := loadHTTPClientWithCACert(); err != nil {
-			panic(fmt.Errorf("failed to load ca-cert for the first time: %v", err))
+			klog.Errorf("Failed to load ca-cert for the first time: %v. Falling back to system defaults.", err)
+			// Fall back to default HTTP client (system root CAs) to avoid panic.
+			lock.Lock()
+			client = http.DefaultClient
+			lock.Unlock()
 		}
-		watcher, err := fsnotify.NewWatcher()
+
+		watcher, err := newWatcher()
 		if err != nil {
-			panic(fmt.Errorf("failed to new ca-cert watcher: %v", err))
+			klog.Errorf("Failed to create ca-cert watcher: %v. Continuing without file watcher.", err)
+			return
 		}
+
 		if err = watcher.Add(caCertFilePath); err != nil {
-			panic(fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err))
+			klog.Errorf("Failed to watch ca-cert file %v: %v. Continuing without file watcher.", caCertFilePath, err)
+			// Close watcher to avoid leaking OS resources before returning.
+			_ = watcher.Close()
+			return
 		}
-		go watchCACert(watcher)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		watchCancel = cancel
+		watchDone = make(chan struct{})
+		go func() {
+			defer close(watchDone)
+			defer watcher.Close()
+			watchCACert(ctx, watcher)
+		}()
 	})
 
 	url := fmt.Sprintf("https://localhost:%d/healthz", webhookutil.GetPort())
@@ -129,9 +156,31 @@ func Checker(_ *http.Request) error {
 	}
 	req.Header.Add("Content-Type", "application/json")
 
+	// If our shared client is the default fallback, attempt to reload CA once.
 	lock.Lock()
-	defer lock.Unlock()
-	_, err = client.Do(req)
+	curClient := client
+	lock.Unlock()
+
+	if curClient == http.DefaultClient || curClient == nil {
+		if err := loadHTTPClientWithCACert(); err != nil {
+			klog.V(2).Infof("Retry loading ca-cert failed: %v", err)
+		} else {
+			lock.Lock()
+			curClient = client
+			lock.Unlock()
+		}
+	}
+
+	if curClient == nil {
+		curClient = http.DefaultClient
+	}
+
+	resp, err := curClient.Do(req)
+	if resp != nil {
+		// Ensure body is always closed to avoid leaking connections.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -1,0 +1,243 @@
+package health
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// helper to create a CA and server cert signed by the CA
+func makeCertAndServer(t *testing.T) (caPEM []byte, serverCert tls.Certificate, port int) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	// server key/cert
+	srvKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour * 24),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     []string{"localhost"},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTmpl, caTmpl, &srvKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(srvKey)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// find free port by listening on :0
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port = ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	return caPEM, cert, port
+}
+
+func TestChecker_FallbackOnMissingCA_NoPanic(t *testing.T) {
+	resetState(t)
+	tmp := t.TempDir()
+	setCertDir(t, tmp)
+	t.Setenv("WEBHOOK_PORT", "0")
+
+	// first call: no ca-cert present -> should return an error but not panic
+	if err := Checker(nil); err == nil {
+		t.Fatalf("expected error when no CA available, got nil")
+	}
+
+	// second call should attempt a retry path and still not panic
+	if err := Checker(nil); err == nil {
+		t.Fatalf("expected error on retry when no CA available, got nil")
+	}
+}
+
+func TestChecker_WithCA_ServerOK(t *testing.T) {
+	resetState(t)
+	tmp := t.TempDir()
+	setCertDir(t, tmp)
+
+	caPEM, cert, _ := makeCertAndServer(t)
+
+	// write ca cert
+	caPath := filepath.Join(tmp, "ca-cert.pem")
+	if err := os.WriteFile(caPath, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// start TLS server using the cert
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	_ = host
+	t.Setenv("WEBHOOK_PORT", portStr)
+
+	// Now Checker should succeed (no panic) when CA is present
+	if err := Checker(nil); err != nil {
+		t.Fatalf("expected Checker to succeed, got error: %v", err)
+	}
+}
+
+func resetState(t *testing.T) {
+	t.Helper()
+	stopWatch()
+	// Reset once and client for test isolation
+	onceWatch = sync.Once{}
+	lock = sync.Mutex{}
+	client = nil
+	// restore newWatcher
+	newWatcher = fsnotify.NewWatcher
+	// Ensure watcher goroutines stop after each test
+	t.Cleanup(stopWatch)
+}
+
+func stopWatch() {
+	if watchCancel != nil {
+		watchCancel()
+	}
+	if watchDone != nil {
+		<-watchDone
+	}
+	watchCancel = nil
+	watchDone = nil
+}
+
+func setCertDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("WEBHOOK_CERT_DIR", dir)
+	setCertFilePath(t, filepath.Join(dir, "ca-cert.pem"))
+}
+
+func setCertFilePath(t *testing.T, filePath string) {
+	t.Helper()
+	old := caCertFilePath
+	caCertFilePath = filePath
+	t.Cleanup(func() {
+		caCertFilePath = old
+	})
+}
+
+func TestChecker_NewWatcherFailure_NoPanic(t *testing.T) {
+	resetState(t)
+	tmp := t.TempDir()
+	setCertDir(t, tmp)
+	t.Setenv("WEBHOOK_PORT", "0")
+
+	// override newWatcher to simulate failure
+	newWatcher = func() (*fsnotify.Watcher, error) {
+		return nil, fmt.Errorf("simulated newwatcher failure")
+	}
+
+	if err := Checker(nil); err == nil {
+		t.Fatalf("expected error when newWatcher fails, got nil")
+	}
+}
+
+func TestChecker_WatcherAddFailure_NoPanic(t *testing.T) {
+	resetState(t)
+	// point caCertFilePath to a non-existent directory to cause watcher.Add to fail
+	tmp := t.TempDir()
+	badPath := filepath.Join(tmp, "nonexistent", "ca-cert.pem")
+	setCertDir(t, tmp)
+	setCertFilePath(t, badPath)
+	t.Setenv("WEBHOOK_PORT", "0")
+
+	if err := Checker(nil); err == nil {
+		t.Fatalf("expected error when watcher.Add fails, got nil")
+	}
+}
+
+func TestChecker_RetryLoadAfterFallback_Succeeds(t *testing.T) {
+	resetState(t)
+	tmp := t.TempDir()
+	setCertDir(t, tmp)
+
+	// start TLS server first
+	caPEM, cert, _ := makeCertAndServer(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "ok")
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, portStr, _ := net.SplitHostPort(u.Host)
+	t.Setenv("WEBHOOK_PORT", portStr)
+
+	// First call: no CA on disk -> should error but set shared client to default
+	if err := Checker(nil); err == nil {
+		t.Fatalf("expected initial Checker to fail without CA, got nil")
+	}
+
+	// Write the CA file so subsequent retry can load it
+	caPath := filepath.Join(tmp, "ca-cert.pem")
+	if err := os.WriteFile(caPath, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call: should retry loading CA and succeed
+	if err := Checker(nil); err != nil {
+		t.Fatalf("expected Checker to succeed after CA present, got: %v", err)
+	}
+}

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -70,14 +70,8 @@ func makeCertAndServer(t *testing.T) (caPEM []byte, serverCert tls.Certificate, 
 		t.Fatal(err)
 	}
 
-	// find free port by listening on :0
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	port = ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
-
+	// Preserve the existing return signature for callers, but avoid probing
+	// the OS for an ephemeral port when the tests do not use it.
 	return caPEM, cert, port
 }
 


### PR DESCRIPTION
## Summary
- avoid panics in webhook health checker by using safe fallbacks
- add unit tests covering CA missing/fallback, watcher failure, and retry paths

## Testing
- `go test ./pkg/webhook/util/health -run TestChecker -v`
