### PR TITLE
rbac: add nodes/finalizers permission to koordlet

### DIFF
--- a/config/rbac/koordlet.yaml
+++ b/config/rbac/koordlet.yaml
@@ -32,6 +32,7 @@ rules:
     - nodes
     - nodes/status
     - nodes/proxy
+    - nodes/finalizers
     - pods
     - pods/status
     - persistentvolumeclaims


### PR DESCRIPTION
Title:
rbac: add nodes/finalizers permission to koordlet

Description:
This fixes #2941 by adding the missing `nodes/finalizers` permission to the koordlet ClusterRole.

Koordlet creates NodeResourceTopology and Device resources with `blockOwnerDeletion=true` owner references pointing to the host Node. Kubernetes requires access to the `nodes/finalizers` subresource for this behavior, otherwise resource creation fails with forbidden errors during resource creation.

The change is intentionally minimal and only adds the required RBAC permission.
