### PR TITLE
scheduler: fix memleak when reservation is deleted before binding completed

### DIFF
--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
@@ -36,6 +36,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 	"github.com/koordinator-sh/koordinator/pkg/util"
+	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
 // podAssignCache stores the NodeMetric and Pod information that has been successfully scheduled or is about to be bound.
@@ -288,7 +289,7 @@ func (p *podAssignCache) tryCleanup(name string, n *nodeInfo) {
 
 // add or update pod with node name provided
 func (p *podAssignCache) assign(nodeName string, pod *corev1.Pod) {
-	if nodeName == "" || util.IsPodTerminated(pod) {
+	if nodeName == "" || util.IsPodTerminated(pod) || reservationutil.IsReservePod(pod) {
 		return
 	}
 	var estimated ResourceVector

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -37,6 +37,24 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/loadaware/estimator"
 )
 
+// makeReservePod creates a reserve pod (fake pod) for testing.
+// A reserve pod has the annotation scheduling.koordinator.sh/reserve-pod=true,
+// which is the key identifier used by reservationutil.IsReservePod().
+func makeReservePod(nodeName, name, uid string) *corev1.Pod {
+	pod := st.MakePod().
+		UID(uid).
+		Namespace(corev1.NamespaceDefault).
+		Name(name).
+		Node(nodeName).
+		Phase(corev1.PodRunning).
+		Obj()
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations["scheduling.koordinator.sh/reserve-pod"] = "true"
+	return pod
+}
+
 func TestPodAssignCache_OnAdd(t *testing.T) {
 	vectorizer := NewResourceVectorizer(corev1.ResourceCPU, corev1.ResourceMemory)
 	node := "test-node"
@@ -118,6 +136,13 @@ func TestPodAssignCache_OnAdd(t *testing.T) {
 				s := sets.New(NamespacedName{Namespace: "default", Name: "test"})
 				assert.Equal(t, s, n.nodeDeltaPods)
 				assert.Equal(t, s, n.nodeEstimatedPods)
+			},
+		},
+		{
+			name: "add reserve pod - should be skipped",
+			pod:  makeReservePod(node, "test-reservation", "reserve-uid-123"),
+			want: func(t *testing.T, n *nodeInfo) {
+				assert.Equal(t, 0, len(n.podInfos), "reserve pod should not be added to podAssignCache")
 			},
 		},
 	}

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -1382,11 +1382,22 @@ func (pl *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, 
 		rName := reservationutil.GetReservationNameFromReservePod(pod)
 		assumedReservation, err := pl.rLister.Get(rName)
 		if err != nil {
-			klog.ErrorS(err, "Failed to get reservation in Unreserve phase", "reservation", rName, "nodeName", nodeName)
-			return
+			klog.ErrorS(err, "Failed to get reservation in Unreserve phase, try to clean up the cache with the reserve pod info", "reservation", rName, "nodeName", nodeName)
+			// If the reservation has been deleted or the lister fails, construct a temporary reservation to clean up the cache.
+			assumedReservation = &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rName,
+					UID:       pod.UID,
+					Namespace: pod.Namespace,
+				},
+				Status: schedulingv1alpha1.ReservationStatus{
+					NodeName: nodeName,
+				},
+			}
+		} else {
+			assumedReservation = assumedReservation.DeepCopy()
+			assumedReservation.Status.NodeName = nodeName
 		}
-		assumedReservation = assumedReservation.DeepCopy()
-		assumedReservation.Status.NodeName = nodeName
 		pl.reservationCache.forgetReservation(assumedReservation)
 		if len(state.preAllocated) == 0 { // reserve pod without pre-allocation
 			return

--- a/pkg/scheduler/plugins/reservation/plugin_test.go
+++ b/pkg/scheduler/plugins/reservation/plugin_test.go
@@ -4512,6 +4512,52 @@ func TestUnreserve(t *testing.T) {
 	}
 }
 
+func TestUnreserveWhenReservationDeleted(t *testing.T) {
+	reservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
+			Name: "test-reservation",
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{},
+			},
+		},
+	}
+
+	suit := newPluginTestSuit(t)
+	suit.start(t)
+	client := suit.extenderFactory.KoordinatorClientSet()
+	_, err := client.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	p, err := suit.pluginFactory()
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	state := &stateData{}
+	cycleState := framework.NewCycleState()
+	cycleState.Write(stateKey, state)
+
+	reservePod := reservationutil.NewReservePod(reservation)
+	status := pl.Reserve(context.TODO(), cycleState, reservePod, "test-node")
+	assert.Nil(t, status)
+
+	// Verify reservation is in cache after Reserve
+	rInfo := pl.reservationCache.getReservationInfoByUID(reservation.UID)
+	assert.NotNil(t, rInfo)
+
+	// Delete the reservation to simulate the scenario where reservation is deleted before binding completes
+	err = client.SchedulingV1alpha1().Reservations().Delete(context.TODO(), reservation.Name, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	// Unreserve should clean up the cache even if reservation is deleted
+	pl.Unreserve(context.TODO(), cycleState, reservePod, "test-node")
+
+	// Verify reservation is removed from cache
+	rInfo = pl.reservationCache.getReservationInfoByUID(reservation.UID)
+	assert.Nil(t, rInfo)
+}
+
 func TestPreBind(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koord-scheduler: fix a memory leak bug when scheduling a deleting reservation.

1. For the Reservation plugin,

When a reservation is created and immediately deleted during the binding cycle, the reservation plugin's Unreserve may fail to get the reservation from the lister and skip the cache cleanup. This leads to memory leaks in the reservationCache.

This patch constructs a temporary reservation object using the reserve pod's info when the lister returns an error, ensuring the cache is always cleaned up during Unreserve.

2. For the LoadAwareScheduling plugin,

The LoadAware plugin stores the reserve pod during the Reserve phase, but never removes it.
To fix the problem, we skip the load-aware Reserve for the reserve pods.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
