### PR TITLE
ExtendedResourceNames: add mid-tier resources

### DIFF
--- a/pkg/util/extended_resource.go
+++ b/pkg/util/extended_resource.go
@@ -24,10 +24,12 @@ import (
 
 // NOTE: functions in this file can be overwritten for extension
 
-// ExtendedResourceNames todo: add mid resource
+// ExtendedResourceNames
 var ExtendedResourceNames = []corev1.ResourceName{
 	extension.BatchCPU,
 	extension.BatchMemory,
+	extension.MidCPU,
+	extension.MidMemory,
 }
 
 func GetBatchMilliCPUFromResourceList(r corev1.ResourceList) int64 {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds the missing Mid-tier resources (`extension.MidCPU` and `extension.MidMemory`) to the `ExtendedResourceNames` slice in `pkg/util/extended_resource.go`. This change resolves an existing `todo` comment and ensures consistency, as the same file already contains helper functions dealing with Mid-tier resources (e.g., `GetMidMilliCPUFromResourceList`, `GetMidMemoryFromResourceList`).

### Ⅱ. Does this pull request fix one issue?

fixes #2939

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
