### PR TITLE
fix: stale gang cache by handling informer tombstones in delete handlers

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -217,7 +218,16 @@ func (gangCache *GangCache) onPodUpdate(oldObj, newObj interface{}) {
 func (gangCache *GangCache) onPodDelete(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		return
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("onPodDelete: couldn't get object from tombstone %+v", obj)
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			klog.Errorf("onPodDelete: tombstone contained object that is not a Pod %+v", tombstone.Obj)
+			return
+		}
 	}
 	gangName := util.GetGangNameByPod(pod)
 	if gangName == "" {
@@ -348,7 +358,16 @@ func (gangCache *GangCache) onPodGroupUpdate(oldObj interface{}, newObj interfac
 func (gangCache *GangCache) onPodGroupDelete(obj interface{}) {
 	pg, ok := obj.(*v1alpha1.PodGroup)
 	if !ok {
-		return
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("onPodGroupDelete: couldn't get object from tombstone %+v", obj)
+			return
+		}
+		pg, ok = tombstone.Obj.(*v1alpha1.PodGroup)
+		if !ok {
+			klog.Errorf("onPodGroupDelete: tombstone contained object that is not a PodGroup %+v", tombstone.Obj)
+			return
+		}
 	}
 	gangNamespace := pg.Namespace
 	gangName := pg.Name

--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 
@@ -1759,4 +1760,134 @@ func TestGangCache_getWaitingPodsNum(t *testing.T) {
 			assert.Equalf(t, tt.want, gangCache.getWaitingPodsNum(tt.args.gangGroup), "getPendingPods(%v)", tt.args.gangGroup)
 		})
 	}
+}
+
+func TestGangCache_onPodDelete_Tombstone(t *testing.T) {
+	preTimeNowFn := timeNowFn
+	defer func() { timeNowFn = preTimeNowFn }()
+	timeNowFn = fakeTimeNowFn
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			Annotations: map[string]string{
+				extension.AnnotationGangName:   "ganga",
+				extension.AnnotationGangMinNum: "1",
+			},
+		},
+	}
+
+	t.Run("valid tombstone deletes pod from gang cache", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultTimeout:     metav1.Duration{Duration: time.Second},
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangCache.onPodAdd(pod)
+		gangId := util.GetId("default", "ganga")
+		assert.NotNil(t, gangCache.gangItems[gangId])
+		assert.Equal(t, 1, len(gangCache.gangItems[gangId].Children))
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: "default/pod1", Obj: pod}
+		gangCache.onPodDelete(tombstone)
+
+		// annotation-based gang with no children should be removed
+		assert.Nil(t, gangCache.gangItems[gangId])
+	})
+
+	t.Run("non-pod tombstone is ignored without panic", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultTimeout:     metav1.Duration{Duration: time.Second},
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangCache.onPodAdd(pod)
+		gangId := util.GetId("default", "ganga")
+		assert.Equal(t, 1, len(gangCache.gangItems[gangId].Children))
+
+		// pass a tombstone wrapping a non-Pod object – should be a no-op
+		tombstone := cache.DeletedFinalStateUnknown{Key: "default/pod1", Obj: "not-a-pod"}
+		gangCache.onPodDelete(tombstone)
+
+		// pod should still be in cache (event was ignored)
+		assert.Equal(t, 1, len(gangCache.gangItems[gangId].Children))
+	})
+
+	t.Run("unknown object type is ignored without panic", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultTimeout:     metav1.Duration{Duration: time.Second},
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangCache.onPodAdd(pod)
+		gangId := util.GetId("default", "ganga")
+		assert.Equal(t, 1, len(gangCache.gangItems[gangId].Children))
+
+		gangCache.onPodDelete("totally-wrong-type")
+
+		assert.Equal(t, 1, len(gangCache.gangItems[gangId].Children))
+	})
+}
+
+func TestGangCache_onPodGroupDelete_Tombstone(t *testing.T) {
+	preTimeNowFn := timeNowFn
+	defer func() { timeNowFn = preTimeNowFn }()
+	timeNowFn = fakeTimeNowFn
+
+	pg := &v1alpha1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "ganga",
+		},
+		Spec: v1alpha1.PodGroupSpec{MinMember: 2},
+	}
+
+	t.Run("valid tombstone removes podgroup gang from cache", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangId := util.GetId("default", "ganga")
+		gangTmp := gangCache.getGangFromCacheByGangId(gangId, true)
+		gangTmp.GangGroupInfo = NewGangGroupInfo("", nil)
+		assert.Equal(t, 1, len(gangCache.gangItems))
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: "default/ganga", Obj: pg}
+		gangCache.onPodGroupDelete(tombstone)
+
+		assert.Equal(t, 0, len(gangCache.gangItems))
+	})
+
+	t.Run("non-podgroup tombstone is ignored without panic", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangId := util.GetId("default", "ganga")
+		gangTmp := gangCache.getGangFromCacheByGangId(gangId, true)
+		gangTmp.GangGroupInfo = NewGangGroupInfo("", nil)
+		assert.Equal(t, 1, len(gangCache.gangItems))
+
+		tombstone := cache.DeletedFinalStateUnknown{Key: "default/ganga", Obj: "not-a-podgroup"}
+		gangCache.onPodGroupDelete(tombstone)
+
+		// gang should still be present (event was ignored)
+		assert.Equal(t, 1, len(gangCache.gangItems))
+	})
+
+	t.Run("unknown object type is ignored without panic", func(t *testing.T) {
+		gangCache := NewGangCache(&config.CoschedulingArgs{
+			DefaultMatchPolicy: extension.GangMatchPolicyOnceSatisfied,
+		}, nil, nil, nil, nil)
+
+		gangId := util.GetId("default", "ganga")
+		gangTmp := gangCache.getGangFromCacheByGangId(gangId, true)
+		gangTmp.GangGroupInfo = NewGangGroupInfo("", nil)
+		assert.Equal(t, 1, len(gangCache.gangItems))
+
+		gangCache.onPodGroupDelete("totally-wrong-type")
+
+		assert.Equal(t, 1, len(gangCache.gangItems))
+	})
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Fixes missing `cache.DeletedFinalStateUnknown` tombstone handling in `onPodDelete` and `onPodGroupDelete` inside the coscheduling gang cache (`gang_cache.go`)

When the Kubernetes informer misses a delete event (e.g., due to a watch timeout or API-server blip), it delivers a `DeletedFinalStateUnknown` tombstone on `resync`. The previous bare type-assertions silently returned on mismatch, leaving deleted Pods and PodGroups forever in the gang cache. This PR adds the standard tombstone-unwrap pattern already used by `elasticquota, nodenumaresource, deviceshare, and reservation delete handlers.`

### Ⅱ. Does this pull request fix one issue?

fixes #2910 

### Ⅲ. Describe how to verify it
* Run go test ./pkg/scheduler/plugins/coscheduling/... — all existing tests pass.
* Six new unit tests cover the three cases for each handler:
    *  Valid tombstone → cleanup executes correctly.
    * Tombstone wrapping a wrong type → event is ignored, no panic.
    * Completely unknown object type → event is ignored, no panic.
### Ⅳ. Special notes for reviews
* Only `gang_cache.go and gang_cache_test.go ` are changed.
* `"k8s.io/client-go/tools/cache"` is the only new import — it is already a transitive dependency of the module.
* The fix mirrors the pattern in `elasticquota/pod_handler.go`exactly.
### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
