### PR TITLE
fix: scheduler/deviceshare: fix nil map panic in device plugin adapter annotation/label writes

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
@@ -277,7 +277,12 @@ func unlockNode(node *corev1.Node, lockKey string) {
 type generalDevicePluginAdapter struct{}
 
 func (a *generalDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, object metav1.Object, _ []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationBindTimestamp] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationBindTimestamp] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
+	object.SetAnnotations(annotations)
 	return nil
 }
 
@@ -287,9 +292,19 @@ type generalGPUDevicePluginAdapter struct {
 }
 
 func (a *generalGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, object metav1.Object, allocation []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationGPUMinors] = buildGPUMinorsStr(allocation, "")
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationGPUMinors] = buildGPUMinorsStr(allocation, "")
+	object.SetAnnotations(annotations)
 	if object.GetLabels()[apiext.LabelGPUIsolationProvider] == string(apiext.GPUIsolationProviderHAMICore) {
-		object.GetLabels()[apiext.LabelHAMIVGPUNodeName] = ctx.node.Name
+		labels := object.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[apiext.LabelHAMIVGPUNodeName] = ctx.node.Name
+		object.SetLabels(labels)
 	}
 	return nil
 }
@@ -297,19 +312,24 @@ func (a *generalGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, obj
 type huaweiGPUDevicePluginAdapter struct{}
 
 func (a *huaweiGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, object metav1.Object, allocation []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationPredicateTime] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationPredicateTime] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
 	switch ctx.gpuModel {
 	case "Ascend-310P3-300I-DUO":
-		object.GetAnnotations()[AnnotationHuaweiAscend310P] = buildGPUMinorsStr(allocation, "Ascend310P-")
+		annotations[AnnotationHuaweiAscend310P] = buildGPUMinorsStr(allocation, "Ascend310P-")
 	default:
 		if allocation[0].Extension != nil && allocation[0].Extension.GPUSharedResourceTemplate != "" {
 			// vNPU
-			object.GetAnnotations()[AnnotationHuaweiNPUCore] = fmt.Sprintf("%d-%s", allocation[0].Minor, allocation[0].Extension.GPUSharedResourceTemplate)
+			annotations[AnnotationHuaweiNPUCore] = fmt.Sprintf("%d-%s", allocation[0].Minor, allocation[0].Extension.GPUSharedResourceTemplate)
 		} else {
 			// full NPU
-			object.GetAnnotations()[AnnotationHuaweiNPUCore] = buildGPUMinorsStr(allocation, "")
+			annotations[AnnotationHuaweiNPUCore] = buildGPUMinorsStr(allocation, "")
 		}
 	}
+	object.SetAnnotations(annotations)
 	return nil
 }
 
@@ -332,8 +352,13 @@ func (a *cambriconGPUDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, obj
 	}
 	vmemory := memory.Value() / cambriconVMemoryUnit
 
-	object.GetAnnotations()[AnnotationCambriconDsmluAssigned] = "false"
-	object.GetAnnotations()[AnnotationCambriconDsmluProfile] = fmt.Sprintf("%d_%d_%d", allocation[0].Minor, vcore, vmemory)
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationCambriconDsmluAssigned] = "false"
+	annotations[AnnotationCambriconDsmluProfile] = fmt.Sprintf("%d_%d_%d", allocation[0].Minor, vcore, vmemory)
+	object.SetAnnotations(annotations)
 	return nil
 }
 
@@ -375,7 +400,12 @@ func (a *metaxDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, object met
 		return err
 	}
 
-	object.GetAnnotations()[AnnotationMetaXGPUDevicesAllocated] = string(allocatedData)
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[AnnotationMetaXGPUDevicesAllocated] = string(allocatedData)
+	object.SetAnnotations(annotations)
 	return nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
@@ -1227,6 +1227,261 @@ func TestPlugin_adaptForDevicePlugin(t *testing.T) {
 	}
 }
 
+// Tests for nil annotations and labels safety
+func TestGeneralDevicePluginAdapter_NilAnnotations(t *testing.T) {
+	now := time.Now()
+	dpAdapterClock = fakeclock.NewFakeClock(now)
+
+	adapter := &generalDevicePluginAdapter{}
+
+	// Test with nil annotations
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+	// Explicitly set annotations to nil
+	pod.Annotations = nil
+
+	err := adapter.Adapt(nil, pod, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod.Annotations)
+	assert.Equal(t, strconv.FormatInt(now.UnixNano(), 10), pod.Annotations[AnnotationBindTimestamp])
+}
+
+func TestGeneralGPUDevicePluginAdapter_NilAnnotationsAndLabels(t *testing.T) {
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	adapter := &generalGPUDevicePluginAdapter{}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+	}{
+		{
+			name: "nil annotations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-nil-annot",
+				},
+			},
+		},
+		{
+			name: "nil labels and nil annotations with HAMI isolation provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-hami",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Explicitly set to nil
+			tt.pod.Annotations = nil
+			tt.pod.Labels = nil
+
+			// For HAMI test case, set the label after creating pod to test nil check
+			if tt.name == "nil labels and nil annotations with HAMI isolation provider" {
+				tt.pod.Labels = map[string]string{
+					apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+				}
+				tt.pod.Annotations = nil
+			}
+
+			allocation := []*apiext.DeviceAllocation{
+				{Minor: 0},
+			}
+
+			ctx := &DevicePluginAdaptContext{
+				Context: context.TODO(),
+				node:    testNode,
+			}
+			err := adapter.Adapt(ctx, tt.pod, allocation)
+			assert.NoError(t, err)
+			assert.NotNil(t, tt.pod.Annotations)
+			assert.Equal(t, "0", tt.pod.Annotations[AnnotationGPUMinors])
+
+			// For HAMI case, verify label was set
+			if tt.name == "nil labels and nil annotations with HAMI isolation provider" {
+				assert.NotNil(t, tt.pod.Labels)
+				assert.Equal(t, testNode.Name, tt.pod.Labels[apiext.LabelHAMIVGPUNodeName])
+			}
+		})
+	}
+}
+
+type nilLabelsObject struct {
+	metav1.ObjectMeta
+	firstLabels map[string]string
+	labelCalls  int
+}
+
+func (o *nilLabelsObject) GetLabels() map[string]string {
+	o.labelCalls++
+	if o.labelCalls == 1 {
+		return o.firstLabels
+	}
+	return nil
+}
+
+func (o *nilLabelsObject) SetLabels(labels map[string]string) {
+	o.ObjectMeta.Labels = labels
+}
+
+func TestGeneralGPUDevicePluginAdapter_NilLabelsMapInit(t *testing.T) {
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	adapter := &generalGPUDevicePluginAdapter{}
+	object := &nilLabelsObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+		firstLabels: map[string]string{
+			apiext.LabelGPUIsolationProvider: string(apiext.GPUIsolationProviderHAMICore),
+		},
+	}
+
+	allocation := []*apiext.DeviceAllocation{
+		{Minor: 0},
+	}
+
+	ctx := &DevicePluginAdaptContext{
+		Context: context.TODO(),
+		node:    testNode,
+	}
+	err := adapter.Adapt(ctx, object, allocation)
+	assert.NoError(t, err)
+	assert.NotNil(t, object.Annotations)
+	assert.Equal(t, "0", object.Annotations[AnnotationGPUMinors])
+	assert.NotNil(t, object.Labels)
+	assert.Equal(t, testNode.Name, object.Labels[apiext.LabelHAMIVGPUNodeName])
+}
+
+func TestHuaweiGPUDevicePluginAdapter_NilAnnotations(t *testing.T) {
+	now := time.Now()
+	dpAdapterClock = fakeclock.NewFakeClock(now)
+
+	adapter := &huaweiGPUDevicePluginAdapter{}
+
+	tests := []struct {
+		name     string
+		gpuModel string
+	}{
+		{
+			name:     "full NPU with nil annotations",
+			gpuModel: "",
+		},
+		{
+			name:     "Ascend-310P3-300I-DUO with nil annotations",
+			gpuModel: "Ascend-310P3-300I-DUO",
+		},
+		{
+			name:     "vNPU with nil annotations",
+			gpuModel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			}
+			// Explicitly set annotations to nil
+			pod.Annotations = nil
+
+			allocation := []*apiext.DeviceAllocation{
+				{Minor: 0},
+			}
+
+			if tt.name == "vNPU with nil annotations" {
+				allocation[0].Extension = &apiext.DeviceAllocationExtension{
+					GPUSharedResourceTemplate: "vir02",
+				}
+			}
+
+			err := adapter.Adapt(&DevicePluginAdaptContext{gpuModel: tt.gpuModel}, pod, allocation)
+			assert.NoError(t, err)
+			assert.NotNil(t, pod.Annotations)
+			assert.NotEmpty(t, pod.Annotations[AnnotationPredicateTime])
+
+			if tt.name == "Ascend-310P3-300I-DUO with nil annotations" {
+				assert.Equal(t, "Ascend310P-0", pod.Annotations[AnnotationHuaweiAscend310P])
+			} else if tt.name == "vNPU with nil annotations" {
+				assert.Equal(t, "0-vir02", pod.Annotations[AnnotationHuaweiNPUCore])
+			} else {
+				assert.Equal(t, "0", pod.Annotations[AnnotationHuaweiNPUCore])
+			}
+		})
+	}
+}
+
+func TestCambriconGPUDevicePluginAdapter_NilAnnotations(t *testing.T) {
+	adapter := &cambriconGPUDevicePluginAdapter{}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+	// Explicitly set annotations to nil
+	pod.Annotations = nil
+
+	allocation := []*apiext.DeviceAllocation{
+		{
+			Minor: 0,
+			Resources: corev1.ResourceList{
+				apiext.ResourceGPUCore:   resource.MustParse("5"),
+				apiext.ResourceGPUMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	err := adapter.Adapt(nil, pod, allocation)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod.Annotations)
+	assert.Equal(t, "false", pod.Annotations[AnnotationCambriconDsmluAssigned])
+	assert.Equal(t, "0_5_4", pod.Annotations[AnnotationCambriconDsmluProfile])
+}
+
+func TestMetaXGPUDevicePluginAdapter_NilAnnotations(t *testing.T) {
+	adapter := &metaxDevicePluginAdapter{}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+	// Explicitly set annotations to nil
+	pod.Annotations = nil
+
+	allocation := []*apiext.DeviceAllocation{
+		{
+			ID: "GPU-0",
+			Resources: corev1.ResourceList{
+				apiext.ResourceGPUCore:   resource.MustParse("5"),
+				apiext.ResourceGPUMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	err := adapter.Adapt(nil, pod, allocation)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod.Annotations)
+	assert.Equal(t, `[[{"uuid":"GPU-0","compute":5,"vRam":1024}]]`, pod.Annotations[AnnotationMetaXGPUDevicesAllocated])
+}
+
 func Test_buildGPUMinorsStr(t *testing.T) {
 	type args struct {
 		allocation []*apiext.DeviceAllocation


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

All five device plugin adapters wrote annotations and labels by indexing directly into the map returned by `object.GetAnnotations()` / `object.GetLabels()`, e.g.:

```go
// BEFORE — panics if the object has no annotations
object.GetAnnotations()[AnnotationBindTimestamp] = strconv.FormatInt(...)
object.GetLabels()[apiext.LabelHAMIVGPUNodeName] = ctx.node.Name
```

In Go, a nil map (returned when the object has no annotations/labels) will panic on write. While the current call-site in `preBindObject` happens to set annotations via `SetDeviceAllocations` first, the adapters themselves carry no such guarantee, making the code fragile and unsafe for direct calls (tests, future refactors).

Fix: use the safe pattern — get, nil-check, initialise, write, `SetAnnotations`/`SetLabels`:

```go
// AFTER — safe for objects with or without existing annotations
annotations := object.GetAnnotations()
if annotations == nil {
    annotations = map[string]string{}
}
annotations[AnnotationBindTimestamp] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
object.SetAnnotations(annotations)
```

Applied to all five adapters. No behavioural change when annotations/labels are already non-nil.

Unit tests were added to exercise adapters against objects with nil annotations and nil labels.


### Ⅱ. Does this pull request fix one issue?

fixes #2947 

### Ⅲ. Describe how to verify it

Run:

```bash
go test ./pkg/scheduler/plugins/deviceshare/... -race
```

Expected result:

* no panic/failure
* tests pass



### Ⅳ. Special notes for reviews

* Only the write pattern is changed; read patterns (`object.GetAnnotations()[key]` without assignment) are safe in Go and left unchanged.
* `SetAnnotations`/`SetLabels` update the in-memory object only; the scheduler's subsequent patch/update call sends the values to the API server.
* All five adapters follow the same new pattern for consistency.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
