### PR TITLE
scheduler: account for reservation CPUs in amplified CPU filter

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -383,7 +383,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod 
 	if !status.IsSuccess() {
 		return status
 	}
-	if status := p.filterAmplifiedCPUs(state.requests.Cpu().MilliValue(), nodeInfo, requestCPUBind); !status.IsSuccess() {
+	if status := p.filterAmplifiedCPUs(cycleState, state.requests.Cpu().MilliValue(), nodeInfo, requestCPUBind); !status.IsSuccess() {
 		return status
 	}
 
@@ -450,7 +450,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod 
 	return nil
 }
 
-func (p *Plugin) filterAmplifiedCPUs(podRequestMilliCPU int64, nodeInfo fwktype.NodeInfo, requestCPUBind bool) *fwktype.Status {
+func (p *Plugin) filterAmplifiedCPUs(cycleState fwktype.CycleState, podRequestMilliCPU int64, nodeInfo fwktype.NodeInfo, requestCPUBind bool) *fwktype.Status {
 	if podRequestMilliCPU == 0 {
 		return nil
 	}
@@ -471,8 +471,6 @@ func (p *Plugin) filterAmplifiedCPUs(podRequestMilliCPU int64, nodeInfo fwktype.
 		podRequestMilliCPU = extension.Amplify(podRequestMilliCPU, cpuAmplificationRatio)
 	}
 
-	// TODO(joseph): Reservations and preemption should be considered here.
-	// TODO: support allocate reserved cpus with amplified ratios
 	_, allocated, err := p.resourceManager.GetAvailableCPUs(node.Name, cpuset.CPUSet{})
 	if err != nil {
 		return fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable, err.Error())
@@ -483,6 +481,30 @@ func (p *Plugin) filterAmplifiedCPUs(podRequestMilliCPU int64, nodeInfo fwktype.
 		requestedMilliCPU = requestedMilliCPU - allocatedMilliCPU
 		requestedMilliCPU += extension.Amplify(allocatedMilliCPU, cpuAmplificationRatio)
 	}
+
+	// Account for reservation CPUs that can be reused by the pod. When
+	// a reservation holds CPUSet CPUs, those CPUs are already counted in
+	// allocatedMilliCPU and amplified in requestedMilliCPU. If the pod
+	// can reuse these reservation CPUs, the effective requested should be
+	// reduced accordingly since the pod replaces the reservation's usage
+	// rather than adding to it.
+	reservationRestoreState := getReservationRestoreState(cycleState)
+	restoreState := reservationRestoreState.getNodeState(node.Name)
+	if restoreState != nil && len(restoreState.matched) > 0 {
+		var reusableCPUSetMilliCPU int64
+		for _, alloc := range restoreState.matched {
+			if !alloc.remainedCPUs.IsEmpty() {
+				reusableCPUSetMilliCPU += int64(alloc.remainedCPUs.Size()) * 1000
+			}
+		}
+		if reusableCPUSetMilliCPU > 0 {
+			// The reservation's CPUSet CPUs consume amplified capacity
+			// in requestedMilliCPU. Since the pod will reuse them,
+			// subtract their amplified contribution.
+			requestedMilliCPU -= extension.Amplify(reusableCPUSetMilliCPU, cpuAmplificationRatio)
+		}
+	}
+
 	if podRequestMilliCPU > nodeInfo.GetAllocatable().GetMilliCPU()-requestedMilliCPU {
 		return fwktype.NewStatus(fwktype.Unschedulable, ErrInsufficientAmplifiedCPU)
 	}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -1249,6 +1249,133 @@ func TestFilterWithAmplifiedCPUs(t *testing.T) {
 	}
 }
 
+func TestFilterAmplifiedCPUsWithReservation(t *testing.T) {
+	cpuTopology := buildCPUTopologyForTest(2, 1, 8, 2)
+	numCPUs := cpuTopology.NumCPUs // 32
+
+	tests := []struct {
+		name                      string
+		pod                       *corev1.Pod
+		existingPods              []*corev1.Pod
+		reservationCPUs           cpuset.CPUSet // CPUs reserved by the reservation
+		nodeCPUAmplificationRatio extension.Ratio
+		wantStatus                *fwktype.Status
+	}{
+		{
+			name:                      "owner pod fits with reservation reserved cpus and amplification",
+			pod:                       makePod(map[corev1.ResourceName]string{"cpu": "4"}, true),
+			existingPods:              []*corev1.Pod{makePodOnNode(map[corev1.ResourceName]string{"cpu": "4"}, "node-1", true)},
+			reservationCPUs:           cpuset.MustParse("4-7"),
+			nodeCPUAmplificationRatio: 2.0,
+		},
+		{
+			name: "owner pod fits when all non-reserved cpus occupied",
+			pod:  makePod(map[corev1.ResourceName]string{"cpu": "4"}, true),
+			// Existing cpuset pod occupies 28 CPUs (0-27), reservation holds 28-31
+			existingPods:              []*corev1.Pod{makePodOnNode(map[corev1.ResourceName]string{"cpu": "28"}, "node-1", true)},
+			reservationCPUs:           cpuset.MustParse("28-31"),
+			nodeCPUAmplificationRatio: 2.0,
+		},
+		{
+			name: "owner cpushare pod fits with reservation and amplification",
+			pod:  makePod(map[corev1.ResourceName]string{"cpu": "4"}, false),
+			// Existing cpuset pod occupies 28 CPUs, reservation holds 4 CPUs
+			existingPods:              []*corev1.Pod{makePodOnNode(map[corev1.ResourceName]string{"cpu": "28"}, "node-1", true)},
+			reservationCPUs:           cpuset.MustParse("28-31"),
+			nodeCPUAmplificationRatio: 2.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu := fmt.Sprintf("%d", numCPUs)
+			node := makeNode("node-1", map[corev1.ResourceName]string{"cpu": cpu, "memory": "40Gi"}, tt.nodeCPUAmplificationRatio)
+
+			// Include the reservation pod in existing pods so it's counted
+			// in nodeInfo.GetRequested().
+			reservationUID := types.UID("test-reservation-uid")
+			reservePod := st.MakePod().
+				Req(map[corev1.ResourceName]string{"cpu": fmt.Sprintf("%d", tt.reservationCPUs.Size())}).
+				Node("node-1").
+				UID(string(reservationUID)).
+				Obj()
+			allPods := append(tt.existingPods, reservePod)
+
+			suit := newPluginTestSuit(t, allPods, []*corev1.Node{node})
+
+			p, err := suit.proxyNew(context.TODO(), suit.nodeNUMAResourceArgs, suit.Handle)
+			assert.NoError(t, err)
+
+			topologyOptions := TopologyOptions{
+				CPUTopology: cpuTopology,
+			}
+			for i := 0; i < cpuTopology.NumNodes; i++ {
+				topologyOptions.NUMANodeResources = append(topologyOptions.NUMANodeResources, NUMANodeResource{
+					Node: i,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", extension.Amplify(int64(cpuTopology.CPUsPerNode()), tt.nodeCPUAmplificationRatio))),
+						corev1.ResourceMemory: resource.MustParse("20Gi"),
+					}})
+			}
+			pl := p.(*Plugin)
+			pl.topologyOptionsManager.UpdateTopologyOptions(node.Name, func(options *TopologyOptions) {
+				*options = topologyOptions
+			})
+
+			suit.start(t)
+
+			handler := &podEventHandler{resourceManager: pl.resourceManager}
+			for _, v := range tt.existingPods {
+				handler.OnAdd(v, true)
+			}
+
+			// Simulate reservation by allocating its CPUs in the resource manager
+			reservationAlloc := &PodAllocation{
+				UID:    reservationUID,
+				CPUSet: tt.reservationCPUs,
+				NUMANodeResources: []NUMANodeResource{
+					{
+						Node: 0,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewQuantity(int64(tt.reservationCPUs.Size()), resource.DecimalSI),
+						},
+					},
+				},
+			}
+			pl.resourceManager.Update(node.Name, reservationAlloc)
+
+			// Set up reservation restore state in the cycle state to indicate
+			// the reservation's CPUs are reusable by the owner pod.
+			cycleState := framework.NewCycleState()
+			_, preFilterStatus := pl.PreFilter(context.TODO(), cycleState, tt.pod, nil)
+			assert.True(t, preFilterStatus.IsSuccess() || preFilterStatus.IsSkip())
+
+			restoreState := &nodeReservationRestoreStateData{
+				matched: map[types.UID]reusableAlloc{
+					reservationUID: {
+						allocatableCPUs: tt.reservationCPUs,
+						allocatedCPUs:   tt.reservationCPUs,
+						remainedCPUs:    tt.reservationCPUs,
+					},
+				},
+			}
+			restoreState.mergeReservationAllocations()
+			reservationState := &reservationRestoreStateData{
+				nodeToState: frameworkext.NodeReservationRestoreStates{
+					node.Name: restoreState,
+				},
+			}
+			cycleState.Write(reservationRestoreStateKey, reservationState)
+
+			nodeInfo, err := suit.Handle.SnapshotSharedLister().NodeInfos().Get("node-1")
+			assert.NoError(t, err)
+
+			gotStatus := pl.Filter(context.TODO(), cycleState, tt.pod, nodeInfo)
+			assert.Equal(t, tt.wantStatus, gotStatus)
+		})
+	}
+}
+
 func TestPlugin_FilterNominateReservation(t *testing.T) {
 	skipState := framework.NewCycleState()
 	skipState.Write(stateKey, &preFilterState{


### PR DESCRIPTION
## Summary

When CPU amplification is enabled, `filterAmplifiedCPUs` was rejecting owner pods that should be able to reuse reservation CPUs. The function counts reservation CPUSet CPUs as consumed (amplified) capacity but didn't know those CPUs could be reused by the pod being scheduled.

The fix reads the reservation restore state from the cycle state and subtracts the amplified contribution of reusable reservation CPUs from the effective requested amount, so the capacity check reflects that the owner pod replaces the reservation's usage rather than adding to it.

Also added tests covering the reservation + amplification scenario (cpuset owner pod, cpushare owner pod, and fully-occupied node cases).

Fixes #2158

## Test plan

- [x] existing `TestFilterWithAmplifiedCPUs` tests pass (no regressions)
- [x] new `TestFilterAmplifiedCPUsWithReservation` tests pass
- [x] full `./pkg/scheduler/...` test suite passes (2106 tests)