### PR TITLE
refactor(scheduler): make reservation Bind non-blocking

### DIFF
--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1573,37 +1574,51 @@ func (pl *Plugin) Bind(ctx context.Context, cycleState fwktype.CycleState, pod *
 	rName := reservationutil.GetReservationNameFromReservePod(pod)
 	klog.V(4).InfoS("Attempting to bind reservation to node", "pod", klog.KObj(pod), "reservation", rName, "node", nodeName)
 
-	var reservation *schedulingv1alpha1.Reservation
-	err := util.RetryOnConflictOrTooManyRequests(func() error {
-		var err error
-		reservation, err = pl.rLister.Get(rName)
-		if err != nil {
-			return err
-		}
-
-		// check if the reservation has been inactive
-		if reservationutil.IsReservationFailed(reservation) {
-			return errors.New(ErrReasonReservationInactive)
-		}
-
-		// mark reservation as available
-		reservation = reservation.DeepCopy()
-		if err = reservationutil.SetReservationAvailable(reservation, nodeName); err != nil {
-			return err
-		}
-		_, err = pl.client.Reservations().UpdateStatus(context.TODO(), reservation, metav1.UpdateOptions{})
-		if err != nil {
-			klog.V(4).ErrorS(err, "failed to update reservation", "reservation", klog.KObj(reservation))
-		}
-		return err
-	})
+	reservation, err := pl.rLister.Get(rName)
 	if err != nil {
-		klog.Errorf("Failed to update bind Reservation %s, err: %v", rName, err)
 		return fwktype.AsStatus(err)
 	}
 
+	// check if the reservation has been inactive
+	if reservationutil.IsReservationFailed(reservation) {
+		return fwktype.AsStatus(errors.New(ErrReasonReservationInactive))
+	}
+
+	pl.updateReservationAvailableAsync(rName, nodeName)
 	pl.handle.EventRecorder().Eventf(reservation, nil, corev1.EventTypeNormal, "Scheduled", "Binding", "Successfully assigned %v to %v", rName, nodeName)
 	return nil
+}
+
+func (pl *Plugin) updateReservationAvailableAsync(reservationName, nodeName string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := util.RetryOnConflictOrTooManyRequests(func() error {
+			reservation, err := pl.rLister.Get(reservationName)
+			if err != nil {
+				return err
+			}
+
+			if reservationutil.IsReservationFailed(reservation) {
+				return errors.New(ErrReasonReservationInactive)
+			}
+
+			reservation = reservation.DeepCopy()
+			if err := reservationutil.SetReservationAvailable(reservation, nodeName); err != nil {
+				return err
+			}
+
+			_, err = pl.client.Reservations().UpdateStatus(ctx, reservation, metav1.UpdateOptions{})
+			if err != nil {
+				klog.V(4).ErrorS(err, "failed to update reservation", "reservation", klog.KObj(reservation))
+			}
+			return err
+		})
+		if err != nil {
+			klog.ErrorS(err, "Failed to update bind Reservation", "reservation", reservationName, "node", nodeName)
+		}
+	}()
 }
 
 func (pl *Plugin) DeleteReservation(r *schedulingv1alpha1.Reservation) *frameworkext.ReservationInfo {

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -4695,7 +4695,7 @@ func TestBind(t *testing.T) {
 			nodeName:    testNodeName,
 			reservation: reservation,
 			fakeClient:  koordfake.NewSimpleClientset(),
-			want:        fwktype.AsStatus(apierrors.NewNotFound(schedulingv1alpha1.Resource("reservations"), reservation.Name)),
+			want:        nil,
 		},
 		{
 			name:            "bind reservation successfully",
@@ -4736,18 +4736,30 @@ func TestBind(t *testing.T) {
 			got := pl.Bind(context.TODO(), nil, tt.pod, tt.nodeName)
 			assert.Equal(t, tt.want, got)
 
-			if tt.want.IsSuccess() && tt.reservation != nil {
-				reservation, err := client.SchedulingV1alpha1().Reservations().Get(context.TODO(), tt.reservation.Name, metav1.GetOptions{})
-				assert.NoError(t, err)
-				for _, r := range []*schedulingv1alpha1.Reservation{reservation, tt.wantReservation} {
-					if r != nil {
-						for i := range r.Status.Conditions {
-							r.Status.Conditions[i].LastProbeTime = metav1.Time{}
-							r.Status.Conditions[i].LastTransitionTime = metav1.Time{}
-						}
+			if (tt.want == nil || tt.want.IsSuccess()) && tt.wantReservation != nil {
+				normalizeConditions := func(r *schedulingv1alpha1.Reservation) *schedulingv1alpha1.Reservation {
+					if r == nil {
+						return nil
 					}
+					cloned := r.DeepCopy()
+					for i := range cloned.Status.Conditions {
+						cloned.Status.Conditions[i].LastProbeTime = metav1.Time{}
+						cloned.Status.Conditions[i].LastTransitionTime = metav1.Time{}
+					}
+					return cloned
 				}
-				assert.Equal(t, tt.wantReservation, reservation)
+				var updatedReservation *schedulingv1alpha1.Reservation
+				err := wait.PollImmediate(20*time.Millisecond, time.Second, func() (bool, error) {
+					reservation, err := client.SchedulingV1alpha1().Reservations().Get(context.TODO(), tt.reservation.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, nil
+					}
+					updatedReservation = normalizeConditions(reservation)
+					wantReservation := normalizeConditions(tt.wantReservation)
+					return equality.Semantic.DeepEqual(updatedReservation, wantReservation), nil
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, normalizeConditions(tt.wantReservation), updatedReservation)
 			}
 		})
 	}


### PR DESCRIPTION
# PR Description

## I. Describe what this PR does

- Makes reservation `Bind()` non-blocking by moving Reservation status updates to an async worker, avoiding scheduler goroutine blocking.
- Adjusts reservation bind tests to tolerate async status updates.

## II. Does this pull request fix one issue?

* fixes #2853

## III. Describe how to verify it

```bash
go test ./pkg/scheduler/plugins/reservation -run TestBind -count=1
```

## IV. Special notes for reviews

- Reservation status updates are now async with retry and timeout; `Bind()` no longer blocks on API calls.

## V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in make test