### PR TITLE
koordlet: select cpu burst cfs candidates by headroom

### DIFF
--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"math/rand"
+	"sort"
 	"strconv"
 	"time"
 
@@ -107,6 +108,48 @@ func (s nodeStateForBurst) String() string {
 	default:
 		return fmt.Sprintf("unrecognized(%d)", s)
 	}
+}
+
+// nodeBurstContext depends on cpu-share-pool usage, used for CFSBurstStrategy.
+type nodeBurstContext struct {
+	state                          nodeStateForBurst
+	sharePoolCPUCoresUsage         float64
+	sharePoolCPUCoresTotal         float64
+	sharePoolThresholdCores        float64
+	sharePoolCoolingThresholdCores float64
+	sharePoolHeadroomCores         float64
+	sharePoolOverageCores          float64
+}
+
+func newNodeBurstContext(state nodeStateForBurst) nodeBurstContext {
+	return nodeBurstContext{state: state}
+}
+
+type cfsQuotaBurstCandidate struct {
+	podMeta         *statesinformer.PodMeta
+	containerStat   *corev1.ContainerStatus
+	namespace       string
+	podName         string
+	containerName   string
+	containerID     string
+	curCFS          int64
+	baseCFS         int64
+	ceilCFS         int64
+	originOperation cfsOperation
+	finalOperation  cfsOperation
+	targetCFS       int64
+}
+
+func (c *cfsQuotaBurstCandidate) stableIdentity() string {
+	return fmt.Sprintf("%s/%s/%s", c.namespace, c.podName, c.containerName)
+}
+
+func (c *cfsQuotaBurstCandidate) excessCFS() int64 {
+	return util.MaxInt64(c.curCFS-c.baseCFS, 0)
+}
+
+func (c *cfsQuotaBurstCandidate) updateTargetCFS() {
+	c.targetCFS = calcContainerTargetCFS(c.curCFS, c.baseCFS, c.ceilCFS, c.finalOperation)
 }
 
 // burstLimiter is a token bucket limiter for CFSQuotaBurst strategy, limit container continuously overused
@@ -218,9 +261,10 @@ func (b *cpuBurst) start() {
 	podsMeta := b.statesInformer.GetAllPods()
 
 	// get node state by node share pool usage
-	nodeState := b.getNodeStateForBurst(*b.nodeCPUBurstStrategy.SharePoolThresholdPercent, podsMeta)
-	klog.V(5).Infof("get node state %v for cpu burst", nodeState)
+	nodeBurstCtx := b.getNodeStateForBurst(*b.nodeCPUBurstStrategy.SharePoolThresholdPercent, podsMeta)
+	klog.V(5).Infof("get node state %v for cpu burst", nodeBurstCtx.state)
 
+	var cfsQuotaBurstCandidates []*cfsQuotaBurstCandidate
 	for _, podMeta := range podsMeta {
 		if podMeta == nil || podMeta.Pod == nil {
 			klog.Warningf("podMeta is illegal, detail %v", podMeta)
@@ -245,32 +289,34 @@ func (b *cpuBurst) start() {
 		klog.V(5).Infof("get pod %v/%v cpu burst config: %v", podMeta.Pod.Namespace, podMeta.Pod.Name, cpuBurstCfg)
 		// set cpu.cfs_burst_us for pod and containers
 		b.applyCPUBurst(cpuBurstCfg, podMeta)
-		// scale cpu.cfs_quota_us for pod and containers
-		b.applyCFSQuotaBurst(cpuBurstCfg, podMeta, nodeState)
+		// collect cpu.cfs_quota_us scaling candidates for pod and containers
+		cfsQuotaBurstCandidates = append(cfsQuotaBurstCandidates, b.collectCFSQuotaBurstCandidates(cpuBurstCfg, podMeta)...)
 	}
+	// scale cpu.cfs_quota_us for pods and containers
+	b.applyCFSQuotaBurstCandidates(selectCFSQuotaBurstCandidates(cfsQuotaBurstCandidates, nodeBurstCtx))
 	b.Recycle()
 }
 
 // getNodeStateForBurst checks whether node share pool cpu usage beyonds the threshold
 // return isOverload, share pool usage ratio and message detail
 func (b *cpuBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
-	podsMeta []*statesinformer.PodMeta) nodeStateForBurst {
+	podsMeta []*statesinformer.PodMeta) nodeBurstContext {
 	overloadMetricDuration := time.Duration(util.MinInt64(int64(b.reconcileInterval*5), int64(10*time.Second)))
 	queryParam := helpers.GenerateQueryParamsAvg(overloadMetricDuration)
 
 	queryMeta, err := metriccache.NodeCPUUsageMetric.BuildQueryMeta(nil)
 	if err != nil {
 		klog.Warningf("get node metric queryMeta failed, error: %v", err)
-		return nodeBurstUnknown
+		return newNodeBurstContext(nodeBurstUnknown)
 	}
 	queryResult, err := helpers.CollectNodeMetrics(b.metricCache, *queryParam.Start, *queryParam.End, queryMeta)
 	if err != nil {
 		klog.Warningf("get node cpu metric failed, error: %v", err)
-		return nodeBurstUnknown
+		return newNodeBurstContext(nodeBurstUnknown)
 	}
 	if queryResult.Count() == 0 {
 		klog.Warning("node metric is empty during handle cfs burst scale down")
-		return nodeBurstUnknown
+		return newNodeBurstContext(nodeBurstUnknown)
 	}
 	nodeCPUUsed, err := queryResult.Value(queryParam.Aggregate)
 	if err != nil {
@@ -280,12 +326,12 @@ func (b *cpuBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 	nodeCPUInfoRaw, exist := b.metricCache.Get(metriccache.NodeCPUInfoKey)
 	if !exist {
 		klog.Warning("get node cpu info failed : not exist")
-		return nodeBurstUnknown
+		return newNodeBurstContext(nodeBurstUnknown)
 	}
 	nodeCPUInfo := nodeCPUInfoRaw.(*metriccache.NodeCPUInfo)
 	if nodeCPUInfo == nil {
 		klog.Warning("get node cpu info failed : value is nil")
-		return nodeBurstUnknown
+		return newNodeBurstContext(nodeBurstUnknown)
 	}
 	podMetricMap := helpers.CollectAllPodMetrics(b.statesInformer, b.metricCache, *queryParam, metriccache.PodCPUUsageMetric)
 
@@ -315,12 +361,22 @@ func (b *cpuBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 	// calculate cpu share pool usage ratio
 	sharePoolThresholdRatio := float64(sharePoolThresholdPercent) / 100
 	sharePoolCoolingRatio := sharePoolThresholdRatio * sharePoolCoolingThresholdRatio
+	sharePoolThresholdCores := sharePoolCPUCoresTotal * sharePoolThresholdRatio
+	sharePoolCoolingThresholdCores := sharePoolCPUCoresTotal * sharePoolCoolingRatio
 	sharePoolUsageRatio := 1.0
 	if sharePoolCPUCoresTotal > 0 {
 		sharePoolUsageRatio = sharePoolCPUCoresUsage / sharePoolCPUCoresTotal
 	}
-	klog.V(5).Infof("share pool usage / share pool total = [%v/%v] = [%v],  threshold = [%v]",
-		sharePoolCPUCoresUsage, sharePoolCPUCoresTotal, sharePoolUsageRatio, sharePoolThresholdRatio)
+	sharePoolHeadroomCores := 0.0
+	if sharePoolThresholdCores > sharePoolCPUCoresUsage {
+		sharePoolHeadroomCores = sharePoolThresholdCores - sharePoolCPUCoresUsage
+	}
+	sharePoolOverageCores := 0.0
+	if sharePoolCPUCoresUsage > sharePoolThresholdCores {
+		sharePoolOverageCores = sharePoolCPUCoresUsage - sharePoolThresholdCores
+	}
+	klog.V(5).Infof("share pool usage / share pool total = [%v/%v] = [%v], threshold = [%v], cooling threshold cores = [%v], headroom cores = [%v], overage cores = [%v]",
+		sharePoolCPUCoresUsage, sharePoolCPUCoresTotal, sharePoolUsageRatio, sharePoolThresholdRatio, sharePoolCoolingThresholdCores, sharePoolHeadroomCores, sharePoolOverageCores)
 
 	// generate node burst state by cpu share pool usage
 	var nodeBurstState nodeStateForBurst
@@ -331,12 +387,21 @@ func (b *cpuBurst) getNodeStateForBurst(sharePoolThresholdPercent int64,
 	} else { // sharePoolUsageRatio < sharePoolCoolingRatio
 		nodeBurstState = nodeBurstIdle
 	}
-	return nodeBurstState
+	return nodeBurstContext{
+		state:                          nodeBurstState,
+		sharePoolCPUCoresUsage:         sharePoolCPUCoresUsage,
+		sharePoolCPUCoresTotal:         sharePoolCPUCoresTotal,
+		sharePoolThresholdCores:        sharePoolThresholdCores,
+		sharePoolCoolingThresholdCores: sharePoolCoolingThresholdCores,
+		sharePoolHeadroomCores:         sharePoolHeadroomCores,
+		sharePoolOverageCores:          sharePoolOverageCores,
+	}
 }
 
-// scale cpu.cfs_quota_us for pod/containers by container throttled state and node state
-func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podMeta *statesinformer.PodMeta,
-	nodeState nodeStateForBurst) {
+// collectCFSQuotaBurstCandidates collects cpu.cfs_quota_us operations for pod/containers by container throttled state.
+func (b *cpuBurst) collectCFSQuotaBurstCandidates(burstCfg *slov1alpha1.CPUBurstConfig,
+	podMeta *statesinformer.PodMeta) []*cfsQuotaBurstCandidate {
+	var candidates []*cfsQuotaBurstCandidate
 	pod := podMeta.Pod
 	containerMap := make(map[string]*corev1.Container)
 	for i := range pod.Spec.Containers {
@@ -386,41 +451,163 @@ func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podM
 		klog.V(6).Infof("cfs burst operation for container %v/%v/%v is %v",
 			pod.Namespace, pod.Name, containerStat.Name, originOperation)
 
-		changed, finalOperation := changeOperationByNode(nodeState, originOperation)
-		if changed {
-			klog.Infof("node is in %v state, switch origin scale operation %v to %v",
-				nodeState, originOperation.String(), finalOperation.String())
-		} else {
-			klog.V(5).Infof("node is in %v state, operation %v is same as before %v",
-				nodeState, finalOperation.String(), originOperation.String())
+		candidate := &cfsQuotaBurstCandidate{
+			podMeta:         podMeta,
+			containerStat:   containerStat,
+			namespace:       pod.Namespace,
+			podName:         pod.Name,
+			containerName:   containerStat.Name,
+			containerID:     containerStat.ContainerID,
+			curCFS:          containerCurCFS,
+			baseCFS:         containerBaseCFS,
+			ceilCFS:         containerCeilCFS,
+			originOperation: originOperation,
+			finalOperation:  originOperation,
 		}
+		candidate.updateTargetCFS()
+		candidates = append(candidates, candidate)
+	} // end for containers
 
-		containerTargetCFS := containerCurCFS
-		if finalOperation == cfsScaleUp {
-			containerTargetCFS = int64(float64(containerCurCFS) * cfsIncreaseStep)
-		} else if finalOperation == cfsScaleDown {
-			containerTargetCFS = int64(float64(containerCurCFS) * cfsDecreaseStep)
-		} else if finalOperation == cfsReset {
-			containerTargetCFS = containerBaseCFS
+	return candidates
+}
+
+// scale cpu.cfs_quota_us for pod/containers by container throttled state and node state
+func (b *cpuBurst) applyCFSQuotaBurst(burstCfg *slov1alpha1.CPUBurstConfig, podMeta *statesinformer.PodMeta,
+	nodeCtx nodeBurstContext) {
+	candidates := b.collectCFSQuotaBurstCandidates(burstCfg, podMeta)
+	b.applyCFSQuotaBurstCandidates(selectCFSQuotaBurstCandidates(candidates, nodeCtx))
+}
+
+func selectCFSQuotaBurstCandidates(candidates []*cfsQuotaBurstCandidate, nodeCtx nodeBurstContext) []*cfsQuotaBurstCandidate {
+	for _, candidate := range candidates {
+		candidate.finalOperation = candidate.originOperation
+		candidate.updateTargetCFS()
+	}
+
+	switch nodeCtx.state {
+	case nodeBurstCooling:
+		selectCFSQuotaBurstScaleUpCandidates(candidates, nodeCtx.sharePoolHeadroomCores)
+	case nodeBurstOverload:
+		selectCFSQuotaBurstScaleDownCandidates(candidates, nodeCtx.sharePoolOverageCores)
+	case nodeBurstUnknown:
+		for _, candidate := range candidates {
+			if candidate.originOperation == cfsScaleUp {
+				candidate.finalOperation = cfsRemain
+				candidate.updateTargetCFS()
+			}
 		}
-		containerTargetCFS = util.MaxInt64(containerBaseCFS, util.MinInt64(containerTargetCFS, containerCeilCFS))
+	}
 
-		if containerTargetCFS == containerCurCFS {
-			klog.V(5).Infof("no need to scale for container %v/%v/%v, operation %v, target cfs quota %v",
-				pod.Namespace, pod.Name, containerStat.Name, finalOperation, containerTargetCFS)
+	return candidates
+}
+
+func selectCFSQuotaBurstScaleUpCandidates(candidates []*cfsQuotaBurstCandidate, headroomCores float64) {
+	var scaleUpCandidates []*cfsQuotaBurstCandidate
+	for _, candidate := range candidates {
+		if candidate.originOperation != cfsScaleUp {
 			continue
 		}
-		deltaContainerCFS := containerTargetCFS - containerCurCFS
-		err = b.applyContainerCFSQuota(podMeta, containerStat, containerCurCFS, deltaContainerCFS)
+		candidate.finalOperation = cfsRemain
+		candidate.updateTargetCFS()
+		scaleUpCandidates = append(scaleUpCandidates, candidate)
+	}
+	sort.SliceStable(scaleUpCandidates, func(i, j int) bool {
+		return scaleUpCandidates[i].stableIdentity() < scaleUpCandidates[j].stableIdentity()
+	})
+
+	for _, candidate := range scaleUpCandidates {
+		scaleUpTargetCFS := calcContainerTargetCFS(candidate.curCFS, candidate.baseCFS, candidate.ceilCFS, cfsScaleUp)
+		scaleUpCores := float64(scaleUpTargetCFS-candidate.curCFS) / float64(system.CFSBasePeriodValue)
+		if scaleUpCores <= 0 || scaleUpCores > headroomCores {
+			continue
+		}
+		candidate.finalOperation = cfsScaleUp
+		candidate.targetCFS = scaleUpTargetCFS
+		headroomCores -= scaleUpCores
+	}
+}
+
+func selectCFSQuotaBurstScaleDownCandidates(candidates []*cfsQuotaBurstCandidate, overageCores float64) {
+	var scaleDownCandidates []*cfsQuotaBurstCandidate
+	for _, candidate := range candidates {
+		if candidate.originOperation == cfsScaleUp {
+			candidate.finalOperation = cfsRemain
+			candidate.updateTargetCFS()
+		}
+		if candidate.originOperation != cfsScaleUp && candidate.originOperation != cfsRemain {
+			continue
+		}
+		if candidate.excessCFS() <= 0 {
+			continue
+		}
+		scaleDownTargetCFS := calcContainerTargetCFS(candidate.curCFS, candidate.baseCFS, candidate.ceilCFS, cfsScaleDown)
+		if scaleDownTargetCFS >= candidate.curCFS {
+			continue
+		}
+		scaleDownCandidates = append(scaleDownCandidates, candidate)
+	}
+	sort.SliceStable(scaleDownCandidates, func(i, j int) bool {
+		leftExcessCFS := scaleDownCandidates[i].excessCFS()
+		rightExcessCFS := scaleDownCandidates[j].excessCFS()
+		if leftExcessCFS != rightExcessCFS {
+			return leftExcessCFS > rightExcessCFS
+		}
+		return scaleDownCandidates[i].stableIdentity() < scaleDownCandidates[j].stableIdentity()
+	})
+
+	for _, candidate := range scaleDownCandidates {
+		if overageCores <= 0 {
+			break
+		}
+		scaleDownTargetCFS := calcContainerTargetCFS(candidate.curCFS, candidate.baseCFS, candidate.ceilCFS, cfsScaleDown)
+		scaleDownCores := float64(candidate.curCFS-scaleDownTargetCFS) / float64(system.CFSBasePeriodValue)
+		if scaleDownCores <= 0 {
+			continue
+		}
+		candidate.finalOperation = cfsScaleDown
+		candidate.targetCFS = scaleDownTargetCFS
+		overageCores -= scaleDownCores
+	}
+}
+
+func (b *cpuBurst) applyCFSQuotaBurstCandidates(candidates []*cfsQuotaBurstCandidate) {
+	for _, candidate := range candidates {
+		if candidate.targetCFS == candidate.curCFS {
+			klog.V(5).Infof("no need to scale for container %v/%v/%v, operation %v, target cfs quota %v",
+				candidate.namespace, candidate.podName, candidate.containerName, candidate.finalOperation, candidate.targetCFS)
+			continue
+		}
+		if candidate.finalOperation != candidate.originOperation {
+			klog.Infof("node is in share-pool guarded state, switch origin scale operation %v to %v for container %v/%v/%v",
+				candidate.originOperation.String(), candidate.finalOperation.String(), candidate.namespace, candidate.podName, candidate.containerName)
+		} else {
+			klog.V(5).Infof("operation %v is same as before %v for container %v/%v/%v",
+				candidate.finalOperation.String(), candidate.originOperation.String(), candidate.namespace, candidate.podName, candidate.containerName)
+		}
+
+		deltaContainerCFS := candidate.targetCFS - candidate.curCFS
+		err := b.applyContainerCFSQuota(candidate.podMeta, candidate.containerStat, candidate.curCFS, deltaContainerCFS)
 		if err != nil {
 			klog.Infof("scale container %v/%v/%v cfs quota failed, operation %v, delta cfs quota %v, reason %v",
-				pod.Namespace, pod.Name, containerStat.Name, finalOperation, deltaContainerCFS, err)
+				candidate.namespace, candidate.podName, candidate.containerName, candidate.finalOperation, deltaContainerCFS, err)
 			continue
 		}
-		metrics.RecordContainerScaledCFSQuotaUS(pod.Namespace, pod.Name, containerStat.ContainerID, containerStat.Name, float64(containerTargetCFS))
+		metrics.RecordContainerScaledCFSQuotaUS(candidate.namespace, candidate.podName, candidate.containerID, candidate.containerName, float64(candidate.targetCFS))
 		klog.Infof("scale container %v/%v/%v cfs quota success, operation %v, current cfs %v, target cfs %v",
-			pod.Namespace, pod.Name, containerStat.Name, finalOperation, containerCurCFS, containerTargetCFS)
+			candidate.namespace, candidate.podName, candidate.containerName, candidate.finalOperation, candidate.curCFS, candidate.targetCFS)
 	} // end for containers
+}
+
+func calcContainerTargetCFS(containerCurCFS, containerBaseCFS, containerCeilCFS int64, operation cfsOperation) int64 {
+	containerTargetCFS := containerCurCFS
+	if operation == cfsScaleUp {
+		containerTargetCFS = int64(float64(containerCurCFS) * cfsIncreaseStep)
+	} else if operation == cfsScaleDown {
+		containerTargetCFS = int64(float64(containerCurCFS) * cfsDecreaseStep)
+	} else if operation == cfsReset {
+		containerTargetCFS = containerBaseCFS
+	}
+	return util.MaxInt64(containerBaseCFS, util.MinInt64(containerTargetCFS, containerCeilCFS))
 }
 
 // check if cfs burst for container is allowed by limiter config, return true if allowed
@@ -698,14 +885,4 @@ func cpuBurstEnabled(burstPolicy slov1alpha1.CPUBurstPolicy) bool {
 
 func cfsQuotaBurstEnabled(burstPolicy slov1alpha1.CPUBurstPolicy) bool {
 	return burstPolicy == slov1alpha1.CPUBurstAuto || burstPolicy == slov1alpha1.CFSQuotaBurstOnly
-}
-
-func changeOperationByNode(nodeState nodeStateForBurst, originOperation cfsOperation) (bool, cfsOperation) {
-	changedOperation := originOperation
-	if nodeState == nodeBurstOverload && (originOperation == cfsScaleUp || originOperation == cfsRemain) {
-		changedOperation = cfsScaleDown
-	} else if (nodeState == nodeBurstCooling || nodeState == nodeBurstUnknown) && originOperation == cfsScaleUp {
-		changedOperation = cfsRemain
-	}
-	return changedOperation != originOperation, changedOperation
 }

--- a/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuburst/cpu_burst_test.go
@@ -209,6 +209,46 @@ func getContainerCFSQuota(podDir string, containerStat *corev1.ContainerStatus, 
 	return val
 }
 
+func getContainerStatusByName(podMeta *statesinformer.PodMeta, containerName string) *corev1.ContainerStatus {
+	for i := range podMeta.Pod.Status.ContainerStatuses {
+		containerStat := &podMeta.Pod.Status.ContainerStatuses[i]
+		if containerStat.Name == containerName {
+			return containerStat
+		}
+	}
+	return nil
+}
+
+func newTestNodeBurstContext(state nodeStateForBurst) nodeBurstContext {
+	nodeCtx := newNodeBurstContext(state)
+	if state == nodeBurstOverload {
+		nodeCtx.sharePoolOverageCores = 1000
+	}
+	return nodeCtx
+}
+
+func newTestCFSQuotaBurstCandidate(t *testing.T, podMeta *statesinformer.PodMeta, containerName string,
+	curCFS, baseCFS int64, operation cfsOperation) *cfsQuotaBurstCandidate {
+	t.Helper()
+	containerStat := getContainerStatusByName(podMeta, containerName)
+	assert.NotNil(t, containerStat)
+	candidate := &cfsQuotaBurstCandidate{
+		podMeta:         podMeta,
+		containerStat:   containerStat,
+		namespace:       podMeta.Pod.Namespace,
+		podName:         podMeta.Pod.Name,
+		containerName:   containerName,
+		containerID:     containerStat.ContainerID,
+		curCFS:          curCFS,
+		baseCFS:         baseCFS,
+		ceilCFS:         baseCFS * 3,
+		originOperation: operation,
+		finalOperation:  operation,
+	}
+	candidate.updateTargetCFS()
+	return candidate
+}
+
 func genTestContainerIDByName(containerName string) string {
 	return fmt.Sprintf("docker://%s-id", containerName)
 }
@@ -410,7 +450,7 @@ func TestCPUBurst_getNodeStateForBurst(t *testing.T) {
 			}
 			b := newTestCPUBurst(opt)
 			got := b.getNodeStateForBurst(tt.args.sharePoolThresholdPercent, podMetas)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, got.state)
 		})
 	}
 }
@@ -1282,7 +1322,7 @@ func TestCPUBurst_applyCFSQuotaBurst(t *testing.T) {
 				containerLimiter: make(map[string]*burstLimiter),
 			}
 			b.init(stop)
-			b.applyCFSQuotaBurst(&tt.args.burstCfg, podMeta, tt.args.nodeState)
+			b.applyCFSQuotaBurst(&tt.args.burstCfg, podMeta, newTestNodeBurstContext(tt.args.nodeState))
 
 			gotPod := getPodCFSQuota(podMeta, testHelper)
 			if !reflect.DeepEqual(gotPod, tt.want.podCFSQuotaVal) {
@@ -1299,6 +1339,132 @@ func TestCPUBurst_applyCFSQuotaBurst(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCPUBurst_applyCFSQuotaBurstCandidatesPartialScaleUpInCooling(t *testing.T) {
+	testHelper := system.NewFileTestUtil(t)
+	stop := make(chan struct{})
+	defer func() { stop <- struct{}{} }()
+
+	podMetaA := createPodMetaByResource("test-pod-a", map[string]corev1.ResourceRequirements{
+		"test-container-a-1": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+		"test-container-a-2": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+	})
+	podMetaB := createPodMetaByResource("test-pod-b", map[string]corev1.ResourceRequirements{
+		"test-container-b-1": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+	})
+
+	baseCFS := int64(2 * system.CFSBasePeriodValue)
+	initPodCFSQuota(podMetaA, 2*baseCFS, testHelper)
+	initContainerCFSQuota(podMetaA, map[string]int64{
+		"test-container-a-1": baseCFS,
+		"test-container-a-2": baseCFS,
+	}, testHelper)
+	initPodCFSQuota(podMetaB, baseCFS, testHelper)
+	initContainerCFSQuota(podMetaB, map[string]int64{
+		"test-container-b-1": baseCFS,
+	}, testHelper)
+
+	candidates := []*cfsQuotaBurstCandidate{
+		newTestCFSQuotaBurstCandidate(t, podMetaB, "test-container-b-1", baseCFS, baseCFS, cfsScaleUp),
+		newTestCFSQuotaBurstCandidate(t, podMetaA, "test-container-a-2", baseCFS, baseCFS, cfsScaleUp),
+		newTestCFSQuotaBurstCandidate(t, podMetaA, "test-container-a-1", baseCFS, baseCFS, cfsScaleUp),
+	}
+	nodeCtx := nodeBurstContext{
+		state:                  nodeBurstCooling,
+		sharePoolHeadroomCores: 0.5,
+	}
+
+	b := &cpuBurst{
+		executor:     newTestExecutor(),
+		cgroupReader: resourceexecutor.NewCgroupReader(),
+	}
+	b.init(stop)
+	b.applyCFSQuotaBurstCandidates(selectCFSQuotaBurstCandidates(candidates, nodeCtx))
+
+	wantScaledCFS := int64(float64(baseCFS) * cfsIncreaseStep)
+	assert.Equal(t, baseCFS+wantScaledCFS, getPodCFSQuota(podMetaA, testHelper))
+	assert.Equal(t, baseCFS, getPodCFSQuota(podMetaB, testHelper))
+	assert.Equal(t, wantScaledCFS, getContainerCFSQuota(podMetaA.CgroupDir, getContainerStatusByName(podMetaA, "test-container-a-1"), testHelper))
+	assert.Equal(t, baseCFS, getContainerCFSQuota(podMetaA.CgroupDir, getContainerStatusByName(podMetaA, "test-container-a-2"), testHelper))
+	assert.Equal(t, baseCFS, getContainerCFSQuota(podMetaB.CgroupDir, getContainerStatusByName(podMetaB, "test-container-b-1"), testHelper))
+}
+
+func TestCPUBurst_applyCFSQuotaBurstCandidatesPartialScaleDownInOverload(t *testing.T) {
+	testHelper := system.NewFileTestUtil(t)
+	stop := make(chan struct{})
+	defer func() { stop <- struct{}{} }()
+
+	podMetaA := createPodMetaByResource("test-pod-a", map[string]corev1.ResourceRequirements{
+		"test-container-a-1": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+		"test-container-a-2": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+	})
+	podMetaB := createPodMetaByResource("test-pod-b", map[string]corev1.ResourceRequirements{
+		"test-container-b-1": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+			},
+		},
+	})
+
+	baseCFS := int64(2 * system.CFSBasePeriodValue)
+	curCFSA1 := int64(3 * system.CFSBasePeriodValue)
+	curCFSA2 := int64(4 * system.CFSBasePeriodValue)
+	curCFSB1 := int64(5 * system.CFSBasePeriodValue)
+	initPodCFSQuota(podMetaA, curCFSA1+curCFSA2, testHelper)
+	initContainerCFSQuota(podMetaA, map[string]int64{
+		"test-container-a-1": curCFSA1,
+		"test-container-a-2": curCFSA2,
+	}, testHelper)
+	initPodCFSQuota(podMetaB, curCFSB1, testHelper)
+	initContainerCFSQuota(podMetaB, map[string]int64{
+		"test-container-b-1": curCFSB1,
+	}, testHelper)
+
+	candidates := []*cfsQuotaBurstCandidate{
+		newTestCFSQuotaBurstCandidate(t, podMetaA, "test-container-a-1", curCFSA1, baseCFS, cfsRemain),
+		newTestCFSQuotaBurstCandidate(t, podMetaA, "test-container-a-2", curCFSA2, baseCFS, cfsRemain),
+		newTestCFSQuotaBurstCandidate(t, podMetaB, "test-container-b-1", curCFSB1, baseCFS, cfsRemain),
+	}
+	nodeCtx := nodeBurstContext{
+		state:                 nodeBurstOverload,
+		sharePoolOverageCores: 1.1,
+	}
+
+	b := &cpuBurst{
+		executor:     newTestExecutor(),
+		cgroupReader: resourceexecutor.NewCgroupReader(),
+	}
+	b.init(stop)
+	b.applyCFSQuotaBurstCandidates(selectCFSQuotaBurstCandidates(candidates, nodeCtx))
+
+	wantCFSA2 := int64(float64(curCFSA2) * cfsDecreaseStep)
+	wantCFSB1 := int64(float64(curCFSB1) * cfsDecreaseStep)
+	assert.Equal(t, curCFSA1+wantCFSA2, getPodCFSQuota(podMetaA, testHelper))
+	assert.Equal(t, wantCFSB1, getPodCFSQuota(podMetaB, testHelper))
+	assert.Equal(t, curCFSA1, getContainerCFSQuota(podMetaA.CgroupDir, getContainerStatusByName(podMetaA, "test-container-a-1"), testHelper))
+	assert.Equal(t, wantCFSA2, getContainerCFSQuota(podMetaA.CgroupDir, getContainerStatusByName(podMetaA, "test-container-a-2"), testHelper))
+	assert.Equal(t, wantCFSB1, getContainerCFSQuota(podMetaB.CgroupDir, getContainerStatusByName(podMetaB, "test-container-b-1"), testHelper))
 }
 
 func Test_burstLimiter_Allow(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

- koordlet
  - Collect CFS quota burst candidates across all burstable Pods before applying CFS quota updates.
  - Use node share-pool threshold headroom to allow only part of throttled scale-up candidates in cooling state.
  - Use node share-pool threshold overage to scale down only enough over-base candidates in overload state.
  - Keep candidate selection deterministic by stable Pod/container identity and largest excess quota first for scale-down.

### Ⅱ. Does this pull request fix one issue?

Fixes #2164

### Ⅲ. Describe how to verify it

- `go test ./pkg/koordlet/qosmanager/plugins/cpuburst`
- `GOOS=darwin CGO_ENABLED=0 go test -c -o /tmp/koordinator-cpuburst-darwin.test ./pkg/koordlet/qosmanager/plugins/cpuburst`
- `git diff --check`

### Ⅳ. Special notes for reviews

This keeps the existing idle and unknown-state behavior, but changes cooling/overload from blanket operation gating to threshold-aware candidate selection.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
