### PR TITLE
feat: support custom GPU/NPU resources in gpudeviceresource plugin

### DIFF
--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/plugin.go
@@ -119,14 +119,10 @@ func (p *Plugin) Prepare(_ *configuration.ColocationStrategy, node *corev1.Node,
 	// prepare node labels
 	// TBD: shall we reset labels if not exist in the NR
 	if nr.Labels != nil {
-		if _, ok := nr.Labels[extension.LabelGPUVendor]; ok {
-			node.Labels[extension.LabelGPUVendor] = nr.Labels[extension.LabelGPUVendor]
-		}
-		if _, ok := nr.Labels[extension.LabelGPUModel]; ok {
-			node.Labels[extension.LabelGPUModel] = nr.Labels[extension.LabelGPUModel]
-		}
-		if _, ok := nr.Labels[extension.LabelGPUDriverVersion]; ok {
-			node.Labels[extension.LabelGPUDriverVersion] = nr.Labels[extension.LabelGPUDriverVersion]
+		for _, label := range Labels {
+			if val, ok := nr.Labels[label]; ok {
+				node.Labels[label] = val
+			}
 		}
 	}
 
@@ -213,14 +209,10 @@ func (p *Plugin) calculate(node *corev1.Node, device *schedulingv1alpha1.Device)
 
 	// calculate labels about gpu driver and model
 	updatedLabels := map[string]string{}
-	if gpuVendor, ok := device.Labels[extension.LabelGPUVendor]; ok {
-		updatedLabels[extension.LabelGPUVendor] = gpuVendor
-	}
-	if gpuModel, ok := device.Labels[extension.LabelGPUModel]; ok {
-		updatedLabels[extension.LabelGPUModel] = gpuModel
-	}
-	if gpuDriverVersion, ok := device.Labels[extension.LabelGPUDriverVersion]; ok {
-		updatedLabels[extension.LabelGPUDriverVersion] = gpuDriverVersion
+	for _, label := range Labels {
+		if val, ok := device.Labels[label]; ok {
+			updatedLabels[label] = val
+		}
 	}
 	if len(updatedLabels) != 0 {
 		items = append(items, framework.ResourceItem{

--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// ResourceNames are the known resources reconciled by the plugin from devices to nodes.
-	// TODO: support custom resources.
+	// Applications can use RegisterGPUDeviceResource to add custom resources.
 	ResourceNames = []corev1.ResourceName{
 		extension.ResourceGPU,
 		extension.ResourceGPUCore,
@@ -42,3 +42,23 @@ var (
 		extension.LabelGPUDriverVersion,
 	}
 )
+
+// RegisterGPUDeviceResource registers a custom GPU/NPU resource to be reconciled.
+func RegisterGPUDeviceResource(resourceName corev1.ResourceName) {
+	for _, name := range ResourceNames {
+		if name == resourceName {
+			return
+		}
+	}
+	ResourceNames = append(ResourceNames, resourceName)
+}
+
+// RegisterGPUDeviceLabel registers a custom GPU/NPU label to be reconciled.
+func RegisterGPUDeviceLabel(label string) {
+	for _, l := range Labels {
+		if l == label {
+			return
+		}
+	}
+	Labels = append(Labels, label)
+}

--- a/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils_test.go
+++ b/pkg/slo-controller/noderesource/plugins/gpudeviceresource/utils_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpudeviceresource
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRegisterGPUDeviceResource(t *testing.T) {
+	orig := make([]corev1.ResourceName, len(ResourceNames))
+	copy(orig, ResourceNames)
+	defer func() { ResourceNames = orig }()
+
+	RegisterGPUDeviceResource("custom.resource/a")
+	if len(ResourceNames) != len(orig)+1 {
+		t.Fatalf("expected length %d, got %d", len(orig)+1, len(ResourceNames))
+	}
+	if ResourceNames[len(ResourceNames)-1] != "custom.resource/a" {
+		t.Fatalf("expected last custom.resource/a, got %s", ResourceNames[len(ResourceNames)-1])
+	}
+
+	// register again
+	RegisterGPUDeviceResource("custom.resource/a")
+	if len(ResourceNames) != len(orig)+1 {
+		t.Fatalf("duplicated registration, expected length %d, got %d", len(orig)+1, len(ResourceNames))
+	}
+}
+
+func TestRegisterGPUDeviceLabel(t *testing.T) {
+	orig := make([]string, len(Labels))
+	copy(orig, Labels)
+	defer func() { Labels = orig }()
+
+	RegisterGPUDeviceLabel("custom.label/a")
+	if len(Labels) != len(orig)+1 {
+		t.Fatalf("expected length %d, got %d", len(orig)+1, len(Labels))
+	}
+	if Labels[len(Labels)-1] != "custom.label/a" {
+		t.Fatalf("expected last custom.label/a, got %s", Labels[len(Labels)-1])
+	}
+
+	// register again
+	RegisterGPUDeviceLabel("custom.label/a")
+	if len(Labels) != len(orig)+1 {
+		t.Fatalf("duplicated registration, expected length %d, got %d", len(orig)+1, len(Labels))
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds configurable registration functionality in the `gpudeviceresource` plugin to support custom GPU/NPU resources instead of relying solely on a hardcoded list.

- Added `RegisterGPUDeviceResource()` to allow custom GPU/NPU resource types to be registered at runtime.
- Added `RegisterGPUDeviceLabel()` to allow configurable device labels to be registered at runtime.
- Removed the `TODO: support custom resources.` comment since this functionality is now implemented via the new registration mechanism.
- Added unit tests for the new custom resource logic ensuring new items are appended correctly and duplicate registrations are safely ignored.

This allows other parts of the codebase, extensions, or third-party vendor integrations to easily inject their specific resource types and labels into the plugin prior to reconciliation without modifying the plugin's source directly.

### Ⅱ. Does this pull request fix one issue?

fixes #2952

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
