### PR TITLE
fix: correct off-by-one bounds check and typo in GetNPUCount

### DIFF
--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -196,11 +196,11 @@ func GetXPUCount(deviceType string) (int, error) {
 		if totalCountLine == "" {
 			return 0, fmt.Errorf("get npu count err, no total count line")
 		}
-		fidlds := strings.Fields(totalCountLine)
-		if len(fidlds) < 4 {
+		fields := strings.Fields(totalCountLine)
+		if len(fields) < 5 {
 			return 0, fmt.Errorf("get npu count err, no total count field")
 		}
-		count, err := strconv.Atoi(fidlds[4])
+		count, err := strconv.Atoi(fields[4])
 		if err != nil {
 			return 0, fmt.Errorf("get npu count err, failed to convert field to integer, %w", err)
 		}


### PR DESCRIPTION
## Summary
- Fixed off-by-one bounds check in `GetNPUCount` (`pkg/device-daemon/resource/utils.go`): changed `len(fidlds) < 4` to `len(fields) < 5`, since the code accesses index 4 which requires at least 5 elements. A 4-element slice previously bypassed the guard and caused an index-out-of-range panic.
- Fixed variable name typo from `fidlds` to `fields`.

Fixes #2972

## Test plan
- [ ] Verify the bounds check now correctly rejects slices with fewer than 5 elements
- [ ] Confirm no other references to the misspelled variable remain in the codebase
- [ ] Existing tests continue to pass