### PR TITLE
coscheduling: use checked type assertion for ExtendedHandle in BeforePreFilter

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -333,7 +333,11 @@ func (pgMgr *PodGroupManager) BeforePreFilter(ctx context.Context, cycleState fw
 			networkTopologySpec: gang.NetworkTopologySpec,
 		}
 		if gangSchedulingContext.networkTopologySpec != nil {
-			gangSchedulingContext.networkTopologySnapshot = pgMgr.handle.(frameworkext.ExtendedHandle).GetNetworkTopologyTreeManager().GetSnapshot()
+			extHandle, ok := pgMgr.handle.(frameworkext.ExtendedHandle)
+			if !ok {
+				return fmt.Errorf("handle does not implement ExtendedHandle, required for NetworkTopologySpec")
+			}
+			gangSchedulingContext.networkTopologySnapshot = extHandle.GetNetworkTopologyTreeManager().GetSnapshot()
 			if gangSchedulingContext.networkTopologySnapshot == nil {
 				return errors.New(ErrNoClusterNetworkTopology)
 			}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`PodGroupManager.BeforePreFilter` performs an unchecked type assertion `pgMgr.handle.(frameworkext.ExtendedHandle)` when a gang enables `NetworkTopologySpec`. If the handle does not implement `ExtendedHandle`, this panics instead of returning an error.

This PR uses a checked assertion (`extHandle, ok := ...`) with a descriptive error message, matching the defensive pattern already used in the constructor at `core.go:129`.

## Which issue(s) this PR fixes

Fixes #2935