### PR TITLE
feat: add job nomination retention scheduler plugin

### DIFF
--- a/cmd/koord-scheduler/main.go
+++ b/cmd/koord-scheduler/main.go
@@ -34,6 +34,7 @@ import (
 	noderesourcesfitplus "github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/noderesourcefitplus"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/reservation"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/scarceresourceavoidance"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/jobnomination"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/schedulinghint"
 
 	// Ensure metric package is initialized
@@ -53,6 +54,7 @@ var koordinatorPlugins = map[string]frameworkruntime.PluginFactory{
 	noderesourcesfitplus.Name:    noderesourcesfitplus.New,
 	scarceresourceavoidance.Name: scarceresourceavoidance.New,
 	schedulinghint.Name:          schedulinghint.New,
+	jobnomination.Name:           jobnomination.New,
 }
 
 func flatten(plugins map[string]frameworkruntime.PluginFactory) []app.Option {

--- a/docs/jobnomination.md
+++ b/docs/jobnomination.md
@@ -1,0 +1,25 @@
+# JobNomination Resource Retention Mechanism
+
+## The Problem
+Currently, when a Pod from a distributed/batch Job fails, its resources immediately become available to other workloads. Because replacement Pods from the same Job may experience scheduling delays, they can lose their previously assigned nodes. This loss of stability means large distributed Jobs may lose locality, and partial Job recovery becomes inefficient.
+
+## The Solution: JobNomination Plugin
+The `JobNomination` scheduler plugin introduces a lightweight resource retention mechanism that allows failed Pods belonging to the same Job to regain scheduling priority on previously used resources, without introducing a full reservation framework.
+
+### Retention Flow
+1. **Detection:** The plugin watches Pod events. When a Pod belonging to a Job transitions to a `Failed` phase, the plugin records its requested resources and the node it was running on.
+2. **In-Memory Tracking:** The requested resources are tracked in an in-memory cache against the Job's UID and the Node's name. A bounded retention timeout (default: 2 minutes) is set for the nomination.
+3. **Protection (Filter phase):** During the `Filter` phase, the plugin calculates the total resources retained by *other* jobs on the node and deducts them from the node's available resources. This prevents unrelated jobs from immediately consuming those retained resources during the retention window.
+4. **Preference (Score phase):** During the `Score` phase, if a replacement Pod from the *same* Job is being scheduled, it receives a maximum score (100) for the node where its resources are retained.
+5. **Consumption (Reserve phase):** When a replacement Pod is successfully reserved on the nominated node, its corresponding nomination is removed from the cache, preventing the Job from double-dipping retained resources.
+
+### Fallback Behavior
+- **Retention Expiration:** The tracking cache uses an expiration mechanism. After the 2-minute window, expired nominations are lazily dropped or cleaned up by a background goroutine. The node's resources then become fully available to all workloads.
+- **Fairness:** The cluster will not be hard-locked globally because the retention window is strictly bounded.
+- **Conflict Handling:** If a retained resource cannot be fulfilled because of other factors, the normal scheduler behaviors take over.
+
+### Limitations of First Iteration
+1. **In-Memory Only:** The state is purely in-memory within the koord-scheduler process. If the scheduler restarts, the tracking state is lost.
+2. **Best-Effort Reservation:** The plugin currently implements retention by hiding resources from unrelated workloads. It does not enforce a rigid guarantee if the node's actual state drifts or if other pods were force-scheduled.
+3. **Simple Timeouts:** Expirations are globally defined at plugin initialization and are not yet configurable per Job.
+4. **Scope Control:** The current iteration does not involve multi-scheduler coordination or CRD-heavy persistent arbitration systems.

--- a/pkg/scheduler/plugins/jobnomination/plugin.go
+++ b/pkg/scheduler/plugins/jobnomination/plugin.go
@@ -1,0 +1,329 @@
+package jobnomination
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	resourceapi "k8s.io/component-helpers/resource"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+const (
+	Name = "JobNomination"
+	// defaultRetentionDuration is the default time retained resources are kept
+	defaultRetentionDuration = 2 * time.Minute
+)
+
+// Nomination tracks retained resources for a failed pod on a specific node.
+type Nomination struct {
+	Resources  *framework.Resource
+	Expiration time.Time
+	PodUID     types.UID
+}
+
+// JobNomination is a plugin that retains resources for failed Job pods.
+type JobNomination struct {
+	handle            fwktype.Handle
+	retentionDuration time.Duration
+
+	// lock protects the cache
+	lock sync.RWMutex
+	// cache maps JobID -> NodeName -> list of Nominations (since multiple pods of same job can fail on same node)
+	cache map[string]map[string][]*Nomination
+}
+
+var _ fwktype.PreFilterPlugin = &JobNomination{}
+var _ fwktype.FilterPlugin = &JobNomination{}
+var _ fwktype.ScorePlugin = &JobNomination{}
+var _ fwktype.ReservePlugin = &JobNomination{}
+
+func New(args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
+	jn := &JobNomination{
+		handle:            handle,
+		retentionDuration: defaultRetentionDuration,
+		cache:             make(map[string]map[string][]*Nomination),
+	}
+
+	podInformer := handle.SharedInformerFactory().Core().V1().Pods().Informer()
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: jn.updatePod,
+		DeleteFunc: jn.deletePod,
+	})
+
+	go jn.cleanupRoutine(context.Background())
+
+	return jn, nil
+}
+
+func (jn *JobNomination) Name() string {
+	return Name
+}
+
+func getJobID(pod *corev1.Pod) string {
+	gangName := extension.GetGangName(pod)
+	if gangName != "" {
+		return gangName
+	}
+	for _, ref := range pod.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return string(ref.UID)
+		}
+	}
+	return ""
+}
+
+func isPodFailed(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed
+}
+
+func (jn *JobNomination) updatePod(oldObj, newObj interface{}) {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	
+	if !isPodFailed(oldPod) && isPodFailed(newPod) {
+		jn.trackPodRetention(newPod)
+	}
+}
+
+func (jn *JobNomination) deletePod(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			return
+		}
+	}
+	jn.trackPodRetention(pod)
+}
+
+func (jn *JobNomination) trackPodRetention(pod *corev1.Pod) {
+	jobID := getJobID(pod)
+	if jobID == "" {
+		return
+	}
+	nodeName := pod.Spec.NodeName
+	if nodeName == "" {
+		return
+	}
+
+	requests := resourceapi.PodRequests(pod, resourceapi.PodResourcesOptions{})
+	res := framework.NewResource(requests)
+	if res.MilliCPU == 0 && res.Memory == 0 {
+		return
+	}
+
+	jn.lock.Lock()
+	defer jn.lock.Unlock()
+
+	if jn.cache[jobID] == nil {
+		jn.cache[jobID] = make(map[string][]*Nomination)
+	}
+
+	for _, nom := range jn.cache[jobID][nodeName] {
+		if nom.PodUID == pod.UID {
+			return
+		}
+	}
+
+	jn.cache[jobID][nodeName] = append(jn.cache[jobID][nodeName], &Nomination{
+		Resources:  res,
+		Expiration: time.Now().Add(jn.retentionDuration),
+		PodUID:     pod.UID,
+	})
+	klog.V(4).Infof("Tracked retention for Job %s Pod %s on Node %s", jobID, pod.Name, nodeName)
+}
+
+func (jn *JobNomination) cleanupRoutine(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			jn.cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (jn *JobNomination) cleanup() {
+	jn.lock.Lock()
+	defer jn.lock.Unlock()
+
+	now := time.Now()
+	for jobID, nodes := range jn.cache {
+		for nodeName, noms := range nodes {
+			var active []*Nomination
+			for _, nom := range noms {
+				if now.Before(nom.Expiration) {
+					active = append(active, nom)
+				}
+			}
+			if len(active) > 0 {
+				nodes[nodeName] = active
+			} else {
+				delete(nodes, nodeName)
+			}
+		}
+		if len(nodes) == 0 {
+			delete(jn.cache, jobID)
+		}
+	}
+}
+
+func (jn *JobNomination) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
+	return nil, fwktype.NewStatus(fwktype.Success)
+}
+
+func (jn *JobNomination) PreFilterExtensions() fwktype.PreFilterExtensions {
+	return nil
+}
+
+func (jn *JobNomination) Filter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) *fwktype.Status {
+	nodeName := nodeInfo.Node().Name
+	jobID := getJobID(pod)
+
+	jn.lock.RLock()
+	defer jn.lock.RUnlock()
+
+	retainedByOthers := framework.NewResource(corev1.ResourceList{})
+	now := time.Now()
+
+	for trackedJobID, nodes := range jn.cache {
+		if trackedJobID == jobID {
+			continue
+		}
+		noms, ok := nodes[nodeName]
+		if !ok {
+			continue
+		}
+		for _, nom := range noms {
+			if now.Before(nom.Expiration) {
+				retainedByOthers.MilliCPU += nom.Resources.MilliCPU
+				retainedByOthers.Memory += nom.Resources.Memory
+				retainedByOthers.EphemeralStorage += nom.Resources.EphemeralStorage
+				retainedByOthers.AllowedPodNumber += nom.Resources.AllowedPodNumber
+			}
+		}
+	}
+
+	if retainedByOthers.MilliCPU == 0 && retainedByOthers.Memory == 0 {
+		return fwktype.NewStatus(fwktype.Success)
+	}
+
+	allocatable := nodeInfo.GetAllocatable().(*framework.Resource)
+	requested := nodeInfo.GetRequested().(*framework.Resource)
+
+	availableCPU := allocatable.MilliCPU - requested.MilliCPU - retainedByOthers.MilliCPU
+	availableMem := allocatable.Memory - requested.Memory - retainedByOthers.Memory
+
+	podRequests := resourceapi.PodRequests(pod, resourceapi.PodResourcesOptions{})
+	podRes := framework.NewResource(podRequests)
+
+	if podRes.MilliCPU > availableCPU || podRes.Memory > availableMem {
+		return fwktype.NewStatus(fwktype.Unschedulable, "Node resources retained by other jobs")
+	}
+
+	return fwktype.NewStatus(fwktype.Success)
+}
+
+func (jn *JobNomination) Score(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) (int64, *fwktype.Status) {
+	jobID := getJobID(pod)
+	if jobID == "" {
+		return 0, fwktype.NewStatus(fwktype.Success)
+	}
+
+	nodeName := nodeInfo.Node().Name
+
+	jn.lock.RLock()
+	defer jn.lock.RUnlock()
+
+	nodes, ok := jn.cache[jobID]
+	if !ok {
+		return 0, fwktype.NewStatus(fwktype.Success)
+	}
+
+	noms, ok := nodes[nodeName]
+	if !ok || len(noms) == 0 {
+		return 0, fwktype.NewStatus(fwktype.Success)
+	}
+
+	now := time.Now()
+	for _, nom := range noms {
+		if now.Before(nom.Expiration) {
+			return 100, fwktype.NewStatus(fwktype.Success)
+		}
+	}
+
+	return 0, fwktype.NewStatus(fwktype.Success)
+}
+
+func (jn *JobNomination) ScoreExtensions() fwktype.ScoreExtensions {
+	return nil
+}
+
+func (jn *JobNomination) Reserve(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) *fwktype.Status {
+	jobID := getJobID(pod)
+	if jobID == "" {
+		return fwktype.NewStatus(fwktype.Success)
+	}
+
+	jn.lock.Lock()
+	defer jn.lock.Unlock()
+
+	nodes, ok := jn.cache[jobID]
+	if !ok {
+		return fwktype.NewStatus(fwktype.Success)
+	}
+
+	noms, ok := nodes[nodeName]
+	if !ok || len(noms) == 0 {
+		return fwktype.NewStatus(fwktype.Success)
+	}
+
+	now := time.Now()
+	var remaining []*Nomination
+	consumed := false
+	for _, nom := range noms {
+		if !consumed && now.Before(nom.Expiration) {
+			consumed = true
+			continue
+		}
+		remaining = append(remaining, nom)
+	}
+
+	if len(remaining) > 0 {
+		nodes[nodeName] = remaining
+	} else {
+		delete(nodes, nodeName)
+	}
+
+	if len(nodes) == 0 {
+		delete(jn.cache, jobID)
+	}
+
+	return fwktype.NewStatus(fwktype.Success)
+}
+
+func (jn *JobNomination) Unreserve(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) {
+}

--- a/pkg/scheduler/plugins/jobnomination/plugin.go
+++ b/pkg/scheduler/plugins/jobnomination/plugin.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 	resourceapi "k8s.io/component-helpers/resource"
+	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
@@ -46,7 +46,7 @@ var _ fwktype.FilterPlugin = &JobNomination{}
 var _ fwktype.ScorePlugin = &JobNomination{}
 var _ fwktype.ReservePlugin = &JobNomination{}
 
-func New(args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
+func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
 	jn := &JobNomination{
 		handle:            handle,
 		retentionDuration: defaultRetentionDuration,
@@ -94,7 +94,7 @@ func (jn *JobNomination) updatePod(oldObj, newObj interface{}) {
 	if !ok {
 		return
 	}
-	
+
 	if !isPodFailed(oldPod) && isPodFailed(newPod) {
 		jn.trackPodRetention(newPod)
 	}

--- a/pkg/scheduler/plugins/jobnomination/plugin_test.go
+++ b/pkg/scheduler/plugins/jobnomination/plugin_test.go
@@ -1,0 +1,167 @@
+package jobnomination
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobNomination_CreationAndExpiration(t *testing.T) {
+	jn := &JobNomination{
+		retentionDuration: 50 * time.Millisecond,
+		cache:             make(map[string]map[string][]*Nomination),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("pod-1"),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID:        types.UID("job-1"),
+					Controller: func(b bool) *bool { return &b }(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test creation
+	jn.trackPodRetention(pod)
+	jn.lock.RLock()
+	assert.Equal(t, 1, len(jn.cache["job-1"]["node-1"]))
+	jn.lock.RUnlock()
+
+	// Test expiration
+	time.Sleep(100 * time.Millisecond)
+	jn.cleanup()
+	jn.lock.RLock()
+	assert.Equal(t, 0, len(jn.cache["job-1"]["node-1"]))
+	jn.lock.RUnlock()
+}
+
+func TestJobNomination_FilterAndScore(t *testing.T) {
+	ctx := context.Background()
+	jn := &JobNomination{
+		retentionDuration: 5 * time.Minute,
+		cache:             make(map[string]map[string][]*Nomination),
+	}
+
+	job1Pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("pod-1"),
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: types.UID("job-1"), Controller: func(b bool) *bool { return &b }(true)},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+					},
+				},
+			},
+		},
+	}
+
+	jn.trackPodRetention(job1Pod1)
+
+	// Node has 10 CPU allocatable, 0 requested
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")},
+		},
+	})
+
+	job2Pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("pod-2"),
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: types.UID("job-2"), Controller: func(b bool) *bool { return &b }(true)},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+					},
+				},
+			},
+		},
+	}
+
+	// 1. Conflict handling: Job2 asks for 8 CPU, but 4 is retained by Job1. Only 6 available. Should fail.
+	status := jn.Filter(ctx, nil, job2Pod1, nodeInfo)
+	assert.False(t, status.IsSuccess())
+	assert.Equal(t, fwktype.Unschedulable, status.Code())
+
+	// 2. Replacement Pod Preference: Job1 replacement asks for 4 CPU. Should fit.
+	job1Pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("pod-3"),
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: types.UID("job-1"), Controller: func(b bool) *bool { return &b }(true)},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+					},
+				},
+			},
+		},
+	}
+	status = jn.Filter(ctx, nil, job1Pod2, nodeInfo)
+	assert.True(t, status.IsSuccess())
+
+	// 3. Score behavior: Job1 replacement should get score 100 on node-1
+	score, status := jn.Score(ctx, nil, job1Pod2, nodeInfo)
+	assert.True(t, status.IsSuccess())
+	assert.Equal(t, int64(100), score)
+
+	nodeInfo2 := framework.NewNodeInfo()
+	nodeInfo2.SetNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}})
+
+	// Score on other node should be 0
+	score, status = jn.Score(ctx, nil, job1Pod2, nodeInfo2)
+	assert.True(t, status.IsSuccess())
+	assert.Equal(t, int64(0), score)
+
+	// 4. Reserve behavior: Reserving should consume the nomination
+	status = jn.Reserve(ctx, nil, job1Pod2, "node-1")
+	assert.True(t, status.IsSuccess())
+
+	jn.lock.RLock()
+	assert.Equal(t, 0, len(jn.cache["job-1"]["node-1"]))
+	jn.lock.RUnlock()
+
+	// 5. Fallback behavior: after reserve, job2 asks for 8 CPU. Should fit now.
+	status = jn.Filter(ctx, nil, job2Pod1, nodeInfo)
+	assert.True(t, status.IsSuccess())
+}


### PR DESCRIPTION
### I. Describe what this PR does

This PR adds a lightweight JobNomination retention plugin for Koordinator scheduler.

It temporarily retains scheduling information for failed/restarting Job Pods and prioritizes replacement Pods on previously associated nodes when possible, while safely falling back to normal scheduling behavior.

### II. Does this pull request fix one issue?

Related to #2803

### III. Describe how to verify it

- Run unit tests
- Verify nomination retention and expiration behavior
- Verify fallback scheduling works correctly

### IV. Special notes for reviews

The implementation is intentionally minimal and avoids scheduler architecture changes.

### V. Checklist

- [x] Added tests
- [x] Added documentation
- [x] Relevant tests passed