### PR TITLE
fix data race on Gang.HasGangInit reads

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -216,7 +216,7 @@ func (pgMgr *PodGroupManager) PreEnqueue(ctx context.Context, pod *corev1.Pod) (
 	}
 
 	// check if gang is initialized
-	if !gang.HasGangInit {
+	if !gang.hasGangInit() {
 		return fmt.Errorf("gang has not init, gangName: %v, podName: %v", gang.Name,
 			util.GetId(pod.Namespace, pod.Name))
 	}
@@ -263,7 +263,7 @@ func (pgMgr *PodGroupManager) basicGangRequirementsCheck(gang *Gang, pod *corev1
 			gangsOfGangIsNil = append(gangsOfGangIsNil, gangID)
 			continue
 		}
-		if !memberGang.HasGangInit {
+		if !memberGang.hasGangInit() {
 			gangsOfGangNotInit = append(gangsOfGangNotInit, gangID)
 			continue
 		}
@@ -304,7 +304,7 @@ func (pgMgr *PodGroupManager) BeforePreFilter(ctx context.Context, cycleState fw
 	}
 
 	// check if gang is initialized
-	if !gang.HasGangInit {
+	if !gang.hasGangInit() {
 		return fmt.Errorf("gang has not init, gangName: %v, podName: %v", gang.Name,
 			util.GetId(pod.Namespace, pod.Name))
 	}
@@ -467,7 +467,7 @@ func (pgMgr *PodGroupManager) Permit(ctx context.Context, pod *corev1.Pod) (time
 	}
 	if !allGangGroupAssumed {
 		gang.addWaitingGang()
-		return gang.WaitTime, Wait
+		return gang.getGangWaitTime(), Wait
 	}
 	return 0, Success
 }

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -739,7 +739,9 @@ func TestBeforePreFilter_SuggestionPropagation(t *testing.T) {
 				gangId := util.GetId(tt.pg.Namespace, tt.pg.Name)
 				gang := mgr.cache.getGangFromCacheByGangId(gangId, false)
 				if gang != nil {
+					gang.lock.Lock()
 					gang.HasGangInit = true
+					gang.lock.Unlock()
 				}
 			}
 			mgr.cache.onPodAdd(tt.pod)

--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -605,3 +605,9 @@ func (gang *Gang) ClearCurrentRepresentative(reason string) {
 	defer gang.lock.Unlock()
 	gang.GangGroupInfo.ClearCurrentRepresentative(reason)
 }
+
+func (gang *Gang) hasGangInit() bool {
+	gang.lock.RLock()
+	defer gang.lock.RUnlock()
+	return gang.HasGangInit
+}

--- a/pkg/scheduler/plugins/coscheduling/core/gang_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_test.go
@@ -1,12 +1,55 @@
 package core
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestGang_hasGangInit(t *testing.T) {
+	gang := NewGang("test-gang")
+
+	assert.False(t, gang.hasGangInit(), "new gang should not be initialized")
+
+	gang.lock.Lock()
+	gang.HasGangInit = true
+	gang.lock.Unlock()
+
+	assert.True(t, gang.hasGangInit(), "gang should be initialized after HasGangInit set")
+}
+
+// TestGang_hasGangInitConcurrent verifies there is no data race between concurrent
+// writers (simulating tryInitByPodConfig/tryInitByPodGroup holding lock.Lock) and
+// concurrent readers (simulating PreEnqueue/BeforePreFilter using hasGangInit).
+// Run with -race to exercise the detector.
+func TestGang_hasGangInitConcurrent(t *testing.T) {
+	gang := NewGang("test-gang-concurrent")
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	for i := 0; i < n; i++ {
+		go func(v bool) {
+			defer wg.Done()
+			gang.lock.Lock()
+			gang.HasGangInit = v
+			gang.lock.Unlock()
+		}(i%2 == 0)
+	}
+
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = gang.hasGangInit()
+		}()
+	}
+
+	wg.Wait()
+}
 
 func TestGang_getWaitingChildrenFromGang(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`Gang.HasGangInit` was written under `gang.lock.Lock()` but read directly in multiple scheduling paths without synchronization:

- `PreEnqueue`
- `basicGangRequirementsCheck`
- `BeforePreFilter`

This creates a data race between informer callbacks initializing gangs and scheduler goroutines reading gang state.

This PR adds a lock-protected accessor:

```go
func (gang *Gang) hasGangInit() bool {
    gang.lock.RLock()
    defer gang.lock.RUnlock()
    return gang.HasGangInit
}
```
and replaces all unsafe direct field reads with the accessor.

Additionally, this PR replaces the direct `gang.WaitTime` read in Permit with the existing safe accessor:
```go
gang.getGangWaitTime()
```
No functional behaviour changes are introduced; this PR only fixes synchronization correctness.

### Ⅱ. Does this pull request fix one issue?

fixes #2966 

### Ⅲ. Describe how to verify it

**Reproduce the original issue**

Run:
```bash
go test ./pkg/scheduler/plugins/coscheduling/... -race -count=20
```
Before the fix, the race detector may report concurrent read/write access on Gang.HasGangInit.

Example:

`WARNING: DATA RACE`

**Verify the fix**

Run:
```bash
go test ./pkg/scheduler/plugins/coscheduling/... -race -count=20
```
Expected result:

- no race detector warnings
- all tests pass

### Ⅳ. Special notes for reviews

- HasGangInit is a boolean field, but Go's memory model still requires synchronization for concurrent access.
- gang.WaitTime fix is included since the lock-protected accessor already existed and follows the same synchronization pattern.
- This PR only changes synchronization access patterns and does not modify scheduling logic.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
