### PR TITLE
fix: scheduler/deviceshare: skip phantom minors in calcFreeWithPreemptible

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -327,6 +327,13 @@ func (n *nodeDevice) calcFreeWithPreemptible(deviceType schedulingv1alpha1.Devic
 	if len(preemptible) > 0 {
 		mergedFreeDevices = make(deviceResources)
 		for minor, v := range preemptible {
+			// Skip minors absent from the device inventory. A minor present in
+			// preemptible but not in deviceTotal is a phantom entry (e.g., the
+			// device was removed after the preemptible snapshot was taken);
+			// including it would pollute mergedFreeDevices with stale capacity.
+			if _, ok := deviceTotal[minor]; !ok {
+				continue
+			}
 			used := quotav1.SubtractWithNonNegativeResult(deviceUsed[minor], v)
 			remaining := quotav1.SubtractWithNonNegativeResult(deviceTotal[minor], used)
 			if !quotav1.IsZero(remaining) {

--- a/pkg/scheduler/plugins/deviceshare/device_cache_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_test.go
@@ -236,3 +236,63 @@ func Test_nodeDevice_calcFreeWithPreemptible(t *testing.T) {
 		})
 	}
 }
+
+func Test_nodeDevice_calcFreeWithPreemptible_preemptibleCases(t *testing.T) {
+	gpu8Gi := corev1.ResourceList{apiext.ResourceGPUMemory: resource.MustParse("8Gi")}
+	gpu4Gi := corev1.ResourceList{apiext.ResourceGPUMemory: resource.MustParse("4Gi")}
+
+	tests := []struct {
+		name        string
+		deviceTotal deviceResources
+		deviceUsed  deviceResources
+		deviceFree  deviceResources
+		preemptible deviceResources
+		wantFree    deviceResources
+	}{
+		{
+			// minor 0 is in both preemptible and deviceTotal; pod using 4Gi is
+			// preemptible, so after preemption used=0 and full 8Gi is free.
+			name:        "normal preemptible minor frees used resources",
+			deviceTotal: deviceResources{0: gpu8Gi.DeepCopy()},
+			deviceUsed:  deviceResources{0: gpu4Gi.DeepCopy()},
+			deviceFree:  deviceResources{0: gpu4Gi.DeepCopy()},
+			preemptible: deviceResources{0: gpu4Gi.DeepCopy()},
+			wantFree:    deviceResources{0: gpu8Gi.DeepCopy()},
+		},
+		{
+			// minor 99 is in preemptible but absent from deviceTotal — it is a
+			// phantom entry and must not appear in the result.
+			name:        "phantom minor absent from deviceTotal is skipped",
+			deviceTotal: deviceResources{0: gpu8Gi.DeepCopy()},
+			deviceUsed:  deviceResources{0: gpu4Gi.DeepCopy()},
+			deviceFree:  deviceResources{0: gpu4Gi.DeepCopy()},
+			preemptible: deviceResources{
+				0:  gpu4Gi.DeepCopy(),
+				99: gpu8Gi.DeepCopy(), // phantom — not in deviceTotal
+			},
+			wantFree: deviceResources{0: gpu8Gi.DeepCopy()},
+		},
+		{
+			// minor 1 is in preemptible and deviceTotal but absent from
+			// deviceUsed. The preemptible pod is the sole user so after
+			// preemption used=0 and remaining=total (all 8Gi free).
+			name:        "minor absent from deviceUsed treated as zero used",
+			deviceTotal: deviceResources{0: gpu8Gi.DeepCopy(), 1: gpu8Gi.DeepCopy()},
+			deviceUsed:  deviceResources{0: gpu4Gi.DeepCopy()},
+			deviceFree:  deviceResources{0: gpu4Gi.DeepCopy()},
+			preemptible: deviceResources{1: gpu4Gi.DeepCopy()},
+			wantFree:    deviceResources{0: gpu4Gi.DeepCopy(), 1: gpu8Gi.DeepCopy()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &nodeDevice{
+				deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{schedulingv1alpha1.GPU: tt.deviceTotal},
+				deviceUsed:  map[schedulingv1alpha1.DeviceType]deviceResources{schedulingv1alpha1.GPU: tt.deviceUsed},
+				deviceFree:  map[schedulingv1alpha1.DeviceType]deviceResources{schedulingv1alpha1.GPU: tt.deviceFree},
+			}
+			got := n.calcFreeWithPreemptible(schedulingv1alpha1.GPU, tt.preemptible, nil)
+			assert.Equal(t, tt.wantFree, got)
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does


`nodeDevice.calcFreeWithPreemptible()` assumed every device minor present in `preemptible` also existed in `deviceTotal`.


However, during device churn or stale preemptible snapshots, a minor may still exist in `preemptible` even after being removed from the tracked device inventory.


Previous logic:


```go

used := quotav1.SubtractWithNonNegativeResult(deviceUsed[minor], v)

remaining := quotav1.SubtractWithNonNegativeResult(deviceTotal[minor], used)

````


This PR adds a check before calculating remaining resources:


```go

if _, ok := deviceTotal[minor]; !ok {

    continue

}

```


This ensures phantom minors are ignored instead of being processed during preemptionaware free resource calculation.


Unit tests were added for the phantom-minor scenario.

### Ⅱ. Does this pull request fix one issue?

fixes #2981 

### Ⅲ. Describe how to verify it

#### Reproduce the original issue


Run:


```bash

go test ./pkg/scheduler/plugins/deviceshare/... -run TestCalcFreeWithPreemptiblePhantomMinor -v

```


Before the fix, phantom minors are still processed during calculation.


#### Verify the fix


Run:


```bash

go test ./pkg/scheduler/plugins/deviceshare/... -race

```

### Ⅳ. Special notes for reviews


* This only affects the preemption-aware calculation path.

* Main allocation logic is unchanged.

* The fix is defensive and only skips device minors absent from the current inventory snapshot.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
