### PR TITLE
 fix: replace custom OnceValues with sync.OnceValues from stdlib

### DIFF
--- a/pkg/koordlet/util/system/resctrl.go
+++ b/pkg/koordlet/util/system/resctrl.go
@@ -31,8 +31,6 @@ import (
 
 	"go.uber.org/multierr"
 	"k8s.io/klog/v2"
-
-	"github.com/koordinator-sh/koordinator/pkg/util"
 )
 
 const (
@@ -72,7 +70,7 @@ var (
 )
 
 func init() {
-	CacheIdsCacheFunc = util.OnceValues(GetCacheIds)
+	CacheIdsCacheFunc = sync.OnceValues(GetCacheIds)
 }
 
 func isCPUSupportResctrl() (bool, error) {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	corev1 "k8s.io/api/core/v1"
@@ -330,32 +329,4 @@ func IsIn(arr []string, val string) bool {
 	}
 
 	return false
-}
-
-// TODO: Replace this function with the standard library after go1.21+ version
-func OnceValues(f func() ([]int, error)) func() ([]int, error) {
-	var (
-		once  sync.Once
-		valid bool
-		p     any
-		r1    []int
-		r2    error
-	)
-	g := func() {
-		defer func() {
-			p = recover()
-			if !valid {
-				panic(p)
-			}
-		}()
-		r1, r2 = f()
-		valid = true
-	}
-	return func() ([]int, error) {
-		once.Do(g)
-		if !valid {
-			panic(p)
-		}
-		return r1, r2
-	}
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1306,25 +1306,6 @@ func TestMinFloat64(t *testing.T) {
 	assert.Equal(t, big, gotMax)
 }
 
-func TestOnceValues(t *testing.T) {
-	calls := []int{0}
-	f := OnceValues(func() ([]int, error) {
-		calls[0]++
-		return calls, nil
-	})
-	allocs := testing.AllocsPerRun(10, func() { f() })
-	v1, v2 := f()
-	if calls[0] != 1 {
-		t.Errorf("want calls==1, got %d", calls)
-	}
-	if v1[0] != 1 || v2 != nil {
-		t.Errorf("want v1[0]==1 and v2==nil, got %d and %d", v1, v2)
-	}
-	if allocs != 0 {
-		t.Errorf("want 0 allocations per call, got %v", allocs)
-	}
-}
-
 func Test_isErrorConnectionClose(t *testing.T) {
 	type args struct {
 		err error


### PR DESCRIPTION
 ### Ⅰ. Describe what this PR does

  Removes the hand-rolled `OnceValues` function from `pkg/util/utils.go` and  replaces the single call site in `pkg/koordlet/util/system/resctrl.go` with  `sync.OnceValues` from the standard library. The custom implementation  predates Go 1.21; `go.mod` now declares `go 1.25.0`, so the stdlib version has been available for four major releases.

  ### Ⅱ. Does this pull request fix one issue?

FIxes #2928 

  ### Ⅲ. Describe how to verify it

  1. `go build ./pkg/util/...` — confirms the deleted function is no longer  referenced within the package.
  2. `go build ./pkg/koordlet/util/system/...` — confirms `resctrl.go` compiles with `sync.OnceValues` and without the `pkg/util` import.
  3. `make fast-test` — all existing tests pass; `TestOnceValues` was removed because the stdlib has its own tests for `sync.OnceValues`.

  ### Ⅳ. Special notes for reviews

  `sync.OnceValues` is generic (`func OnceValues[F1, F2 any](...)`), while the deleted function had a concrete signature `func(func() ([]int, error))`. There was exactly one call site (`resctrl.go:75`); `GetCacheIds` returns `([]int, error)`, which satisfies the generic instantiatio  `sync.OnceValues[[]int, error]` without any cast.

  ### V. Checklist

  - [x] I have written necessary docs and comments
  - [x] I have added necessary unit tests and integration tests
  - [x] All checks passed in `make test`