### PR TITLE
feat: implement pod update mutating logic

### DIFF
--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/metrics"
 )
 
@@ -110,53 +111,43 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	return admission.PatchResponseFromRaw(original, marshaled)
 }
 
-func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
-	start := time.Now()
-	if err := h.clusterColocationProfileMutatingPod(ctx, req, obj); err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by ClusterColocationProfile, err: %v", obj.Namespace, obj.Name, err)
-		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-			metrics.Pod, string(req.Operation), err, ClusterColocationProfile, time.Since(start).Seconds())
-		return err
+// runMutatingPlugins executes all pod-mutating plugins in sequence, recording
+// per-plugin metrics. It is called by both handleCreate and handleUpdate.
+func (h *PodMutatingHandler) runMutatingPlugins(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
+	type step struct {
+		name string
+		fn   func(context.Context, admission.Request, *corev1.Pod) error
 	}
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), nil, ClusterColocationProfile, time.Since(start).Seconds())
-
-	start = time.Now()
-	if err := h.extendedResourceSpecMutatingPod(ctx, req, obj); err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by ExtendedResourceSpec, err: %v", obj.Namespace, obj.Name, err)
-		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-			metrics.Pod, string(req.Operation), err, ExtendedResourceSpec, time.Since(start).Seconds())
-		return err
+	steps := []step{
+		{ClusterColocationProfile, h.clusterColocationProfileMutatingPod},
+		{ExtendedResourceSpec, h.extendedResourceSpecMutatingPod},
+		{MultiQuotaTree, h.addNodeAffinityForMultiQuotaTree},
+		{DeviceResourceSpec, h.deviceResourceSpecMutatingPod},
 	}
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), nil, ExtendedResourceSpec, time.Since(start).Seconds())
-
-	start = time.Now()
-	if err := h.addNodeAffinityForMultiQuotaTree(ctx, req, obj); err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by MultiQuotaTree, err: %v", obj.Namespace, obj.Name, err)
+	for _, s := range steps {
+		start := time.Now()
+		if err := s.fn(ctx, req, obj); err != nil {
+			klog.Errorf("Failed to mutating Pod %s/%s by %s, err: %v",
+				obj.Namespace, obj.Name, s.name, err)
+			metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
+				metrics.Pod, string(req.Operation), err, s.name, time.Since(start).Seconds())
+			return err
+		}
 		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-			metrics.Pod, string(req.Operation), err, MultiQuotaTree, time.Since(start).Seconds())
-		return err
+			metrics.Pod, string(req.Operation), nil, s.name, time.Since(start).Seconds())
 	}
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), nil, MultiQuotaTree, time.Since(start).Seconds())
-
-	start = time.Now()
-	if err := h.deviceResourceSpecMutatingPod(ctx, req, obj); err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by DeviceResourceSpec, err: %v", obj.Namespace, obj.Name, err)
-		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-			metrics.Pod, string(req.Operation), err, DeviceResourceSpec, time.Since(start).Seconds())
-		return err
-	}
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), nil, DeviceResourceSpec, time.Since(start).Seconds())
-
 	return nil
 }
 
+func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
+	return h.runMutatingPlugins(ctx, req, obj)
+}
+
 func (h *PodMutatingHandler) handleUpdate(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
-	// TODO: add mutating logic for pod update here
-	return nil
+	if obj.Labels[extension.LabelPodMutatingUpdate] != "true" {
+		return nil
+	}
+	return h.runMutatingPlugins(ctx, req, obj)
 }
 
 // var _ inject.Client = &PodMutatingHandler{}

--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/metrics"
 )
 
@@ -114,55 +115,44 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	return admission.PatchResponseFromRaw(original, marshaled)
 }
 
-func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Request, obj *corev1.Pod) (bool, error) {
+// runMutatingPlugins executes all pod-mutating plugins in sequence, recording
+// per-plugin metrics. It is called by both handleCreate and handleUpdate.
+func (h *PodMutatingHandler) runMutatingPlugins(ctx context.Context, req admission.Request, obj *corev1.Pod) (bool, error) {
+	type step struct {
+		name string
+		fn   func(context.Context, admission.Request, *corev1.Pod) (bool, error)
+	}
+	steps := []step{
+		{ClusterColocationProfile, h.clusterColocationProfileMutatingPod},
+		{ExtendedResourceSpec, h.extendedResourceSpecMutatingPod},
+		{MultiQuotaTree, h.addNodeAffinityForMultiQuotaTree},
+		{DeviceResourceSpec, h.deviceResourceSpecMutatingPod},
+	}
 	var mutated bool
-
-	start := time.Now()
-	m, err := h.clusterColocationProfileMutatingPod(ctx, req, obj)
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), err, ClusterColocationProfile, time.Since(start).Seconds())
-	if err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by ClusterColocationProfile, err: %v", obj.Namespace, obj.Name, err)
-		return mutated, err
+	for _, s := range steps {
+		start := time.Now()
+		m, err := s.fn(ctx, req, obj)
+		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
+			metrics.Pod, string(req.Operation), err, s.name, time.Since(start).Seconds())
+		if err != nil {
+			klog.Errorf("Failed to mutating Pod %s/%s by %s, err: %v",
+				obj.Namespace, obj.Name, s.name, err)
+			return mutated, err
+		}
+		mutated = mutated || m
 	}
-	mutated = mutated || m
-
-	start = time.Now()
-	m, err = h.extendedResourceSpecMutatingPod(ctx, req, obj)
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), err, ExtendedResourceSpec, time.Since(start).Seconds())
-	if err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by ExtendedResourceSpec, err: %v", obj.Namespace, obj.Name, err)
-		return mutated, err
-	}
-	mutated = mutated || m
-
-	start = time.Now()
-	m, err = h.addNodeAffinityForMultiQuotaTree(ctx, req, obj)
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), err, MultiQuotaTree, time.Since(start).Seconds())
-	if err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by MultiQuotaTree, err: %v", obj.Namespace, obj.Name, err)
-		return mutated, err
-	}
-	mutated = mutated || m
-
-	start = time.Now()
-	m, err = h.deviceResourceSpecMutatingPod(ctx, req, obj)
-	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
-		metrics.Pod, string(req.Operation), err, DeviceResourceSpec, time.Since(start).Seconds())
-	if err != nil {
-		klog.Errorf("Failed to mutating Pod %s/%s by DeviceResourceSpec, err: %v", obj.Namespace, obj.Name, err)
-		return mutated, err
-	}
-	mutated = mutated || m
-
 	return mutated, nil
 }
 
+func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Request, obj *corev1.Pod) (bool, error) {
+	return h.runMutatingPlugins(ctx, req, obj)
+}
+
 func (h *PodMutatingHandler) handleUpdate(ctx context.Context, req admission.Request, obj *corev1.Pod) (bool, error) {
-	// TODO: add mutating logic for pod update here
-	return false, nil
+	if obj.Labels[extension.LabelPodMutatingUpdate] != "true" {
+		return false, nil
+	}
+	return h.runMutatingPlugins(ctx, req, obj)
 }
 
 // var _ inject.Client = &PodMutatingHandler{}

--- a/pkg/webhook/pod/mutating/mutating_handler_test.go
+++ b/pkg/webhook/pod/mutating/mutating_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/elasticquota"
 )
@@ -201,4 +203,55 @@ func (h *PodMutatingHandler) InjectCache(cache sigcache.Cache) error {
 		DeleteFunc: qt.OnQuotaDelete,
 	})
 	return nil
+}
+
+func TestHandleUpdate_SkippedWithoutLabel(t *testing.T) {
+	handler, _ := makeTestHandler()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+	// No LabelPodMutatingUpdate label → handler must be a no-op
+	err := handler.handleUpdate(context.TODO(), admission.Request{}, pod)
+	assert.NoError(t, err)
+	// pod must be unmodified
+	assert.Nil(t, pod.Labels)
+}
+
+func TestHandleUpdate_RunsPluginsWhenLabelSet(t *testing.T) {
+	handler, _ := makeTestHandler()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				extension.LabelPodMutatingUpdate: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							extension.BatchCPU: *resource.NewQuantity(1, resource.DecimalSI),
+						},
+						Limits: corev1.ResourceList{
+							extension.BatchCPU: *resource.NewQuantity(1, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := handler.handleUpdate(context.TODO(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+		},
+	}, pod)
+	assert.NoError(t, err)
+	// assert expected pod mutations were applied by ExtendedResourceSpec
+	// The koordinator.sh/extended-resource-spec annotation should be set
+	assert.NotEmpty(t, pod.Annotations[extension.AnnotationExtendedResourceSpec])
 }

--- a/pkg/webhook/pod/mutating/mutating_handler_test.go
+++ b/pkg/webhook/pod/mutating/mutating_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/elasticquota"
 )
@@ -201,4 +203,57 @@ func (h *PodMutatingHandler) InjectCache(cache sigcache.Cache) error {
 		DeleteFunc: qt.OnQuotaDelete,
 	})
 	return nil
+}
+
+func TestHandleUpdate_SkippedWithoutLabel(t *testing.T) {
+	handler, _ := makeTestHandler()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+	// No LabelPodMutatingUpdate label → handler must be a no-op
+	mutated, err := handler.handleUpdate(context.TODO(), admission.Request{}, pod)
+	assert.NoError(t, err)
+	assert.False(t, mutated)
+	// pod must be unmodified
+	assert.Nil(t, pod.Labels)
+}
+
+func TestHandleUpdate_RunsPluginsWhenLabelSet(t *testing.T) {
+	handler, _ := makeTestHandler()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				extension.LabelPodMutatingUpdate: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							extension.BatchCPU: *resource.NewQuantity(1, resource.DecimalSI),
+						},
+						Limits: corev1.ResourceList{
+							extension.BatchCPU: *resource.NewQuantity(1, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mutated, err := handler.handleUpdate(context.TODO(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+		},
+	}, pod)
+	assert.NoError(t, err)
+	assert.True(t, mutated)
+	// assert expected pod mutations were applied by ExtendedResourceSpec
+	// The koordinator.sh/extended-resource-spec annotation should be set
+	assert.NotEmpty(t, pod.Annotations[extension.AnnotationExtendedResourceSpec])
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds mutating logic for Pod `UPDATE` admission requests.

Previously, `handleUpdate` was a no-op and skipped all mutating plugins. This PR:
- Refactors the plugin execution flow into a shared `runMutatingPlugins` helper.
- Reuses the same mutation flow for both `handleCreate` and `handleUpdate`.
- Restricts update mutations behind `extension.LabelPodMutatingUpdate` to avoid unintended immutable field changes.
- Adds unit tests for the update path and label guard logic.

### Ⅱ. Does this pull request fix one issue?

fixes #2954

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

`handleUpdate` now uses the same plugin sequence as `handleCreate`, but only when the Pod explicitly opts in through `extension.LabelPodMutatingUpdate`.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`