### PR TITLE
test: add E2E tests for koordlet GroupIdentity (CPU BVT) plugin

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/koordinator-sh/koordinator/test/utils/image"
 
 	// test sources
+	_ "github.com/koordinator-sh/koordinator/test/e2e/koordlet"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/quota"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/scheduling"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/slocontroller"

--- a/test/e2e/koordlet/cpuburst.go
+++ b/test/e2e/koordlet/cpuburst.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	e2enode "github.com/koordinator-sh/koordinator/test/e2e/framework/node"
+)
+
+const (
+	// cpuBurstTimeout is how long to wait for koordlet to apply the cpu.cfs_burst_us value.
+	cpuBurstTimeout = 90 * time.Second
+	cpuBurstPoll    = 5 * time.Second
+
+	// cpuLimitMillis is the CPU limit used for the test pod (200m).
+	cpuLimitMillis = 200
+
+	// cpuBurstPercent is the burst percent set in the config (1000% = 10x).
+	// cpu.cfs_burst_us = limit_cores * burstPercent/100 * cfs_period_us
+	// = 0.2 * 10 * 100000 = 200000 µs
+	cpuBurstPercentValue = 1000
+
+	// cfsPeriodUs is the standard CFS period in microseconds.
+	cfsPeriodUs = 100000
+)
+
+// expectedCFSBurstUs calculates the expected cpu.cfs_burst_us value.
+// Formula from koordlet: limit_cores * (burstPercent/100) * cfs_period_us
+func expectedCFSBurstUs(cpuMilliLimit int64, burstPercent int64) int64 {
+	limitCores := float64(cpuMilliLimit) / 1000.0
+	return int64(limitCores * float64(burstPercent) / 100.0 * cfsPeriodUs)
+}
+
+var _ = SIGDescribe("CPUBurst", func() {
+	var (
+		c              clientset.Interface
+		nodeList       *corev1.NodeList
+		err            error
+		koordNamespace string
+		sloConfigName  string
+	)
+
+	f := framework.NewDefaultFramework("cpuburst")
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		koordNamespace = framework.TestContext.KoordinatorComponentNamespace
+		sloConfigName = framework.TestContext.SLOCtrlConfigMap
+
+		framework.Logf("getting ready and schedulable nodes")
+		nodeList, err = e2enode.GetReadySchedulableNodes(c)
+		framework.ExpectNoError(err)
+		gomega.Expect(len(nodeList.Items)).NotTo(gomega.BeZero(),
+			"at least one schedulable node is required")
+	})
+
+	framework.KoordinatorDescribe("CPUBurst CFSBurstUs", func() {
+		// Test 1: LS pod gets cpu.cfs_burst_us set when CPUBurst is enabled
+		framework.ConformanceIt("should set cpu.cfs_burst_us on LS pod containers when CPUBurst is enabled", func() {
+			ginkgo.By("enabling CPUBurst in slo-controller-config")
+			rollback := ensureCPUBurstEnabled(f, c, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod with a known CPU limit")
+			pod := newCPUBurstTestPod(f.Namespace.Name, "cpuburst-ls-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for the pod to be Running")
+			waitForPodRunning(f, c, pod)
+
+			// expected: 0.2 cores * (1000/100) * 100000µs = 200000µs
+			expected := expectedCFSBurstUs(cpuLimitMillis, cpuBurstPercentValue)
+			ginkgo.By(fmt.Sprintf("verifying cpu.cfs_burst_us=%d on the container cgroup", expected))
+			verifyCFSBurstUs(f, pod, expected)
+		})
+
+		// Test 2: Disabling CPUBurst resets cpu.cfs_burst_us to 0
+		framework.ConformanceIt("should reset cpu.cfs_burst_us to 0 after CPUBurst is disabled", func() {
+			ginkgo.By("enabling CPUBurst in slo-controller-config")
+			rollback := ensureCPUBurstEnabled(f, c, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod")
+			pod := newCPUBurstTestPod(f.Namespace.Name, "cpuburst-reset-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for pod Running")
+			waitForPodRunning(f, c, pod)
+
+			expected := expectedCFSBurstUs(cpuLimitMillis, cpuBurstPercentValue)
+			ginkgo.By(fmt.Sprintf("verifying initial cpu.cfs_burst_us=%d", expected))
+			verifyCFSBurstUs(f, pod, expected)
+
+			ginkgo.By("disabling CPUBurst in slo-controller-config")
+			disableCPUBurst(f, c, koordNamespace, sloConfigName)
+
+			ginkgo.By("verifying cpu.cfs_burst_us resets to 0")
+			verifyCFSBurstUs(f, pod, 0)
+		})
+	})
+})
+
+// newCPUBurstTestPod creates a pod with a fixed CPU limit so we can calculate the expected cfs_burst_us.
+func newCPUBurstTestPod(namespace, name string, qos apiext.QoSClass) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				apiext.LabelPodQoS: string(qos),
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "stress",
+					Image:   "busybox",
+					Command: []string{"/bin/sh", "-c", "sleep 3600"},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						Limits: corev1.ResourceList{
+							// Keep this in sync with cpuLimitMillis constant above.
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// verifyCFSBurstUs execs into the pod's first container, finds its cgroup, and checks
+// that cpu.cfs_burst_us matches expectedUs. Polls for cpuBurstTimeout.
+func verifyCFSBurstUs(f *framework.Framework, pod *corev1.Pod, expectedUs int64) {
+	gomega.Eventually(func() bool {
+		// Get the cgroup path from /proc/self/cgroup.
+		cgroupOut, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", "cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3",
+		)
+		if err != nil || strings.TrimSpace(cgroupOut) == "" {
+			framework.Logf("could not read cgroup path from pod %s: %v", pod.Name, err)
+			return false
+		}
+		cgroupPath := strings.TrimSpace(cgroupOut)
+
+		// Read cpu.cfs_burst_us (cgroup v1 only).
+		burstPath := fmt.Sprintf("/sys/fs/cgroup/cpu%s/cpu.cfs_burst_us", cgroupPath)
+		burstOut, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", fmt.Sprintf("cat %s 2>/dev/null || echo NOT_SUPPORTED", burstPath),
+		)
+		if err != nil {
+			framework.Logf("error reading cpu.cfs_burst_us from pod %s: %v", pod.Name, err)
+			return false
+		}
+		val := strings.TrimSpace(burstOut)
+		framework.Logf("pod %s cpu.cfs_burst_us=%q (expected %d)", pod.Name, val, expectedUs)
+
+		if val == "NOT_SUPPORTED" {
+			ginkgo.Skip("cpu.cfs_burst_us not available on this node (cgroup v2 or kernel < 5.14)")
+			return true
+		}
+
+		got, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			framework.Logf("could not parse cpu.cfs_burst_us value %q: %v", val, err)
+			return false
+		}
+		return got == expectedUs
+	}, cpuBurstTimeout, cpuBurstPoll).Should(gomega.BeTrue(),
+		fmt.Sprintf("expected cpu.cfs_burst_us=%d for pod %s", expectedUs, pod.Name))
+}
+
+// ensureCPUBurstEnabled patches slo-controller-config to enable CPUBurst with a 1000% burst ceiling.
+// Returns a rollback function.
+func ensureCPUBurstEnabled(f *framework.Framework, c clientset.Interface, koordNamespace, sloConfigName string) func() {
+	cpuBurstEnabledData := fmt.Sprintf(`{
+  "clsCFSQuotaBurstPercent": %d,
+  "cpuBurstPercent": %d
+}`, cpuBurstPercentValue, cpuBurstPercentValue)
+
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("slo-controller-config not found, skipping CPUBurst config patch: %v", err)
+		return nil
+	}
+
+	oldData := map[string]string{}
+	if configMap.Data != nil {
+		for k, v := range configMap.Data {
+			oldData[k] = v
+		}
+	}
+
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.CPUBurstConfigKey] = cpuBurstEnabledData
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "failed to update slo-controller-config to enable CPUBurst")
+	framework.Logf("enabled CPUBurst in slo-controller-config (burstPercent=%d)", cpuBurstPercentValue)
+
+	return func() {
+		cm, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("error getting configmap for rollback: %v", err)
+			return
+		}
+		rollback := cm.DeepCopy()
+		rollback.Data = oldData
+		_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), rollback, metav1.UpdateOptions{})
+		if err != nil {
+			framework.Logf("error rolling back slo-controller-config: %v", err)
+		} else {
+			framework.Logf("rolled back slo-controller-config after CPUBurst test")
+		}
+	}
+}
+
+// disableCPUBurst patches slo-controller-config to turn off CPUBurst.
+func disableCPUBurst(f *framework.Framework, c clientset.Interface, koordNamespace, sloConfigName string) {
+	const disabledData = `{
+  "cpuBurstPercent": 0
+}`
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.CPUBurstConfigKey] = disabledData
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err)
+	framework.Logf("disabled CPUBurst in slo-controller-config")
+}

--- a/test/e2e/koordlet/doc.go
+++ b/test/e2e/koordlet/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package koordlet contains E2E tests for the koordlet component.
+// These tests validate QoS strategies applied by koordlet on individual
+// nodes: GroupIdentity (CPU BVT), CPUBurst, BECPUSuppress, etc.
+//
+// Tests in this package require a running Kubernetes cluster with
+// koordlet deployed as a DaemonSet on every node.
+package koordlet

--- a/test/e2e/koordlet/framework.go
+++ b/test/e2e/koordlet/framework.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import "github.com/onsi/ginkgo/v2"
+
+// SIGDescribe describes SIG information for koordlet e2e tests.
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[koordlet] "+text, body)
+}

--- a/test/e2e/koordlet/groupidentity.go
+++ b/test/e2e/koordlet/groupidentity.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	e2enode "github.com/koordinator-sh/koordinator/test/e2e/framework/node"
+)
+
+const (
+	// groupIdentityEnabledConfigData enables GroupIdentity (CPU BVT) for LS (+2) and BE (-1).
+	groupIdentityEnabledConfigData = `{
+  "lsClass": {
+    "cpuQOS": {
+      "enable": true,
+      "groupIdentity": 2
+    }
+  },
+  "beClass": {
+    "cpuQOS": {
+      "enable": true,
+      "groupIdentity": -1
+    }
+  }
+}`
+
+	// groupIdentityTimeout is how long to wait for koordlet to reconcile BVT values.
+	groupIdentityTimeout = 60 * time.Second
+	groupIdentityPoll    = 3 * time.Second
+)
+
+var _ = SIGDescribe("GroupIdentity", func() {
+	var (
+		c           clientset.Interface
+		koordClient koordinatorclientset.Interface
+		nodeList    *corev1.NodeList
+		err         error
+
+		koordNamespace string
+		sloConfigName  string
+	)
+
+	f := framework.NewDefaultFramework("groupidentity")
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		koordClient = f.KoordinatorClientSet
+		koordNamespace = framework.TestContext.KoordinatorComponentNamespace
+		sloConfigName = framework.TestContext.SLOCtrlConfigMap
+
+		framework.Logf("getting ready and schedulable nodes")
+		nodeList, err = e2enode.GetReadySchedulableNodes(c)
+		framework.ExpectNoError(err)
+		gomega.Expect(len(nodeList.Items)).NotTo(gomega.BeZero(),
+			"at least one schedulable node is required")
+	})
+
+	framework.KoordinatorDescribe("GroupIdentity BVT", func() {
+		// Test 1: LS pod gets BVT value +2
+		framework.ConformanceIt("should set cpu.bvt_warp_ns=2 for an LS pod when GroupIdentity is enabled", func() {
+			ginkgo.By("enabling GroupIdentity in slo-controller-config")
+			rollback := ensureGroupIdentityEnabled(f, c, koordClient, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod with koordinator QoS label")
+			pod := newGroupIdentityTestPod(f.Namespace.Name, "gi-ls-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for the pod to be Running")
+			waitForPodRunning(f, c, pod)
+
+			ginkgo.By("verifying that koordlet set cpu.bvt_warp_ns=2 on the pod's cgroup")
+			verifyPodBVTValue(f, c, pod, 2)
+		})
+
+		// Test 2: BE pod gets BVT value -1
+		framework.ConformanceIt("should set cpu.bvt_warp_ns=-1 for a BE pod when GroupIdentity is enabled", func() {
+			ginkgo.By("enabling GroupIdentity in slo-controller-config")
+			rollback := ensureGroupIdentityEnabled(f, c, koordClient, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating a BE pod with koordinator QoS label")
+			pod := newGroupIdentityTestPod(f.Namespace.Name, "gi-be-pod", apiext.QoSBE)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for the pod to be Running")
+			waitForPodRunning(f, c, pod)
+
+			ginkgo.By("verifying that koordlet set cpu.bvt_warp_ns=-1 on the pod's cgroup")
+			verifyPodBVTValue(f, c, pod, -1)
+		})
+
+		// Test 3: Disabling GroupIdentity resets BVT to 0
+		framework.ConformanceIt("should reset cpu.bvt_warp_ns to 0 after GroupIdentity is disabled", func() {
+			ginkgo.By("enabling GroupIdentity in slo-controller-config")
+			rollback := ensureGroupIdentityEnabled(f, c, koordClient, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod")
+			pod := newGroupIdentityTestPod(f.Namespace.Name, "gi-reset-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for pod Running and BVT=2")
+			waitForPodRunning(f, c, pod)
+			verifyPodBVTValue(f, c, pod, 2)
+
+			ginkgo.By("disabling GroupIdentity in slo-controller-config")
+			disableGroupIdentity(f, c, koordClient, koordNamespace, sloConfigName)
+
+			ginkgo.By("verifying that koordlet resets cpu.bvt_warp_ns to 0")
+			verifyPodBVTValue(f, c, pod, 0)
+		})
+	})
+})
+
+// newGroupIdentityTestPod creates a minimal long-running pod with the given koordinator QoS label.
+func newGroupIdentityTestPod(namespace, name string, qos apiext.QoSClass) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				apiext.LabelPodQoS: string(qos),
+			},
+		},
+		Spec: corev1.PodSpec{
+			// Use a node with koordlet running — no specific node selector needed
+			// since all nodes should have koordlet via DaemonSet.
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "sleep",
+					Image: "busybox",
+					Command: []string{
+						"/bin/sh", "-c", "sleep 3600",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// waitForPodRunning polls until the pod is in Running state.
+func waitForPodRunning(f *framework.Framework, c clientset.Interface, pod *corev1.Pod) {
+	gomega.Eventually(func() bool {
+		p, err := c.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("error getting pod %s: %v", pod.Name, err)
+			return false
+		}
+		_, podReady := k8spodutil.GetPodCondition(&p.Status, corev1.PodReady)
+		if podReady == nil || podReady.Status != corev1.ConditionTrue {
+			framework.Logf("pod %s not ready yet, phase=%s", pod.Name, p.Status.Phase)
+			return false
+		}
+		return true
+	}, 120*time.Second, 3*time.Second).Should(gomega.BeTrue(), "pod should become Running")
+}
+
+// verifyPodBVTValue exec's into the pod to read the cgroup's cpu.bvt_warp_ns file
+// and asserts it equals the expected value. Retries for groupIdentityTimeout to
+// allow koordlet's reconcile loop to run.
+func verifyPodBVTValue(f *framework.Framework, c clientset.Interface, pod *corev1.Pod, expectedBVT int) {
+	gomega.Eventually(func() bool {
+		// Read /proc/self/cgroup to find the cgroup path of the container.
+		cgroupOut, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", "cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3",
+		)
+		if err != nil || strings.TrimSpace(cgroupOut) == "" {
+			framework.Logf("could not get cgroup path from pod %s: %v", pod.Name, err)
+			return false
+		}
+		cgroupPath := strings.TrimSpace(cgroupOut)
+		framework.Logf("pod %s cgroup path: %s", pod.Name, cgroupPath)
+
+		// Read cpu.bvt_warp_ns from the cgroup directory (cgroup v1: /sys/fs/cgroup/cpu/<path>).
+		bvtPath := fmt.Sprintf("/sys/fs/cgroup/cpu%s/cpu.bvt_warp_ns", cgroupPath)
+		bvtOut, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", fmt.Sprintf("cat %s 2>/dev/null || echo NOT_SUPPORTED", bvtPath),
+		)
+		if err != nil {
+			framework.Logf("error reading bvt file from pod %s: %v", pod.Name, err)
+			return false
+		}
+		bvtStr := strings.TrimSpace(bvtOut)
+		framework.Logf("pod %s bvt value: %q (expected %d)", pod.Name, bvtStr, expectedBVT)
+
+		if bvtStr == "NOT_SUPPORTED" {
+			// cgroup v2 path or file doesn't exist — skip gracefully.
+			ginkgo.Skip("cpu.bvt_warp_ns not available on this node (cgroup v2 or Anolis kernel not present)")
+			return true
+		}
+
+		return bvtStr == fmt.Sprintf("%d", expectedBVT)
+	}, groupIdentityTimeout, groupIdentityPoll).Should(gomega.BeTrue(),
+		fmt.Sprintf("expected cpu.bvt_warp_ns=%d for pod %s", expectedBVT, pod.Name))
+}
+
+// ensureGroupIdentityEnabled patches slo-controller-config to enable GroupIdentity
+// for LS and BE classes. Returns a rollback function that restores the previous config.
+func ensureGroupIdentityEnabled(
+	f *framework.Framework,
+	c clientset.Interface,
+	koordClient koordinatorclientset.Interface,
+	koordNamespace, sloConfigName string,
+) func() {
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("slo-controller-config not found, skipping GroupIdentity config patch: %v", err)
+		return nil
+	}
+
+	oldData := map[string]string{}
+	if configMap.Data != nil {
+		for k, v := range configMap.Data {
+			oldData[k] = v
+		}
+	}
+
+	// Patch the resource QoS config key.
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.ResourceQOSConfigKey] = groupIdentityEnabledConfigData
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "failed to update slo-controller-config to enable GroupIdentity")
+	framework.Logf("enabled GroupIdentity in slo-controller-config")
+
+	// Return a rollback closure.
+	return func() {
+		cm, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("error getting configmap for rollback: %v", err)
+			return
+		}
+		rollback := cm.DeepCopy()
+		rollback.Data = oldData
+		_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), rollback, metav1.UpdateOptions{})
+		if err != nil {
+			framework.Logf("error rolling back slo-controller-config: %v", err)
+		} else {
+			framework.Logf("rolled back slo-controller-config to previous state")
+		}
+	}
+}
+
+// disableGroupIdentity patches the slo-controller-config to turn off CPU QoS.
+func disableGroupIdentity(
+	f *framework.Framework,
+	c clientset.Interface,
+	koordClient koordinatorclientset.Interface,
+	koordNamespace, sloConfigName string,
+) {
+	const disabledData = `{
+  "lsClass": {
+    "cpuQOS": {
+      "enable": false
+    }
+  },
+  "beClass": {
+    "cpuQOS": {
+      "enable": false
+    }
+  }
+}`
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.ResourceQOSConfigKey] = disabledData
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err)
+	framework.Logf("disabled GroupIdentity in slo-controller-config")
+	// koordClient retained in signature for consistency with ensureGroupIdentityEnabled
+	_ = koordClient
+}

--- a/test/e2e/koordlet/memoryqos.go
+++ b/test/e2e/koordlet/memoryqos.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	e2enode "github.com/koordinator-sh/koordinator/test/e2e/framework/node"
+)
+
+const (
+	// memoryQoSTimeout is how long to wait for koordlet to apply memory QoS cgroup values.
+	memoryQoSTimeout = 90 * time.Second
+	memoryQoSPoll    = 5 * time.Second
+
+	// wmarkRatioValue is the memory.wmark_ratio we configure (0–100).
+	// koordlet writes this directly to the cgroup file.
+	wmarkRatioValue = 95
+
+	// wmarkMinAdjBE is the memory.wmark_min_adj for BE pods (positive = raises watermark).
+	wmarkMinAdjBE = 50
+)
+
+// memoryQoSEnabledConfigData enables MemoryQoS for LS and BE pods with specific watermark settings.
+func memoryQoSEnabledConfigData() string {
+	return fmt.Sprintf(`{
+  "lsClass": {
+    "memoryQOS": {
+      "enable": true,
+      "wmarkRatio": %d
+    }
+  },
+  "beClass": {
+    "memoryQOS": {
+      "enable": true,
+      "wmarkRatio": %d,
+      "wmarkMinAdj": %d
+    }
+  }
+}`, wmarkRatioValue, wmarkRatioValue, wmarkMinAdjBE)
+}
+
+var _ = SIGDescribe("MemoryQoS", func() {
+	var (
+		c              clientset.Interface
+		nodeList       *corev1.NodeList
+		err            error
+		koordNamespace string
+		sloConfigName  string
+	)
+
+	f := framework.NewDefaultFramework("memoryqos")
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		koordNamespace = framework.TestContext.KoordinatorComponentNamespace
+		sloConfigName = framework.TestContext.SLOCtrlConfigMap
+
+		framework.Logf("getting ready and schedulable nodes")
+		nodeList, err = e2enode.GetReadySchedulableNodes(c)
+		framework.ExpectNoError(err)
+		gomega.Expect(len(nodeList.Items)).NotTo(gomega.BeZero(),
+			"at least one schedulable node is required")
+	})
+
+	framework.KoordinatorDescribe("MemoryQoS Watermarks", func() {
+		// Test 1: LS pod gets memory.wmark_ratio set by koordlet
+		framework.ConformanceIt("should set memory.wmark_ratio on an LS pod when MemoryQoS is enabled", func() {
+			ginkgo.By("enabling MemoryQoS in slo-controller-config")
+			rollback := ensureMemoryQoSEnabled(f, c, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod")
+			pod := newMemoryQoSTestPod(f.Namespace.Name, "memqos-ls-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for the pod to be Running")
+			waitForPodRunning(f, c, pod)
+
+			ginkgo.By(fmt.Sprintf("verifying memory.wmark_ratio=%d on the pod's cgroup", wmarkRatioValue))
+			verifyMemoryCgroupValue(f, pod, "memory.wmark_ratio", int64(wmarkRatioValue))
+		})
+
+		// Test 2: BE pod gets memory.wmark_min_adj set by koordlet
+		framework.ConformanceIt("should set memory.wmark_min_adj on a BE pod when MemoryQoS is enabled", func() {
+			ginkgo.By("enabling MemoryQoS in slo-controller-config")
+			rollback := ensureMemoryQoSEnabled(f, c, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating a BE pod")
+			pod := newMemoryQoSTestPod(f.Namespace.Name, "memqos-be-pod", apiext.QoSBE)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for the pod to be Running")
+			waitForPodRunning(f, c, pod)
+
+			ginkgo.By(fmt.Sprintf("verifying memory.wmark_min_adj=%d on the BE pod's cgroup", wmarkMinAdjBE))
+			verifyMemoryCgroupValue(f, pod, "memory.wmark_min_adj", int64(wmarkMinAdjBE))
+		})
+
+		// Test 3: Disabling MemoryQoS resets memory.wmark_ratio to 0
+		framework.ConformanceIt("should reset memory.wmark_ratio to 0 after MemoryQoS is disabled", func() {
+			ginkgo.By("enabling MemoryQoS in slo-controller-config")
+			rollback := ensureMemoryQoSEnabled(f, c, koordNamespace, sloConfigName)
+			if rollback != nil {
+				defer rollback()
+			}
+
+			ginkgo.By("creating an LS pod")
+			pod := newMemoryQoSTestPod(f.Namespace.Name, "memqos-reset-pod", apiext.QoSLS)
+			pod, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("waiting for pod Running and watermark applied")
+			waitForPodRunning(f, c, pod)
+			verifyMemoryCgroupValue(f, pod, "memory.wmark_ratio", int64(wmarkRatioValue))
+
+			ginkgo.By("disabling MemoryQoS in slo-controller-config")
+			disableMemoryQoS(f, c, koordNamespace, sloConfigName)
+
+			ginkgo.By("verifying memory.wmark_ratio resets to 0")
+			verifyMemoryCgroupValue(f, pod, "memory.wmark_ratio", 0)
+		})
+	})
+})
+
+// newMemoryQoSTestPod creates a pod with a memory limit so koordlet can compute memory.min.
+func newMemoryQoSTestPod(namespace, name string, qos apiext.QoSClass) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				apiext.LabelPodQoS: string(qos),
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "sleep",
+					Image:   "busybox",
+					Command: []string{"/bin/sh", "-c", "sleep 3600"},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// verifyMemoryCgroupValue execs into the pod to check that a given memory cgroup file
+// holds the expected value. Polls for memoryQoSTimeout.
+func verifyMemoryCgroupValue(f *framework.Framework, pod *corev1.Pod, filename string, expectedVal int64) {
+	gomega.Eventually(func() bool {
+		// Get cgroup path from /proc/self/cgroup (memory subsystem).
+		cgroupOut, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", "cat /proc/self/cgroup | grep ':memory:' | head -1 | cut -d: -f3",
+		)
+		if err != nil || strings.TrimSpace(cgroupOut) == "" {
+			// Fall back to cpu subsystem cgroup path if memory line not present.
+			cgroupOut, _, err = f.ExecCommandInContainerWithFullOutput(
+				pod.Name,
+				pod.Spec.Containers[0].Name,
+				"/bin/sh", "-c", "cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3",
+			)
+			if err != nil || strings.TrimSpace(cgroupOut) == "" {
+				framework.Logf("could not read cgroup path from pod %s: %v", pod.Name, err)
+				return false
+			}
+		}
+		cgroupPath := strings.TrimSpace(cgroupOut)
+
+		filePath := fmt.Sprintf("/sys/fs/cgroup/memory%s/%s", cgroupPath, filename)
+		out, _, err := f.ExecCommandInContainerWithFullOutput(
+			pod.Name,
+			pod.Spec.Containers[0].Name,
+			"/bin/sh", "-c", fmt.Sprintf("cat %s 2>/dev/null || echo NOT_SUPPORTED", filePath),
+		)
+		if err != nil {
+			framework.Logf("error reading %s from pod %s: %v", filename, pod.Name, err)
+			return false
+		}
+		val := strings.TrimSpace(out)
+		framework.Logf("pod %s %s=%q (expected %d)", pod.Name, filename, val, expectedVal)
+
+		if val == "NOT_SUPPORTED" {
+			ginkgo.Skip(fmt.Sprintf("%s not available on this node — skipping", filename))
+			return true
+		}
+		got, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			framework.Logf("could not parse %s value %q: %v", filename, val, err)
+			return false
+		}
+		return got == expectedVal
+	}, memoryQoSTimeout, memoryQoSPoll).Should(gomega.BeTrue(),
+		fmt.Sprintf("expected %s=%d for pod %s", filename, expectedVal, pod.Name))
+}
+
+// ensureMemoryQoSEnabled patches slo-controller-config to enable MemoryQoS.
+func ensureMemoryQoSEnabled(f *framework.Framework, c clientset.Interface, koordNamespace, sloConfigName string) func() {
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("slo-controller-config not found, skipping MemoryQoS config patch: %v", err)
+		return nil
+	}
+
+	oldData := map[string]string{}
+	if configMap.Data != nil {
+		for k, v := range configMap.Data {
+			oldData[k] = v
+		}
+	}
+
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.ResourceQOSConfigKey] = memoryQoSEnabledConfigData()
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "failed to update slo-controller-config to enable MemoryQoS")
+	framework.Logf("enabled MemoryQoS in slo-controller-config")
+
+	return func() {
+		cm, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("error getting configmap for rollback: %v", err)
+			return
+		}
+		rb := cm.DeepCopy()
+		rb.Data = oldData
+		_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), rb, metav1.UpdateOptions{})
+		if err != nil {
+			framework.Logf("error rolling back slo-controller-config: %v", err)
+		} else {
+			framework.Logf("rolled back slo-controller-config after MemoryQoS test")
+		}
+	}
+}
+
+// disableMemoryQoS patches the slo-controller-config to disable MemoryQoS.
+func disableMemoryQoS(f *framework.Framework, c clientset.Interface, koordNamespace, sloConfigName string) {
+	const disabledData = `{
+  "lsClass": {
+    "memoryQOS": {
+      "enable": false
+    }
+  },
+  "beClass": {
+    "memoryQOS": {
+      "enable": false
+    }
+  }
+}`
+	configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	newConfigMap := configMap.DeepCopy()
+	if newConfigMap.Data == nil {
+		newConfigMap.Data = map[string]string{}
+	}
+	newConfigMap.Data[configuration.ResourceQOSConfigKey] = disabledData
+	_, err = c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err)
+	framework.Logf("disabled MemoryQoS in slo-controller-config")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This adds the first koordlet-specific E2E tests, starting with the **GroupIdentity (CPU BVT)** plugin. It's part of the roadmap in #1704.

The GroupIdentity plugin sets `cpu.bvt_warp_ns` on pod cgroup directories to give LS pods scheduling priority and throttle BE pods. There was no E2E coverage for this at all — this PR adds it.

Three test cases under `test/e2e/koordlet/`:

1. LS pod gets `cpu.bvt_warp_ns=2` when GroupIdentity is enabled
2. BE pod gets `cpu.bvt_warp_ns=-1` when GroupIdentity is enabled
3. BVT resets to `0` after GroupIdentity is disabled

The test enables GroupIdentity via `slo-controller-config`, creates a pod with the right koordinator QoS label, waits for it to run, then execs into the container to read the cgroup file directly. It always restores the original config afterward via defer, and skips gracefully on nodes where `cpu.bvt_warp_ns` doesn't exist (cgroup v2 / non-Anolis kernels).

### Ⅱ. Does this pull request fix one issue?

Part of #1704

### Ⅲ. Describe how to verify it

Deploy koordinator on an Anolis OS node (cgroup v1 with BVT support), then run:

```bash
go test ./test/e2e/... -v --ginkgo.focus="GroupIdentity"
```

### Ⅳ. Special notes for reviews

- Skips cleanly on nodes without `cpu.bvt_warp_ns` so it won't fail on standard upstream kernels
- Polls for 60s to give koordlet's reconcile loop time to apply the value
- Config is always rolled back in defer — no side effects on the cluster after the test

### V. Checklist

- [x] I have written necessary docs and comments
- [x] Tests are self-cleaning (config rollback via defer)
