### PR TITLE
fix: rename PageCacheCollector to UsageWithCacheCollector

### DIFF
--- a/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector.go
+++ b/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector.go
@@ -34,22 +34,22 @@ import (
 )
 
 const (
-	CollectorName = "PageCacheCollector"
+	CollectorName = "UsageWithCacheCollector"
 )
 
 var (
 	timeNow = time.Now
 )
 
-type pageCacheCollector struct {
-	collectInterval       time.Duration
-	started               *atomic.Bool
-	appendableDB          metriccache.Appendable
-	metricDB              metriccache.MetricCache
-	statesInformer        statesinformer.StatesInformer
-	cgroupReader          resourceexecutor.CgroupReader
-	podFilter             framework.PodFilter
-	coldPageCollectorGate bool
+type usageWithCacheCollector struct {
+	collectInterval             time.Duration
+	started                     *atomic.Bool
+	appendableDB                metriccache.Appendable
+	metricDB                    metriccache.MetricCache
+	statesInformer              statesinformer.StatesInformer
+	cgroupReader                resourceexecutor.CgroupReader
+	podFilter                   framework.PodFilter
+	usageWithCacheCollectorGate bool
 }
 
 func New(opt *framework.Options) framework.Collector {
@@ -57,54 +57,54 @@ func New(opt *framework.Options) framework.Collector {
 	if filter, ok := opt.PodFilters[CollectorName]; ok {
 		podFilter = filter
 	}
-	return &pageCacheCollector{
-		collectInterval:       opt.Config.CollectResUsedInterval,
-		started:               atomic.NewBool(false),
-		appendableDB:          opt.MetricCache,
-		metricDB:              opt.MetricCache,
-		statesInformer:        opt.StatesInformer,
-		cgroupReader:          opt.CgroupReader,
-		podFilter:             podFilter,
-		coldPageCollectorGate: opt.Config.EnablePageCacheCollector,
+	return &usageWithCacheCollector{
+		collectInterval:             opt.Config.CollectResUsedInterval,
+		started:                     atomic.NewBool(false),
+		appendableDB:                opt.MetricCache,
+		metricDB:                    opt.MetricCache,
+		statesInformer:              opt.StatesInformer,
+		cgroupReader:                opt.CgroupReader,
+		podFilter:                   podFilter,
+		usageWithCacheCollectorGate: opt.Config.EnableUsageWithCacheCollector,
 	}
 }
 
-func (p *pageCacheCollector) Enabled() bool {
-	return p.coldPageCollectorGate
+func (p *usageWithCacheCollector) Enabled() bool {
+	return p.usageWithCacheCollectorGate
 }
 
-func (p *pageCacheCollector) Setup(c *framework.Context) {}
+func (p *usageWithCacheCollector) Setup(c *framework.Context) {}
 
-func (p *pageCacheCollector) Run(stopCh <-chan struct{}) {
-	go wait.Until(p.collectPageCache, p.collectInterval, stopCh)
+func (p *usageWithCacheCollector) Run(stopCh <-chan struct{}) {
+	go wait.Until(p.collectUsageWithCache, p.collectInterval, stopCh)
 }
 
-func (p *pageCacheCollector) Started() bool {
+func (p *usageWithCacheCollector) Started() bool {
 	return p.started.Load()
 }
 
-func (p *pageCacheCollector) FilterPod(meta *statesinformer.PodMeta) (bool, string) {
+func (p *usageWithCacheCollector) FilterPod(meta *statesinformer.PodMeta) (bool, string) {
 	return p.podFilter.FilterPod(meta)
 }
 
-func (p *pageCacheCollector) collectPageCache() {
+func (p *usageWithCacheCollector) collectUsageWithCache() {
 	if p.statesInformer == nil {
 		return
 	}
-	p.collectNodePageCache()
-	p.collectPodPageCache()
+	p.collectNodeUsageWithCache()
+	p.collectPodUsageWithCache()
 	p.started.Store(true)
 }
 
-func (p *pageCacheCollector) collectNodePageCache() {
-	klog.V(6).Info("start collect node PageCache")
+func (p *usageWithCacheCollector) collectNodeUsageWithCache() {
+	klog.V(6).Info("start collect node memory usage with cache")
 	nodeMetrics := make([]metriccache.MetricSample, 0)
 	collectTime := timeNow()
 
 	// NOTE: The collected memory usage is in kilobytes not bytes.
 	memInfo, err := koordletutil.GetMemInfo()
 	if err != nil {
-		klog.Warningf("failed to collect page cache of node err: %s", err)
+		klog.Warningf("failed to collect memory usage with cache of node, err: %s", err)
 		return
 	}
 
@@ -127,12 +127,12 @@ func (p *pageCacheCollector) collectNodePageCache() {
 		return
 	}
 
-	klog.V(4).Infof("collectNodePageCache finished, count %v, memUsageWithPageCache[%v]",
+	klog.V(4).Infof("collectNodeUsageWithCache finished, count %v, memUsageWithPageCache[%v]",
 		len(nodeMetrics), memUsageWithPageCacheValue)
 }
 
-func (p *pageCacheCollector) collectPodPageCache() {
-	klog.V(6).Info("start collect pods PageCache")
+func (p *usageWithCacheCollector) collectPodUsageWithCache() {
+	klog.V(6).Info("start collect pods memory usage with cache")
 	podMetas := p.statesInformer.GetAllPods()
 	count := 0
 	metrics := make([]metriccache.MetricSample, 0)
@@ -151,10 +151,10 @@ func (p *pageCacheCollector) collectPodPageCache() {
 		if err != nil {
 			// higher verbosity for probably non-running pods
 			if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
-				klog.V(6).Infof("failed to collect non-running pod page cache for %s, page cache err: %s",
+				klog.V(6).Infof("failed to collect non-running pod memory usage with cache for %s, page cache err: %s",
 					podKey, err)
 			} else {
-				klog.Warningf("failed to collect pod page cache for %s, page cache err: %s", podKey, err)
+				klog.Warningf("failed to collect pod memory usage with cache for %s, page cache err: %s", podKey, err)
 			}
 			continue
 		}
@@ -171,7 +171,7 @@ func (p *pageCacheCollector) collectPodPageCache() {
 		klog.V(6).Infof("collect pod %s, uid %s finished, metric %+v", podKey, pod.UID, metrics)
 
 		count++
-		containerMetrics := p.collectContainerPageCache(meta)
+		containerMetrics := p.collectContainerUsageWithCache(meta)
 		metrics = append(metrics, containerMetrics...)
 	}
 
@@ -186,11 +186,11 @@ func (p *pageCacheCollector) collectPodPageCache() {
 		return
 	}
 
-	klog.V(4).Infof("collectPodPageCache finished, pod num %d, collected %d", len(podMetas), count)
+	klog.V(4).Infof("collectPodUsageWithCache finished, pod num %d, collected %d", len(podMetas), count)
 }
 
-func (p *pageCacheCollector) collectContainerPageCache(meta *statesinformer.PodMeta) []metriccache.MetricSample {
-	klog.V(6).Infof("start collect containers pagecache")
+func (p *usageWithCacheCollector) collectContainerUsageWithCache(meta *statesinformer.PodMeta) []metriccache.MetricSample {
+	klog.V(6).Infof("start collect containers memory usage with cache")
 	pod := meta.Pod
 	count := 0
 	containerMetrics := make([]metriccache.MetricSample, 0)
@@ -215,10 +215,10 @@ func (p *pageCacheCollector) collectContainerPageCache(meta *statesinformer.PodM
 		if err != nil {
 			// higher verbosity for probably non-running pods
 			if containerStat.State.Running == nil {
-				klog.V(6).Infof("failed to collect non-running container page cache for %s, page cache err: %s",
+				klog.V(6).Infof("failed to collect non-running container memory usage with cache for %s, page cache err: %s",
 					containerKey, err)
 			} else {
-				klog.V(4).Infof("failed to collect container page cache for %s, page cache err: %s",
+				klog.V(4).Infof("failed to collect container memory usage with cache for %s, page cache err: %s",
 					containerKey, err)
 			}
 			continue
@@ -237,7 +237,7 @@ func (p *pageCacheCollector) collectContainerPageCache(meta *statesinformer.PodM
 		klog.V(6).Infof("collect container %s, id %s finished, metric %+v", containerKey, pod.UID, containerMetrics)
 		count++
 	}
-	klog.V(5).Infof("collectContainerPageCache for pod %s/%s finished, container num %d, collected %d",
+	klog.V(5).Infof("collectContainerUsageWithCache for pod %s/%s finished, container num %d, collected %d",
 		pod.Namespace, pod.Name, len(pod.Status.ContainerStatuses), count)
 	return containerMetrics
 }

--- a/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
+++ b/pkg/koordlet/metricsadvisor/collectors/pagecache/page_cache_collector_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
 
-func Test_collectPageCache(t *testing.T) {
+func Test_collectUsageWithCache(t *testing.T) {
 	testNow := time.Now()
 	testContainerID := "containerd://123abc"
 	testPodMetaDir := "kubepods.slice/kubepods-podxxxxxxxx.slice"
@@ -249,15 +249,15 @@ DirectMap1G:           0 kB`
 			statesInformer.EXPECT().GetAllPods().Return(tt.fields.getPodMetas).AnyTimes()
 			collector := New(&framework.Options{
 				Config: &framework.Config{
-					EnablePageCacheCollector: true,
+					EnableUsageWithCacheCollector: true,
 				},
 				StatesInformer: statesInformer,
 				MetricCache:    metricCache,
 				CgroupReader:   resourceexecutor.NewCgroupReader(),
 			})
-			c := collector.(*pageCacheCollector)
+			c := collector.(*usageWithCacheCollector)
 			assert.NotPanics(t, func() {
-				c.collectPageCache()
+				c.collectUsageWithCache()
 			})
 			assert.NotPanics(t, func() {
 				c.Setup(&framework.Context{})

--- a/pkg/koordlet/metricsadvisor/framework/config.go
+++ b/pkg/koordlet/metricsadvisor/framework/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	CPICollectorTimeWindow           time.Duration
 	ColdPageCollectorInterval        time.Duration
 	ResctrlCollectorInterval         time.Duration
-	EnablePageCacheCollector         bool
+	EnableUsageWithCacheCollector    bool
 	EnableResctrlCollector           bool
 }
 
@@ -51,7 +51,7 @@ func NewDefaultConfig() *Config {
 		CPICollectorTimeWindow:           10 * time.Second,
 		ColdPageCollectorInterval:        5 * time.Second,
 		ResctrlCollectorInterval:         10 * time.Second,
-		EnablePageCacheCollector:         false,
+		EnableUsageWithCacheCollector:    false,
 		EnableResctrlCollector:           false,
 	}
 }
@@ -65,7 +65,7 @@ func (c *Config) InitFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.PSICollectorInterval, "psi-collector-interval", c.PSICollectorInterval, "Collect psi interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.DurationVar(&c.CPICollectorTimeWindow, "collect-cpi-timewindow", c.CPICollectorTimeWindow, "Collect cpi time window. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	fs.DurationVar(&c.ColdPageCollectorInterval, "coldpage-collector-interval", c.ColdPageCollectorInterval, "Collect cold page interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
-	fs.BoolVar(&c.EnablePageCacheCollector, "enable-pagecache-collector", c.EnablePageCacheCollector, "Enable cache collector of node, pods and containers")
+	fs.BoolVar(&c.EnableUsageWithCacheCollector, "enable-usage-with-cache-collector", c.EnableUsageWithCacheCollector, "Enable memory usage with cache collector for node, pods and containers")
 	fs.BoolVar(&c.EnableResctrlCollector, "enable-resctrl-collector", c.EnableResctrlCollector, "Enable RDT(resource director technology) collector for QoS groups (LSR/LS/BE)")
 	fs.DurationVar(&c.ResctrlCollectorInterval, "resctrl-collector-interval", c.ResctrlCollectorInterval, "Collect RDT metrics interval. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 }

--- a/pkg/koordlet/metricsadvisor/framework/config_test.go
+++ b/pkg/koordlet/metricsadvisor/framework/config_test.go
@@ -35,7 +35,7 @@ func Test_NewDefaultConfig(t *testing.T) {
 		CPICollectorTimeWindow:           10 * time.Second,
 		ColdPageCollectorInterval:        5 * time.Second,
 		ResctrlCollectorInterval:         10 * time.Second,
-		EnablePageCacheCollector:         false,
+		EnableUsageWithCacheCollector:    false,
 	}
 	defaultConfig := NewDefaultConfig()
 	assert.Equal(t, expectConfig, defaultConfig)

--- a/pkg/koordlet/util/meminfo.go
+++ b/pkg/koordlet/util/meminfo.go
@@ -108,7 +108,9 @@ func (i *MemInfo) MemUsageBytes() uint64 {
 	return (i.MemTotal - i.MemAvailable) * 1024
 }
 
-// MemWithPageCacheUsageBytes returns the usage of mem with page cache bytes.
+// MemUsageWithPageCache returns the memory usage with page cache in bytes.
+// This calculates total - free, which includes anonymous pages, file cache (page cache),
+// slab, and other kernel memory.
 func (i *MemInfo) MemUsageWithPageCache() uint64 {
 	// total - free
 	return (i.MemTotal - i.MemFree) * 1024


### PR DESCRIPTION
## Summary

- Renamed `PageCacheCollector` to `UsageWithCacheCollector` since it actually collects memory usage *including* page cache, not page cache itself
- Renamed config field `EnablePageCacheCollector` -> `EnableUsageWithCacheCollector` and CLI flag `--enable-pagecache-collector` -> `--enable-usage-with-cache-collector`
- Updated internal struct/method names and log messages to match the new naming
- Fixed misleading `MemUsageWithPageCache` doc comment in `meminfo.go`

The collector was named `PageCacheCollector` but it collects `total - free` at the node level and `inactive_anon + active_anon + unevictable + active_file + inactive_file` at the cgroup level, which is memory usage with cache included -- not page cache alone. The maintainer confirmed the rename in the issue discussion.

## Test plan

- [x] `go build ./pkg/koordlet/...` passes
- [x] `go test ./pkg/koordlet/metricsadvisor/collectors/pagecache/...` passes
- [x] `go test ./pkg/koordlet/metricsadvisor/framework/...` passes

Fixes #2508