### PR TITLE
koordlet: support configurable QoS mapping for Guaranteed pods

### DIFF
--- a/apis/extension/qos_utils.go
+++ b/apis/extension/qos_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package extension
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubectl/pkg/util/qos"
 )
@@ -25,8 +27,16 @@ import (
 
 // QoSClassForGuaranteed indicates the QoSClass which a Guaranteed Pod without a koordinator QoSClass specified should
 // be regarded by default.
-// TODO: add component options to customize it.
 var QoSClassForGuaranteed = QoSLSR
+
+// SetQoSClassForGuaranteed configures the default QoSClass for Guaranteed Pods without a koordinator QoSClass specified.
+func SetQoSClassForGuaranteed(qosClass QoSClass) error {
+	if GetPodQoSClassByName(string(qosClass)) == QoSNone {
+		return fmt.Errorf("unsupported QoSClass %q for Guaranteed Pods", qosClass)
+	}
+	QoSClassForGuaranteed = qosClass
+	return nil
+}
 
 // GetPodQoSClassWithDefault gets the pod's QoSClass with the default config.
 func GetPodQoSClassWithDefault(pod *corev1.Pod) QoSClass {

--- a/apis/extension/qos_utils_test.go
+++ b/apis/extension/qos_utils_test.go
@@ -109,3 +109,64 @@ func TestGetQoSClassByAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestSetQoSClassForGuaranteed(t *testing.T) {
+	original := QoSClassForGuaranteed
+	defer func() {
+		QoSClassForGuaranteed = original
+	}()
+
+	assert.NoError(t, SetQoSClassForGuaranteed(QoSLS))
+	assert.Equal(t, QoSLS, QoSClassForGuaranteed)
+
+	assert.Error(t, SetQoSClassForGuaranteed(QoSNone))
+	assert.Equal(t, QoSLS, QoSClassForGuaranteed)
+
+	assert.Error(t, SetQoSClassForGuaranteed(QoSClass("invalid")))
+	assert.Equal(t, QoSLS, QoSClassForGuaranteed)
+}
+
+func TestGetPodQoSClassWithKubeQoS(t *testing.T) {
+	original := QoSClassForGuaranteed
+	defer func() {
+		QoSClassForGuaranteed = original
+	}()
+
+	tests := []struct {
+		name    string
+		kubeQOS corev1.PodQOSClass
+		want    QoSClass
+	}{
+		{
+			name:    "guaranteed uses default",
+			kubeQOS: corev1.PodQOSGuaranteed,
+			want:    QoSLSR,
+		},
+		{
+			name:    "burstable uses LS",
+			kubeQOS: corev1.PodQOSBurstable,
+			want:    QoSLS,
+		},
+		{
+			name:    "besteffort uses BE",
+			kubeQOS: corev1.PodQOSBestEffort,
+			want:    QoSBE,
+		},
+		{
+			name:    "unknown uses none",
+			kubeQOS: corev1.PodQOSClass("unknown"),
+			want:    QoSNone,
+		},
+	}
+
+	QoSClassForGuaranteed = QoSLSR
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodQoSClassWithKubeQoS(tt.kubeQOS)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	assert.NoError(t, SetQoSClassForGuaranteed(QoSLS))
+	assert.Equal(t, QoSLS, GetPodQoSClassWithKubeQoS(corev1.PodQOSGuaranteed))
+}

--- a/pkg/koordlet/config/config.go
+++ b/pkg/koordlet/config/config.go
@@ -25,6 +25,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/audit"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/metriccache"
@@ -56,20 +57,22 @@ type Configuration struct {
 	AuditConf          *audit.Config
 	PredictionConf     *prediction.Config
 
-	FeatureGates map[string]bool
+	DefaultQoSClassForGuaranteedPods apiext.QoSClass
+	FeatureGates                     map[string]bool
 }
 
 func NewConfiguration() *Configuration {
 	return &Configuration{
-		ConfigMapName:      DefaultKoordletConfigMapName,
-		ConfigMapNamesapce: DefaultKoordletConfigMapNamespace,
-		StatesInformerConf: statesinformerimpl.NewDefaultConfig(),
-		CollectorConf:      maframework.NewDefaultConfig(),
-		MetricCacheConf:    metriccache.NewDefaultConfig(),
-		QOSManagerConf:     qmframework.NewDefaultConfig(),
-		RuntimeHookConf:    runtimehooks.NewDefaultConfig(),
-		AuditConf:          audit.NewDefaultConfig(),
-		PredictionConf:     prediction.NewDefaultConfig(),
+		ConfigMapName:                    DefaultKoordletConfigMapName,
+		ConfigMapNamesapce:               DefaultKoordletConfigMapNamespace,
+		StatesInformerConf:               statesinformerimpl.NewDefaultConfig(),
+		CollectorConf:                    maframework.NewDefaultConfig(),
+		MetricCacheConf:                  metriccache.NewDefaultConfig(),
+		QOSManagerConf:                   qmframework.NewDefaultConfig(),
+		RuntimeHookConf:                  runtimehooks.NewDefaultConfig(),
+		AuditConf:                        audit.NewDefaultConfig(),
+		PredictionConf:                   prediction.NewDefaultConfig(),
+		DefaultQoSClassForGuaranteedPods: apiext.QoSClassForGuaranteed,
 	}
 }
 
@@ -85,6 +88,7 @@ func (c *Configuration) InitFlags(fs *flag.FlagSet) {
 	c.AuditConf.InitFlags(fs)
 	c.PredictionConf.InitFlags(fs)
 	resourceexecutor.Conf.InitFlags(fs)
+	fs.Var(newQoSClassForGuaranteedFlag(&c.DefaultQoSClassForGuaranteedPods), "default-qos-class-for-guaranteed-pods", "default Koordinator QoSClass for Kubernetes Guaranteed Pods without koordinator QoSClass specified")
 	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(features.DefaultKoordletFeatureGate.KnownFeatures(), "\n"))
 }
@@ -100,5 +104,29 @@ func (c *Configuration) InitKubeConfigForKoordlet(kubeAPIQPS float64, kubeAPIBur
 	cfg.ContentType = runtime.ContentTypeProtobuf
 	cfg.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
 	c.KubeRestConf = cfg
+	return nil
+}
+
+type qosClassForGuaranteedFlag struct {
+	value *apiext.QoSClass
+}
+
+func newQoSClassForGuaranteedFlag(value *apiext.QoSClass) *qosClassForGuaranteedFlag {
+	return &qosClassForGuaranteedFlag{value: value}
+}
+
+func (f *qosClassForGuaranteedFlag) String() string {
+	if f == nil || f.value == nil {
+		return ""
+	}
+	return string(*f.value)
+}
+
+func (f *qosClassForGuaranteedFlag) Set(value string) error {
+	qosClass := apiext.QoSClass(value)
+	if err := apiext.SetQoSClassForGuaranteed(qosClass); err != nil {
+		return err
+	}
+	*f.value = qosClass
 	return nil
 }

--- a/pkg/koordlet/config/config_test.go
+++ b/pkg/koordlet/config/config_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 )
 
 func TestConfiguration_InitFlags(t *testing.T) {
@@ -38,4 +40,37 @@ func TestConfiguration_InitFlags(t *testing.T) {
 		err := fs.Parse(cmdArgs[1:])
 		assert.NoError(t, err)
 	})
+}
+
+func TestConfiguration_InitFlags_DefaultQoSClassForGuaranteedPods(t *testing.T) {
+	original := apiext.QoSClassForGuaranteed
+	defer func() {
+		apiext.QoSClassForGuaranteed = original
+	}()
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := NewConfiguration()
+	cfg.InitFlags(fs)
+
+	err := fs.Parse([]string{"--default-qos-class-for-guaranteed-pods=LS"})
+	assert.NoError(t, err)
+	assert.Equal(t, apiext.QoSLS, cfg.DefaultQoSClassForGuaranteedPods)
+	assert.Equal(t, apiext.QoSLS, apiext.QoSClassForGuaranteed)
+}
+
+func TestConfiguration_InitFlags_InvalidDefaultQoSClassForGuaranteedPods(t *testing.T) {
+	original := apiext.QoSClassForGuaranteed
+	defer func() {
+		apiext.QoSClassForGuaranteed = original
+	}()
+
+	apiext.QoSClassForGuaranteed = apiext.QoSLSR
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := NewConfiguration()
+	cfg.InitFlags(fs)
+
+	err := fs.Parse([]string{"--default-qos-class-for-guaranteed-pods=invalid"})
+	assert.Error(t, err)
+	assert.Equal(t, apiext.QoSLSR, cfg.DefaultQoSClassForGuaranteedPods)
+	assert.Equal(t, apiext.QoSLSR, apiext.QoSClassForGuaranteed)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds a koordlet component option to configure the default Koordinator QoS class used for Kubernetes Guaranteed pods that do not explicitly set `koordinator.sh/qosClass`.

The previous default was hardcoded through `QoSClassForGuaranteed = QoSLSR`. This PR keeps `LSR` as the default behavior, but allows operators to override it through:

```bash
--default-qos-class-for-guaranteed-pods=<QoSClass>
```

Invalid QoS class values are rejected during flag parsing so the Guaranteed pod mapping cannot be accidentally changed to an unsupported value.

### Ⅱ. Does this pull request fix one issue?

fixes #2923

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews


### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`