### PR TITLE
[scheduler] add required NRI plugin annotations for CPUSet and GPUShare workloads

### DIFF
--- a/apis/extension/nri.go
+++ b/apis/extension/nri.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// AnnotationRequiredPluginsContainerPrefix is the prefix of required plugins annotation key for a container.
+	AnnotationRequiredPluginsContainerPrefix = "required-plugins.noderesource.dev/container."
+
+	// DefaultNRIPluginName is the default NRI plugin name of koordlet runtime hooks.
+	DefaultNRIPluginName = "koordlet_nri"
+
+	// DefaultRequiredPluginsValue is the default value of required plugins annotation, which is a JSON array of the koordlet NRI plugin name.
+	DefaultRequiredPluginsValue = "[\"koordlet_nri\"]"
+)
+
+// SetPodRequiredNRIPlugins sets the NRI required plugins annotations for each container and init container of the pod.
+func SetPodRequiredNRIPlugins(pod *corev1.Pod) {
+	if pod == nil {
+		return
+	}
+	annotations := pod.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for _, container := range pod.Spec.InitContainers {
+		key := AnnotationRequiredPluginsContainerPrefix + container.Name
+		annotations[key] = DefaultRequiredPluginsValue
+	}
+	for _, container := range pod.Spec.Containers {
+		key := AnnotationRequiredPluginsContainerPrefix + container.Name
+		annotations[key] = DefaultRequiredPluginsValue
+	}
+	pod.SetAnnotations(annotations)
+}

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -730,6 +730,10 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState fwktype.CycleStat
 		return fwktype.NewStatus(fwktype.Error, err.Error())
 	}
 
+	if pod, ok := object.(*corev1.Pod); ok {
+		apiext.SetPodRequiredNRIPlugins(pod)
+	}
+
 	if k8sfeature.DefaultMutableFeatureGate.Enabled(features.DevicePluginAdaption) {
 		if err := p.adaptForDevicePlugin(ctx, object, state.allocationResult, nodeName); err != nil {
 			return fwktype.AsStatus(err)

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -5653,7 +5653,8 @@ func Test_Plugin_PreBind(t *testing.T) {
 					Namespace: "default",
 					Name:      "test",
 					Annotations: map[string]string{
-						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":0,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-8c25ea37-2909-6e62-b7bf-e2fcadebea8d"},{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-befd76c3-8a36-7b8a-179c-eae75aa7d9f2"}],"rdma":[{"minor":1,"resources":{"koordinator.sh/rdma":"100"},"id":"0000:1f:00.0"}]}`,
+						apiext.AnnotationDeviceAllocated:                               `{"gpu":[{"minor":0,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-8c25ea37-2909-6e62-b7bf-e2fcadebea8d"},{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-befd76c3-8a36-7b8a-179c-eae75aa7d9f2"}],"rdma":[{"minor":1,"resources":{"koordinator.sh/rdma":"100"},"id":"0000:1f:00.0"}]}`,
+						"required-plugins.noderesource.dev/container.test-container-a": `["koordlet_nri"]`,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -5729,6 +5730,7 @@ func Test_Plugin_PreBind(t *testing.T) {
 						apiext.AnnotationDeviceAllocated: `{"gpu":[{"minor":0,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-8c25ea37-2909-6e62-b7bf-e2fcadebea8d"},{"minor":1,"resources":{"koordinator.sh/gpu-core":"100","koordinator.sh/gpu-memory":"16Gi","koordinator.sh/gpu-memory-ratio":"100"},"id":"GPU-befd76c3-8a36-7b8a-179c-eae75aa7d9f2"}],"rdma":[{"minor":1,"resources":{"koordinator.sh/rdma":"100"},"id":"0000:1f:00.0"}]}`,
 						AnnotationBindTimestamp:          strconv.FormatInt(now.UnixNano(), 10),
 						AnnotationGPUMinors:              "0,1",
+						"required-plugins.noderesource.dev/container.test-container-a": `["koordlet_nri"]`,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -739,6 +739,9 @@ func (p *Plugin) preBindObject(ctx context.Context, cycleState fwktype.CycleStat
 		if err := appendResourceSpecIfMissed(object, state, node, &topologyOptions); err != nil {
 			return fwktype.AsStatus(err)
 		}
+		if pod, ok := object.(*corev1.Pod); ok {
+			extension.SetPodRequiredNRIPlugins(pod)
+		}
 	}
 
 	resourceStatus := &extension.ResourceStatus{

--- a/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin_test.go
@@ -2258,6 +2258,13 @@ func TestPlugin_PreBind(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-pod-1",
 		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main-container",
+				},
+			},
+		},
 	}
 
 	_, status := suit.Handle.ClientSet().CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -2286,6 +2293,7 @@ func TestPlugin_PreBind(t *testing.T) {
 		CPUSet: "0-3",
 	}
 	assert.Equal(t, expectResourceStatus, resourceStatus)
+	assert.Equal(t, "[\"koordlet_nri\"]", pod.Annotations["required-plugins.noderesource.dev/container.main-container"])
 }
 
 func TestPlugin_PreBindWithCPUBindPolicyNone(t *testing.T) {
@@ -2304,6 +2312,13 @@ func TestPlugin_PreBindWithCPUBindPolicyNone(t *testing.T) {
 			UID:       uuid.NewUUID(),
 			Namespace: "default",
 			Name:      "test-pod-1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main-container",
+				},
+			},
 		},
 	}
 
@@ -2341,6 +2356,7 @@ func TestPlugin_PreBindWithCPUBindPolicyNone(t *testing.T) {
 		PreferredCPUBindPolicy: extension.CPUBindPolicyFullPCPUs,
 	}
 	assert.Equal(t, expectedResourceSpec, resourceSpec)
+	assert.Equal(t, "[\"koordlet_nri\"]", pod.Annotations["required-plugins.noderesource.dev/container.main-container"])
 }
 
 func TestPlugin_PreBindReservation(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR implements support for NRI required-plugin annotations (`required-plugins.noderesource.dev/container.<container-name>`) for workloads that rely on specific Koordinator resources.

It selectively injects `["koordlet_nri"]` during the `PreBind` phase only for:
1. **CPUSet Workloads** (via `NodeNUMAResource`)
2. **GPUShare Workloads** (via `DeviceShare`)

Unrelated pods and ephemeral containers are untouched to minimize blast radius and ensure runtime stability.

## Key Changes
* Added `apis/extension/nri.go` helper to easily annotate Pod containers.
* Integrated helper into `NodeNUMAResource` and `DeviceShare` `PreBind` flows.
* Updated unit tests for both plugins and verified the annotations persist correctly.

## Verification
Ran all scheduler tests successfully:
`go test ./pkg/scheduler/plugins/...`
