### PR TITLE
  fix: correct IX and MLU log messages in GetXPUMemory

### DIFF
--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -334,12 +334,12 @@ func GetXPUMemory(deviceType string) (string, error) {
 		cmd := exec.Command(ChangeRootCmd, HostRootDir, IXSmiCmd, QueryGPUMemArgs, QuerGPUFormatArgs, QueryGPUIdArgs)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get ix memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.TrimSpace(string(output))
 		results = strings.ReplaceAll(results, " ", "")
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", results)
+		klog.Infof("GetIXMemory, end to get ix memory: %s", results)
 
 		results = strings.ReplaceAll(results, "MiB", "Mi")
 
@@ -364,7 +364,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 			ChangeRootCmd, HostRootDir, MLUCmd, QueryMLUInfoArgs))
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get mlu memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.Split(string(output), "\n")
@@ -377,7 +377,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 				break
 			}
 		}
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", realResults)
+		klog.Infof("GetMLUMemory, end to get mlu memory: %s", realResults)
 
 		realResults = fmt.Sprintf("%sMi", realResults)
 


### PR DESCRIPTION
 ### Ⅰ. Describe what this PR does

  `GetXPUMemory` in `pkg/device-daemon/resource/utils.go` was copy-pasted from the `GPU` case without updating the log and error strings in the `IX` and `MLU`  branches. Both non-GPU cases logged `"GetGPUMemory, end to get ix memory"` and  returned errors saying `"get gpu memory err"`, making IX and MLU failures indistinguishable from GPU failures in logs. This PR corrects all four affected strings to use the correct device-type prefix.

  ### Ⅱ. Does this pull request fix one issue?

  fixes #2977 

  ### Ⅲ. Describe how to verify it

  In `pkg/device-daemon/resource/utils.go` inside `GetXPUMemory`:
  - Line 337 (`case IX` error path): changed `"get gpu memory err"` → `"get ix memory err"`
  - Line 342 (`case IX` success log): changed `"GetGPUMemory, end to get ix memory"` → `"GetIXMemory, end to get ix memory"`
  - Line 367 (`case MLU` error path): changed `"get gpu memory err"` → `"get mlu memory err"`
  - Line 380 (`case MLU` success log): changed `"GetGPUMemory, end to get ix memory"` → `"GetMLUMemory, end to get mlu memory"`

  ### V. Checklist

  - [x] I have written necessary docs and comments
  - [ ] I have added necessary unit tests and integration tests
  - [x] All checks passed in `make test`