### PR TITLE
[scheduler] implement queueing hints for core plugins

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -80,6 +80,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {
@@ -136,6 +138,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -216,6 +220,8 @@ type ReservationArgs struct {
 	// PreAllocationConfig defines the configuration for pre-allocation feature.
 	// +optional
 	PreAllocationConfig *PreAllocationConfig
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // PreAllocationConfig defines the configuration for pre-allocation feature.
@@ -340,6 +346,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -80,6 +80,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {
@@ -136,6 +138,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -231,6 +235,8 @@ type ReservationArgs struct {
 	// instead of scanning every node that owns reservations.
 	// +optional
 	ReservationSelectorIndex *ReservationSelectorIndexArgs
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // ReservationSelectorIndexArgs configures the reservationSelector white-list
@@ -381,6 +387,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint bool
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -122,6 +122,9 @@ func SetDefaults_LoadAwareSchedulingArgs(obj *LoadAwareSchedulingArgs) {
 			}
 		}
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 // SetDefaults_NodeNUMAResourceArgs sets the default parameters for NodeNUMANodeResource plugin.
@@ -160,6 +163,9 @@ func SetDefaults_NodeNUMAResourceArgs(obj *NodeNUMAResourceArgs) {
 			},
 		}
 	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
+	}
 }
 
 func SetDefaults_ReservationArgs(obj *ReservationArgs) {
@@ -183,6 +189,9 @@ func SetDefaults_ReservationArgs(obj *ReservationArgs) {
 	}
 	if obj.ResyncIntervalSeconds == 0 {
 		obj.ResyncIntervalSeconds = *defaultResyncIntervalSeconds
+	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
 	}
 }
 
@@ -278,6 +287,9 @@ func SetDefaults_DeviceShareArgs(obj *DeviceShareArgs) {
 	}
 	if obj.GPUSharedResourceTemplatesConfig == nil {
 		obj.GPUSharedResourceTemplatesConfig = defaultGPUSharedResourceTemplatesConfig
+	}
+	if obj.EnableQueueHint == nil {
+		obj.EnableQueueHint = defaultEnableQueueHint
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -79,6 +79,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName `json:"supportedResources,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {
@@ -131,6 +133,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy `json:"numaScoringStrategy,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -211,6 +215,8 @@ type ReservationArgs struct {
 	// PreAllocationConfig defines the configuration for pre-allocation feature.
 	// +optional
 	PreAllocationConfig *PreAllocationConfig `json:"preAllocationConfig,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // PreAllocationConfig defines the configuration for pre-allocation feature.
@@ -339,6 +345,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel `json:"gpuShareUnsupportedModels,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/v1/types.go
+++ b/pkg/scheduler/apis/config/v1/types.go
@@ -79,6 +79,8 @@ type LoadAwareSchedulingArgs struct {
 	// and only set up in custom node annotations,
 	// we should pass these resource names in plugin args explicitly.
 	SupportedResources []corev1.ResourceName `json:"supportedResources,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 type LoadAwareSchedulingAggregatedArgs struct {
@@ -131,6 +133,8 @@ type NodeNUMAResourceArgs struct {
 	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 	// NUMAScoringStrategy is used to configure the scoring strategy of the NUMANode-level
 	NUMAScoringStrategy *ScoringStrategy `json:"numaScoringStrategy,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // CPUBindPolicy defines the CPU binding policy
@@ -227,6 +231,8 @@ type ReservationArgs struct {
 	// enumerate the candidate nodes that hold any matching reservation.
 	// +optional
 	ReservationSelectorIndex *ReservationSelectorIndexArgs `json:"reservationSelectorIndex,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // ReservationSelectorIndexArgs configures the reservationSelector white-list
@@ -374,6 +380,8 @@ type DeviceShareArgs struct {
 	// GPUShareUnsupportedModels lists GPU vendor-model pairs that do not support GPU sharing (e.g. vNPU).
 	// Pods requesting gpu.shared resources will be filtered out from nodes matching any of these models.
 	GPUShareUnsupportedModels []GPUShareUnsupportedModel `json:"gpuShareUnsupportedModels,omitempty"`
+	// EnableQueueHint if true, enables QueueHint optimization to filter unnecessary pod re-queuing events.
+	EnableQueueHint *bool `json:"enableQueueHint,omitempty"`
 }
 
 // GPUShareUnsupportedModel identifies a GPU model that does not support GPU sharing.

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -256,6 +256,9 @@ func autoConvert_v1_DeviceShareArgs_To_config_DeviceShareArgs(in *DeviceShareArg
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*config.GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]config.GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -270,6 +273,9 @@ func autoConvert_config_DeviceShareArgs_To_v1_DeviceShareArgs(in *config.DeviceS
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -491,6 +497,9 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -526,6 +535,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -538,6 +550,9 @@ func autoConvert_v1_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in *Node
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (*github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy vs string)
 	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -545,6 +560,9 @@ func autoConvert_config_NodeNUMAResourceArgs_To_v1_NodeNUMAResourceArgs(in *conf
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (string vs *github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy)
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -612,6 +630,9 @@ func autoConvert_v1_ReservationArgs_To_config_ReservationArgs(in *ReservationArg
 	out.DisableGarbageCollection = in.DisableGarbageCollection
 	out.ResyncIntervalSeconds = in.ResyncIntervalSeconds
 	out.PreAllocationConfig = (*config.PreAllocationConfig)(unsafe.Pointer(in.PreAllocationConfig))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -638,6 +659,9 @@ func autoConvert_config_ReservationArgs_To_v1_ReservationArgs(in *config.Reserva
 	out.DisableGarbageCollection = in.DisableGarbageCollection
 	out.ResyncIntervalSeconds = in.ResyncIntervalSeconds
 	out.PreAllocationConfig = (*PreAllocationConfig)(unsafe.Pointer(in.PreAllocationConfig))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -266,6 +266,9 @@ func autoConvert_v1_DeviceShareArgs_To_config_DeviceShareArgs(in *DeviceShareArg
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*config.GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]config.GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -280,6 +283,9 @@ func autoConvert_config_DeviceShareArgs_To_v1_DeviceShareArgs(in *config.DeviceS
 	out.DisableDeviceNUMATopologyAlignment = in.DisableDeviceNUMATopologyAlignment
 	out.GPUSharedResourceTemplatesConfig = (*GPUSharedResourceTemplatesConfig)(unsafe.Pointer(in.GPUSharedResourceTemplatesConfig))
 	out.GPUShareUnsupportedModels = *(*[]GPUShareUnsupportedModel)(unsafe.Pointer(&in.GPUShareUnsupportedModels))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -501,6 +507,9 @@ func autoConvert_v1_LoadAwareSchedulingArgs_To_config_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -536,6 +545,9 @@ func autoConvert_config_LoadAwareSchedulingArgs_To_v1_LoadAwareSchedulingArgs(in
 		out.Aggregated = nil
 	}
 	out.SupportedResources = *(*[]corev1.ResourceName)(unsafe.Pointer(&in.SupportedResources))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -548,6 +560,9 @@ func autoConvert_v1_NodeNUMAResourceArgs_To_config_NodeNUMAResourceArgs(in *Node
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (*github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy vs string)
 	out.ScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*config.ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -555,6 +570,9 @@ func autoConvert_config_NodeNUMAResourceArgs_To_v1_NodeNUMAResourceArgs(in *conf
 	// WARNING: in.DefaultCPUBindPolicy requires manual conversion: inconvertible types (string vs *github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config/v1.CPUBindPolicy)
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
 	out.NUMAScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(in.NUMAScoringStrategy))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -625,6 +643,9 @@ func autoConvert_v1_ReservationArgs_To_config_ReservationArgs(in *ReservationArg
 	out.IgnoredResources = *(*[]string)(unsafe.Pointer(&in.IgnoredResources))
 	out.IgnoredResourceGroups = *(*[]string)(unsafe.Pointer(&in.IgnoredResourceGroups))
 	out.ReservationSelectorIndex = (*config.ReservationSelectorIndexArgs)(unsafe.Pointer(in.ReservationSelectorIndex))
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -654,6 +675,9 @@ func autoConvert_config_ReservationArgs_To_v1_ReservationArgs(in *config.Reserva
 	out.IgnoredResources = *(*[]string)(unsafe.Pointer(&in.IgnoredResources))
 	out.IgnoredResourceGroups = *(*[]string)(unsafe.Pointer(&in.IgnoredResourceGroups))
 	out.ReservationSelectorIndex = (*ReservationSelectorIndexArgs)(unsafe.Pointer(in.ReservationSelectorIndex))
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.EnableQueueHint, &out.EnableQueueHint, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *DeviceShareArgs) DeepCopyInto(out *DeviceShareArgs) {
 		*out = make([]GPUShareUnsupportedModel, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -370,6 +375,11 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 		*out = make([]corev1.ResourceName, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -409,6 +419,11 @@ func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 		in, out := &in.NUMAScoringStrategy, &out.NUMAScoringStrategy
 		*out = new(ScoringStrategy)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -506,6 +521,11 @@ func (in *ReservationArgs) DeepCopyInto(out *ReservationArgs) {
 	if in.PreAllocationConfig != nil {
 		in, out := &in.PreAllocationConfig, &out.PreAllocationConfig
 		*out = new(PreAllocationConfig)
+		**out = **in
+	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *DeviceShareArgs) DeepCopyInto(out *DeviceShareArgs) {
 		*out = make([]GPUShareUnsupportedModel, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -370,6 +375,11 @@ func (in *LoadAwareSchedulingArgs) DeepCopyInto(out *LoadAwareSchedulingArgs) {
 		*out = make([]corev1.ResourceName, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -409,6 +419,11 @@ func (in *NodeNUMAResourceArgs) DeepCopyInto(out *NodeNUMAResourceArgs) {
 		in, out := &in.NUMAScoringStrategy, &out.NUMAScoringStrategy
 		*out = new(ScoringStrategy)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -522,6 +537,11 @@ func (in *ReservationArgs) DeepCopyInto(out *ReservationArgs) {
 		in, out := &in.ReservationSelectorIndex, &out.ReservationSelectorIndex
 		*out = new(ReservationSelectorIndexArgs)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.EnableQueueHint != nil {
+		in, out := &in.EnableQueueHint, &out.EnableQueueHint
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -110,7 +110,8 @@ func New(_ context.Context, obj runtime.Object, handle fwktype.Handle) (fwktype.
 }
 
 func (cs *Coscheduling) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWithHint, error) {
-	// indicates that we are not interested in any events
+	// Coscheduling plugin does not benefit from QueueingHints as gang pods are managed by the controller
+	// and re-queued together. Returning nil indicates we don't register any custom events for re-queuing individual pods.
 	return nil, nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -83,6 +83,7 @@ type Plugin struct {
 	gpuSharedResourceTemplatesMatchedResources []corev1.ResourceName
 	gpuShareUnsupportedModels                  map[string]sets.Set[string]
 	scorer                                     *resourceAllocationScorer
+	enableQueueHint                            bool
 }
 
 type preFilterState struct {
@@ -180,10 +181,18 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("devices.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterDeviceChanged},
+		}
+	}
+	return events, nil
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
@@ -851,5 +860,6 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 		gpuShareUnsupportedModels:                  gpuShareUnsupportedModels,
 		scorer:                                     scorePlugin(args),
 		disableDeviceNUMATopologyAlignment:         args.DisableDeviceNUMATopologyAlignment,
+		enableQueueHint:                            args.EnableQueueHint,
 	}, nil
 }

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -83,6 +83,7 @@ type Plugin struct {
 	gpuSharedResourceTemplatesMatchedResources []corev1.ResourceName
 	gpuShareUnsupportedModels                  map[string]sets.Set[string]
 	scorer                                     *resourceAllocationScorer
+	enableQueueHint                            bool
 }
 
 type preFilterState struct {
@@ -180,10 +181,18 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("devices.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterDeviceChanged},
+		}
+	}
+	return events, nil
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
@@ -860,5 +869,6 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 		gpuShareUnsupportedModels:                  gpuShareUnsupportedModels,
 		scorer:                                     scorePlugin(args),
 		disableDeviceNUMATopologyAlignment:         args.DisableDeviceNUMATopologyAlignment,
+		enableQueueHint:                            args.EnableQueueHint,
 	}, nil
 }

--- a/pkg/scheduler/plugins/deviceshare/queueinghint.go
+++ b/pkg/scheduler/plugins/deviceshare/queueinghint.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+
+	// If the unschedulable pod doesn't require device resources, we can skip.
+	// But since PreFilter already skips if no device is needed, this pod must be one that needs devices.
+
+	// Check if the deleted pod was using any device resources.
+	// We check both annotations (allocated) and requests.
+	if hasDeviceAllocated(deletedPod) || hasDeviceRequest(deletedPod) {
+		logger.V(5).Info("Queuing pod because a pod with device resources was deleted", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func (p *Plugin) isSchedulableAfterDeviceChanged(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	originalDevice, modifiedDevice, err := schedutil.As[*schedulingv1alpha1.Device](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj or newObj to Device", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+
+	if originalDevice == nil || modifiedDevice == nil {
+		return fwktype.Queue, nil
+	}
+
+	// For Update event, check if resources increased or metadata changed significantly.
+	if isDeviceMoreSchedulable(originalDevice, modifiedDevice) {
+		logger.V(5).Info("Queuing pod because device resources became more available", "pod", klog.KObj(pod), "device", klog.KObj(modifiedDevice))
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func isDeviceMoreSchedulable(oldDevice, newDevice *schedulingv1alpha1.Device) bool {
+	// Check if any device became healthy
+	if countHealthyDevices(newDevice) > countHealthyDevices(oldDevice) {
+		return true
+	}
+	// Check if allocations decreased
+	if len(newDevice.Status.Allocations) < len(oldDevice.Status.Allocations) {
+		return true
+	}
+	return false
+}
+
+func countHealthyDevices(device *schedulingv1alpha1.Device) int {
+	count := 0
+	for _, d := range device.Spec.Devices {
+		if d.Health {
+			count++
+		}
+	}
+	return count
+}
+
+func hasDeviceAllocated(pod *corev1.Pod) bool {
+	allocations, err := apiext.GetDeviceAllocations(pod.Annotations)
+	if err != nil || len(allocations) == 0 {
+		return false
+	}
+	return true
+}
+
+func hasDeviceRequest(pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		for r := range container.Resources.Requests {
+			if isDeviceResource(r) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isDeviceResource(name corev1.ResourceName) bool {
+	_, ok := DeviceResourceFlags[name]
+	return ok
+}

--- a/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/queueinghint_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestIsSchedulableAfterPodDeletion(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name       string
+		deletedPod *corev1.Pod
+		want       fwktype.QueueingHint
+	}{
+		{
+			name: "deleted pod has no device resources",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+			},
+			want: fwktype.QueueSkip,
+		},
+		{
+			name: "deleted pod has device requests",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									apiext.ResourceGPUCore: *resource.NewQuantity(100, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "deleted pod has device allocations",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod1",
+					Annotations: map[string]string{
+						apiext.AnnotationDeviceAllocated: `{"gpu": [{"minor": 0}]}`,
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterPodDeletion(logger, nil, tt.deletedPod, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsSchedulableAfterDeviceChanged(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name   string
+		oldObj *schedulingv1alpha1.Device
+		newObj *schedulingv1alpha1.Device
+		want   fwktype.QueueingHint
+	}{
+		{
+			name:   "add device",
+			oldObj: nil,
+			newObj: &schedulingv1alpha1.Device{},
+			want:   fwktype.Queue,
+		},
+		{
+			name: "device health increased",
+			oldObj: &schedulingv1alpha1.Device{
+				Spec: schedulingv1alpha1.DeviceSpec{
+					Devices: []schedulingv1alpha1.DeviceInfo{{Health: false}},
+				},
+			},
+			newObj: &schedulingv1alpha1.Device{
+				Spec: schedulingv1alpha1.DeviceSpec{
+					Devices: []schedulingv1alpha1.DeviceInfo{{Health: true}},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "device allocations decreased",
+			oldObj: &schedulingv1alpha1.Device{
+				Status: schedulingv1alpha1.DeviceStatus{
+					Allocations: []schedulingv1alpha1.DeviceAllocation{{}, {}},
+				},
+			},
+			newObj: &schedulingv1alpha1.Device{
+				Status: schedulingv1alpha1.DeviceStatus{
+					Allocations: []schedulingv1alpha1.DeviceAllocation{{}},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "irrelevant update",
+			oldObj: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "b"}},
+			},
+			newObj: &schedulingv1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "c"}},
+			},
+			want: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterDeviceChanged(logger, nil, tt.oldObj, tt.newObj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/loadaware/load_aware.go
+++ b/pkg/scheduler/plugins/loadaware/load_aware.go
@@ -70,13 +70,14 @@ var (
 )
 
 type Plugin struct {
-	handle         fwktype.Handle
-	args           *config.LoadAwareSchedulingArgs
-	vectorizer     ResourceVectorizer
-	filterProfile  *usageThresholdsFilterProfile
-	scoreWeights   ResourceVector
-	estimator      estimator.Estimator
-	podAssignCache *podAssignCache
+	handle          fwktype.Handle
+	args            *config.LoadAwareSchedulingArgs
+	vectorizer      ResourceVectorizer
+	filterProfile   *usageThresholdsFilterProfile
+	scoreWeights    ResourceVector
+	estimator       estimator.Estimator
+	podAssignCache  *podAssignCache
+	enableQueueHint bool
 }
 
 func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
@@ -114,13 +115,14 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 		scoreWeights = nil
 	}
 	return &Plugin{
-		handle:         handle,
-		args:           pluginArgs,
-		vectorizer:     vectorizer,
-		filterProfile:  NewUsageThresholdsFilterProfile(pluginArgs, vectorizer),
-		scoreWeights:   scoreWeights,
-		estimator:      estimator,
-		podAssignCache: assignCache,
+		handle:          handle,
+		args:            pluginArgs,
+		vectorizer:      vectorizer,
+		filterProfile:   NewUsageThresholdsFilterProfile(pluginArgs, vectorizer),
+		scoreWeights:    scoreWeights,
+		estimator:       estimator,
+		podAssignCache:  assignCache,
+		enableQueueHint: pluginArgs.EnableQueueHint,
 	}, nil
 }
 
@@ -130,10 +132,18 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("nodemetrics.%v.%v", slov1alpha1.GroupVersion.Version, slov1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterNodeMetricChanged},
+		}
+	}
+	return events, nil
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/loadaware/queueinghint.go
+++ b/pkg/scheduler/plugins/loadaware/queueinghint.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadaware
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+)
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+
+	// For LoadAware, we check if the deleted pod was on a node.
+	// If it was assigned, its deletion will decrease the estimated load on that node.
+	if deletedPod.Spec.NodeName != "" {
+		logger.V(5).Info("Queuing pod because a pod was deleted from a node", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod), "node", deletedPod.Spec.NodeName)
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func (p *Plugin) isSchedulableAfterNodeMetricChanged(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	oldMetric, newMetric, err := schedutil.As[*slov1alpha1.NodeMetric](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj or newObj to NodeMetric", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+
+	if oldMetric == nil || newMetric == nil {
+		return fwktype.Queue, nil
+	}
+
+	// If the usage decreased, the node might be schedulable now.
+	if isNodeMetricMoreSchedulable(oldMetric, newMetric) {
+		logger.V(5).Info("Queuing pod because node usage decreased", "pod", klog.KObj(pod), "node", newMetric.Name)
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func isNodeMetricMoreSchedulable(oldMetric, newMetric *slov1alpha1.NodeMetric) bool {
+	if oldMetric.Status.NodeMetric == nil || newMetric.Status.NodeMetric == nil {
+		return true
+	}
+	for res, newVal := range newMetric.Status.NodeMetric.NodeUsage.ResourceList {
+		oldVal, ok := oldMetric.Status.NodeMetric.NodeUsage.ResourceList[res]
+		if !ok || newVal.Cmp(oldVal) < 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/scheduler/plugins/loadaware/queueinghint_test.go
+++ b/pkg/scheduler/plugins/loadaware/queueinghint_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadaware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	slov1alpha1 "github.com/koordinator-sh/koordinator/apis/slo/v1alpha1"
+)
+
+func TestIsSchedulableAfterPodDeletion(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name       string
+		deletedPod *corev1.Pod
+		want       fwktype.QueueingHint
+	}{
+		{
+			name: "deleted pod not assigned",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+			},
+			want: fwktype.QueueSkip,
+		},
+		{
+			name: "deleted pod assigned to node",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+				Spec:       corev1.PodSpec{NodeName: "node1"},
+			},
+			want: fwktype.Queue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterPodDeletion(logger, nil, tt.deletedPod, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsSchedulableAfterNodeMetricChanged(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name      string
+		oldMetric *slov1alpha1.NodeMetric
+		newMetric *slov1alpha1.NodeMetric
+		want      fwktype.QueueingHint
+	}{
+		{
+			name:      "add NodeMetric",
+			oldMetric: nil,
+			newMetric: &slov1alpha1.NodeMetric{},
+			want:      fwktype.Queue,
+		},
+		{
+			name: "usage decreased",
+			oldMetric: &slov1alpha1.NodeMetric{
+				Status: slov1alpha1.NodeMetricStatus{
+					NodeMetric: &slov1alpha1.NodeMetricInfo{
+						NodeUsage: slov1alpha1.ResourceMap{
+							ResourceList: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			newMetric: &slov1alpha1.NodeMetric{
+				Status: slov1alpha1.NodeMetricStatus{
+					NodeMetric: &slov1alpha1.NodeMetricInfo{
+						NodeUsage: slov1alpha1.ResourceMap{
+							ResourceList: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(5, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "usage increased",
+			oldMetric: &slov1alpha1.NodeMetric{
+				Status: slov1alpha1.NodeMetricStatus{
+					NodeMetric: &slov1alpha1.NodeMetricInfo{
+						NodeUsage: slov1alpha1.ResourceMap{
+							ResourceList: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(5, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			newMetric: &slov1alpha1.NodeMetric{
+				Status: slov1alpha1.NodeMetricStatus{
+					NodeMetric: &slov1alpha1.NodeMetricInfo{
+						NodeUsage: slov1alpha1.ResourceMap{
+							ResourceList: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			want: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterNodeMetricChanged(logger, nil, tt.oldMetric, tt.newMetric)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -87,6 +87,7 @@ type Plugin struct {
 	numaScorer             *resourceAllocationScorer
 	resourceManager        ResourceManager
 	topologyOptionsManager TopologyOptionsManager
+	enableQueueHint        bool
 }
 
 type Option func(*pluginOptions)
@@ -164,6 +165,7 @@ func NewWithOptions(args runtime.Object, handle fwktype.Handle, opts ...Option) 
 		numaScorer:             numaScorer,
 		resourceManager:        options.resourceManager,
 		topologyOptionsManager: options.topologyOptionsManager,
+		enableQueueHint:        pluginArgs.EnableQueueHint,
 	}, nil
 }
 
@@ -258,10 +260,18 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("noderesourcetopologies.%v.%v", nrtv1alpha1.SchemeGroupVersion.Version, nrtv1alpha1.SchemeGroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterNRTChanged},
+		}
+	}
+	return events, nil
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -88,6 +88,7 @@ type Plugin struct {
 	numaScorer             *resourceAllocationScorer
 	resourceManager        ResourceManager
 	topologyOptionsManager TopologyOptionsManager
+	enableQueueHint        bool
 }
 
 type Option func(*pluginOptions)
@@ -165,6 +166,7 @@ func NewWithOptions(args runtime.Object, handle fwktype.Handle, opts ...Option) 
 		numaScorer:             numaScorer,
 		resourceManager:        options.resourceManager,
 		topologyOptionsManager: options.topologyOptionsManager,
+		enableQueueHint:        pluginArgs.EnableQueueHint,
 	}, nil
 }
 
@@ -258,10 +260,18 @@ func (p *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWith
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("noderesourcetopologies.%v.%v", nrtv1alpha1.SchemeGroupVersion.Version, nrtv1alpha1.SchemeGroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if p.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: p.isSchedulableAfterNRTChanged},
+		}
+	}
+	return events, nil
 }
 
 func (p *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {

--- a/pkg/scheduler/plugins/nodenumaresource/queueinghint.go
+++ b/pkg/scheduler/plugins/nodenumaresource/queueinghint.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+func (p *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+
+	// Any pod deletion might free up resources on a NUMA node.
+	// To be precise, we check if it had any resource status related to NUMA.
+	if hasNUMAResourceStatus(deletedPod) {
+		logger.V(5).Info("Queuing pod because a pod with NUMA resources was deleted", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func (p *Plugin) isSchedulableAfterNRTChanged(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	oldNRT, newNRT, err := schedutil.As[*nrtv1alpha1.NodeResourceTopology](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj or newObj to NodeResourceTopology", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+
+	if oldNRT == nil || newNRT == nil {
+		return fwktype.Queue, nil
+	}
+
+	// If available resources increased in any zone, the pod might be schedulable now.
+	if isNRTMoreSchedulable(oldNRT, newNRT) {
+		logger.V(5).Info("Queuing pod because NRT resources increased", "pod", klog.KObj(pod), "node", newNRT.Name)
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func isNRTMoreSchedulable(oldNRT, newNRT *nrtv1alpha1.NodeResourceTopology) bool {
+	for i := range newNRT.Zones {
+		newZone := &newNRT.Zones[i]
+		var oldZone *nrtv1alpha1.Zone
+		for j := range oldNRT.Zones {
+			if oldNRT.Zones[j].Name == newZone.Name {
+				oldZone = &oldNRT.Zones[j]
+				break
+			}
+		}
+		if oldZone == nil {
+			return true
+		}
+		for _, newRes := range newZone.Resources {
+			for _, oldRes := range oldZone.Resources {
+				if newRes.Name == oldRes.Name {
+					if newRes.Available.Cmp(oldRes.Available) > 0 {
+						return true
+					}
+					break
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasNUMAResourceStatus(pod *corev1.Pod) bool {
+	status, err := extension.GetResourceStatus(pod.Annotations)
+	if err != nil || status == nil {
+		return false
+	}
+	if len(status.NUMANodeResources) > 0 || status.CPUSet != "" {
+		return true
+	}
+	return false
+}

--- a/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/queueinghint_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodenumaresource
+
+import (
+	"testing"
+
+	nrtv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+)
+
+func TestIsSchedulableAfterPodDeletion(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name       string
+		deletedPod *corev1.Pod
+		want       fwktype.QueueingHint
+	}{
+		{
+			name: "deleted pod has no NUMA status",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+			},
+			want: fwktype.QueueSkip,
+		},
+		{
+			name: "deleted pod has NUMA status",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod1",
+					Annotations: map[string]string{
+						"scheduling.koordinator.sh/resource-status": `{"numaNodeResources": [{"node": 0, "resources": {"cpu": "1"}}]}`,
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterPodDeletion(logger, nil, tt.deletedPod, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsSchedulableAfterNRTChanged(t *testing.T) {
+	p := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name   string
+		oldNRT *nrtv1alpha1.NodeResourceTopology
+		newNRT *nrtv1alpha1.NodeResourceTopology
+		want   fwktype.QueueingHint
+	}{
+		{
+			name:   "add NRT",
+			oldNRT: nil,
+			newNRT: &nrtv1alpha1.NodeResourceTopology{},
+			want:   fwktype.Queue,
+		},
+		{
+			name: "resources increased",
+			oldNRT: &nrtv1alpha1.NodeResourceTopology{
+				Zones: nrtv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: nrtv1alpha1.ResourceInfoList{
+							{Name: "cpu", Available: *resource.NewQuantity(1, resource.DecimalSI)},
+						},
+					},
+				},
+			},
+			newNRT: &nrtv1alpha1.NodeResourceTopology{
+				Zones: nrtv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: nrtv1alpha1.ResourceInfoList{
+							{Name: "cpu", Available: *resource.NewQuantity(2, resource.DecimalSI)},
+						},
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "resources decreased",
+			oldNRT: &nrtv1alpha1.NodeResourceTopology{
+				Zones: nrtv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: nrtv1alpha1.ResourceInfoList{
+							{Name: "cpu", Available: *resource.NewQuantity(2, resource.DecimalSI)},
+						},
+					},
+				},
+			},
+			newNRT: &nrtv1alpha1.NodeResourceTopology{
+				Zones: nrtv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Resources: nrtv1alpha1.ResourceInfoList{
+							{Name: "cpu", Available: *resource.NewQuantity(1, resource.DecimalSI)},
+						},
+					},
+				},
+			},
+			want: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.isSchedulableAfterNRTChanged(logger, nil, tt.oldNRT, tt.newNRT)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -109,6 +109,7 @@ type Plugin struct {
 	enableLazyReservationRestore   bool
 	enableSkipReservationFitsNode  bool
 	enablePreAllocationClusterMode bool
+	enableQueueHint                bool
 }
 
 func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
@@ -156,6 +157,7 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 	if pluginArgs.PreAllocationConfig != nil && pluginArgs.PreAllocationConfig.EnableClusterMode {
 		p.enablePreAllocationClusterMode = true
 	}
+	p.enableQueueHint = pluginArgs.EnableQueueHint
 
 	return p, nil
 }
@@ -176,10 +178,18 @@ func (pl *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWit
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("reservations.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if pl.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: pl.isSchedulableAfterReservationChanged},
+		}
+	}
+	return events, nil
 }
 
 // PreFilter checks if the pod is a reserve pod. If it is, update cycle state to annotate reservation scheduling.

--- a/pkg/scheduler/plugins/reservation/plugin.go
+++ b/pkg/scheduler/plugins/reservation/plugin.go
@@ -111,6 +111,7 @@ type Plugin struct {
 	enablePreAllocationClusterMode bool
 	ignoredResources               sets.Set[string]
 	ignoredResourceGroups          sets.Set[string]
+	enableQueueHint                bool
 }
 
 func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
@@ -161,6 +162,7 @@ func New(_ context.Context, args runtime.Object, handle fwktype.Handle) (fwktype
 	if pluginArgs.PreAllocationConfig != nil && pluginArgs.PreAllocationConfig.EnableClusterMode {
 		p.enablePreAllocationClusterMode = true
 	}
+	p.enableQueueHint = pluginArgs.EnableQueueHint
 
 	return p, nil
 }
@@ -181,10 +183,18 @@ func (pl *Plugin) EventsToRegister(_ context.Context) ([]fwktype.ClusterEventWit
 	// To register a custom event, follow the naming convention at:
 	// https://github.com/kubernetes/kubernetes/blob/e1ad9bee5bba8fbe85a6bf6201379ce8b1a611b1/pkg/scheduler/eventhandlers.go#L415-L422
 	gvk := fmt.Sprintf("reservations.%v.%v", schedulingv1alpha1.GroupVersion.Version, schedulingv1alpha1.GroupVersion.Group)
-	return []fwktype.ClusterEventWithHint{
+	events := []fwktype.ClusterEventWithHint{
 		{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}},
 		{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}},
-	}, nil
+	}
+
+	if pl.enableQueueHint {
+		events = []fwktype.ClusterEventWithHint{
+			{Event: fwktype.ClusterEvent{Resource: fwktype.Pod, ActionType: fwktype.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeletion},
+			{Event: fwktype.ClusterEvent{Resource: fwktype.EventResource(gvk), ActionType: fwktype.Add | fwktype.Update | fwktype.Delete}, QueueingHintFn: pl.isSchedulableAfterReservationChanged},
+		}
+	}
+	return events, nil
 }
 
 // PreFilter checks if the pod is a reserve pod. If it is, update cycle state to annotate reservation scheduling.

--- a/pkg/scheduler/plugins/reservation/queueinghint.go
+++ b/pkg/scheduler/plugins/reservation/queueinghint.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func (pl *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	deletedPod, _, err := schedutil.As[*corev1.Pod](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj to Pod in isSchedulableAfterPodDeletion", "oldObj", oldObj)
+		return fwktype.Queue, nil
+	}
+
+	if deletedPod == nil {
+		return fwktype.Queue, nil
+	}
+
+	// Any pod deletion might free up resources for reservations or pods using reservations.
+	// To be simple, we queue if the pod was assigned to a node.
+	if deletedPod.Spec.NodeName != "" {
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func (pl *Plugin) isSchedulableAfterReservationChanged(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
+	oldRes, newRes, err := schedutil.As[*schedulingv1alpha1.Reservation](oldObj, newObj)
+	if err != nil {
+		logger.Error(err, "Failed to convert oldObj or newObj to Reservation", "oldObj", oldObj, "newObj", newObj)
+		return fwktype.Queue, nil
+	}
+
+	if oldRes == nil || newRes == nil {
+		return fwktype.Queue, nil
+	}
+
+	// 1. If a Reservation becomes Available, it might satisfy a pod's reservation affinity.
+	if oldRes.Status.Phase != newRes.Status.Phase && newRes.Status.Phase == schedulingv1alpha1.ReservationAvailable {
+		logger.V(5).Info("Queuing pod because reservation became Available", "pod", klog.KObj(pod), "reservation", klog.KObj(newRes))
+		return fwktype.Queue, nil
+	}
+
+	// 2. If allocated resources decreased, more space might be available.
+	if isReservationMoreSchedulable(oldRes, newRes) {
+		logger.V(5).Info("Queuing pod because reservation allocated resources decreased", "pod", klog.KObj(pod), "reservation", klog.KObj(newRes))
+		return fwktype.Queue, nil
+	}
+
+	return fwktype.QueueSkip, nil
+}
+
+func isReservationMoreSchedulable(oldRes, newRes *schedulingv1alpha1.Reservation) bool {
+	for resName, newVal := range newRes.Status.Allocated {
+		oldVal, ok := oldRes.Status.Allocated[resName]
+		if ok && newVal.Cmp(oldVal) < 0 {
+			return true
+		}
+	}
+	// Also check if current owners count decreased
+	if len(newRes.Status.CurrentOwners) < len(oldRes.Status.CurrentOwners) {
+		return true
+	}
+	return false
+}

--- a/pkg/scheduler/plugins/reservation/queueinghint_test.go
+++ b/pkg/scheduler/plugins/reservation/queueinghint_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+func TestIsSchedulableAfterPodDeletion(t *testing.T) {
+	pl := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name       string
+		deletedPod *corev1.Pod
+		want       fwktype.QueueingHint
+	}{
+		{
+			name: "deleted pod not assigned",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+			},
+			want: fwktype.QueueSkip,
+		},
+		{
+			name: "deleted pod assigned to node",
+			deletedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+				Spec:       corev1.PodSpec{NodeName: "node1"},
+			},
+			want: fwktype.Queue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := pl.isSchedulableAfterPodDeletion(logger, nil, tt.deletedPod, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsSchedulableAfterReservationChanged(t *testing.T) {
+	pl := &Plugin{}
+	logger := klog.Background()
+
+	tests := []struct {
+		name   string
+		oldRes *schedulingv1alpha1.Reservation
+		newRes *schedulingv1alpha1.Reservation
+		want   fwktype.QueueingHint
+	}{
+		{
+			name:   "add reservation",
+			oldRes: nil,
+			newRes: &schedulingv1alpha1.Reservation{},
+			want:   fwktype.Queue,
+		},
+		{
+			name: "reservation became available",
+			oldRes: &schedulingv1alpha1.Reservation{
+				Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+			},
+			newRes: &schedulingv1alpha1.Reservation{
+				Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationAvailable},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "allocated resources decreased",
+			oldRes: &schedulingv1alpha1.Reservation{
+				Status: schedulingv1alpha1.ReservationStatus{
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+					},
+				},
+			},
+			newRes: &schedulingv1alpha1.Reservation{
+				Status: schedulingv1alpha1.ReservationStatus{
+					Allocated: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(5, resource.DecimalSI),
+					},
+				},
+			},
+			want: fwktype.Queue,
+		},
+		{
+			name: "irrelevant update",
+			oldRes: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "b"}},
+			},
+			newRes: &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "c"}},
+			},
+			want: fwktype.QueueSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := pl.isSchedulableAfterReservationChanged(logger, nil, tt.oldRes, tt.newRes)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds SchedulerQueueingHints support for core scheduler plugins to avoid unnecessary pod re-queueing on unrelated cluster events.

Implemented queue hint handling for:

Reservation
DeviceShare
NodeNUMAResource
LoadAwareScheduling

Changes included:

added QueueingHintFn support in EventsToRegister()
added conservative filtering logic for resource-related updates
added EnableQueueHint plugin configuration
added queueing hint unit tests for all affected plugins
documented Coscheduling as an intentional no-op for queueing hints

The queueing hints now only re-queue pods when resource availability or scheduling conditions become more favorable, instead of re-queueing on every update event.

Related:

#2852
#2851