### PR TITLE
  fix: use reservation key and message in PatchReservation log calls

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -240,10 +240,10 @@ func PatchReservation(ctx context.Context, clientset koordinatorclientset.Interf
 	patched, err := clientset.SchedulingV1alpha1().Reservations().
 		Patch(ctx, oldReservation.Name, apimachinerytypes.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		klog.V(5).InfoS("failed to patch pod", "pod", klog.KObj(oldReservation), "patch", string(patchBytes), "err", err)
+		klog.V(5).InfoS("failed to patch reservation", "reservation", klog.KObj(oldReservation), "patch", string(patchBytes), "err", err)
 		return nil, err
 	}
-	klog.V(6).InfoS("successfully patch pod", "pod", klog.KObj(oldReservation), "patch", string(patchBytes))
+	klog.V(6).InfoS("successfully patch reservation", "reservation", klog.KObj(oldReservation), "patch", string(patchBytes))
 	return patched, nil
 }
 
@@ -265,10 +265,10 @@ func PatchReservationSafe(ctx context.Context, clientset koordinatorclientset.In
 	patched, err := clientset.SchedulingV1alpha1().Reservations().
 		Patch(ctx, oldReservation.Name, apimachinerytypes.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		klog.V(5).InfoS("failed to patch pod", "pod", klog.KObj(oldReservation), "patch", string(patchBytes), "err", err)
+		klog.V(5).InfoS("failed to patch reservation", "reservation", klog.KObj(oldReservation), "patch", string(patchBytes), "err", err)
 		return nil, err
 	}
-	klog.V(6).InfoS("successfully patch pod", "pod", klog.KObj(oldReservation), "patch", string(patchBytes))
+	klog.V(6).InfoS("successfully patch reservation", "reservation", klog.KObj(oldReservation), "patch", string(patchBytes))
 	return patched, nil
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

  `PatchReservation` and `PatchReservationSafe` in `pkg/util/utils.go` were copy-pasted from `PatchPod`/`PatchPodSafe` but the log message strings and structured-log keys were never updated. Both functions logged `"failed to  patch pod"` / `"successfully patch pod"` with key `"pod"` when operating on  a `Reservation` object. This makes log-based debugging and log filtering
  misleading. This PR corrects all four call sites to use `"failed to patch  reservation"` / `"successfully patch reservation"` with key `"reservation"`.

  ### Ⅱ. Does this pull request fix one issue?

  fixes #2974 

  ### Ⅲ. Describe how to verify it

  In `pkg/util/utils.go`:
  - Line 243 (`PatchReservation` error path): changed message from `"failed to patch pod"` to `"failed to patch reservation"` and key from `"pod"` to
  `"reservation"`.
  - Line 246 (`PatchReservation` success path): changed message from `"successfully patch pod"` to `"successfully patch reservation"` and key from `"pod"` to     
  `"reservation"`.
  - Lines 268 and 271 (`PatchReservationSafe`): same corrections as above.

  ### Ⅳ. Special notes for reviews

  Only log strings and key names are changed — no logic, no control flow, no API surface.

  ### V. Checklist

  - [x] I have written necessary docs and comments
  - [ ] I have added necessary unit tests and integration tests
  - [x] All checks passed in `make test`

