### PR TITLE
fix: include init containers in BE pod resource calculations

### DIFF
--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -44,9 +44,16 @@ func GetPodTargetExtendedResources(pod *corev1.Pod, resourceNames ...corev1.Reso
 
 	extendedResources := GetEmptyPodExtendedResources()
 
-	// TODO: count init containers and pod overhead
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
+		r := GetContainerTargetExtendedResources(container, resourceNames...)
+		if r == nil {
+			continue
+		}
+		extendedResources.Containers[container.Name] = *r
+	}
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
 		r := GetContainerTargetExtendedResources(container, resourceNames...)
 		if r == nil {
 			continue

--- a/pkg/util/pod_resources_utils.go
+++ b/pkg/util/pod_resources_utils.go
@@ -56,7 +56,6 @@ func GetPodRequest(pod *corev1.Pod, resourceNames ...corev1.ResourceName) corev1
 
 func GetPodBEMilliCPURequest(pod *corev1.Pod) int64 {
 	podCPUMilliReq := int64(0)
-	// TODO: count init containers and pod overhead
 	for _, container := range pod.Spec.Containers {
 		containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
 		if containerCPUMilliReq <= 0 {
@@ -64,19 +63,31 @@ func GetPodBEMilliCPURequest(pod *corev1.Pod) int64 {
 		}
 		podCPUMilliReq += containerCPUMilliReq
 	}
-
+	for _, container := range pod.Spec.InitContainers {
+		containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
+		if containerCPUMilliReq <= 0 {
+			containerCPUMilliReq = 0
+		}
+		podCPUMilliReq = MaxInt64(podCPUMilliReq, containerCPUMilliReq)
+	}
 	return podCPUMilliReq
 }
 
 func GetPodBEMilliCPULimit(pod *corev1.Pod) int64 {
 	podCPUMilliLimit := int64(0)
-	// TODO: count init containers and pod overhead
 	for _, container := range pod.Spec.Containers {
 		containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
 		if containerCPUMilliLimit <= 0 {
 			return -1
 		}
 		podCPUMilliLimit += containerCPUMilliLimit
+	}
+	for _, container := range pod.Spec.InitContainers {
+		containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
+		if containerCPUMilliLimit <= 0 {
+			return -1
+		}
+		podCPUMilliLimit = MaxInt64(podCPUMilliLimit, containerCPUMilliLimit)
 	}
 	if podCPUMilliLimit <= 0 {
 		return -1
@@ -86,7 +97,6 @@ func GetPodBEMilliCPULimit(pod *corev1.Pod) int64 {
 
 func GetPodBEMemoryByteRequestIgnoreUnlimited(pod *corev1.Pod) int64 {
 	podMemoryByteRequest := int64(0)
-	// TODO: count init containers and pod overhead
 	for _, container := range pod.Spec.Containers {
 		containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
 		if containerMemByteRequest < 0 {
@@ -95,18 +105,31 @@ func GetPodBEMemoryByteRequestIgnoreUnlimited(pod *corev1.Pod) int64 {
 		}
 		podMemoryByteRequest += containerMemByteRequest
 	}
+	for _, container := range pod.Spec.InitContainers {
+		containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
+		if containerMemByteRequest < 0 {
+			continue
+		}
+		podMemoryByteRequest = MaxInt64(podMemoryByteRequest, containerMemByteRequest)
+	}
 	return podMemoryByteRequest
 }
 
 func GetPodBEMemoryByteLimit(pod *corev1.Pod) int64 {
 	podMemoryByteLimit := int64(0)
-	// TODO: count init containers and pod overhead
 	for _, container := range pod.Spec.Containers {
 		containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
 		if containerMemByteLimit <= 0 {
 			return -1
 		}
 		podMemoryByteLimit += containerMemByteLimit
+	}
+	for _, container := range pod.Spec.InitContainers {
+		containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
+		if containerMemByteLimit <= 0 {
+			return -1
+		}
+		podMemoryByteLimit = MaxInt64(podMemoryByteLimit, containerMemByteLimit)
 	}
 	if podMemoryByteLimit <= 0 {
 		return -1

--- a/pkg/util/pod_resources_utils_test.go
+++ b/pkg/util/pod_resources_utils_test.go
@@ -211,6 +211,102 @@ func Test_GetPodBEMilliCPURequest(t *testing.T) {
 			wantRequest: 0,
 			wantLimit:   -1,
 		},
+		{
+			name: "init container dominates containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("4000"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("100"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 4000,
+			wantLimit:   4000,
+		},
+		{
+			name: "containers dominate init container",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("500"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("500"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("2000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("3000"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 2000,
+			wantLimit:   3000,
+		},
+		{
+			name: "unlimited init container limit returns -1",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("1000"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("1000"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchCPU: resource.MustParse("1000"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 1000,
+			wantLimit:   -1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -295,6 +391,72 @@ func Test_GetPodBEMemoryRequest(t *testing.T) {
 			},
 			wantRequest: 0,
 			wantLimit:   -1,
+		},
+		{
+			name: "init container dominates containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("8Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("8Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 8388608,
+			wantLimit:   8388608,
+		},
+		{
+			name: "containers dominate init container",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("1Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("4Mi"),
+								},
+								Limits: corev1.ResourceList{
+									apiext.BatchMemory: resource.MustParse("6Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequest: 4194304,
+			wantLimit:   6291456,
 		},
 	}
 

--- a/pkg/util/pod_test.go
+++ b/pkg/util/pod_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -58,6 +59,87 @@ func Test_GetCPUSetFromPod(t *testing.T) {
 			}
 			got, err := GetCPUSetFromPod(tt.args.podAnnotations)
 			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPodTargetExtendedResources(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want *apiext.ExtendedResourceSpec
+	}{
+		{
+			name: "nil pod returns nil",
+			pod:  nil,
+			want: nil,
+		},
+		{
+			name: "only regular containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+								Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+							},
+						},
+					},
+				},
+			},
+			want: &apiext.ExtendedResourceSpec{
+				Containers: map[string]apiext.ExtendedResourceContainerSpec{
+					"main": {
+						Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+						Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+					},
+				},
+			},
+		},
+		{
+			name: "init container is included",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("500")},
+								Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("500")},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+								Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+							},
+						},
+					},
+				},
+			},
+			want: &apiext.ExtendedResourceSpec{
+				Containers: map[string]apiext.ExtendedResourceContainerSpec{
+					"init": {
+						Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("500")},
+						Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("500")},
+					},
+					"main": {
+						Requests: corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+						Limits:   corev1.ResourceList{apiext.BatchCPU: resource.MustParse("1000")},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodTargetExtendedResources(tt.pod, apiext.BatchCPU)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/webhook/pod/mutating/extended_resource_spec.go
+++ b/pkg/webhook/pod/mutating/extended_resource_spec.go
@@ -42,9 +42,19 @@ func (h *PodMutatingHandler) mutateByExtendedResources(pod *corev1.Pod) error {
 	extendedResourceSpec := &extension.ExtendedResourceSpec{}
 	containersSpec := map[string]extension.ExtendedResourceContainerSpec{}
 
-	// TODO: count init containers and pod overhead
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
+		r := getContainerExtendedResourcesRequirement(container, []corev1.ResourceName{
+			extension.BatchCPU,
+			extension.BatchMemory,
+		})
+		if r == nil {
+			continue
+		}
+		containersSpec[container.Name] = *r
+	}
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
 		r := getContainerExtendedResourcesRequirement(container, []corev1.ResourceName{
 			extension.BatchCPU,
 			extension.BatchMemory,

--- a/pkg/webhook/pod/mutating/extended_resource_spec_test.go
+++ b/pkg/webhook/pod/mutating/extended_resource_spec_test.go
@@ -137,3 +137,62 @@ func TestExtendedResourceSpecMutatingPod(t *testing.T) {
 	}
 	assert.Equal(expectPod, pod)
 }
+
+func TestExtendedResourceSpecMutatingPod_InitContainers(t *testing.T) {
+	assert := assert.New(t)
+
+	client := fake.NewClientBuilder().Build()
+	decoder := admission.NewDecoder(scheme.Scheme)
+	handler := &PodMutatingHandler{
+		Client:  client,
+		Decoder: decoder,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod-init",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init-container-a",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							extension.BatchCPU:    resource.MustParse("500"),
+							extension.BatchMemory: resource.MustParse("1Gi"),
+						},
+						Requests: corev1.ResourceList{
+							extension.BatchCPU:    resource.MustParse("500"),
+							extension.BatchMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "main-container-a",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							extension.BatchCPU:    resource.MustParse("1000"),
+							extension.BatchMemory: resource.MustParse("4Gi"),
+						},
+						Requests: corev1.ResourceList{
+							extension.BatchCPU:    resource.MustParse("1000"),
+							extension.BatchMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
+	err := handler.extendedResourceSpecMutatingPod(context.TODO(), req, pod)
+	assert.NoError(err)
+
+	spec, err := extension.GetExtendedResourceSpec(pod.Annotations)
+	assert.NoError(err)
+	assert.NotNil(spec)
+	assert.Contains(spec.Containers, "main-container-a")
+	assert.Contains(spec.Containers, "init-container-a")
+}


### PR DESCRIPTION
  ### Ⅰ. Describe what this PR does

  Four functions in `pkg/util/pod_resources_utils.go` calculated BE pod CPU and memory resources by summing only `pod.Spec.Containers`, ignoring  `pod.Spec.InitContainers`. This caused koordlet to undercount resource usage for pods with heavyweight init containers, leading to incorrect CPU suppression  thresholds and memory eviction decisions.

 The fix applies Kubernetes scheduling semantics — `max(max(init_i), sum(containers))` — to all four BE resource functions, matching the pattern already used by  `GetPodMilliCPULimit` in the same file. The same gap is fixed in `GetPodTargetExtendedResources` (pkg/util/pod.go) and `mutateByExtendedResources` (pkg/webhook/pod/mutating/extended_resource_spec.go), which also build per-container resource maps used by koordlet and the admission webhook.

  ### Ⅱ. Does this pull request fix one issue?

  fixes #2960 

  ### Ⅲ. Describe how to verify it

  ```bash
  go test ./pkg/util/... -v -run 'Test_GetPodBEMilliCPURequest|Test_GetPodBEMemoryRequest|TestGetPodTargetExtendedResources'
  go test ./pkg/webhook/pod/mutating/... -v -run TestExtendedResourceSpecMutatingPod
```
Before this fix, GetPodBEMilliCPURequest on a pod with a 4000m init container and a 100m regular container returned 100. After the fix it returns 4000. All existing tests continue to pass.

## Before fix:

<img width="1555" height="984" alt="Screenshot 2026-05-16 083651" src="https://github.com/user-attachments/assets/5480667e-8955-499f-affa-ea07f55905c7" />


<img width="1359" height="973" alt="Screenshot 2026-05-16 083818" src="https://github.com/user-attachments/assets/ee5166f9-c456-4446-9e6a-c5716fcc47eb" />

## After fix



<img width="1572" height="1042" alt="Screenshot 2026-05-16 083844" src="https://github.com/user-attachments/assets/c73f7047-60e7-45d7-8ea1-529157c13c7e" />

 ###  Ⅳ. Special notes for reviews

The init container loop pattern follows GetPodMilliCPULimit exactly: sum regular containers first, then MaxInt64(running_total, init_value) for each init  container. No behavior change for pods with no init containers.

 ###  V. Checklist- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`