### PR TITLE
fix: correct log messages in GetXPUMemory for IX and MLU device types

### DIFF
--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -334,12 +334,12 @@ func GetXPUMemory(deviceType string) (string, error) {
 		cmd := exec.Command(ChangeRootCmd, HostRootDir, IXSmiCmd, QueryGPUMemArgs, QuerGPUFormatArgs, QueryGPUIdArgs)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get ix memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.TrimSpace(string(output))
 		results = strings.ReplaceAll(results, " ", "")
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", results)
+		klog.Infof("GetIXMemory, end to get ix memory: %s", results)
 
 		results = strings.ReplaceAll(results, "MiB", "Mi")
 
@@ -364,7 +364,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 			ChangeRootCmd, HostRootDir, MLUCmd, QueryMLUInfoArgs))
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get mlu memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.Split(string(output), "\n")
@@ -377,7 +377,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 				break
 			}
 		}
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", realResults)
+		klog.Infof("GetMLUMemory, end to get mlu memory: %s", realResults)
 
 		realResults = fmt.Sprintf("%sMi", realResults)
 


### PR DESCRIPTION
## Summary

- Fixed copy-paste errors in `GetXPUMemory` where the IX and MLU cases used GPU-specific log/error messages
- IX case: changed `"get gpu memory err"` to `"get ix memory err"` and `"GetGPUMemory"` to `"GetIXMemory"`
- MLU case: changed `"get gpu memory err"` to `"get mlu memory err"` and `"GetGPUMemory, end to get ix memory"` to `"GetMLUMemory, end to get mlu memory"`

Fixes #2977