### PR TITLE
fix: coscheduling avoid panic from unchecked ExtendedHandle assertion

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -333,7 +333,15 @@ func (pgMgr *PodGroupManager) BeforePreFilter(ctx context.Context, cycleState fw
 			networkTopologySpec: gang.NetworkTopologySpec,
 		}
 		if gangSchedulingContext.networkTopologySpec != nil {
-			gangSchedulingContext.networkTopologySnapshot = pgMgr.handle.(frameworkext.ExtendedHandle).GetNetworkTopologyTreeManager().GetSnapshot()
+			extHandle, ok := pgMgr.handle.(frameworkext.ExtendedHandle)
+			if !ok {
+				return errors.New(ErrNoClusterNetworkTopology)
+			}
+			tm := extHandle.GetNetworkTopologyTreeManager()
+			if tm == nil {
+				return errors.New(ErrNoClusterNetworkTopology)
+			}
+			gangSchedulingContext.networkTopologySnapshot = tm.GetSnapshot()
 			if gangSchedulingContext.networkTopologySnapshot == nil {
 				return errors.New(ErrNoClusterNetworkTopology)
 			}

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -764,6 +764,53 @@ func TestBeforePreFilter_SuggestionPropagation(t *testing.T) {
 	}
 }
 
+func TestBeforePreFilter_NetworkTopologyHandleNotExtended(t *testing.T) {
+	gangaCreatedTime := time.Now()
+	mgr := NewManagerForTest().pgMgr
+
+	pg := makePg("gangNT", "default", 1, &gangaCreatedTime, nil)
+	pg.Annotations = map[string]string{
+		extension.AnnotationGangNetworkTopologySpec: `{"gatherStrategy":[{"layer":"NodeTopologyLayer","strategy":"MustGather"}]}`,
+	}
+	mgr.cache.onPodGroupAdd(pg)
+
+	pod := st.MakePod().Name("pod-nt").UID("pod-nt").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangNT").Obj()
+	mgr.cache.onPodAdd(pod)
+
+	cycleState := framework.NewCycleState()
+	frameworkext.InitDiagnosis(cycleState, pod)
+
+	assert.NotPanics(t, func() {
+		err := mgr.BeforePreFilter(context.TODO(), cycleState, pod)
+		assert.Error(t, err)
+		assert.Equal(t, ErrNoClusterNetworkTopology, err.Error())
+	})
+}
+
+func TestBeforePreFilter_NetworkTopologyManagerNil(t *testing.T) {
+	gangaCreatedTime := time.Now()
+	mgr := NewManagerForTest().pgMgr
+	// Replace the nil handle with a proper ExtendedHandle that has no TreeManager configured,
+	// so GetNetworkTopologyTreeManager() returns nil (covering the tm == nil guard).
+	mgr.handle = NewFakeExtendedFramework(t, nil, nil, nil, nil, nil)
+
+	pg := makePg("gangNT3", "default", 1, &gangaCreatedTime, nil)
+	pg.Annotations = map[string]string{
+		extension.AnnotationGangNetworkTopologySpec: `{"gatherStrategy":[{"layer":"NodeTopologyLayer","strategy":"MustGather"}]}`,
+	}
+	mgr.cache.onPodGroupAdd(pg)
+
+	pod := st.MakePod().Name("pod-nt3").UID("pod-nt3").Namespace("default").Label(v1alpha1.PodGroupLabel, "gangNT3").Obj()
+	mgr.cache.onPodAdd(pod)
+
+	cycleState := framework.NewCycleState()
+	frameworkext.InitDiagnosis(cycleState, pod)
+
+	err := mgr.BeforePreFilter(context.TODO(), cycleState, pod)
+	assert.Error(t, err)
+	assert.Equal(t, ErrNoClusterNetworkTopology, err.Error())
+}
+
 func TestGetGangBindingInfo(t *testing.T) {
 	gangCreatedTime := time.Now()
 	pg1 := makePg("gangA", "gangA_ns", 2, &gangCreatedTime, nil)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a potential panic in `PodGroupManager.BeforePreFilter` caused by an unchecked assertion to `frameworkext.ExtendedHandle` in the network topology scheduling path.
Prev code:
```
gangSchedulingContext.networkTopologySnapshot =
    pgMgr.handle.(frameworkext.ExtendedHandle).
        GetNetworkTopologyTreeManager().
        GetSnapshot()
```
could panic when the scheduler handle did not implement `frameworkext.ExtendedHandle`, which commonly occurs in unit tests using mock handles.

This PR replaces the unchecked assertion with a checked assertion and returns `ErrNoClusterNetworkTopology` instead of panicking.

The fix also aligns this code path with the safe assertion pattern already used in the constructor logic in the same file.

Additionally, a regression unit test is added to verify:

* no panic occurs
* the correct error is returned

### Ⅱ. Does this pull request fix one issue?
fixes #2935 

### Ⅲ. Describe how to verify it
**Reproduce the original issue (pre-fix behavior)**

Preconditions:

* A Gang/PodGroup has a non-nil `NetworkTopologySpec` configured via `extension.AnnotationGangNetworkTopologySpec`
* The scheduler handle does not implement `frameworkext.ExtendedHandle` (for example, handle == nil or a mock handle used in unit tests)
* Steps:

* Invoke `PodGroupManager.BeforePreFilter(...)` for the first Pod of the gang
* The previous implementation reaches the unchecked assertion:
   ```
   pgMgr.handle.(frameworkext.ExtendedHandle)
   ```
* Observe Panic.

**Verify the fix**

Run the regression test added in this PR:
```
go test ./pkg/scheduler/plugins/coscheduling/core \
  -run TestBeforePreFilter_NetworkTopologyHandleNotExtended \
  -count=1
```
Expected result:

- no panic occurs
- test passes successfully
- `BeforePreFilter` returns `ErrNoClusterNetworkTopology`

### Ⅳ. Special notes for reviews
* Only defensive handling logic is changed
* No behavior changes occur for valid ExtendedHandle implementations
* Added regression unit test for the panic scenari
### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
