### PR TITLE
Fix potential index out of range panic in GetXPUCount and incorrect device logging for IX/MLU in utils.go

### DIFF
--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -196,11 +196,11 @@ func GetXPUCount(deviceType string) (int, error) {
 		if totalCountLine == "" {
 			return 0, fmt.Errorf("get npu count err, no total count line")
 		}
-		fidlds := strings.Fields(totalCountLine)
-		if len(fidlds) < 4 {
+		fields := strings.Fields(totalCountLine)
+		if len(fields) < 5 {
 			return 0, fmt.Errorf("get npu count err, no total count field")
 		}
-		count, err := strconv.Atoi(fidlds[4])
+		count, err := strconv.Atoi(fields[4])
 		if err != nil {
 			return 0, fmt.Errorf("get npu count err, failed to convert field to integer, %w", err)
 		}
@@ -334,12 +334,12 @@ func GetXPUMemory(deviceType string) (string, error) {
 		cmd := exec.Command(ChangeRootCmd, HostRootDir, IXSmiCmd, QueryGPUMemArgs, QuerGPUFormatArgs, QueryGPUIdArgs)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get ix memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.TrimSpace(string(output))
 		results = strings.ReplaceAll(results, " ", "")
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", results)
+		klog.Infof("GetIXMemory, end to get ix memory: %s", results)
 
 		results = strings.ReplaceAll(results, "MiB", "Mi")
 
@@ -364,7 +364,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 			ChangeRootCmd, HostRootDir, MLUCmd, QueryMLUInfoArgs))
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "0Mi", fmt.Errorf("get gpu memory err: %w, output %v", err, string(output))
+			return "0Mi", fmt.Errorf("get mlu memory err: %w, output %v", err, string(output))
 		}
 
 		results := strings.Split(string(output), "\n")
@@ -377,7 +377,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 				break
 			}
 		}
-		klog.Infof("GetGPUMemory, end to get ix memory: %s", realResults)
+		klog.Infof("GetMLUMemory, end to get mlu memory: %s", realResults)
 
 		realResults = fmt.Sprintf("%sMi", realResults)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

- **Summarize your change**:
  This PR addresses two bugs in `pkg/device-daemon/resource/utils.go`:
  1. Fixes a potential out-of-bounds slice indexing runtime panic in `GetXPUCount` for NPU devices by correcting the slice length validation check from `< 4` to `< 5` (as we access index `4` / the 5th element). Also renames the typo `fidlds` to `fields`.
  2. Resolves incorrect logging and error contexts in `GetXPUMemory` for `IX` and `MLU` devices where the log labels and messages incorrectly referenced `gpu` or `ix` context instead of their respective types.

- **How does this PR work?**:
  - Updates the slice checking in `GetXPUCount` (NPU case) to `len(fields) < 5` before converting `fields[4]` to an integer.
  - Updates `klog.Infof` prefixes and `fmt.Errorf` strings in `GetXPUMemory` (cases `IX` and `MLU`) to correctly matches the device context.

---

### Ⅱ. Does this pull request fix one issue?

fixes #xxxx 
*(Note: Replace `xxxx` with the issue number of the issue you just created)*

---

### Ⅲ. Describe how to verify it

We can verify that the code compiles successfully and the logic prevents panic when total count lines have fewer than 5 fields. You can also run the local package tests:
```bash
go test -v ./pkg/device-daemon/resource/...
```

### Ⅳ. Special notes for reviews
This is a safe and localized bugfix to improve operator runtime stability (panic prevention) and log cleanliness.

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`

fixes #2991
