### PR TITLE
koordlet: stabilize CPU shared pool annotations for mixed-socket nodes

### DIFF
--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology.go
@@ -773,17 +773,23 @@ func (s *nodeTopoInformer) calCPUSharePools(lsSharedPoolCPUs map[int32]*extensio
 		}
 	}
 
-	lsSharePools = covertCPUsToSharePool(lsSharedPoolCPUs)
-	beSharePools = covertCPUsToSharePool(beSharedPoolCPUs)
+	lsSharePools = convertCPUsToSharePool(lsSharedPoolCPUs)
+	beSharePools = convertCPUsToSharePool(beSharedPoolCPUs)
 	return
 }
 
-func covertCPUsToSharePool(cpuIDMap map[int32]*extension.CPUInfo) (sharePools []extension.CPUSharedPool) {
+func convertCPUsToSharePool(cpuIDMap map[int32]*extension.CPUInfo) (sharePools []extension.CPUSharedPool) {
 	// nodeID -> cpulist
 	nodeIDToCpus := make(map[int32][]int)
+	// nodeID -> socket set
+	nodeIDToSockets := make(map[int32]map[int32]struct{})
 	for cpuID, info := range cpuIDMap {
 		if info != nil {
 			nodeIDToCpus[info.Node] = append(nodeIDToCpus[info.Node], int(cpuID))
+			if nodeIDToSockets[info.Node] == nil {
+				nodeIDToSockets[info.Node] = map[int32]struct{}{}
+			}
+			nodeIDToSockets[info.Node][info.Socket] = struct{}{}
 		}
 	}
 
@@ -791,19 +797,28 @@ func covertCPUsToSharePool(cpuIDMap map[int32]*extension.CPUInfo) (sharePools []
 		if len(cpus) <= 0 {
 			continue
 		}
+		sort.Ints(cpus)
+
+		// Shared pools are node-scoped. Use the socket only when all CPUs in the node pool
+		// belong to the same socket; otherwise keep it as -1 to avoid unstable/misleading data.
+		socket := int32(-1)
+		if sockets := nodeIDToSockets[nodeID]; len(sockets) == 1 {
+			for s := range sockets {
+				socket = s
+			}
+		}
 		set := cpuset.NewCPUSet(cpus...)
 		sharePools = append(sharePools, extension.CPUSharedPool{
 			CPUSet: set.String(),
 			Node:   nodeID,
-			Socket: cpuIDMap[int32(cpus[0])].Socket,
+			Socket: socket,
 		})
 	}
 	sort.Slice(sharePools, func(i, j int) bool {
-		iPool := sharePools[i]
-		jPool := sharePools[j]
-		iID := int(iPool.Socket)<<32 | int(iPool.Node)
-		jID := int(jPool.Socket)<<32 | int(jPool.Node)
-		return iID < jID
+		if sharePools[i].Node != sharePools[j].Node {
+			return sharePools[i].Node < sharePools[j].Node
+		}
+		return sharePools[i].Socket < sharePools[j].Socket
 	})
 	return
 }

--- a/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
+++ b/pkg/koordlet/statesinformer/impl/states_noderesourcetopology_test.go
@@ -3763,3 +3763,37 @@ func Test_nodeTopoInformer_getNodeKubeletReservedResources(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertCPUsToSharePool(t *testing.T) {
+	t.Run("uses unique socket for single-socket node pool", func(t *testing.T) {
+		cpuIDMap := map[int32]*extension.CPUInfo{
+			1: {ID: 1, Node: 0, Socket: 2},
+			0: {ID: 0, Node: 0, Socket: 2},
+			3: {ID: 3, Node: 1, Socket: 3},
+			2: {ID: 2, Node: 1, Socket: 3},
+		}
+
+		got := convertCPUsToSharePool(cpuIDMap)
+		want := []extension.CPUSharedPool{
+			{Socket: 2, Node: 0, CPUSet: "0-1"},
+			{Socket: 3, Node: 1, CPUSet: "2-3"},
+		}
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("uses unknown socket for node pool spanning multiple sockets and stays stable", func(t *testing.T) {
+		cpuIDMap := map[int32]*extension.CPUInfo{
+			3: {ID: 3, Node: 0, Socket: 3},
+			1: {ID: 1, Node: 0, Socket: 1},
+			2: {ID: 2, Node: 0, Socket: 2},
+			0: {ID: 0, Node: 0, Socket: 0},
+		}
+
+		want := []extension.CPUSharedPool{{Socket: -1, Node: 0, CPUSet: "0-3"}}
+		for i := 0; i < 100; i++ {
+			got := convertCPUsToSharePool(cpuIDMap)
+			assert.Equal(t, want, got)
+		}
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The node topology informer builds shared CPU pools per NUMA node, but it
previously picked the pool socket from the first CPU in the node's CPU
list. Since that list comes from map iteration, the chosen socket could
change across reconciliations when CPUs in the same node report
different socket IDs.

On small or irregular topologies this caused annotation churn in
NodeResourceTopology, especially for:

- node.koordinator.sh/cpu-shared-pools
- node.koordinator.sh/be-cpu-shared-pools

Fix it by making shared pool generation deterministic:
- sort CPU IDs before building the cpuset
- track all sockets seen in a node-scoped pool
- use the socket only when it is unique
- otherwise set socket to -1 for mixed-socket/undefined node pools
- sort the resulting pools for stable JSON output

Also add tests covering both single-socket and mixed-socket cases.

### Ⅱ. Does this pull request fix one issue?

fixes #2942 

### Ⅲ. Describe how to verify it
Before the change, if you run `k get noderesourcetopologies -w` you'll see the high frequency of updates (~n/2 per second for a cluster with n nodes). After updating koordlet's image, the same command won't show that frequency. Actually, no unnecessary updates will happen on node resource topologies.

The output of lscpu on one of our worker nodes:
```
Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          40 bits physical, 48 bits virtual
  Byte Order:             Little Endian
CPU(s):                   4
  On-line CPU(s) list:    0-3
Vendor ID:                GenuineIntel
  Model name:             Intel Xeon Processor (Cascadelake)
    CPU family:           6
    Model:                85
    Thread(s) per core:   1
    Core(s) per socket:   1
    Socket(s):            4
    Stepping:             6
    BogoMIPS:             5786.39
    Flags:                ...
Virtualization features:
  Virtualization:         VT-x
  Hypervisor vendor:      KVM
  Virtualization type:    full
Caches (sum of all): ...
NUMA:
  NUMA node(s):           1
  NUMA node0 CPU(s):      0-3
Vulnerabilities: ...
  ```
  
The output of `lscpu -e=CPU,NODE,SOCKET,CORE,CACHE,ONLINE` on the same node:
```
  CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
  0    0      0    0 0:0:0:0          yes
  1    0      1    1 1:1:1:1          yes
  2    0      2    2 2:2:2:2          yes
  3    0      3    3 3:3:3:3          yes
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
