### PR TITLE
feat: add dynamic sample weighting for CPU/memory histograms

### DIFF
--- a/pkg/koordlet/prediction/predict_server.go
+++ b/pkg/koordlet/prediction/predict_server.go
@@ -156,7 +156,8 @@ func (p *peakPredictServer) training() {
 		}
 
 		// update the pod model
-		p.updateModel(uid, lastCPUUsage, lastMemoryUsage)
+		weight := p.computePodSampleWeight(pod)
+		p.updateModel(uid, lastCPUUsage, lastMemoryUsage, weight)
 
 		// update the node priority metric
 		priorityItemID := string(extension.GetPodPriorityClassWithDefault(pod))
@@ -173,7 +174,7 @@ func (p *peakPredictServer) training() {
 	if errCPU != nil || errMem != nil {
 		klog.Warningf("failed to query node cpu and memory metric, CPU err: %s, Memory err: %s", errCPU, errMem)
 	} else {
-		p.updateModel(nodeUID, lastNodeCPUUsage, lastNodeMemoryUsage)
+		p.updateModel(nodeUID, lastNodeCPUUsage, lastNodeMemoryUsage, 1.0)
 	}
 
 	// 3. update node priority models
@@ -182,10 +183,10 @@ func (p *peakPredictServer) training() {
 		priorityUID := p.uidGenerator.NodeItem(itemID)
 		metric, ok := nodeItemsMetric.GetMetric(itemID)
 		if ok {
-			p.updateModel(priorityUID, metric.LastCPUUsage, metric.LastMemoryUsage)
+			p.updateModel(priorityUID, metric.LastCPUUsage, metric.LastMemoryUsage, 1.0)
 		} else {
 			// reset the priority usage
-			p.updateModel(priorityUID, 0, 0)
+			p.updateModel(priorityUID, 0, 0, 1.0)
 		}
 	}
 
@@ -198,7 +199,7 @@ func (p *peakPredictServer) training() {
 		sysMemoryUsage = math.Max(sysMemoryUsage-allPodsMetric.LastMemoryUsage, 0)
 	}
 	systemUID := p.uidGenerator.NodeItem(SystemItemID)
-	p.updateModel(systemUID, sysCPUUsage, sysMemoryUsage)
+	p.updateModel(systemUID, sysCPUUsage, sysMemoryUsage, 1.0)
 
 	p.hasSynced.Store(true)
 }
@@ -221,7 +222,44 @@ func (p *peakPredictServer) defaultMemoryHistogram() histogram.Histogram {
 	return histogram.NewDecayingHistogram(options, p.cfg.MemoryHistogramDecayHalfLife)
 }
 
-func (p *peakPredictServer) updateModel(uid UIDType, cpu, memory float64) {
+func (p *peakPredictServer) computePodSampleWeight(pod *v1.Pod) float64 {
+	weight := 1.0
+
+	// 1. Pod QoS / Priority Class: higher priority gets higher weight baseline
+	priorityClass := extension.GetPodPriorityClassWithDefault(pod)
+	if priorityClass == extension.PriorityProd {
+		weight = 1.0
+	} else if priorityClass == extension.PriorityBatch {
+		weight = 0.8
+	} else if priorityClass == extension.PriorityFree {
+		weight = 0.5
+	} else {
+		weight = 0.9 // Default or intermediate priorities
+	}
+
+	// 2. Pod age / cold start: dampen early samples
+	now := p.clock.Now()
+	if !pod.CreationTimestamp.IsZero() {
+		age := now.Sub(pod.CreationTimestamp.Time)
+		coldStartDuration := 5 * time.Minute
+		if age < coldStartDuration && age > 0 {
+			ageWeight := float64(age) / float64(coldStartDuration)
+			if ageWeight < weight {
+				weight = ageWeight
+			}
+		}
+	}
+
+	if weight < MinSampleWeight {
+		return MinSampleWeight
+	}
+	if weight > 1.0 {
+		return 1.0
+	}
+	return weight
+}
+
+func (p *peakPredictServer) updateModel(uid UIDType, cpu, memory float64, weight float64) {
 	p.modelsLock.Lock()
 	defer p.modelsLock.Unlock()
 	model, ok := p.models[uid]
@@ -236,9 +274,8 @@ func (p *peakPredictServer) updateModel(uid UIDType, cpu, memory float64) {
 	model.Lock.Lock()
 	defer model.Lock.Unlock()
 	model.LastUpdated = now
-	// TODO Add adjusted weights
-	model.CPU.AddSample(cpu, 1, now)
-	model.Memory.AddSample(memory, 1, now)
+	model.CPU.AddSample(cpu, weight, now)
+	model.Memory.AddSample(memory, weight, now)
 }
 
 func (p *peakPredictServer) GetPrediction(metric MetricDesc) (Result, error) {

--- a/pkg/koordlet/prediction/predict_server_test.go
+++ b/pkg/koordlet/prediction/predict_server_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/koordinator-sh/koordinator/apis/extension"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
@@ -528,4 +530,95 @@ func TestDoCheckpoint_RestoreModels(t *testing.T) {
 
 	unknownUIDs := predictServer.restoreModels()
 	assert.Equal(t, 1, len(unknownUIDs), "unknown uids")
+}
+
+func TestComputePodSampleWeight(t *testing.T) {
+	fakeClock := clock.NewFakeClock(time.Now())
+	predictServer := &peakPredictServer{
+		clock: fakeClock,
+	}
+
+	testCases := []struct {
+		name           string
+		pod            *v1.Pod
+		expectedWeight float64
+	}{
+		{
+			name: "prod pod, no age",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityProd),
+					},
+				},
+			},
+			expectedWeight: 1.0,
+		},
+		{
+			name: "batch pod, no age",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityBatch),
+					},
+				},
+			},
+			expectedWeight: 0.8,
+		},
+		{
+			name: "prod pod, very new cold start",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityProd),
+					},
+					CreationTimestamp: metav1.Time{Time: fakeClock.Now().Add(-1 * time.Minute)},
+				},
+			},
+			expectedWeight: 0.2, // 1 min / 5 min
+		},
+		{
+			name: "batch pod, mid cold start",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityBatch),
+					},
+					CreationTimestamp: metav1.Time{Time: fakeClock.Now().Add(-2 * time.Minute)},
+				},
+			},
+			expectedWeight: 0.4, // 2 min / 5 min = 0.4
+		},
+		{
+			name: "prod pod, out of cold start",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityProd),
+					},
+					CreationTimestamp: metav1.Time{Time: fakeClock.Now().Add(-6 * time.Minute)},
+				},
+			},
+			expectedWeight: 1.0,
+		},
+		{
+			name: "free pod, cold start limit below MinSampleWeight",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						extension.LabelPodPriorityClass: string(extension.PriorityFree),
+					},
+					CreationTimestamp: metav1.Time{Time: fakeClock.Now().Add(-1 * time.Second)}, // very new
+				},
+			},
+			expectedWeight: MinSampleWeight, // should hit min 0.1
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			weight := predictServer.computePodSampleWeight(tc.pod)
+			assert.InDelta(t, tc.expectedWeight, weight, 0.01)
+		})
+	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds dynamic sample weighting for CPU and memory histograms in `predict_server`.

Previously, all samples were added with a fixed weight of `1.0`, which treated all workloads equally regardless of priority or pod age.

This change introduces `computePodSampleWeight` to adjust weights based on:
- workload priority,
- cold-start pod age.

Production workloads keep higher weights, while lower-priority workloads receive lower baseline weights. Newly created pods are also gradually ramped up during the first few minutes to reduce the impact of unstable startup behavior.

All weights are clamped within `[MinSampleWeight, 1.0]` to remain consistent with the existing histogram logic.

### Ⅱ. Does this pull request fix one issue?

Fixes #2975

### Ⅲ. Describe how to verify it

1. Review the added tests in:
   `pkg/koordlet/prediction/predict_server_test.go`

2. Run:
   ```bash
   go test ./pkg/koordlet/prediction -run TestComputePodSampleWeight
   ```

3. Optionally verify behavior in a local cluster with short-lived and low-priority workloads.

### Ⅳ. Special notes for reviews

- The cold-start window is currently hardcoded to 5 minutes.
- Undefined priority classes use a default baseline weight of `0.9`.

### Ⅴ. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`