### PR TITLE
 fix: correct off-by-one bounds check in GetNPUCount

### DIFF
--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -196,11 +196,11 @@ func GetXPUCount(deviceType string) (int, error) {
 		if totalCountLine == "" {
 			return 0, fmt.Errorf("get npu count err, no total count line")
 		}
-		fidlds := strings.Fields(totalCountLine)
-		if len(fidlds) < 4 {
+		fields := strings.Fields(totalCountLine)
+		if len(fields) < 5 {
 			return 0, fmt.Errorf("get npu count err, no total count field")
 		}
-		count, err := strconv.Atoi(fidlds[4])
+		count, err := strconv.Atoi(fields[4])
 		if err != nil {
 			return 0, fmt.Errorf("get npu count err, failed to convert field to integer, %w", err)
 		}


### PR DESCRIPTION


  ### Ⅰ. Describe what this PR does

  `GetXPUCount` in `pkg/device-daemon/resource/utils.go` parses the `npu-smi info -l` output to find the total NPU count. The "Total Count"  line is split by whitespace and the count is read from index 4 (the fifth  element). The bounds guard was `if len(fields) < 4`, which only ensures four elements exist (indices 0–3); it does not protect the subsequent
  access at index 4. Any "Total Count" line with exactly four  whitespace-separated fields bypasses the guard and panics with an index  out of range. This PR fixes the guard to `< 5` and also corrects the  misspelling of the local variable (`fidlds` → `fields`).

  ### Ⅱ. Does this pull request fix one issue?

Fixes #2972 

  ### Ⅲ. Describe how to verify it

  - `pkg/device-daemon/resource/utils.go:200` was changed from   `if len(fidlds) < 4` to `if len(fields) < 5`.
  - `pkg/device-daemon/resource/utils.go:199` was changed from   `fidlds := strings.Fields(...)` to `fields := strings.Fields(...)`.
  - `pkg/device-daemon/resource/utils.go:203` was updated from `fidlds[4]`    to `fields[4]` to match the rename.
  - All checks pass: `go mod tidy`, `make fmt`, `make vet`, `make fast-test`,    `make lint`.

  ### Ⅳ. Special notes for reviews

  The only behavioral change is the stricter bounds guard. A four-field  "Total Count" line now returns the existing `"get npu count err, no total  count field"` error instead of panicking. The rename of `fidlds` to  `fields` is cosmetic and does not affect runtime behavior.

  ### V. Checklist

  - [x] I have written necessary docs and comments
  - [ ] I have added necessary unit tests and integration tests
  - [x] All checks passed in `make test`