### PR TITLE
koordlet: sync qos cgroup updates to systemd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/containerd/nri v0.11.0
 	github.com/coreos/go-iptables v0.5.0
+	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.9.0
@@ -17,6 +18,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.11.2
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/golang/protobuf v1.5.4
 	github.com/google/btree v1.1.3
@@ -108,7 +110,6 @@ require (
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -131,7 +132,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/pkg/koordlet/resourceexecutor/systemd.go
+++ b/pkg/koordlet/resourceexecutor/systemd.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2026 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceexecutor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
+	godbus "github.com/godbus/dbus/v5"
+	"k8s.io/klog/v2"
+
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+const systemdSetUnitPropertiesTimeout = 5 * time.Second
+
+var errSystemdDBusUnavailable = errors.New("systemd dbus is unavailable")
+
+var kubeQOSSystemdUnits = map[string]string{
+	"kubepods.slice": "kubepods.slice",
+	"kubepods.slice/kubepods-burstable.slice":  "kubepods-burstable.slice",
+	"kubepods.slice/kubepods-besteffort.slice": "kubepods-besteffort.slice",
+}
+
+type systemdUnitPropertyWriter interface {
+	SetUnitProperties(ctx context.Context, unitName string, runtime bool, properties ...systemddbus.Property) error
+}
+
+type systemdDBusPropertyWriter struct {
+	lock sync.Mutex
+	conn *systemddbus.Conn
+}
+
+func (w *systemdDBusPropertyWriter) SetUnitProperties(ctx context.Context, unitName string, runtime bool, properties ...systemddbus.Property) error {
+	conn, err := w.getConn(ctx)
+	if err != nil {
+		return err
+	}
+	return conn.SetUnitPropertiesContext(ctx, unitName, runtime, properties...)
+}
+
+func (w *systemdDBusPropertyWriter) getConn(ctx context.Context) (*systemddbus.Conn, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if w.conn != nil {
+		return w.conn, nil
+	}
+	address := systemBusAddress()
+	if address == "" {
+		return nil, errSystemdDBusUnavailable
+	}
+	conn, err := newSystemdConnection(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+	w.conn = conn
+	return conn, nil
+}
+
+var systemdPropertyWriter systemdUnitPropertyWriter = &systemdDBusPropertyWriter{}
+
+func setSystemdPropertyWriterForTest(writer systemdUnitPropertyWriter) func() {
+	oldWriter := systemdPropertyWriter
+	systemdPropertyWriter = writer
+	return func() {
+		systemdPropertyWriter = oldWriter
+	}
+}
+
+func updateSystemdUnitPropertyForCgroup(c *CgroupResourceUpdater, value string) (bool, error) {
+	unitName, ok := systemdQOSUnitName(c.parentDir)
+	if !ok {
+		return false, nil
+	}
+
+	property, ok, err := systemdPropertyForCgroupResource(c.ResourceType(), value)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), systemdSetUnitPropertiesTimeout)
+	defer cancel()
+
+	if err := systemdPropertyWriter.SetUnitProperties(ctx, unitName, true, property); errors.Is(err, errSystemdDBusUnavailable) {
+		klog.V(5).Infof("skip setting systemd unit %s property %s since system dbus is unavailable", unitName, property.Name)
+		return true, nil
+	} else if err != nil {
+		klog.V(4).Infof("failed to set systemd unit %s property %s, direct cgroup write has been applied, err: %v",
+			unitName, property.Name, err)
+		return true, nil
+	}
+	klog.V(6).Infof("successfully set systemd unit %s property %s to %v", unitName, property.Name, property.Value.Value())
+	return true, nil
+}
+
+func newSystemdConnection(ctx context.Context, address string) (*systemddbus.Conn, error) {
+	return systemddbus.NewConnection(func() (*godbus.Conn, error) {
+		conn, err := godbus.Dial(address, godbus.WithContext(ctx))
+		if err != nil {
+			return nil, err
+		}
+		methods := []godbus.Auth{godbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+		if err = conn.Auth(methods); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		if err = conn.Hello(); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		return conn, nil
+	})
+}
+
+func systemBusAddress() string {
+	if address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"); address != "" {
+		return address
+	}
+	for _, socketPath := range []string{
+		filepath.Join(sysutil.Conf.RunRootDir, "dbus/system_bus_socket"),
+		filepath.Join(sysutil.Conf.VarRunRootDir, "dbus/system_bus_socket"),
+		"/run/dbus/system_bus_socket",
+		"/var/run/dbus/system_bus_socket",
+	} {
+		if _, err := os.Stat(socketPath); err == nil {
+			return "unix:path=" + socketPath
+		}
+	}
+	return ""
+}
+
+func systemdQOSUnitName(parentDir string) (string, bool) {
+	cleaned := filepath.ToSlash(filepath.Clean(parentDir))
+	cleaned = strings.Trim(cleaned, "/")
+	unitName, ok := kubeQOSSystemdUnits[cleaned]
+	return unitName, ok
+}
+
+func systemdPropertyForCgroupResource(resourceType sysutil.ResourceType, value string) (systemddbus.Property, bool, error) {
+	switch resourceType {
+	case sysutil.CPUCFSQuotaName:
+		v, err := cpuQuotaToCPUQuotaPerSecUSec(value)
+		if err != nil {
+			return systemddbus.Property{}, false, err
+		}
+		return newSystemdProperty("CPUQuotaPerSecUSec", v), true, nil
+	case sysutil.MemoryMinName:
+		v, err := memoryValueToSystemdValue(value)
+		if err != nil {
+			return systemddbus.Property{}, false, err
+		}
+		return newSystemdProperty("MemoryMin", v), true, nil
+	case sysutil.MemoryLowName:
+		v, err := memoryValueToSystemdValue(value)
+		if err != nil {
+			return systemddbus.Property{}, false, err
+		}
+		return newSystemdProperty("MemoryLow", v), true, nil
+	case sysutil.MemoryHighName:
+		v, err := memoryValueToSystemdValue(value)
+		if err != nil {
+			return systemddbus.Property{}, false, err
+		}
+		return newSystemdProperty("MemoryHigh", v), true, nil
+	default:
+		return systemddbus.Property{}, false, nil
+	}
+}
+
+func newSystemdProperty(name string, value interface{}) systemddbus.Property {
+	return systemddbus.Property{
+		Name:  name,
+		Value: godbus.MakeVariant(value),
+	}
+}
+
+func cpuQuotaToCPUQuotaPerSecUSec(value string) (uint64, error) {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("cpu quota is empty")
+	}
+
+	quota := fields[0]
+	if quota == sysutil.CgroupMaxSymbolStr || quota == sysutil.CgroupUnlimitedSymbolStr {
+		return uint64(math.MaxUint64), nil
+	}
+
+	quotaUSec, err := strconv.ParseInt(quota, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cpu quota %q is not int64: %w", quota, err)
+	}
+	if quotaUSec <= 0 {
+		return uint64(math.MaxUint64), nil
+	}
+
+	periodUSec := sysutil.DefaultCPUCFSPeriod
+	if len(fields) > 1 {
+		periodUSec, err = strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cpu quota period %q is not int64: %w", fields[1], err)
+		}
+	}
+	if periodUSec <= 0 {
+		return 0, fmt.Errorf("cpu quota period %d is invalid", periodUSec)
+	}
+
+	return uint64(quotaUSec) * uint64(time.Second/time.Microsecond) / uint64(periodUSec), nil
+}
+
+func memoryValueToSystemdValue(value string) (uint64, error) {
+	v := strings.TrimSpace(value)
+	if v == sysutil.CgroupMaxSymbolStr || v == sysutil.CgroupUnlimitedSymbolStr {
+		return uint64(math.MaxUint64), nil
+	}
+	memoryValue, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("memory value %q is not uint64: %w", v, err)
+	}
+	return memoryValue, nil
+}

--- a/pkg/koordlet/resourceexecutor/updater.go
+++ b/pkg/koordlet/resourceexecutor/updater.go
@@ -436,7 +436,17 @@ func MergeFuncUpdateCgroup(resource ResourceUpdater, mergeCondition MergeConditi
 	klog.V(6).Infof("merge update cgroup %v with merged value[%v], original new[%v], old[%v]",
 		c.Path(), mergedValue, c.value, oldStr)
 	// suppose current value is different
-	return resource, cgroupFileWrite(c.parentDir, c.file, mergedValue)
+	if err := cgroupFileWrite(c.parentDir, c.file, mergedValue); err != nil {
+		return resource, err
+	}
+	systemdUpdated, err := updateSystemdUnitPropertyForCgroup(c, mergedValue)
+	if err != nil {
+		return resource, err
+	}
+	if systemdUpdated {
+		err = cgroupFileWrite(c.parentDir, c.file, mergedValue)
+	}
+	return resource, err
 }
 
 // MergeConditionIfValueIsLarger returns a merge condition where only do update when the new value is larger.
@@ -526,6 +536,18 @@ func cgroupWriteIfDifferentWithLog(c *CgroupResourceUpdater) error {
 	updated, err := cgroupFileWriteIfDifferent(c.parentDir, c.file, c.value)
 	if err != nil {
 		return err
+	}
+	systemdUpdated, err := updateSystemdUnitPropertyForCgroup(c, c.value)
+	if err != nil {
+		return err
+	}
+	if systemdUpdated {
+		var restored bool
+		restored, err = cgroupFileWriteIfDifferent(c.parentDir, c.file, c.value)
+		if err != nil {
+			return err
+		}
+		updated = updated || restored
 	}
 	if updated && c.eventHelper != nil {
 		_ = c.eventHelper.Do()

--- a/pkg/koordlet/resourceexecutor/updater_test.go
+++ b/pkg/koordlet/resourceexecutor/updater_test.go
@@ -17,13 +17,35 @@ limitations under the License.
 package resourceexecutor
 
 import (
+	"context"
+	"math"
 	"path/filepath"
 	"testing"
 
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/stretchr/testify/assert"
 
 	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
+
+type fakeSystemdPropertyWriter struct {
+	calls []systemdPropertyCall
+}
+
+type systemdPropertyCall struct {
+	unitName   string
+	runtime    bool
+	properties []systemddbus.Property
+}
+
+func (f *fakeSystemdPropertyWriter) SetUnitProperties(_ context.Context, unitName string, runtime bool, properties ...systemddbus.Property) error {
+	f.calls = append(f.calls, systemdPropertyCall{
+		unitName:   unitName,
+		runtime:    runtime,
+		properties: append([]systemddbus.Property(nil), properties...),
+	})
+	return nil
+}
 
 func TestNewCommonCgroupUpdater(t *testing.T) {
 	type fields struct {
@@ -179,6 +201,125 @@ func TestCgroupResourceUpdater_Update(t *testing.T) {
 	}
 }
 
+func TestCgroupResourceUpdater_UpdateSystemdCPUQuotaForQOSPath(t *testing.T) {
+	helper := sysutil.NewFileTestUtil(t)
+	defer helper.Cleanup()
+
+	writer := &fakeSystemdPropertyWriter{}
+	restoreWriter := setSystemdPropertyWriterForTest(writer)
+	defer restoreWriter()
+
+	beQOSDir := "kubepods.slice/kubepods-besteffort.slice"
+	helper.WriteCgroupFileContents(beQOSDir, sysutil.CPUCFSQuota, "100000")
+
+	u, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, beQOSDir, "-1", nil)
+	assert.NoError(t, err)
+
+	err = u.update()
+	assert.NoError(t, err)
+	assert.Equal(t, "-1", helper.ReadCgroupFileContents(beQOSDir, sysutil.CPUCFSQuota))
+	assert.Len(t, writer.calls, 1)
+	assert.Equal(t, "kubepods-besteffort.slice", writer.calls[0].unitName)
+	assert.True(t, writer.calls[0].runtime)
+	assert.Len(t, writer.calls[0].properties, 1)
+	assert.Equal(t, "CPUQuotaPerSecUSec", writer.calls[0].properties[0].Name)
+	assert.Equal(t, uint64(math.MaxUint64), writer.calls[0].properties[0].Value.Value())
+}
+
+func TestCgroupResourceUpdater_UpdateSystemdOnlyForExactQOSPath(t *testing.T) {
+	helper := sysutil.NewFileTestUtil(t)
+	defer helper.Cleanup()
+
+	writer := &fakeSystemdPropertyWriter{}
+	restoreWriter := setSystemdPropertyWriterForTest(writer)
+	defer restoreWriter()
+
+	podDir := "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podxxx.slice"
+	helper.WriteCgroupFileContents(podDir, sysutil.CPUCFSQuota, "100000")
+
+	u, err := DefaultCgroupUpdaterFactory.New(sysutil.CPUCFSQuotaName, podDir, "200000", nil)
+	assert.NoError(t, err)
+
+	err = u.update()
+	assert.NoError(t, err)
+	assert.Equal(t, "200000", helper.ReadCgroupFileContents(podDir, sysutil.CPUCFSQuota))
+	assert.Empty(t, writer.calls)
+}
+
+func TestSystemdPropertyForCgroupResource(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceType  sysutil.ResourceType
+		value         string
+		wantName      string
+		wantValue     uint64
+		wantSupported bool
+	}{
+		{
+			name:          "finite cpu quota",
+			resourceType:  sysutil.CPUCFSQuotaName,
+			value:         "200000",
+			wantName:      "CPUQuotaPerSecUSec",
+			wantValue:     2000000,
+			wantSupported: true,
+		},
+		{
+			name:          "cpu quota max",
+			resourceType:  sysutil.CPUCFSQuotaName,
+			value:         "max",
+			wantName:      "CPUQuotaPerSecUSec",
+			wantValue:     uint64(math.MaxUint64),
+			wantSupported: true,
+		},
+		{
+			name:          "memory high max",
+			resourceType:  sysutil.MemoryHighName,
+			value:         "max",
+			wantName:      "MemoryHigh",
+			wantValue:     uint64(math.MaxUint64),
+			wantSupported: true,
+		},
+		{
+			name:          "unsupported resource",
+			resourceType:  sysutil.CPUSharesName,
+			value:         "1024",
+			wantSupported: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			property, supported, err := systemdPropertyForCgroupResource(tt.resourceType, tt.value)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantSupported, supported)
+			if !tt.wantSupported {
+				return
+			}
+			assert.Equal(t, tt.wantName, property.Name)
+			assert.Equal(t, tt.wantValue, property.Value.Value())
+		})
+	}
+}
+
+func TestSystemBusAddressUsesHostRunRoot(t *testing.T) {
+	helper := sysutil.NewFileTestUtil(t)
+	defer helper.Cleanup()
+	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "")
+
+	oldRunRootDir := sysutil.Conf.RunRootDir
+	oldVarRunRootDir := sysutil.Conf.VarRunRootDir
+	defer func() {
+		sysutil.Conf.RunRootDir = oldRunRootDir
+		sysutil.Conf.VarRunRootDir = oldVarRunRootDir
+	}()
+
+	sysutil.Conf.RunRootDir = filepath.Join(helper.TempDir, "host-run")
+	sysutil.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "host-var-run")
+	socketPath := filepath.Join(sysutil.Conf.RunRootDir, "dbus/system_bus_socket")
+	helper.WriteFileContents(socketPath, "")
+
+	assert.Equal(t, "unix:path="+socketPath, systemBusAddress())
+}
+
 func TestCgroupResourceUpdater_MergeUpdate(t *testing.T) {
 	type fields struct {
 		UseCgroupsV2 bool
@@ -325,6 +466,56 @@ func TestCgroupResourceUpdater_MergeUpdate(t *testing.T) {
 			gotErr = u.update()
 			assert.NoError(t, gotErr)
 			assert.Equal(t, tt.wantFinal, helper.ReadCgroupFileContents(c.parentDir, c.file))
+		})
+	}
+}
+
+func TestCgroupResourceUpdater_MergeUpdateSystemdMemoryQOS(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType sysutil.ResourceType
+		file         sysutil.Resource
+		propertyName string
+	}{
+		{
+			name:         "memory.min",
+			resourceType: sysutil.MemoryMinName,
+			file:         sysutil.MemoryMinV2,
+			propertyName: "MemoryMin",
+		},
+		{
+			name:         "memory.low",
+			resourceType: sysutil.MemoryLowName,
+			file:         sysutil.MemoryLowV2,
+			propertyName: "MemoryLow",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := sysutil.NewFileTestUtil(t)
+			defer helper.Cleanup()
+			helper.SetCgroupsV2(true)
+
+			writer := &fakeSystemdPropertyWriter{}
+			restoreWriter := setSystemdPropertyWriterForTest(writer)
+			defer restoreWriter()
+
+			burstableQOSDir := "kubepods.slice/kubepods-burstable.slice"
+			helper.WriteCgroupFileContents(burstableQOSDir, tt.file, "1024")
+
+			u, err := DefaultCgroupUpdaterFactory.New(tt.resourceType, burstableQOSDir, "2048", nil)
+			assert.NoError(t, err)
+
+			mergedUpdater, err := u.MergeUpdate()
+			assert.NoError(t, err)
+			assert.NotNil(t, mergedUpdater)
+			assert.Equal(t, "2048", helper.ReadCgroupFileContents(burstableQOSDir, tt.file))
+			assert.Len(t, writer.calls, 1)
+			assert.Equal(t, "kubepods-burstable.slice", writer.calls[0].unitName)
+			assert.True(t, writer.calls[0].runtime)
+			assert.Len(t, writer.calls[0].properties, 1)
+			assert.Equal(t, tt.propertyName, writer.calls[0].properties[0].Name)
+			assert.Equal(t, uint64(2048), writer.calls[0].properties[0].Value.Value())
 		})
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

- koordlet
  - Set systemd unit properties when updating QoS-level Kubernetes cgroups on systemd paths.
  - Map QoS cgroup resources to systemd properties for CPU quota and memory QoS.
  - Keep direct cgroup writes for cgroupfs, unsupported resources, and pod/container-level cgroups.
  - Route merge updates through the same systemd-aware path so memory QoS reconciliation is not bypassed.

### Ⅱ. Does this pull request fix one issue?

Fixes #1734

### Ⅲ. Describe how to verify it

- `go mod tidy`
- `go test ./pkg/koordlet/resourceexecutor`
- `go test ./pkg/koordlet/qosmanager/plugins/cpusuppress`
- `GOOS=darwin CGO_ENABLED=0 go test -c -o /tmp/koordinator-resourceexecutor-darwin.test ./pkg/koordlet/resourceexecutor`
- `git diff --check`

### Ⅳ. Special notes for reviews

The systemd sync is limited to exact QoS-level slice paths: `kubepods.slice`, `kubepods.slice/kubepods-burstable.slice`, and `kubepods.slice/kubepods-besteffort.slice`. Pod-level and container-level cgroups continue to use direct cgroup file updates only.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
