### PR TITLE
fix: CPUBurst and CPUNormalization coexistence

### DIFF
--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
@@ -19,6 +19,7 @@ package cpuburst
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"math/rand"
 	"strconv"
@@ -217,6 +218,15 @@ func (b *cpuBurst) start() {
 	b.nodeCPUBurstStrategy = nodeSLO.Spec.CPUBurstStrategy
 	podsMeta := b.statesInformer.GetAllPods()
 
+	cpuNormalizationRatio := 1.0
+	if node := b.statesInformer.GetNode(); node != nil {
+		if ratio, err := apiext.GetCPUNormalizationRatio(node); err != nil {
+			klog.V(4).Infof("get cpu normalization ratio failed, err: %v", err)
+		} else if ratio > 1.0 {
+			cpuNormalizationRatio = ratio
+		}
+	}
+
 	// get node state by node share pool usage
 	nodeState := b.getNodeStateForBurst(*b.nodeCPUBurstStrategy.SharePoolThresholdPercent, podsMeta)
 	klog.V(5).Infof("get node state %v for cpu burst", nodeState)
@@ -246,7 +256,7 @@ func (b *cpuBurst) start() {
 		// set cpu.cfs_burst_us for pod and containers
 		b.applyCPUBurst(cpuBurstCfg, podMeta)
 		// scale cpu.cfs_quota_us for pod and containers
-		b.applyCFSQuotaBurst(cpuBurstCfg, podMeta, nodeState)
+		b.applyCFSQuotaBurst(cpuBurstCfg, podMeta, nodeState, cpuNormalizationRatio)
 	}
 	b.Recycle()
 }
@@ -336,7 +346,7 @@ func (b *cpuBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 
 // scale cpu.cfs_quota_us for pod/containers by container throttled state and node state
 func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podMeta *statesinformer.PodMeta,
-	nodeState nodeStateForBurst) {
+	nodeState nodeStateForBurst, cpuNormalizationRatio float64) {
 	pod := podMeta.Pod
 	containerMap := make(map[string]*corev1.Container)
 	for i := range pod.Spec.Containers {
@@ -361,6 +371,7 @@ func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podM
 		if containerBaseCFS <= 0 {
 			continue
 		}
+		containerBaseCFS = normalizeCFSQuota(containerBaseCFS, cpuNormalizationRatio)
 		containerPath, err := koordletutil.GetContainerCgroupParentDir(podMeta.CgroupDir, containerStat)
 		if err != nil {
 			klog.Infof("get container %s/%s/%s cgroup path failed, err %v",
@@ -379,7 +390,9 @@ func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podM
 		}
 		containerCeilCFS := containerBaseCFS
 		if burstCfg.CFSQuotaBurstPercent != nil && *burstCfg.CFSQuotaBurstPercent > 100 {
-			containerCeilCFS = int64(float64(containerBaseCFS) * float64(*burstCfg.CFSQuotaBurstPercent) / 100)
+			originalBaseCFS := koordletutil.GetContainerBaseCFSQuota(container)
+			rawCeilCFS := int64(float64(originalBaseCFS) * float64(*burstCfg.CFSQuotaBurstPercent) / 100)
+			containerCeilCFS = normalizeCFSQuota(rawCeilCFS, cpuNormalizationRatio)
 		}
 
 		originOperation := b.genOperationByContainer(burstCfg, pod, container, containerStat)
@@ -411,7 +424,7 @@ func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podM
 			continue
 		}
 		deltaContainerCFS := containerTargetCFS - containerCurCFS
-		err = b.applyContainerCFSQuota(podMeta, containerStat, containerCurCFS, deltaContainerCFS)
+		err = b.applyContainerCFSQuota(podMeta, containerStat, containerCurCFS, deltaContainerCFS, burstCfg, cpuNormalizationRatio)
 		if err != nil {
 			klog.Infof("scale container %v/%v/%v cfs quota failed, operation %v, delta cfs quota %v, reason %v",
 				pod.Namespace, pod.Name, containerStat.Name, finalOperation, deltaContainerCFS, err)
@@ -502,7 +515,7 @@ func (b *cpuBurst) genOperationByContainer(burstCfg *slov1alpha1.CPUBurstConfig,
 }
 
 func (b *cpuBurst) applyContainerCFSQuota(podMeta *statesinformer.PodMeta, containerStat *corev1.ContainerStatus,
-	curContaienrCFS, deltaContainerCFS int64) error {
+	curContaienrCFS, deltaContainerCFS int64, burstCfg *slov1alpha1.CPUBurstConfig, cpuNormalizationRatio float64) error {
 	podDir := podMeta.CgroupDir
 	curPodCFS, podPathErr := b.cgroupReader.ReadCPUQuota(podDir)
 	if podPathErr != nil {
@@ -520,8 +533,19 @@ func (b *cpuBurst) applyContainerCFSQuota(podMeta *statesinformer.PodMeta, conta
 		if curPodCFS <= 0 {
 			return nil
 		}
+		podBaseMilli := util.GetPodMilliCPULimit(podMeta.Pod)
+		podBaseCFS := system.MilliCPUToQuota(podBaseMilli)
+		podBaseCFS = normalizeCFSQuota(podBaseCFS, cpuNormalizationRatio)
+		podCeilCFS := podBaseCFS
+		if burstCfg != nil && burstCfg.CFSQuotaBurstPercent != nil && *burstCfg.CFSQuotaBurstPercent > 100 {
+			rawCeilCFS := int64(float64(system.MilliCPUToQuota(podBaseMilli)) * float64(*burstCfg.CFSQuotaBurstPercent) / 100)
+			podCeilCFS = normalizeCFSQuota(rawCeilCFS, cpuNormalizationRatio)
+		}
 
 		targetPodCFS := curPodCFS + deltaContainerCFS
+		if podBaseCFS > 0 {
+			targetPodCFS = util.MaxInt64(podBaseCFS, util.MinInt64(targetPodCFS, podCeilCFS))
+		}
 		podCFSValStr := strconv.FormatInt(targetPodCFS, 10)
 		eventHelper := audit.V(3).Pod(podMeta.Pod.Namespace, podMeta.Pod.Name).Reason("CFSQuotaBurst").Message("update pod CFSQuota: %v", podCFSValStr)
 		updater, _ := resourceexecutor.DefaultCgroupUpdaterFactory.New(system.CPUCFSQuotaName, podDir, podCFSValStr, eventHelper)
@@ -558,6 +582,13 @@ func (b *cpuBurst) applyContainerCFSQuota(podMeta *statesinformer.PodMeta, conta
 	}
 
 	return nil
+}
+
+func normalizeCFSQuota(cfsQuota int64, cpuNormalizationRatio float64) int64 {
+	if cfsQuota <= 0 || cpuNormalizationRatio <= 1.0 {
+		return cfsQuota
+	}
+	return int64(math.Ceil(float64(cfsQuota) / cpuNormalizationRatio))
 }
 
 // set cpu.cfs_burst_us for containers

--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
@@ -1282,7 +1282,7 @@ func TestCPUBurst_applyCFSQuotaBurst(t *testing.T) {
 				containerLimiter: make(map[string]*burstLimiter),
 			}
 			b.init(stop)
-			b.applyCFSQuotaBurst(&tt.args.burstCfg, podMeta, tt.args.nodeState)
+			b.applyCFSQuotaBurst(&tt.args.burstCfg, podMeta, tt.args.nodeState, 1.0)
 
 			gotPod := getPodCFSQuota(podMeta, testHelper)
 			if !reflect.DeepEqual(gotPod, tt.want.podCFSQuotaVal) {
@@ -1559,6 +1559,7 @@ func TestCPUBurst_start(t *testing.T) {
 			mockStatesInformer := mock_statesinformer.NewMockStatesInformer(ctl)
 			mockStatesInformer.EXPECT().GetAllPods().Return(testutil.GetPodMetas(tt.fields.pods)).AnyTimes()
 			mockStatesInformer.EXPECT().GetNodeSLO().Return(tt.fields.nodeSLO).AnyTimes()
+			mockStatesInformer.EXPECT().GetNode().Return(nil).AnyTimes()
 
 			mockResultFactory := mock_metriccache.NewMockAggregateResultFactory(ctl)
 			metriccache.DefaultAggregateResultFactory = mockResultFactory

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
@@ -81,6 +82,10 @@ func (p *Plugin) AdjustPodCFSQuota(proto protocol.HooksProtocol) error {
 	if podCtx == nil {
 		return fmt.Errorf("pod protocol is nil for plugin %s", name)
 	}
+	if features.DefaultKoordletFeatureGate.Enabled(features.CPUBurst) {
+		klog.V(5).Infof("skip %s pod cfs quota adjustment since CPUBurst is enabled", name)
+		return nil
+	}
 	if podCtx.Request.Resources == nil { // currently only reconciler mode provides Resources in ctx
 		return nil
 	}
@@ -96,6 +101,10 @@ func (p *Plugin) AdjustContainerCFSQuota(proto protocol.HooksProtocol) error {
 	containerCtx := proto.(*protocol.ContainerContext)
 	if containerCtx == nil {
 		return fmt.Errorf("container protocol is nil for plugin %s", name)
+	}
+	if features.DefaultKoordletFeatureGate.Enabled(features.CPUBurst) {
+		klog.V(5).Infof("skip %s container cfs quota adjustment since CPUBurst is enabled", name)
+		return nil
 	}
 	if containerCtx.Request.Resources == nil { // currently only reconciler mode provides Resources in ctx
 		return nil

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/cpu_normalization_test.go
@@ -23,8 +23,10 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
 func TestPlugin(t *testing.T) {
@@ -42,6 +44,7 @@ func TestPlugin_Register(t *testing.T) {
 }
 
 func TestPluginAdjustPodCFSQuota(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, features.DefaultMutableKoordletFeatureGate, features.CPUBurst, false)()
 	type fields struct {
 		rule *Rule
 	}
@@ -265,6 +268,7 @@ func TestPluginAdjustPodCFSQuota(t *testing.T) {
 }
 
 func TestPluginAdjustContainerCFSQuota(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, features.DefaultMutableKoordletFeatureGate, features.CPUBurst, false)()
 	type fields struct {
 		rule *Rule
 	}

--- a/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/cpunormalization/rule_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+	utilfeature "github.com/koordinator-sh/koordinator/pkg/util/feature"
 )
 
 func TestRule(t *testing.T) {
@@ -133,6 +135,7 @@ func TestPlugin_parseRule(t *testing.T) {
 }
 
 func TestPlugin_ruleUpdateCb(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, features.DefaultMutableKoordletFeatureGate, features.CPUBurst, false)()
 	type fields struct {
 		rule    *Rule
 		prepare func(t *testing.T, helper *system.FileTestUtil)


### PR DESCRIPTION
# PR Description

## I. Describe what this PR does

- Prevents CFS quota conflicts by letting CPUBurst own CFS updates when enabled.
- Applies the node CPU-normalization ratio inside CPUBurst when scaling CFS quotas.
- Ensures pod/container CFS quota updates are clamped by normalized base/ceiling values.
- Updates CPUNormalization and CPUBurst tests to reflect the new behavior.


## II. Does this pull request fix one issue?

* #2306

## III. Describe how to verify it

```bash
go test ./pkg/koordlet/runtimehooks/hooks/cpunormalization -run TestPluginAdjust
go test ./pkg/koordlet/qosmanager/plugins/cpuburst
```
### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
