### PR TITLE
deviceshare: fix nil map panic in device plugin adapters

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter.go
@@ -272,12 +272,30 @@ func unlockNode(node *corev1.Node, lockKey string) {
 	delete(node.Annotations, lockKey)
 }
 
+func ensureAnnotations(object metav1.Object) map[string]string {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+		object.SetAnnotations(annotations)
+	}
+	return annotations
+}
+
+func ensureLabels(object metav1.Object) map[string]string {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+		object.SetLabels(labels)
+	}
+	return labels
+}
+
 // generalDevicePluginAdapter annotates the bind timestamp to pod which enables users to write their own device plugins
 // that can be used with koord-scheduler.
 type generalDevicePluginAdapter struct{}
 
 func (a *generalDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, object metav1.Object, _ []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationBindTimestamp] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
+	ensureAnnotations(object)[AnnotationBindTimestamp] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
 	return nil
 }
 
@@ -287,9 +305,9 @@ type generalGPUDevicePluginAdapter struct {
 }
 
 func (a *generalGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, object metav1.Object, allocation []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationGPUMinors] = buildGPUMinorsStr(allocation, "")
+	ensureAnnotations(object)[AnnotationGPUMinors] = buildGPUMinorsStr(allocation, "")
 	if object.GetLabels()[apiext.LabelGPUIsolationProvider] == string(apiext.GPUIsolationProviderHAMICore) {
-		object.GetLabels()[apiext.LabelHAMIVGPUNodeName] = ctx.node.Name
+		ensureLabels(object)[apiext.LabelHAMIVGPUNodeName] = ctx.node.Name
 	}
 	return nil
 }
@@ -297,17 +315,18 @@ func (a *generalGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, obj
 type huaweiGPUDevicePluginAdapter struct{}
 
 func (a *huaweiGPUDevicePluginAdapter) Adapt(ctx *DevicePluginAdaptContext, object metav1.Object, allocation []*apiext.DeviceAllocation) error {
-	object.GetAnnotations()[AnnotationPredicateTime] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
+	annotations := ensureAnnotations(object)
+	annotations[AnnotationPredicateTime] = strconv.FormatInt(dpAdapterClock.Now().UnixNano(), 10)
 	switch ctx.gpuModel {
 	case "Ascend-310P3-300I-DUO":
-		object.GetAnnotations()[AnnotationHuaweiAscend310P] = buildGPUMinorsStr(allocation, "Ascend310P-")
+		annotations[AnnotationHuaweiAscend310P] = buildGPUMinorsStr(allocation, "Ascend310P-")
 	default:
 		if allocation[0].Extension != nil && allocation[0].Extension.GPUSharedResourceTemplate != "" {
 			// vNPU
-			object.GetAnnotations()[AnnotationHuaweiNPUCore] = fmt.Sprintf("%d-%s", allocation[0].Minor, allocation[0].Extension.GPUSharedResourceTemplate)
+			annotations[AnnotationHuaweiNPUCore] = fmt.Sprintf("%d-%s", allocation[0].Minor, allocation[0].Extension.GPUSharedResourceTemplate)
 		} else {
 			// full NPU
-			object.GetAnnotations()[AnnotationHuaweiNPUCore] = buildGPUMinorsStr(allocation, "")
+			annotations[AnnotationHuaweiNPUCore] = buildGPUMinorsStr(allocation, "")
 		}
 	}
 	return nil
@@ -332,8 +351,9 @@ func (a *cambriconGPUDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, obj
 	}
 	vmemory := memory.Value() / cambriconVMemoryUnit
 
-	object.GetAnnotations()[AnnotationCambriconDsmluAssigned] = "false"
-	object.GetAnnotations()[AnnotationCambriconDsmluProfile] = fmt.Sprintf("%d_%d_%d", allocation[0].Minor, vcore, vmemory)
+	annotations := ensureAnnotations(object)
+	annotations[AnnotationCambriconDsmluAssigned] = "false"
+	annotations[AnnotationCambriconDsmluProfile] = fmt.Sprintf("%d_%d_%d", allocation[0].Minor, vcore, vmemory)
 	return nil
 }
 
@@ -375,7 +395,7 @@ func (a *metaxDevicePluginAdapter) Adapt(_ *DevicePluginAdaptContext, object met
 		return err
 	}
 
-	object.GetAnnotations()[AnnotationMetaXGPUDevicesAllocated] = string(allocatedData)
+	ensureAnnotations(object)[AnnotationMetaXGPUDevicesAllocated] = string(allocatedData)
 	return nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
@@ -64,6 +64,22 @@ func TestGeneralDevicePluginAdapter_Adapt(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nil annotations",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationBindTimestamp: strconv.FormatInt(now.UnixNano(), 10),
+					},
+				},
+			},
+		},
 	}
 
 	adapter := &generalDevicePluginAdapter{}
@@ -111,6 +127,25 @@ func TestGeneralGPUDevicePluginAdapter_Adapt(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						AnnotationGPUMinors: "0,1",
+					},
+				},
+			},
+		},
+		{
+			name: "nil annotations",
+			args: args{
+				object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+				allocation: []*apiext.DeviceAllocation{
+					{Minor: 0},
+				},
+			},
+			wantErr: false,
+			wantObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationGPUMinors: "0",
 					},
 				},
 			},


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

All five device plugin adapters (`generalDevicePluginAdapter`, `generalGPUDevicePluginAdapter`, `huaweiGPUDevicePluginAdapter`, `cambriconGPUDevicePluginAdapter`, `metaxDevicePluginAdapter`) write directly to the map returned by `GetAnnotations()` / `GetLabels()`. When a pod has no pre-existing annotations or labels, these getters return `nil`, and writing to a `nil` map panics.

This PR adds `ensureAnnotations` and `ensureLabels` helpers that initialize the map via `SetAnnotations` / `SetLabels` if it is `nil`, then returns it for safe writing. All five adapters are updated to use these helpers.

Test cases for nil annotations are added for `generalDevicePluginAdapter` and `generalGPUDevicePluginAdapter`.

## Which issue(s) this PR fixes

Fixes #2947