### PR TITLE
webhook: enable mutation for pod update requests

### DIFF
--- a/pkg/webhook/pod/mutating/cluster_colocation_profile.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.koordinator.sh,resources=clustercolocationprofiles,verbs=get;list;watch
 
-func (h *PodMutatingHandler) clusterColocationProfileMutatingPod(ctx context.Context, req admission.Request, pod *corev1.Pod) error {
+func (h *PodMutatingHandler) clusterColocationProfileMutatingPod(ctx context.Context, req admission.Request, pod, oldPod *corev1.Pod) error {
 	if req.Operation != admissionv1.Create {
 		return nil
 	}
@@ -76,7 +76,7 @@ func (h *PodMutatingHandler) clusterColocationProfileMutatingPod(ctx context.Con
 			}
 		}
 		if profile.Spec.Selector != nil {
-			matched, err := h.matchObjectSelector(pod, nil, profile.Spec.Selector)
+			matched, err := h.matchObjectSelector(pod, oldPod, profile.Spec.Selector)
 			if !matched && err == nil {
 				continue
 			}

--- a/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
+++ b/pkg/webhook/pod/mutating/cluster_colocation_profile_test.go
@@ -1852,7 +1852,7 @@ func TestClusterColocationProfileMutatingPod(t *testing.T) {
 			assert.NoError(err)
 
 			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
-			err = handler.clusterColocationProfileMutatingPod(context.TODO(), req, tc.pod)
+			err = handler.clusterColocationProfileMutatingPod(context.TODO(), req, tc.pod, nil)
 			assert.NoError(err)
 
 			assert.Equal(tc.expected, tc.pod)

--- a/pkg/webhook/pod/mutating/device_resource_spec.go
+++ b/pkg/webhook/pod/mutating/device_resource_spec.go
@@ -28,7 +28,7 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 )
 
-func (h *PodMutatingHandler) deviceResourceSpecMutatingPod(ctx context.Context, req admission.Request, pod *corev1.Pod) error {
+func (h *PodMutatingHandler) deviceResourceSpecMutatingPod(ctx context.Context, req admission.Request, pod, oldPod *corev1.Pod) error {
 	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
 		return nil
 	}
@@ -68,10 +68,16 @@ func (h *PodMutatingHandler) mutateByDeviceResources(pod *corev1.Pod) error {
 }
 
 func injectResourceContainerSpec(c *corev1.Container, s *extension.ExtendedResourceContainerSpec) {
+	if len(s.Requests) > 0 && c.Resources.Requests == nil {
+		c.Resources.Requests = corev1.ResourceList{}
+	}
 	for resource := range s.Requests {
 		c.Resources.Requests[resource] = s.Requests[resource]
 	}
 
+	if len(s.Limits) > 0 && c.Resources.Limits == nil {
+		c.Resources.Limits = corev1.ResourceList{}
+	}
 	for resource := range s.Limits {
 		c.Resources.Limits[resource] = s.Limits[resource]
 	}

--- a/pkg/webhook/pod/mutating/device_resource_spec_test.go
+++ b/pkg/webhook/pod/mutating/device_resource_spec_test.go
@@ -166,7 +166,7 @@ func TestDeviceResourceSpecMutatingPod(t *testing.T) {
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	for i := range testCases {
 		pod.Spec.Containers[0].Resources = testCases[i].resourceRequirements
-		err := handler.deviceResourceSpecMutatingPod(context.TODO(), req, pod)
+		err := handler.deviceResourceSpecMutatingPod(context.TODO(), req, pod, nil)
 
 		assert.NoError(err)
 		assert.Equal(pod.Spec.Containers[0].Resources, testCases[i].expectedResourceRequirements)

--- a/pkg/webhook/pod/mutating/extended_resource_spec.go
+++ b/pkg/webhook/pod/mutating/extended_resource_spec.go
@@ -29,7 +29,7 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 )
 
-func (h *PodMutatingHandler) extendedResourceSpecMutatingPod(ctx context.Context, req admission.Request, pod *corev1.Pod) error {
+func (h *PodMutatingHandler) extendedResourceSpecMutatingPod(ctx context.Context, req admission.Request, pod, oldPod *corev1.Pod) error {
 	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
 		return nil
 	}

--- a/pkg/webhook/pod/mutating/extended_resource_spec_test.go
+++ b/pkg/webhook/pod/mutating/extended_resource_spec_test.go
@@ -96,7 +96,7 @@ func TestExtendedResourceSpecMutatingPod(t *testing.T) {
 	assert.NoError(err)
 
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
-	err = handler.extendedResourceSpecMutatingPod(context.TODO(), req, pod)
+	err = handler.extendedResourceSpecMutatingPod(context.TODO(), req, pod, nil)
 	assert.NoError(err)
 
 	expectPod := &corev1.Pod{

--- a/pkg/webhook/pod/mutating/multi_quota_tree_affinity.go
+++ b/pkg/webhook/pod/mutating/multi_quota_tree_affinity.go
@@ -34,7 +34,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/webhook/elasticquota"
 )
 
-func (h *PodMutatingHandler) addNodeAffinityForMultiQuotaTree(ctx context.Context, req admission.Request, pod *corev1.Pod) error {
+func (h *PodMutatingHandler) addNodeAffinityForMultiQuotaTree(ctx context.Context, req admission.Request, pod, oldPod *corev1.Pod) error {
 	if req.Operation != admissionv1.Create {
 		return nil
 	}

--- a/pkg/webhook/pod/mutating/multi_quota_tree_affinity_test.go
+++ b/pkg/webhook/pod/mutating/multi_quota_tree_affinity_test.go
@@ -434,7 +434,7 @@ func TestAddNodeAffinityForMultiQuotaTree(t *testing.T) {
 			defer feature.SetFeatureGateDuringTest(t, feature.DefaultMutableFeatureGate, features.MultiQuotaTree, true)()
 
 			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
-			err := handler.addNodeAffinityForMultiQuotaTree(context.TODO(), req, tc.pod)
+			err := handler.addNodeAffinityForMultiQuotaTree(context.TODO(), req, tc.pod, nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tc.expected, tc.pod)

--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -70,6 +70,14 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	clone := obj.DeepCopy()
+	var oldObj *corev1.Pod
+	if req.Operation == admissionv1.Update {
+		oldObj = &corev1.Pod{}
+		if err := h.Decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+
 	// when pod.namespace is empty, using req.namespace
 	var isNamespaceEmpty bool
 	if obj.Namespace == "" {
@@ -78,10 +86,8 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	switch req.Operation {
-	case admissionv1.Create:
-		err = h.handleCreate(ctx, req, obj)
-	case admissionv1.Update:
-		err = h.handleUpdate(ctx, req, obj)
+	case admissionv1.Create, admissionv1.Update:
+		err = h.handleMutatePod(ctx, req, obj, oldObj)
 	default:
 		return admission.Allowed("")
 	}
@@ -110,9 +116,9 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	return admission.PatchResponseFromRaw(original, marshaled)
 }
 
-func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
+func (h *PodMutatingHandler) handleMutatePod(ctx context.Context, req admission.Request, obj, oldObj *corev1.Pod) error {
 	start := time.Now()
-	if err := h.clusterColocationProfileMutatingPod(ctx, req, obj); err != nil {
+	if err := h.clusterColocationProfileMutatingPod(ctx, req, obj, oldObj); err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by ClusterColocationProfile, err: %v", obj.Namespace, obj.Name, err)
 		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 			metrics.Pod, string(req.Operation), err, ClusterColocationProfile, time.Since(start).Seconds())
@@ -122,7 +128,7 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 		metrics.Pod, string(req.Operation), nil, ClusterColocationProfile, time.Since(start).Seconds())
 
 	start = time.Now()
-	if err := h.extendedResourceSpecMutatingPod(ctx, req, obj); err != nil {
+	if err := h.extendedResourceSpecMutatingPod(ctx, req, obj, oldObj); err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by ExtendedResourceSpec, err: %v", obj.Namespace, obj.Name, err)
 		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 			metrics.Pod, string(req.Operation), err, ExtendedResourceSpec, time.Since(start).Seconds())
@@ -132,7 +138,7 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 		metrics.Pod, string(req.Operation), nil, ExtendedResourceSpec, time.Since(start).Seconds())
 
 	start = time.Now()
-	if err := h.addNodeAffinityForMultiQuotaTree(ctx, req, obj); err != nil {
+	if err := h.addNodeAffinityForMultiQuotaTree(ctx, req, obj, oldObj); err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by MultiQuotaTree, err: %v", obj.Namespace, obj.Name, err)
 		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 			metrics.Pod, string(req.Operation), err, MultiQuotaTree, time.Since(start).Seconds())
@@ -142,7 +148,7 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 		metrics.Pod, string(req.Operation), nil, MultiQuotaTree, time.Since(start).Seconds())
 
 	start = time.Now()
-	if err := h.deviceResourceSpecMutatingPod(ctx, req, obj); err != nil {
+	if err := h.deviceResourceSpecMutatingPod(ctx, req, obj, oldObj); err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by DeviceResourceSpec, err: %v", obj.Namespace, obj.Name, err)
 		metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 			metrics.Pod, string(req.Operation), err, DeviceResourceSpec, time.Since(start).Seconds())
@@ -151,11 +157,6 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 		metrics.Pod, string(req.Operation), nil, DeviceResourceSpec, time.Since(start).Seconds())
 
-	return nil
-}
-
-func (h *PodMutatingHandler) handleUpdate(ctx context.Context, req admission.Request, obj *corev1.Pod) error {
-	// TODO: add mutating logic for pod update here
 	return nil
 }
 

--- a/pkg/webhook/pod/mutating/mutating_handler_test.go
+++ b/pkg/webhook/pod/mutating/mutating_handler_test.go
@@ -18,12 +18,15 @@ package mutating
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configv1alpha1 "github.com/koordinator-sh/koordinator/apis/config/v1alpha1"
+	"github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/webhook/elasticquota"
 )
@@ -185,6 +189,145 @@ func TestMutatingHandler(t *testing.T) {
 	}
 }
 
+func TestMutatingHandler_Update(t *testing.T) {
+	handler, _ := makeTestHandler()
+	ctx := context.Background()
+
+	testCases := []struct {
+		name     string
+		pod      *corev1.Pod
+		hasPatch bool
+	}{
+		{
+			name: "pod update with extended resources",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									extension.BatchCPU: resource.MustParse("1000"),
+								},
+							},
+						},
+					},
+				},
+			},
+			hasPatch: true,
+		},
+		{
+			name: "pod update without changes",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+						},
+					},
+				},
+			},
+			hasPatch: false,
+		},
+		{
+			name: "pod update with GPU resources",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									extension.ResourceGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			hasPatch: true,
+		},
+		{
+			name: "pod update with GPU resources in limits only and empty namespace",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod4",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									extension.ResourceGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			hasPatch: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podBytes, _ := json.Marshal(tc.pod)
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Resource:  gvr("pods"),
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw: podBytes,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: podBytes, // For simplicity in this test, old and new are same or similar enough
+					},
+				},
+			}
+			response := handler.Handle(ctx, req)
+			assert.True(t, response.Allowed)
+			if tc.hasPatch {
+				assert.NotEmpty(t, response.Patches)
+				if tc.name == "pod update with extended resources" {
+					found := false
+					for _, p := range response.Patches {
+						if strings.Contains(p.Path, "annotations") {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "ExtendedResourceSpec annotation patch not found")
+				}
+				if tc.name == "pod update with GPU resources" {
+					found := false
+					for _, p := range response.Patches {
+						if strings.Contains(p.Path, "koordinator.sh~1gpu-core") {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "GPU core resource patch not found")
+				}
+			} else {
+				assert.Empty(t, response.Patches)
+			}
+		})
+	}
+}
+
 // var _ inject.Cache = &PodMutatingHandler{}
 
 func (h *PodMutatingHandler) InjectCache(cache sigcache.Cache) error {
@@ -201,4 +344,58 @@ func (h *PodMutatingHandler) InjectCache(cache sigcache.Cache) error {
 		DeleteFunc: qt.OnQuotaDelete,
 	})
 	return nil
+}
+
+func TestMutatingHandler_Handle_InvalidOldObject(t *testing.T) {
+	handler, _ := makeTestHandler()
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+	podBytes, _ := json.Marshal(pod)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Resource:  gvr("pods"),
+			Operation: admissionv1.Update,
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+			OldObject: runtime.RawExtension{
+				Raw: []byte(`{"invalid": "json"`),
+			},
+		},
+	}
+	response := handler.Handle(ctx, req)
+	assert.False(t, response.Allowed)
+	assert.Equal(t, int32(http.StatusBadRequest), response.AdmissionResponse.Result.Code)
+}
+
+func TestMutatingHandler_Handle_CreateEmptyNamespace(t *testing.T) {
+	handler, _ := makeTestHandler()
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+		},
+	}
+	podBytes, _ := json.Marshal(pod)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Resource:  gvr("pods"),
+			Operation: admissionv1.Create,
+			Namespace: "default",
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+		},
+	}
+	response := handler.Handle(ctx, req)
+	assert.True(t, response.Allowed)
 }


### PR DESCRIPTION

This fixes #2954 by enabling pod mutation logic during Update operations.

Previously, pod updates bypassed all mutation stages because `handleUpdate` was a no-op. This change reuses the existing mutation flow for both Create and Update requests while keeping plugin-specific operation checks unchanged.

The patch also:

* fixes a potential nil map panic in device resource mutation handling
* adds update path unit tests for extended resources and GPU mutations
* keeps the implementation minimal and aligned with existing webhook patterns

Tests run:

* `go test ./pkg/webhook/pod/mutating/...`
* `go test ./pkg/webhook/...`
* `go vet ./pkg/webhook/...`
