### PR TITLE
fix(webhook): replace panic with retryable error handling in health checker

### DIFF
--- a/pkg/webhook/util/health/checker.go
+++ b/pkg/webhook/util/health/checker.go
@@ -34,10 +34,33 @@ import (
 var (
 	caCertFilePath = path.Join(webhookutil.GetCertDir(), "ca-cert.pem")
 
-	onceWatch sync.Once
-	lock      sync.Mutex
-	client    *http.Client
+	initMu      sync.Mutex
+	initialized bool
+	lock        sync.Mutex
+	client      *http.Client
 )
+
+func tryInit() error {
+	initMu.Lock()
+	defer initMu.Unlock()
+	if initialized {
+		return nil
+	}
+	if err := loadHTTPClientWithCACert(); err != nil {
+		return fmt.Errorf("failed to load ca-cert for the first time: %v", err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to new ca-cert watcher: %v", err)
+	}
+	if err = watcher.Add(caCertFilePath); err != nil {
+		_ = watcher.Close()
+		return fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err)
+	}
+	go watchCACert(watcher)
+	initialized = true
+	return nil
+}
 
 func loadHTTPClientWithCACert() error {
 	caCert, err := os.ReadFile(caCertFilePath)
@@ -108,19 +131,9 @@ func isRemove(event fsnotify.Event) bool {
 }
 
 func Checker(_ *http.Request) error {
-	onceWatch.Do(func() {
-		if err := loadHTTPClientWithCACert(); err != nil {
-			panic(fmt.Errorf("failed to load ca-cert for the first time: %v", err))
-		}
-		watcher, err := fsnotify.NewWatcher()
-		if err != nil {
-			panic(fmt.Errorf("failed to new ca-cert watcher: %v", err))
-		}
-		if err = watcher.Add(caCertFilePath); err != nil {
-			panic(fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err))
-		}
-		go watchCACert(watcher)
-	})
+	if err := tryInit(); err != nil {
+		return err
+	}
 
 	url := fmt.Sprintf("https://localhost:%d/healthz", webhookutil.GetPort())
 	req, err := http.NewRequest("GET", url, nil)

--- a/pkg/webhook/util/health/checker.go
+++ b/pkg/webhook/util/health/checker.go
@@ -34,10 +34,11 @@ import (
 var (
 	caCertFilePath = path.Join(webhookutil.GetCertDir(), "ca-cert.pem")
 
-	initMu      sync.Mutex
-	initialized bool
-	lock        sync.Mutex
-	client      *http.Client
+	initMu         sync.Mutex
+	initialized    bool
+	currentWatcher *fsnotify.Watcher
+	lock           sync.Mutex
+	client         *http.Client
 )
 
 func tryInit() error {
@@ -47,17 +48,18 @@ func tryInit() error {
 		return nil
 	}
 	if err := loadHTTPClientWithCACert(); err != nil {
-		return fmt.Errorf("failed to load ca-cert for the first time: %v", err)
+		return fmt.Errorf("failed to load ca-cert for the first time: %w", err)
 	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("failed to new ca-cert watcher: %v", err)
+		return fmt.Errorf("failed to create ca-cert watcher: %w", err)
 	}
 	if err = watcher.Add(caCertFilePath); err != nil {
 		_ = watcher.Close()
-		return fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err)
+		return fmt.Errorf("failed to add %v into watcher: %w", caCertFilePath, err)
 	}
 	go watchCACert(watcher)
+	currentWatcher = watcher
 	initialized = true
 	return nil
 }

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -29,6 +29,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 // resetState resets package-level globals between tests.
@@ -112,15 +114,68 @@ func TestCheckerRetryAfterFailure(t *testing.T) {
 		t.Fatalf("failed to write cert: %v", err)
 	}
 
-	// tryInit must succeed now that the cert exists.
-	if err := tryInit(); err != nil {
-		t.Fatalf("expected tryInit to succeed after cert written, got: %v", err)
-	}
+	// Second Checker() call: tryInit succeeds, then the HTTP request to localhost
+	// fails with a connection error (no server running) — that's expected.
+	// The important thing is that tryInit completed successfully.
+	_ = Checker(nil)
 	initMu.Lock()
 	initDone = initialized
 	initMu.Unlock()
 	if !initDone {
-		t.Fatal("initialized must be true after successful init")
+		t.Fatal("initialized must be true after successful init via Checker")
+	}
+}
+
+func TestTryInitFastPath(t *testing.T) {
+	resetState()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+
+	orig := caCertFilePath
+	caCertFilePath = certPath
+	defer func() {
+		caCertFilePath = orig
+		resetState()
+	}()
+
+	if err := os.WriteFile(certPath, generateTestCACert(t), 0644); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+
+	// First call: performs full initialization.
+	if err := tryInit(); err != nil {
+		t.Fatalf("first tryInit failed: %v", err)
+	}
+
+	// Second call: must hit the fast path (initialized == true) and return nil.
+	if err := tryInit(); err != nil {
+		t.Fatalf("second tryInit (fast path) failed: %v", err)
+	}
+}
+
+func TestIsWriteCreateRemove(t *testing.T) {
+	writeEvent := fsnotify.Event{Op: fsnotify.Write}
+	createEvent := fsnotify.Event{Op: fsnotify.Create}
+	removeEvent := fsnotify.Event{Op: fsnotify.Remove}
+	noneEvent := fsnotify.Event{Op: fsnotify.Chmod}
+
+	if !isWrite(writeEvent) {
+		t.Error("expected isWrite to return true for Write event")
+	}
+	if isWrite(createEvent) {
+		t.Error("expected isWrite to return false for Create event")
+	}
+	if !isCreate(createEvent) {
+		t.Error("expected isCreate to return true for Create event")
+	}
+	if isCreate(writeEvent) {
+		t.Error("expected isCreate to return false for Write event")
+	}
+	if !isRemove(removeEvent) {
+		t.Error("expected isRemove to return true for Remove event")
+	}
+	if isRemove(noneEvent) {
+		t.Error("expected isRemove to return false for Chmod event")
 	}
 }
 

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// resetState resets package-level globals between tests.
+func resetState() {
+	initMu.Lock()
+	initialized = false
+	initMu.Unlock()
+	lock.Lock()
+	client = nil
+	lock.Unlock()
+}
+
+// generateTestCACert creates a self-signed CA certificate PEM for testing.
+func generateTestCACert(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func TestCheckerMissingCertFile(t *testing.T) {
+	resetState()
+	orig := caCertFilePath
+	caCertFilePath = filepath.Join(t.TempDir(), "nonexistent-ca-cert.pem")
+	defer func() {
+		caCertFilePath = orig
+		resetState()
+	}()
+
+	err := Checker(nil)
+	if err == nil {
+		t.Fatal("expected error when cert file is missing, got nil")
+	}
+}
+
+func TestCheckerRetryAfterFailure(t *testing.T) {
+	resetState()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+
+	orig := caCertFilePath
+	caCertFilePath = certPath
+	defer func() {
+		caCertFilePath = orig
+		resetState()
+	}()
+
+	// First call: cert does not exist yet → must return error, not panic.
+	err := Checker(nil)
+	if err == nil {
+		t.Fatal("expected error on first call with missing cert")
+	}
+	if initialized {
+		t.Fatal("initialized must be false after failed init attempt")
+	}
+
+	// Write the cert file so the next attempt can succeed.
+	if err := os.WriteFile(certPath, generateTestCACert(t), 0644); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+
+	// tryInit must succeed now that the cert exists.
+	if err := tryInit(); err != nil {
+		t.Fatalf("expected tryInit to succeed after cert written, got: %v", err)
+	}
+	if !initialized {
+		t.Fatal("initialized must be true after successful init")
+	}
+}
+
+func TestLoadHTTPClientWithCACert(t *testing.T) {
+	resetState()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+
+	orig := caCertFilePath
+	caCertFilePath = certPath
+	defer func() {
+		caCertFilePath = orig
+		resetState()
+	}()
+
+	if err := os.WriteFile(certPath, generateTestCACert(t), 0644); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+
+	if err := loadHTTPClientWithCACert(); err != nil {
+		t.Fatalf("expected no error loading CA cert, got: %v", err)
+	}
+
+	lock.Lock()
+	c := client
+	lock.Unlock()
+
+	if c == nil {
+		t.Fatal("expected client to be set after loadHTTPClientWithCACert")
+	}
+	transport, ok := c.Transport.(*http.Transport)
+	if !ok || transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected TLS config with RootCAs to be set on client transport")
+	}
+}

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -34,6 +34,10 @@ import (
 // resetState resets package-level globals between tests.
 func resetState() {
 	initMu.Lock()
+	if currentWatcher != nil {
+		_ = currentWatcher.Close()
+		currentWatcher = nil
+	}
 	initialized = false
 	initMu.Unlock()
 	lock.Lock()
@@ -96,7 +100,10 @@ func TestCheckerRetryAfterFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on first call with missing cert")
 	}
-	if initialized {
+	initMu.Lock()
+	initDone := initialized
+	initMu.Unlock()
+	if initDone {
 		t.Fatal("initialized must be false after failed init attempt")
 	}
 
@@ -109,7 +116,10 @@ func TestCheckerRetryAfterFailure(t *testing.T) {
 	if err := tryInit(); err != nil {
 		t.Fatalf("expected tryInit to succeed after cert written, got: %v", err)
 	}
-	if !initialized {
+	initMu.Lock()
+	initDone = initialized
+	initMu.Unlock()
+	if !initDone {
 		t.Fatal("initialized must be true after successful init")
 	}
 }


### PR DESCRIPTION
## What this PR does

Fixes #2902.

The `Checker()` function in `pkg/webhook/util/health/checker.go` called `panic()` on three initialization failures:
- CA cert load failure (`loadHTTPClientWithCACert`)
- `fsnotify.NewWatcher()` failure
- `watcher.Add()` failure

This crashed the entire webhook process instead of returning an error to the caller.

## Root Cause

`sync.Once` combined with `panic()` is a deadly pattern here: the first call panics and kills the process rather than allowing the polling loop in `WaitReady()` to retry on transient startup errors (e.g. cert file not yet written).

## Solution

Replace `sync.Once` with a mutex+bool `tryInit()` function that:
- Returns errors instead of panicking, allowing `WaitReady()` to retry on each poll
- Sets `initialized = true` only after **all three** steps succeed, so any partial failure is retryable
- Closes the `fsnotify.Watcher` if `watcher.Add()` fails, preventing fd leaks

## Tests

Added `checker_test.go` with three unit tests:
- `TestCheckerMissingCertFile` — missing cert returns error without panic
- `TestCheckerRetryAfterFailure` — proves `sync.Once` is gone: fails first, succeeds after cert is written
- `TestLoadHTTPClientWithCACert` — cert loading correctly populates TLS client

All tests pass: `go test ./pkg/webhook/util/health/... -v`

## Checklist
- [x] Code compiles (`go build ./pkg/webhook/...`)
- [x] Unit tests pass (`go test ./pkg/webhook/util/health/...`)
- [x] No new panics introduced
- [x] Existing behaviour preserved (watcher goroutine, cert reload on file events)