### PR TITLE
fix: use namespace-scoped list to resolve ElasticQuota name for pod

### DIFF
--- a/pkg/webhook/elasticquota/pod_check.go
+++ b/pkg/webhook/elasticquota/pod_check.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,6 +73,10 @@ func (qt *quotaTopology) getQuotaNameFromPodNoLock(pod *corev1.Pod) string {
 }
 
 func GetQuotaName(pod *corev1.Pod, kubeClient client.Client) string {
+	if name := pod.Annotations[extension.LabelQuotaName]; name != "" {
+		return name
+	}
+
 	quotaName := extension.GetQuotaName(pod)
 	if utilfeature.DefaultFeatureGate.Enabled(features.DisableDefaultQuota) {
 		return quotaName
@@ -84,22 +86,31 @@ func GetQuotaName(pod *corev1.Pod, kubeClient client.Client) string {
 		return quotaName
 	}
 
-	eq := &v1alpha1.ElasticQuota{}
-	err := kubeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Namespace}, eq)
-	if err == nil {
-		return eq.Name
-	} else if !errors.IsNotFound(err) {
-		klog.Errorf("Failed to Get ElasticQuota %s, err: %v", pod.Namespace, err)
-	}
-
+	// Find a quota in the pod's own namespace.
 	eqList := &v1alpha1.ElasticQuotaList{}
 	if err := kubeClient.List(context.TODO(), eqList, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("annotation.namespaces", pod.Namespace),
+		Namespace: pod.Namespace,
 	}, utilclient.DisableDeepCopy); err != nil {
+		klog.Errorf("Failed to list ElasticQuota in namespace %s, err: %v", pod.Namespace, err)
+	} else {
+		for i := range eqList.Items {
+			if eqList.Items[i].Labels[extension.LabelQuotaIsParent] != "true" {
+				return eqList.Items[i].Name
+			}
+		}
+	}
+
+	// Find a quota whose AnnotationQuotaNamespaces covers this pod's namespace.
+	allEqList := &v1alpha1.ElasticQuotaList{}
+	if err := kubeClient.List(context.TODO(), allEqList, utilclient.DisableDeepCopy); err != nil {
 		return extension.DefaultQuotaName
 	}
-	for _, quota := range eqList.Items {
-		return quota.Name
+	for i := range allEqList.Items {
+		for _, ns := range extension.GetAnnotationQuotaNamespaces(&allEqList.Items[i]) {
+			if ns == pod.Namespace {
+				return allEqList.Items[i].Name
+			}
+		}
 	}
 
 	return extension.DefaultQuotaName

--- a/pkg/webhook/elasticquota/pod_check_test.go
+++ b/pkg/webhook/elasticquota/pod_check_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elasticquota
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+)
+
+func TestGetQuotaName(t *testing.T) {
+	tests := []struct {
+		name   string
+		pod    *v1.Pod
+		quotas []*v1alpha1.ElasticQuota
+		want   string
+	}{
+		{
+			name: "pod has quota annotation",
+			pod: func() *v1.Pod {
+				p := MakePod("team-a", "pod1").Obj()
+				p.Annotations = map[string]string{extension.LabelQuotaName: "annotated-quota"}
+				return p
+			}(),
+			want: "annotated-quota",
+		},
+		{
+			name: "pod has quota label",
+			pod:  MakePod("team-a", "pod1").Label(extension.LabelQuotaName, "my-quota").Obj(),
+			want: "my-quota",
+		},
+		{
+			name: "no label, quota in pod namespace with same name as namespace",
+			pod:  MakePod("team-a", "pod1").Obj(),
+			quotas: []*v1alpha1.ElasticQuota{
+				MakeQuota("team-a").Namespace("team-a").Obj(),
+			},
+			want: "team-a",
+		},
+		{
+			name: "no label, quota in pod namespace with different name from namespace",
+			pod:  MakePod("team-a", "pod1").Obj(),
+			quotas: []*v1alpha1.ElasticQuota{
+				MakeQuota("team-a-quota").Namespace("team-a").Obj(),
+			},
+			want: "team-a-quota",
+		},
+		{
+			name: "no label, cross-namespace quota covers pod namespace",
+			pod:  MakePod("team-a", "pod1").Obj(),
+			quotas: []*v1alpha1.ElasticQuota{
+				MakeQuota("shared-quota").Namespace("kube-system").
+					Annotations(map[string]string{
+						extension.AnnotationQuotaNamespaces: `["team-a","team-b"]`,
+					}).Obj(),
+			},
+			want: "shared-quota",
+		},
+		{
+			name: "no label, no quota anywhere",
+			pod:  MakePod("team-a", "pod1").Obj(),
+			want: extension.DefaultQuotaName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := fake.NewClientBuilder().Build()
+			sche := kubeClient.Scheme()
+			v1alpha1.AddToScheme(sche)
+			for _, q := range tt.quotas {
+				assert.NoError(t, kubeClient.Create(context.TODO(), q))
+			}
+			got := GetQuotaName(tt.pod, kubeClient)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`GetQuotaName` in `pkg/webhook/elasticquota/pod_check.go` was calling  `kubeClient.Get` with `Name: pod.Namespace`  repeating the namespace as the  quota name. This only worked when the ElasticQuota happened to share a name  with its namespace. The list fallback used a non-standard field selector  (`annotation.namespaces`) which the controller-runtime cache does not index,  so it could return quotas from any namespace and the first item was returned  unconditionally regardless of which namespace it belonged to.

 Replace the broken `Get` with a `List` scoped to the pod's own namespace, and  replace the unindexed field-selector fallback with a cluster-wide `List`  filtered by checking `GetAnnotationQuotaNamespaces` per item. Add annotation  lookup (`pod.Annotations[extension.LabelQuotaName]`) as the highest-priority  path before the existing label check.

  ### Ⅱ. Does this pull request fix one issue?

Fixes #2930 

  ### Ⅲ. Describe how to verify it

  1. `go test ./pkg/webhook/elasticquota/... -run TestGetQuotaName` — all six   table cases pass, including the regression case where the quota name differs from the namespace name.
  2. Create namespace `team-a`, ElasticQuota named `team-a-quota` in `team-a` (name ≠ namespace), deploy a pod into `team-a` with the webhook enabled. The pod now resolves to `team-a-quota` instead of falling through to`DefaultQuotaName`.

  ### Ⅳ. Special notes for reviews

  The `Get` call is removed entirely — there is no convention guaranteeing a  quota's name equals its namespace name, so a namespace-scoped `List` is the  correct approach. The `fields` import is retained because `hasQuotaBoundedPods`  (same file) still uses `fields.OneTermEqualSelector`. The `DisableDefaultQuota` feature gate is preserved between the annotation check and the namespace list.

  ### V. Checklist

  - [x] I have written necessary docs and comments
  - [x] I have added necessary unit tests and integration tests
  - [x] All checks passed in `make test`