### PR TITLE
[proposal] support initContainers and sidecars in runtime hooks

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
+++ b/pkg/koordlet/runtimehooks/hooks/batchresource/batch_resource.go
@@ -136,16 +136,46 @@ func (p *plugin) SetPodCPUShares(proto protocol.HooksProtocol) error {
 	}
 
 	milliCPURequest := int64(0)
-	// TODO: count init container and pod overhead
-	for _, c := range extendedResourceSpec.Containers {
-		if c.Requests == nil {
-			continue
+	pod := podCtx.Request.Pod
+	if pod == nil {
+		for _, c := range extendedResourceSpec.Containers {
+			if c.Requests != nil {
+				containerRequest := util.GetBatchMilliCPUFromResourceList(c.Requests)
+				if containerRequest > 0 {
+					milliCPURequest += containerRequest
+				}
+			}
 		}
-		containerRequest := util.GetBatchMilliCPUFromResourceList(c.Requests)
-		if containerRequest <= 0 {
-			continue
+	} else {
+		appCPUMilliReq := int64(0)
+		sidecarCPUMilliReq := int64(0)
+		maxInitCPUMilliReq := int64(0)
+
+		for _, container := range pod.Spec.Containers {
+			if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+				if c.Requests != nil {
+					containerRequest := util.GetBatchMilliCPUFromResourceList(c.Requests)
+					if containerRequest > 0 {
+						appCPUMilliReq += containerRequest
+					}
+				}
+			}
 		}
-		milliCPURequest += containerRequest
+		for _, container := range pod.Spec.InitContainers {
+			if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+				if c.Requests != nil {
+					containerRequest := util.GetBatchMilliCPUFromResourceList(c.Requests)
+					if containerRequest > 0 {
+						if util.IsSidecarContainer(&container) {
+							sidecarCPUMilliReq += containerRequest
+						} else {
+							maxInitCPUMilliReq = util.MaxInt64(maxInitCPUMilliReq, containerRequest)
+						}
+					}
+				}
+			}
+		}
+		milliCPURequest = util.MaxInt64(maxInitCPUMilliReq, appCPUMilliReq+sidecarCPUMilliReq)
 	}
 
 	cpuShares := sysutil.MilliCPUToShares(milliCPURequest)
@@ -180,18 +210,80 @@ func (p *plugin) SetPodCFSQuota(proto protocol.HooksProtocol) error {
 	}
 
 	milliCPULimit := int64(0)
-	// TODO: count init container and pod overhead
-	for _, c := range extendedResourceSpec.Containers {
-		if c.Limits == nil {
-			milliCPULimit = -1
-			break
+	pod := podCtx.Request.Pod
+	if pod == nil {
+		for _, c := range extendedResourceSpec.Containers {
+			if c.Limits == nil {
+				milliCPULimit = -1
+				break
+			}
+			containerLimit := util.GetBatchMilliCPUFromResourceList(c.Limits)
+			if containerLimit <= 0 { // pod unlimited once a container is unlimited
+				milliCPULimit = -1
+				break
+			}
+			milliCPULimit += containerLimit
 		}
-		containerLimit := util.GetBatchMilliCPUFromResourceList(c.Limits)
-		if containerLimit <= 0 { // pod unlimited once a container is unlimited
-			milliCPULimit = -1
-			break
+	} else {
+		appCPUMilliLimit := int64(0)
+		sidecarCPUMilliLimit := int64(0)
+		maxInitCPUMilliLimit := int64(0)
+
+		for _, container := range pod.Spec.Containers {
+			if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+				if c.Limits == nil {
+					appCPUMilliLimit = -1
+					break
+				}
+				containerLimit := util.GetBatchMilliCPUFromResourceList(c.Limits)
+				if containerLimit <= 0 { // pod unlimited once a container is unlimited
+					appCPUMilliLimit = -1
+					break
+				}
+				appCPUMilliLimit += containerLimit
+			}
 		}
-		milliCPULimit += containerLimit
+
+		if appCPUMilliLimit >= 0 {
+			for _, container := range pod.Spec.InitContainers {
+				if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+					if c.Limits == nil {
+						if util.IsSidecarContainer(&container) {
+							sidecarCPUMilliLimit = -1
+							break
+						} else {
+							maxInitCPUMilliLimit = -1
+						}
+					} else {
+						containerLimit := util.GetBatchMilliCPUFromResourceList(c.Limits)
+						if containerLimit <= 0 {
+							if util.IsSidecarContainer(&container) {
+								sidecarCPUMilliLimit = -1
+								break
+							} else {
+								maxInitCPUMilliLimit = -1
+							}
+						} else {
+							if util.IsSidecarContainer(&container) {
+								if sidecarCPUMilliLimit >= 0 {
+									sidecarCPUMilliLimit += containerLimit
+								}
+							} else {
+								if maxInitCPUMilliLimit >= 0 {
+									maxInitCPUMilliLimit = util.MaxInt64(maxInitCPUMilliLimit, containerLimit)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if appCPUMilliLimit < 0 || sidecarCPUMilliLimit < 0 || maxInitCPUMilliLimit < 0 {
+			milliCPULimit = -1
+		} else {
+			milliCPULimit = util.MaxInt64(maxInitCPUMilliLimit, appCPUMilliLimit+sidecarCPUMilliLimit)
+		}
 	}
 
 	cfsQuota := sysutil.MilliCPUToQuota(milliCPULimit)
@@ -223,18 +315,80 @@ func (p *plugin) SetPodMemoryLimit(proto protocol.HooksProtocol) error {
 	}
 
 	memoryLimit := int64(0)
-	// TODO: count init container and pod overhead
-	for _, c := range extendedResourceSpec.Containers {
-		if c.Limits == nil {
-			memoryLimit = -1
-			break
+	pod := podCtx.Request.Pod
+	if pod == nil {
+		for _, c := range extendedResourceSpec.Containers {
+			if c.Limits == nil {
+				memoryLimit = -1
+				break
+			}
+			containerLimit := util.GetBatchMemoryFromResourceList(c.Limits)
+			if containerLimit <= 0 { // pod unlimited once a container is unlimited
+				memoryLimit = -1
+				break
+			}
+			memoryLimit += containerLimit
 		}
-		containerLimit := util.GetBatchMemoryFromResourceList(c.Limits)
-		if containerLimit <= 0 { // pod unlimited once a container is unlimited
-			memoryLimit = -1
-			break
+	} else {
+		appMemoryLimit := int64(0)
+		sidecarMemoryLimit := int64(0)
+		maxInitMemoryLimit := int64(0)
+
+		for _, container := range pod.Spec.Containers {
+			if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+				if c.Limits == nil {
+					appMemoryLimit = -1
+					break
+				}
+				containerLimit := util.GetBatchMemoryFromResourceList(c.Limits)
+				if containerLimit <= 0 { // pod unlimited once a container is unlimited
+					appMemoryLimit = -1
+					break
+				}
+				appMemoryLimit += containerLimit
+			}
 		}
-		memoryLimit += containerLimit
+
+		if appMemoryLimit >= 0 {
+			for _, container := range pod.Spec.InitContainers {
+				if c, ok := extendedResourceSpec.Containers[container.Name]; ok {
+					if c.Limits == nil {
+						if util.IsSidecarContainer(&container) {
+							sidecarMemoryLimit = -1
+							break
+						} else {
+							maxInitMemoryLimit = -1
+						}
+					} else {
+						containerLimit := util.GetBatchMemoryFromResourceList(c.Limits)
+						if containerLimit <= 0 {
+							if util.IsSidecarContainer(&container) {
+								sidecarMemoryLimit = -1
+								break
+							} else {
+								maxInitMemoryLimit = -1
+							}
+						} else {
+							if util.IsSidecarContainer(&container) {
+								if sidecarMemoryLimit >= 0 {
+									sidecarMemoryLimit += containerLimit
+								}
+							} else {
+								if maxInitMemoryLimit >= 0 {
+									maxInitMemoryLimit = util.MaxInt64(maxInitMemoryLimit, containerLimit)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if appMemoryLimit < 0 || sidecarMemoryLimit < 0 || maxInitMemoryLimit < 0 {
+			memoryLimit = -1
+		} else {
+			memoryLimit = util.MaxInt64(maxInitMemoryLimit, appMemoryLimit+sidecarMemoryLimit)
+		}
 	}
 
 	podCtx.Response.Resources.MemoryLimit = ptr.To[int64](memoryLimit)

--- a/pkg/koordlet/runtimehooks/hooks/coresched/helper.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/helper.go
@@ -323,13 +323,21 @@ func (p *Plugin) getAllContainerPIDs(podMeta *statesinformer.PodMeta) []*contain
 	}
 
 	// for containers
-	containerMap := make(map[string]*corev1.Container, len(pod.Spec.Containers))
+	containerMap := make(map[string]*corev1.Container, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		containerMap[container.Name] = container
+	}
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		containerMap[container.Name] = container
 	}
-	for i := range pod.Status.ContainerStatuses {
-		containerStat := &pod.Status.ContainerStatuses[i]
+
+	allContainerStatuses := make([]corev1.ContainerStatus, 0, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
+	allContainerStatuses = append(allContainerStatuses, pod.Status.InitContainerStatuses...)
+	allContainerStatuses = append(allContainerStatuses, pod.Status.ContainerStatuses...)
+
+	for _, containerStat := range allContainerStatuses {
 		if containerStat.State.Running == nil || len(containerStat.ContainerID) <= 0 {
 			klog.V(6).Infof("skip sync core sched cookie for non-running container %s/%s, ID %s, state %+v",
 				podMeta.Key(), containerStat.Name, containerStat.ContainerID, containerStat.State)
@@ -343,7 +351,7 @@ func (p *Plugin) getAllContainerPIDs(podMeta *statesinformer.PodMeta) []*contain
 			continue
 		}
 
-		containerPIDs, err := p.getNormalContainerPIDs(podMeta, containerStat)
+		containerPIDs, err := p.getNormalContainerPIDs(podMeta, &containerStat)
 		if err != nil {
 			klog.V(5).Infof("failed to get container %s PID for pod %s, err: %s",
 				container.Name, podMeta.Key(), err)

--- a/pkg/koordlet/runtimehooks/protocol/pod_context.go
+++ b/pkg/koordlet/runtimehooks/protocol/pod_context.go
@@ -73,6 +73,7 @@ type PodRequest struct {
 	Resources         *Resources // TODO: support proxy & nri mode
 	ExtendedResources *apiext.ExtendedResourceSpec
 	ContainerTaskIds  map[string][]int32
+	Pod               *corev1.Pod
 }
 
 func (p *PodRequest) FromNri(pod *api.PodSandbox) {
@@ -108,6 +109,7 @@ func (p *PodRequest) FromProxy(req *runtimeapi.PodSandboxHookRequest) {
 }
 
 func (p *PodRequest) FromReconciler(podMeta *statesinformer.PodMeta) {
+	p.Pod = podMeta.Pod
 	p.PodMeta.FromReconciler(podMeta.Pod.ObjectMeta)
 	p.Labels = podMeta.Pod.Labels
 	p.Annotations = podMeta.Pod.Annotations

--- a/pkg/koordlet/statesinformer/impl/states_pods.go
+++ b/pkg/koordlet/statesinformer/impl/states_pods.go
@@ -147,13 +147,21 @@ func (s *podsInformer) GetAllPods() []*statesinformer.PodMeta {
 
 func (s *podsInformer) getTaskIds(podMeta *statesinformer.PodMeta) {
 	pod := podMeta.Pod
-	containerMap := make(map[string]*corev1.Container, len(pod.Spec.Containers))
+	containerMap := make(map[string]*corev1.Container, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		containerMap[container.Name] = container
+	}
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		containerMap[container.Name] = container
 	}
 
-	for _, containerStat := range pod.Status.ContainerStatuses {
+	allContainerStatuses := make([]corev1.ContainerStatus, 0, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
+	allContainerStatuses = append(allContainerStatuses, pod.Status.InitContainerStatuses...)
+	allContainerStatuses = append(allContainerStatuses, pod.Status.ContainerStatuses...)
+
+	for _, containerStat := range allContainerStatuses {
 		container, exist := containerMap[containerStat.Name]
 		if !exist {
 			klog.Warningf("container %s/%s/%s lost during reconcile resctrl group", pod.Namespace,
@@ -330,11 +338,25 @@ func recordPodResourceMetrics(podMeta *statesinformer.PodMeta) {
 	}
 	pod := podMeta.Pod
 
-	// record (regular) container metrics
 	containerStatusMap := map[string]*corev1.ContainerStatus{}
+	for i := range pod.Status.InitContainerStatuses {
+		containerStatus := &pod.Status.InitContainerStatuses[i]
+		containerStatusMap[containerStatus.Name] = containerStatus
+	}
 	for i := range pod.Status.ContainerStatuses {
 		containerStatus := &pod.Status.ContainerStatuses[i]
 		containerStatusMap[containerStatus.Name] = containerStatus
+	}
+
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		containerStatus, ok := containerStatusMap[c.Name]
+		if !ok {
+			klog.V(6).Infof("skip record container resources metric, init container %s/%s/%s status not exist",
+				pod.Namespace, pod.Name, c.Name)
+			continue
+		}
+		recordContainerResourceMetrics(c, containerStatus, pod)
 	}
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -44,7 +44,14 @@ func GetPodTargetExtendedResources(pod *corev1.Pod, resourceNames ...corev1.Reso
 
 	extendedResources := GetEmptyPodExtendedResources()
 
-	// TODO: count init containers and pod overhead
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		r := GetContainerTargetExtendedResources(container, resourceNames...)
+		if r == nil {
+			continue
+		}
+		extendedResources.Containers[container.Name] = *r
+	}
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		r := GetContainerTargetExtendedResources(container, resourceNames...)
@@ -97,4 +104,9 @@ func GetCPUSetFromPod(podAnnotations map[string]string) (string, error) {
 		return "", err
 	}
 	return podAlloc.CPUSet, nil
+}
+
+func IsSidecarContainer(container *corev1.Container) bool {
+	return container != nil && container.RestartPolicy != nil &&
+		*container.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }

--- a/pkg/util/pod_resources_utils.go
+++ b/pkg/util/pod_resources_utils.go
@@ -26,24 +26,44 @@ import (
 
 func GetPodMilliCPULimit(pod *corev1.Pod) int64 {
 	podCPUMilliLimit := int64(0)
+	sidecarCPUMilliLimit := int64(0)
+	maxInitCPUMilliLimit := int64(0)
+
 	for _, container := range pod.Spec.Containers {
 		containerCPUMilliLimit := GetContainerMilliCPULimit(&container)
 		if containerCPUMilliLimit <= 0 {
-			return -1
+			podCPUMilliLimit = -1
+			break
 		}
 		podCPUMilliLimit += containerCPUMilliLimit
 	}
 	for _, container := range pod.Spec.InitContainers {
 		containerCPUMilliLimit := GetContainerMilliCPULimit(&container)
-		if containerCPUMilliLimit <= 0 {
-			return -1
+		if IsSidecarContainer(&container) {
+			if containerCPUMilliLimit <= 0 {
+				sidecarCPUMilliLimit = -1
+			} else if sidecarCPUMilliLimit >= 0 {
+				sidecarCPUMilliLimit += containerCPUMilliLimit
+			}
+		} else {
+			if containerCPUMilliLimit <= 0 {
+				maxInitCPUMilliLimit = -1
+			} else if maxInitCPUMilliLimit >= 0 {
+				maxInitCPUMilliLimit = MaxInt64(maxInitCPUMilliLimit, containerCPUMilliLimit)
+			}
 		}
-		podCPUMilliLimit = MaxInt64(podCPUMilliLimit, containerCPUMilliLimit)
 	}
-	if podCPUMilliLimit <= 0 {
+
+	if podCPUMilliLimit >= 0 && sidecarCPUMilliLimit >= 0 {
+		podCPUMilliLimit += sidecarCPUMilliLimit
+	} else {
+		podCPUMilliLimit = -1
+	}
+
+	if podCPUMilliLimit < 0 || maxInitCPUMilliLimit < 0 {
 		return -1
 	}
-	return podCPUMilliLimit
+	return MaxInt64(podCPUMilliLimit, maxInitCPUMilliLimit)
 }
 
 func GetPodRequest(pod *corev1.Pod, resourceNames ...corev1.ResourceName) corev1.ResourceList {
@@ -56,62 +76,139 @@ func GetPodRequest(pod *corev1.Pod, resourceNames ...corev1.ResourceName) corev1
 
 func GetPodBEMilliCPURequest(pod *corev1.Pod) int64 {
 	podCPUMilliReq := int64(0)
-	// TODO: count init containers and pod overhead
+	sidecarCPUMilliReq := int64(0)
+	maxInitCPUMilliReq := int64(0)
+
 	for _, container := range pod.Spec.Containers {
 		containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
-		if containerCPUMilliReq <= 0 {
-			containerCPUMilliReq = 0
+		if containerCPUMilliReq > 0 {
+			podCPUMilliReq += containerCPUMilliReq
 		}
-		podCPUMilliReq += containerCPUMilliReq
+	}
+	for _, container := range pod.Spec.InitContainers {
+		containerCPUMilliReq := GetContainerBatchMilliCPURequest(&container)
+		if IsSidecarContainer(&container) {
+			if containerCPUMilliReq > 0 {
+				sidecarCPUMilliReq += containerCPUMilliReq
+			}
+		} else {
+			if containerCPUMilliReq > 0 {
+				maxInitCPUMilliReq = MaxInt64(maxInitCPUMilliReq, containerCPUMilliReq)
+			}
+		}
 	}
 
-	return podCPUMilliReq
+	return MaxInt64(maxInitCPUMilliReq, podCPUMilliReq+sidecarCPUMilliReq)
 }
 
 func GetPodBEMilliCPULimit(pod *corev1.Pod) int64 {
 	podCPUMilliLimit := int64(0)
-	// TODO: count init containers and pod overhead
+	sidecarCPUMilliLimit := int64(0)
+	maxInitCPUMilliLimit := int64(0)
+
 	for _, container := range pod.Spec.Containers {
 		containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
 		if containerCPUMilliLimit <= 0 {
-			return -1
+			podCPUMilliLimit = -1
+			break
 		}
 		podCPUMilliLimit += containerCPUMilliLimit
 	}
-	if podCPUMilliLimit <= 0 {
+	for _, container := range pod.Spec.InitContainers {
+		containerCPUMilliLimit := GetContainerBatchMilliCPULimit(&container)
+		if IsSidecarContainer(&container) {
+			if containerCPUMilliLimit <= 0 {
+				sidecarCPUMilliLimit = -1
+			} else if sidecarCPUMilliLimit >= 0 {
+				sidecarCPUMilliLimit += containerCPUMilliLimit
+			}
+		} else {
+			if containerCPUMilliLimit <= 0 {
+				maxInitCPUMilliLimit = -1
+			} else if maxInitCPUMilliLimit >= 0 {
+				maxInitCPUMilliLimit = MaxInt64(maxInitCPUMilliLimit, containerCPUMilliLimit)
+			}
+		}
+	}
+
+	if podCPUMilliLimit >= 0 && sidecarCPUMilliLimit >= 0 {
+		podCPUMilliLimit += sidecarCPUMilliLimit
+	} else {
+		podCPUMilliLimit = -1
+	}
+
+	if podCPUMilliLimit < 0 || maxInitCPUMilliLimit < 0 {
 		return -1
 	}
-	return podCPUMilliLimit
+	return MaxInt64(podCPUMilliLimit, maxInitCPUMilliLimit)
 }
 
 func GetPodBEMemoryByteRequestIgnoreUnlimited(pod *corev1.Pod) int64 {
 	podMemoryByteRequest := int64(0)
-	// TODO: count init containers and pod overhead
+	sidecarMemoryByteRequest := int64(0)
+	maxInitMemoryByteRequest := int64(0)
+
 	for _, container := range pod.Spec.Containers {
 		containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
-		if containerMemByteRequest < 0 {
-			// consider request of unlimited container as 0
-			continue
+		if containerMemByteRequest > 0 {
+			podMemoryByteRequest += containerMemByteRequest
 		}
-		podMemoryByteRequest += containerMemByteRequest
 	}
-	return podMemoryByteRequest
+	for _, container := range pod.Spec.InitContainers {
+		containerMemByteRequest := GetContainerBatchMemoryByteRequest(&container)
+		if IsSidecarContainer(&container) {
+			if containerMemByteRequest > 0 {
+				sidecarMemoryByteRequest += containerMemByteRequest
+			}
+		} else {
+			if containerMemByteRequest > 0 {
+				maxInitMemoryByteRequest = MaxInt64(maxInitMemoryByteRequest, containerMemByteRequest)
+			}
+		}
+	}
+	return MaxInt64(maxInitMemoryByteRequest, podMemoryByteRequest+sidecarMemoryByteRequest)
 }
 
 func GetPodBEMemoryByteLimit(pod *corev1.Pod) int64 {
 	podMemoryByteLimit := int64(0)
-	// TODO: count init containers and pod overhead
+	sidecarMemoryByteLimit := int64(0)
+	maxInitMemoryByteLimit := int64(0)
+
 	for _, container := range pod.Spec.Containers {
 		containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
 		if containerMemByteLimit <= 0 {
-			return -1
+			podMemoryByteLimit = -1
+			break
 		}
 		podMemoryByteLimit += containerMemByteLimit
 	}
-	if podMemoryByteLimit <= 0 {
+	for _, container := range pod.Spec.InitContainers {
+		containerMemByteLimit := GetContainerBatchMemoryByteLimit(&container)
+		if IsSidecarContainer(&container) {
+			if containerMemByteLimit <= 0 {
+				sidecarMemoryByteLimit = -1
+			} else if sidecarMemoryByteLimit >= 0 {
+				sidecarMemoryByteLimit += containerMemByteLimit
+			}
+		} else {
+			if containerMemByteLimit <= 0 {
+				maxInitMemoryByteLimit = -1
+			} else if maxInitMemoryByteLimit >= 0 {
+				maxInitMemoryByteLimit = MaxInt64(maxInitMemoryByteLimit, containerMemByteLimit)
+			}
+		}
+	}
+
+	if podMemoryByteLimit >= 0 && sidecarMemoryByteLimit >= 0 {
+		podMemoryByteLimit += sidecarMemoryByteLimit
+	} else {
+		podMemoryByteLimit = -1
+	}
+
+	if podMemoryByteLimit < 0 || maxInitMemoryByteLimit < 0 {
 		return -1
 	}
-	return podMemoryByteLimit
+	return MaxInt64(podMemoryByteLimit, maxInitMemoryByteLimit)
 }
 
 // AddResourceList adds the resources in newList to list.

--- a/pkg/webhook/pod/mutating/extended_resource_spec.go
+++ b/pkg/webhook/pod/mutating/extended_resource_spec.go
@@ -42,7 +42,17 @@ func (h *PodMutatingHandler) mutateByExtendedResources(pod *corev1.Pod) error {
 	extendedResourceSpec := &extension.ExtendedResourceSpec{}
 	containersSpec := map[string]extension.ExtendedResourceContainerSpec{}
 
-	// TODO: count init containers and pod overhead
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		r := getContainerExtendedResourcesRequirement(container, []corev1.ResourceName{
+			extension.BatchCPU,
+			extension.BatchMemory,
+		})
+		if r == nil {
+			continue
+		}
+		containersSpec[container.Name] = *r
+	}
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		r := getContainerExtendedResourcesRequirement(container, []corev1.ResourceName{


### PR DESCRIPTION
This PR implements support for initContainers and native sidecars in runtime hooks, as proposed in issue #2115.

Key changes:
- Update core utilities to implement K8s 1.28+ sidecar resource calculation logic.
- Update pod mutating webhook to include initContainers in ExtendedResourceSpec.
- Update BatchResource runtime hook to account for sidecars in pod-level aggregate resource allocation.
- Update statesinformer and coresched hook to include initContainers in task ID collection and metric recording.

Fixes #2115