### PR TITLE
koordlet: fix kubelet restart failure by setting cpu.idle at pod level

### DIFF
--- a/pkg/koordlet/runtimehooks/hooks/coresched/core_sched.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/core_sched.go
@@ -116,9 +116,10 @@ func (p *Plugin) Register(op hooks.Options) {
 	reconciler.RegisterCgroupReconciler(reconciler.SandboxLevel, sysutil.VirtualCoreSchedCookie,
 		"set core sched cookie to process groups of sandbox container specified",
 		p.SetContainerCookie, reconciler.PodQOSFilter(), podQOSConditions...)
-	// TODO: support host application
-	reconciler.RegisterCgroupReconciler(reconciler.KubeQOSLevel, sysutil.CPUIdle, "reconcile QoS level cpu idle",
-		p.SetKubeQOSCPUIdle, reconciler.NoneFilter())
+	// Register pod-level cpu.idle reconciler to avoid conflicting with kubelet's
+	// cpu.shares writes at the QoS-class root cgroup directory.
+	reconciler.RegisterCgroupReconciler(reconciler.PodLevel, sysutil.CPUIdle,
+		"reconcile pod level cpu idle", p.SetPodQOSCPUIdle, reconciler.NoneFilter())
 	p.Setup(op)
 }
 
@@ -163,6 +164,32 @@ func (p *Plugin) SetKubeQOSCPUIdle(proto protocol.HooksProtocol) error {
 		kubeQOSCtx.Response.Resources.CPUIdle = ptr.To[int64](0)
 	}
 
+	return nil
+}
+
+// SetPodQOSCPUIdle reconciles the cpu.idle setting for a pod cgroup.
+// Unlike SetKubeQOSCPUIdle which operates at the QoS-class root level,
+// this function operates at the individual pod level, which avoids conflicting
+// with kubelet's cpu.shares writes at the QoS-class root cgroup directory.
+// See: https://github.com/koordinator-sh/koordinator/issues/2732
+func (p *Plugin) SetPodQOSCPUIdle(proto protocol.HooksProtocol) error {
+	podCtx := proto.(*protocol.PodContext)
+	if podCtx == nil {
+		return fmt.Errorf("podCtx protocol is nil for plugin %s", name)
+	}
+	podQOS := extension.GetQoSClassByAttrs(podCtx.Request.Labels, podCtx.Request.Annotations)
+	if !p.rule.IsInited() {
+		klog.V(5).Infof("plugin %s has not been inited, rule inited %v, aborted to set cpu idle for QoS %s",
+			name, p.rule.IsInited(), podQOS)
+		return nil
+	}
+
+	isCPUIdle := p.rule.IsPodQOSCPUIdle(podQOS)
+	if isCPUIdle {
+		podCtx.Response.Resources.CPUIdle = ptr.To[int64](1)
+	} else {
+		podCtx.Response.Resources.CPUIdle = ptr.To[int64](0)
+	}
 	return nil
 }
 

--- a/pkg/koordlet/runtimehooks/hooks/coresched/core_sched_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/core_sched_test.go
@@ -2224,3 +2224,124 @@ func testGetEnabledPlugin() *Plugin {
 		initialized:     atomic.NewBool(true),
 	}
 }
+
+func TestPlugin_SetPodQOSCPUIdle(t *testing.T) {
+	type fields struct {
+		rule *Rule
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		arg       protocol.HooksProtocol
+		wantErr   bool
+		wantField *protocol.PodContext
+	}{
+		{
+			name:    "nil context",
+			arg:     (*protocol.PodContext)(nil),
+			wantErr: true,
+		},
+		{
+			name: "rule not inited",
+			fields: fields{
+				rule: newRule(),
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "cpu idle disabled for BE pod",
+			fields: fields{
+				rule: testGetDisabledRule(),
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUIdle: ptr.To[int64](0),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu idle enabled for BE pod",
+			fields: fields{
+				rule: testGetAllEnabledRule(),
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSBE)},
+					Annotations: map[string]string{},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUIdle: ptr.To[int64](1),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu idle not applied for LS pod",
+			fields: fields{
+				rule: testGetAllEnabledRule(),
+			},
+			arg: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSLS)},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr: false,
+			wantField: &protocol.PodContext{
+				Request: protocol.PodRequest{
+					Labels:      map[string]string{extension.LabelPodQoS: string(extension.QoSLS)},
+					Annotations: map[string]string{},
+				},
+				Response: protocol.PodResponse{
+					Resources: protocol.Resources{
+						CPUIdle: ptr.To[int64](0),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin()
+			p.rule = tt.fields.rule
+			gotErr := p.SetPodQOSCPUIdle(tt.arg)
+			assert.Equal(t, tt.wantErr, gotErr != nil, gotErr)
+			if !tt.wantErr {
+				assert.Equal(t, tt.wantField, tt.arg)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/hooks/coresched/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/rule.go
@@ -101,6 +101,19 @@ func (r *Rule) IsKubeQOSCPUIdle(KubeQOS corev1.PodQOSClass) bool {
 	return false
 }
 
+// IsPodQOSCPUIdle returns whether cpu.idle should be set for a pod based on its
+// koordinator QoS class. This is used to set cpu.idle at the pod cgroup level
+// rather than the QoS-class root level, avoiding kubelet restart failures.
+// See: https://github.com/koordinator-sh/koordinator/issues/2732
+func (r *Rule) IsPodQOSCPUIdle(podQOS extension.QoSClass) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	if val, exist := r.podQOSParams[podQOS]; exist {
+		return val.IsCPUIdle
+	}
+	return false
+}
+
 func (r *Rule) Update(ruleNew *Rule) bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -213,19 +226,6 @@ func (p *Plugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
 }
 
 func (p *Plugin) refreshForAllPods(podMetas []*statesinformer.PodMeta) error {
-	for _, kubeQOS := range []corev1.PodQOSClass{
-		corev1.PodQOSGuaranteed, corev1.PodQOSBurstable, corev1.PodQOSBestEffort} {
-		kubeQOSCtx := &protocol.KubeQOSContext{}
-		kubeQOSCtx.FromReconciler(kubeQOS)
-
-		if err := p.SetKubeQOSCPUIdle(kubeQOSCtx); err != nil {
-			klog.V(4).Infof("callback %s set cpu idle for kube qos %s failed, err: %v", name, kubeQOS, err)
-		} else {
-			kubeQOSCtx.ReconcilerDone(p.executor)
-			klog.V(5).Infof("callback %s set cpu idle for kube qos %s finished", name, kubeQOS)
-		}
-	}
-
 	sort.Slice(podMetas, func(i, j int) bool {
 		if podMetas[i].Pod == nil || podMetas[j].Pod == nil {
 			return podMetas[j].Pod == nil
@@ -241,6 +241,17 @@ func (p *Plugin) refreshForAllPods(podMetas []*statesinformer.PodMeta) error {
 		if qos := extension.QoSClass(filter.Filter(podMeta)); qos == extension.QoSSystem {
 			klog.V(6).Infof("skip refresh core sched cookie for pod %s whose QoS is SYSTEM", podMeta.Key())
 			continue
+		}
+
+		// pod-level cpu.idle: set at individual pod cgroup to avoid conflicting with
+		// kubelet's cpu.shares writes at the QoS-class root cgroup directory.
+		podCtx := &protocol.PodContext{}
+		podCtx.FromReconciler(podMeta)
+		if err := p.SetPodQOSCPUIdle(podCtx); err != nil {
+			klog.Warningf("callback %s set cpu idle for pod %s failed, err: %v", name, podMeta.Key(), err)
+		} else {
+			podCtx.ReconcilerDone(p.executor)
+			klog.V(5).Infof("callback %s set cpu idle for pod %s finished", name, podMeta.Key())
 		}
 
 		// sandbox-container-level

--- a/pkg/koordlet/runtimehooks/hooks/coresched/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/coresched/rule_test.go
@@ -994,8 +994,9 @@ func Test_ruleUpdateCb(t *testing.T) {
 				parentDirToCPUIdle: map[string]int64{
 					util.GetPodQoSRelativePath(corev1.PodQOSGuaranteed): 0,
 					util.GetPodQoSRelativePath(corev1.PodQOSBurstable):  0,
-					util.GetPodQoSRelativePath(corev1.PodQOSBestEffort): 1,
-					"kubepods.slice/kubepods-podxxxxxx.slice":           0,
+					util.GetPodQoSRelativePath(corev1.PodQOSBestEffort): 0,
+					// pod-level cpu.idle: LS pod gets 0 (LS is not cpu-idle), LSR pod skipped (failed)
+					"kubepods.slice/kubepods-podxxxxxx.slice": 0,
 				},
 			},
 		},
@@ -1824,4 +1825,80 @@ func testGetContainerCgroupParentDir(t *testing.T, podParentDir string, containe
 	dir, err := util.GetContainerCgroupParentDirByID(podParentDir, containerID)
 	assert.NoError(t, err)
 	return dir
+}
+
+func TestRule_IsPodQOSCPUIdle(t *testing.T) {
+	tests := []struct {
+		name   string
+		rule   *Rule
+		podQOS extension.QoSClass
+		want   bool
+	}{
+		{
+			name:   "uninitialized rule returns false for BE",
+			rule:   newRule(),
+			podQOS: extension.QoSBE,
+			want:   false,
+		},
+		{
+			name:   "uninitialized rule returns false for LS",
+			rule:   newRule(),
+			podQOS: extension.QoSLS,
+			want:   false,
+		},
+		{
+			name:   "disabled rule returns false for BE",
+			rule:   testGetDisabledRule(),
+			podQOS: extension.QoSBE,
+			want:   false,
+		},
+		{
+			name:   "disabled rule returns false for LS",
+			rule:   testGetDisabledRule(),
+			podQOS: extension.QoSLS,
+			want:   false,
+		},
+		{
+			name:   "all-enabled rule returns true for BE",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSBE,
+			want:   true,
+		},
+		{
+			name:   "all-enabled rule returns false for LS (LS is not cpu-idle)",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSLS,
+			want:   false,
+		},
+		{
+			name:   "all-enabled rule returns false for LSR",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSLSR,
+			want:   false,
+		},
+		{
+			name:   "all-enabled rule returns false for LSE",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSLSE,
+			want:   false,
+		},
+		{
+			name:   "all-enabled rule returns false for unknown QoS class",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSClass("unknown"),
+			want:   false,
+		},
+		{
+			name:   "all-enabled rule returns false for empty QoS class",
+			rule:   testGetAllEnabledRule(),
+			podQOS: extension.QoSClass(""),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.rule.IsPodQOSCPUIdle(tt.podQOS)
+			assert.Equal(t, tt.want, got, "IsPodQOSCPUIdle(%v)", tt.podQOS)
+		})
+	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

I ran into issue #2732 while testing CPU QoS with core scheduling. The root cause is a subtle Linux kernel constraint — when `cpu.idle=1` is set on a cgroup directory, the kernel rejects any `cpu.shares` writes to that **same directory**. 

The problem is that koordinator was setting `cpu.idle` on the **QoS-class root cgroup** (e.g. `kubepods-besteffort.slice/`), which is the exact same directory kubelet writes `cpu.shares` to during startup. So every time kubelet restarted, it crashed with:

```
Failed to start ContainerManager: failed to update top level BestEffort QOS cgroup:
failed to write "2": write .../kubepods-besteffort.slice/cpu.shares: invalid argument
```

Kernel reference: https://github.com/torvalds/linux/blob/v6.18/kernel/sched/fair.c#L13526

**The fix:** move `cpu.idle` reconciliation from the QoS-class root directory down to individual pod cgroup directories. Kubelet never writes to pod-level cgroups, so there's no conflict.

```
# Before (broken)
kubepods.slice/kubepods-besteffort.slice/cpu.idle = 1
↑ kubelet also writes cpu.shares here → EINVAL on restart

# After (fixed)  
kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podXXX.slice/cpu.idle = 1
↑ kubelet never touches this → safe
```

The scheduling behavior per-pod is identical — only the cgroup level where `cpu.idle` is applied changes.

**Changes:**
- Replaced the `KubeQOSLevel` CPUIdle reconciler with a `PodLevel` one using a new `SetPodQOSCPUIdle` handler
- Added `SetPodQOSCPUIdle()` — operates on individual pod cgroups instead of the QoS root
- Added `IsPodQOSCPUIdle()` rule method — looks up the koordinator `podQOSParams` map
- Removed the QoS-class-level `cpu.idle` loop from `refreshForAllPods()`, added per-pod reconciliation inside the existing pod loop
- `SetKubeQOSCPUIdle` is kept intact — nothing that calls it directly will break
- Uses `ptr.To[int64]()` (consistent with the rest of the file, non-deprecated)

### Ⅱ. Does this pull request fix one issue?

Fixes #2732

### Ⅲ. Describe how to verify it

1. Enable CPU QoS with `cpuPolicy: coreSched` in NodeSLO
2. Restart kubelet — should start successfully without the `invalid argument` error
3. Verify `cpu.idle` is set at pod level, not the class root:

```bash
# QoS-class root should remain 0 (untouched)
cat /sys/fs/cgroup/cpu/kubepods.slice/kubepods-besteffort.slice/cpu.idle
# expected: 0

# Individual BE pod cgroup should have cpu.idle=1
cat /sys/fs/cgroup/cpu/kubepods.slice/kubepods-besteffort.slice/<pod-cgroup>/cpu.idle
# expected: 1
```

### Ⅳ. Special notes for reviews

- `SetKubeQOSCPUIdle` is preserved — only the reconciler registration is replaced. No breaking changes.
- `IsPodQOSCPUIdle` reads from `podQOSParams` (koordinator QoS classes: LSE/LSR/LS/BE) — consistent with how `SetPodQOSCPUIdle` resolves QoS class from pod labels/annotations.
- Updated `Test_ruleUpdateCb` expectation: BestEffort root stays `0` since we no longer write `cpu.idle` there.
- Added `TestRule_IsPodQOSCPUIdle` with 10 test cases covering all QoS classes, uninitialized rules, disabled rules, and edge cases (empty/unknown QoS class).

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
