### PR TITLE
Include init containers and pod overhead in BE resource calculations

### DIFF
--- a/pkg/util/pod_resources_utils.go
+++ b/pkg/util/pod_resources_utils.go
@@ -79,14 +79,21 @@ func GetPodBEMilliCPURequest(pod *corev1.Pod) int64 {
 		podCPUMilliReq += containerCPUMilliReq
 	}
 	// Sidecar containers run alongside regular containers and should be summed.
+	// Regular init containers run sequentially, so take the max.
 	for _, container := range pod.Spec.InitContainers {
-		if IsSidecarContainer(container) {
-			containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
-			if containerCPUMilliReq <= 0 {
-				containerCPUMilliReq = 0
-			}
-			podCPUMilliReq += containerCPUMilliReq
+		containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
+		if containerCPUMilliReq <= 0 {
+			containerCPUMilliReq = 0
 		}
+		if IsSidecarContainer(container) {
+			podCPUMilliReq += containerCPUMilliReq
+		} else {
+			podCPUMilliReq = MaxInt64(podCPUMilliReq, containerCPUMilliReq)
+		}
+	}
+	// Add pod overhead if BE CPU overhead is defined.
+	if overheadCPUMilliReq := GetBatchMilliCPUFromResourceList(pod.Spec.Overhead); overheadCPUMilliReq > 0 {
+		podCPUMilliReq += overheadCPUMilliReq
 	}
 
 	return podCPUMilliReq
@@ -102,17 +109,24 @@ func GetPodBEMilliCPULimit(pod *corev1.Pod) int64 {
 		podCPUMilliLimit += containerCPUMilliLimit
 	}
 	// Sidecar containers run alongside regular containers and should be summed.
+	// Regular init containers run sequentially, so take the max.
 	for _, container := range pod.Spec.InitContainers {
+		containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
+		if containerCPUMilliLimit <= 0 {
+			return -1
+		}
 		if IsSidecarContainer(container) {
-			containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
-			if containerCPUMilliLimit <= 0 {
-				return -1
-			}
 			podCPUMilliLimit += containerCPUMilliLimit
+		} else {
+			podCPUMilliLimit = MaxInt64(podCPUMilliLimit, containerCPUMilliLimit)
 		}
 	}
 	if podCPUMilliLimit <= 0 {
 		return -1
+	}
+	// Add pod overhead if BE CPU overhead is defined.
+	if overheadCPUMilliLimit := GetBatchMilliCPUFromResourceList(pod.Spec.Overhead); overheadCPUMilliLimit > 0 {
+		podCPUMilliLimit += overheadCPUMilliLimit
 	}
 	return podCPUMilliLimit
 }
@@ -128,14 +142,22 @@ func GetPodBEMemoryByteRequestIgnoreUnlimited(pod *corev1.Pod) int64 {
 		podMemoryByteRequest += containerMemByteRequest
 	}
 	// Sidecar containers run alongside regular containers and should be summed.
+	// Regular init containers run sequentially, so take the max.
 	for _, container := range pod.Spec.InitContainers {
-		if IsSidecarContainer(container) {
-			containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
-			if containerMemByteRequest < 0 {
-				continue
-			}
-			podMemoryByteRequest += containerMemByteRequest
+		containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
+		if containerMemByteRequest < 0 {
+			// consider request of unlimited container as 0
+			containerMemByteRequest = 0
 		}
+		if IsSidecarContainer(container) {
+			podMemoryByteRequest += containerMemByteRequest
+		} else {
+			podMemoryByteRequest = MaxInt64(podMemoryByteRequest, containerMemByteRequest)
+		}
+	}
+	// Add pod overhead if BE memory overhead is defined.
+	if overheadMemByteRequest := GetBatchMemoryFromResourceList(pod.Spec.Overhead); overheadMemByteRequest > 0 {
+		podMemoryByteRequest += overheadMemByteRequest
 	}
 	return podMemoryByteRequest
 }
@@ -150,17 +172,24 @@ func GetPodBEMemoryByteLimit(pod *corev1.Pod) int64 {
 		podMemoryByteLimit += containerMemByteLimit
 	}
 	// Sidecar containers run alongside regular containers and should be summed.
+	// Regular init containers run sequentially, so take the max.
 	for _, container := range pod.Spec.InitContainers {
+		containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
+		if containerMemByteLimit <= 0 {
+			return -1
+		}
 		if IsSidecarContainer(container) {
-			containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
-			if containerMemByteLimit <= 0 {
-				return -1
-			}
 			podMemoryByteLimit += containerMemByteLimit
+		} else {
+			podMemoryByteLimit = MaxInt64(podMemoryByteLimit, containerMemByteLimit)
 		}
 	}
 	if podMemoryByteLimit <= 0 {
 		return -1
+	}
+	// Add pod overhead if BE memory overhead is defined.
+	if overheadMemByteLimit := GetBatchMemoryFromResourceList(pod.Spec.Overhead); overheadMemByteLimit > 0 {
+		podMemoryByteLimit += overheadMemByteLimit
 	}
 	return podMemoryByteLimit
 }

--- a/pkg/util/pod_resources_utils_test.go
+++ b/pkg/util/pod_resources_utils_test.go
@@ -321,6 +321,42 @@ func Test_GetPodBEMilliCPURequest(t *testing.T) {
 			wantLimit:   -1,
 		},
 		{
+			name: "init container without request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("3000"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 2000,
+			wantLimit:   4000,
+		},
+		{
+			name:        "no containers",
+			pod:         &corev1.Pod{},
+			wantRequest: 0,
+			wantLimit:   -1,
+		},
+		{
 			name: "empty resource",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -560,6 +596,42 @@ func Test_GetPodBEMemoryRequest(t *testing.T) {
 				},
 			},
 			wantRequest: 3 * 1024 * 1024,
+			wantLimit:   -1,
+		},
+		{
+			name: "init container without request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("4Mi"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("3Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 2 * 1024 * 1024,
+			wantLimit:   4 * 1024 * 1024,
+		},
+		{
+			name:        "no containers",
+			pod:         &corev1.Pod{},
+			wantRequest: 0,
 			wantLimit:   -1,
 		},
 		{

--- a/pkg/util/pod_resources_utils_test.go
+++ b/pkg/util/pod_resources_utils_test.go
@@ -199,6 +199,128 @@ func Test_GetPodBEMilliCPURequest(t *testing.T) {
 			wantLimit:   8000,
 		},
 		{
+			name: "init container less than app containers and overhead",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("5000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("7000"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU: resource.MustParse("500"),
+					},
+				},
+			},
+			wantRequest: 6500,
+			wantLimit:   8500,
+		},
+		{
+			name: "init container greater than app containers and overhead",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("1000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("1000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("5000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("7000"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchCPU: resource.MustParse("500"),
+					},
+				},
+			},
+			wantRequest: 5500,
+			wantLimit:   7500,
+		},
+		{
+			name: "init container without limit",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("3000"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 3000,
+			wantLimit:   -1,
+		},
+		{
 			name: "empty resource",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -317,6 +439,128 @@ func Test_GetPodBEMemoryRequest(t *testing.T) {
 			},
 			wantRequest: 4194304,
 			wantLimit:   6291456,
+		},
+		{
+			name: "init container less than app containers and overhead",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("4Mi"),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("3Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("5Mi"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchMemory: resource.MustParse("1Mi"),
+					},
+				},
+			},
+			wantRequest: 5 * 1024 * 1024,
+			wantLimit:   7 * 1024 * 1024,
+		},
+		{
+			name: "init container greater than app containers and overhead",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("3Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("5Mi"),
+								},
+							},
+						},
+					},
+					Overhead: corev1.ResourceList{
+						apiext.BatchMemory: resource.MustParse("1Mi"),
+					},
+				},
+			},
+			wantRequest: 4 * 1024 * 1024,
+			wantLimit:   6 * 1024 * 1024,
+		},
+		{
+			name: "init container without limit",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("2Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("4Mi"),
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("3Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 3 * 1024 * 1024,
+			wantLimit:   -1,
 		},
 		{
 			name: "empty resource",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR updates Batch (BE) pod resource calculation utilities to account for init containers and pod overhead.

The BE CPU and memory request/limit helpers now follow Kubernetes pod resource semantics more closely:

- Sum BE resources from regular containers
- Compare that sum with the maximum BE resource requirement among init containers
- Add `pod.Spec.Overhead` when BE CPU or BE memory overhead is defined

This applies to:

- `GetPodBEMilliCPURequest`
- `GetPodBEMilliCPULimit`
- `GetPodBEMemoryByteRequestIgnoreUnlimited`
- `GetPodBEMemoryByteLimit`

The existing behavior for unlimited or missing BE limits is preserved.

### Ⅱ. Does this pull request fix one issue?

fixes #2915 

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/util -run 'Test_GetPodBE'
go test ./pkg/util
go vet ./pkg/util
git diff --check
