### PR TITLE
util: add MidCPU and MidMemory to ExtendedResourceNames

### DIFF
--- a/pkg/util/extended_resource.go
+++ b/pkg/util/extended_resource.go
@@ -24,10 +24,11 @@ import (
 
 // NOTE: functions in this file can be overwritten for extension
 
-// ExtendedResourceNames todo: add mid resource
 var ExtendedResourceNames = []corev1.ResourceName{
 	extension.BatchCPU,
 	extension.BatchMemory,
+	extension.MidCPU,
+	extension.MidMemory,
 }
 
 func GetBatchMilliCPUFromResourceList(r corev1.ResourceList) int64 {


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Adds `extension.MidCPU` and `extension.MidMemory` to the `ExtendedResourceNames` variable in `pkg/util/extended_resource.go`, resolving the existing TODO comment.

The same file already contains helper functions for Mid resources (`GetMidMilliCPUFromResourceList`, `GetMidMemoryFromResourceList`, `GetContainerMidMilliCPURequest`, `GetContainerMidMemoryByteRequest`), but `ExtendedResourceNames` only included Batch resources.

## Which issue(s) this PR fixes

Fixes #2939