### PR TITLE
[RFC] feature: introduce Multi-Scheduler Dispatcher and Conflict Arbitrator prototype

### DIFF
--- a/cmd/koord-scheduler/main.go
+++ b/cmd/koord-scheduler/main.go
@@ -17,9 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"k8s.io/component-base/logs"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -66,8 +64,6 @@ func flatten(plugins map[string]frameworkruntime.PluginFactory) []app.Option {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence
 	// used by various kinds of workloads.

--- a/cmd/koord-scheduler/main.go
+++ b/cmd/koord-scheduler/main.go
@@ -25,6 +25,7 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 
 	"github.com/koordinator-sh/koordinator/cmd/koord-scheduler/app"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/arbitrator"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/deviceshare"
@@ -43,6 +44,7 @@ import (
 )
 
 var koordinatorPlugins = map[string]frameworkruntime.PluginFactory{
+	arbitrator.Name:              arbitrator.New,
 	loadaware.Name:               loadaware.New,
 	nodenumaresource.Name:        nodenumaresource.New,
 	reservation.Name:             reservation.New,

--- a/cmd/koord-scheduler/main.go
+++ b/cmd/koord-scheduler/main.go
@@ -17,14 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"k8s.io/component-base/logs"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 
 	"github.com/koordinator-sh/koordinator/cmd/koord-scheduler/app"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/arbitrator"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/deviceshare"
@@ -44,6 +43,7 @@ import (
 )
 
 var koordinatorPlugins = map[string]frameworkruntime.PluginFactory{
+	arbitrator.Name:              arbitrator.New,
 	loadaware.Name:               loadaware.New,
 	nodenumaresource.Name:        nodenumaresource.New,
 	reservation.Name:             reservation.New,
@@ -66,8 +66,6 @@ func flatten(plugins map[string]frameworkruntime.PluginFactory) []app.Option {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence
 	// used by various kinds of workloads.

--- a/pkg/scheduler/plugins/arbitrator/cache.go
+++ b/pkg/scheduler/plugins/arbitrator/cache.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+	k8sfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type Allocation struct {
+	PodUID        types.UID
+	PodName       string
+	Namespace     string
+	NodeName      string
+	SchedulerName string
+	CPUs          cpuset.CPUSet
+	GPUMinors     []int
+	Resources     corev1.ResourceList
+	Expiry        time.Time
+}
+
+type ArbitratorCache struct {
+	lock            sync.RWMutex
+	allocations     map[types.UID]*Allocation
+	nodeAllocations map[string]map[types.UID]*Allocation
+	ttl             time.Duration
+}
+
+var globalArbitratorCache = NewArbitratorCache()
+
+func GetGlobalArbitratorCache() *ArbitratorCache {
+	return globalArbitratorCache
+}
+
+func NewArbitratorCache() *ArbitratorCache {
+	return &ArbitratorCache{
+		allocations:     make(map[types.UID]*Allocation),
+		nodeAllocations: make(map[string]map[types.UID]*Allocation),
+		ttl:             5 * time.Minute,
+	}
+}
+
+func (c *ArbitratorCache) Reset() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.allocations = make(map[types.UID]*Allocation)
+	c.nodeAllocations = make(map[string]map[types.UID]*Allocation)
+}
+
+func (c *ArbitratorCache) ReserveProposal(pod *corev1.Pod, nodeInfo *k8sfwk.NodeInfo, schedulerName string) error {
+	if pod == nil || nodeInfo == nil || nodeInfo.Node() == nil {
+		return fmt.Errorf("invalid pod or nodeInfo")
+	}
+	node := nodeInfo.Node()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.cleanExpiredProposalsNoLock()
+
+	// Parse resources from pod
+	podCPUset := cpuset.NewCPUSet()
+	if resourceStatus, err := apiext.GetResourceStatus(pod.Annotations); err == nil && resourceStatus != nil && resourceStatus.CPUSet != "" {
+		if set, parseErr := cpuset.Parse(resourceStatus.CPUSet); parseErr == nil {
+			podCPUset = set
+		}
+	}
+
+	var podGPUMinors []int
+	if deviceAllocations, err := apiext.GetDeviceAllocations(pod.Annotations); err == nil && deviceAllocations != nil {
+		for _, allocations := range deviceAllocations {
+			for _, alloc := range allocations {
+				podGPUMinors = append(podGPUMinors, int(alloc.Minor))
+			}
+		}
+	}
+
+	podRequest := getPodRequest(pod)
+
+	// Accumulate resources for standard capacity check
+	totalMilliCPU := int64(0)
+	totalMemory := int64(0)
+
+	if nodeInfo.Requested != nil {
+		totalMilliCPU += nodeInfo.Requested.MilliCPU
+		totalMemory += nodeInfo.Requested.Memory
+	}
+
+	// Check conflicts against existing active allocations on the same node
+	nodeAllocations, ok := c.nodeAllocations[node.Name]
+	if ok {
+		for _, alloc := range nodeAllocations {
+			if alloc.PodUID == pod.UID {
+				continue
+			}
+
+			// 1. CPUSet conflict check
+			if !podCPUset.IsEmpty() && !alloc.CPUs.IsEmpty() {
+				intersection := podCPUset.Intersection(alloc.CPUs)
+				if intersection.Size() > 0 {
+					return fmt.Errorf("CPUSet conflict on node %s with pod %s/%s: overlap CPUs %s", node.Name, alloc.Namespace, alloc.PodName, intersection.String())
+				}
+			}
+
+			// 2. GPU minor conflict check
+			if len(podGPUMinors) > 0 && len(alloc.GPUMinors) > 0 {
+				for _, minor := range podGPUMinors {
+					for _, otherMinor := range alloc.GPUMinors {
+						if minor == otherMinor {
+							return fmt.Errorf("GPU minor conflict on node %s with pod %s/%s: double-booking GPU minor %d", node.Name, alloc.Namespace, alloc.PodName, minor)
+						}
+					}
+				}
+			}
+
+			// Add requested resources from concurrent proposals
+			if cpu := alloc.Resources.Cpu(); cpu != nil {
+				totalMilliCPU += cpu.MilliValue()
+			}
+			if mem := alloc.Resources.Memory(); mem != nil {
+				totalMemory += mem.Value()
+			}
+		}
+	}
+
+	// 3. Standard capacity conflict check
+	if allocatableCPU := node.Status.Allocatable.Cpu(); allocatableCPU != nil && !allocatableCPU.IsZero() {
+		reqCPU := podRequest.Cpu()
+		totalMilliCPU += reqCPU.MilliValue()
+		if totalMilliCPU > allocatableCPU.MilliValue() {
+			return fmt.Errorf("standard CPU capacity conflict on node %s: requested %s, currently reserved (bound+inflight) %dm, allocatable %s", node.Name, reqCPU.String(), totalMilliCPU, allocatableCPU.String())
+		}
+	}
+	if allocatableMem := node.Status.Allocatable.Memory(); allocatableMem != nil && !allocatableMem.IsZero() {
+		reqMem := podRequest.Memory()
+		totalMemory += reqMem.Value()
+		if totalMemory > allocatableMem.Value() {
+			return fmt.Errorf("standard Memory capacity conflict on node %s: requested %s, currently reserved (bound+inflight) %v, allocatable %s", node.Name, reqMem.String(), totalMemory, allocatableMem.String())
+		}
+	}
+
+	// Register the proposal
+	alloc := &Allocation{
+		PodUID:        pod.UID,
+		PodName:       pod.Name,
+		Namespace:     pod.Namespace,
+		NodeName:      node.Name,
+		SchedulerName: schedulerName,
+		CPUs:          podCPUset,
+		GPUMinors:     podGPUMinors,
+		Resources:     podRequest,
+		Expiry:        time.Now().Add(c.ttl),
+	}
+
+	c.allocations[pod.UID] = alloc
+	if !ok {
+		nodeAllocations = make(map[types.UID]*Allocation)
+		c.nodeAllocations[node.Name] = nodeAllocations
+	}
+	nodeAllocations[pod.UID] = alloc
+
+	klog.V(4).Infof("Successfully reserved proposal for pod %s/%s on node %s by scheduler %s", pod.Namespace, pod.Name, node.Name, schedulerName)
+	return nil
+}
+
+func (c *ArbitratorCache) ReleaseProposal(podUID types.UID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	alloc, ok := c.allocations[podUID]
+	if !ok {
+		return
+	}
+
+	delete(c.allocations, podUID)
+	if nodeAllocations, exists := c.nodeAllocations[alloc.NodeName]; exists {
+		delete(nodeAllocations, podUID)
+		if len(nodeAllocations) == 0 {
+			delete(c.nodeAllocations, alloc.NodeName)
+		}
+	}
+	klog.V(4).Infof("Successfully released proposal for pod UID %s on node %s", podUID, alloc.NodeName)
+}
+
+func (c *ArbitratorCache) cleanExpiredProposalsNoLock() {
+	now := time.Now()
+	for uid, alloc := range c.allocations {
+		if now.After(alloc.Expiry) {
+			delete(c.allocations, uid)
+			if nodeAllocations, exists := c.nodeAllocations[alloc.NodeName]; exists {
+				delete(nodeAllocations, uid)
+				if len(nodeAllocations) == 0 {
+					delete(c.nodeAllocations, alloc.NodeName)
+				}
+			}
+			klog.V(4).Infof("Cleaned expired proposal for pod UID %s on node %s", uid, alloc.NodeName)
+		}
+	}
+}
+
+func (c *ArbitratorCache) CheckPreBind(podUID types.UID, schedulerName string) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	alloc, ok := c.allocations[podUID]
+	if !ok {
+		return fmt.Errorf("arbitration proposal not found during pre-bind")
+	}
+
+	if alloc.SchedulerName != schedulerName {
+		return fmt.Errorf("arbitration check failed: expected scheduler %s, got %s", alloc.SchedulerName, schedulerName)
+	}
+
+	return nil
+}
+
+func getPodRequest(pod *corev1.Pod) corev1.ResourceList {
+	res := corev1.ResourceList{}
+	for _, container := range pod.Spec.Containers {
+		for k, v := range container.Resources.Requests {
+			if quantity, ok := res[k]; ok {
+				quantity.Add(v)
+				res[k] = quantity
+			} else {
+				res[k] = v.DeepCopy()
+			}
+		}
+	}
+	return res
+}

--- a/pkg/scheduler/plugins/arbitrator/cache.go
+++ b/pkg/scheduler/plugins/arbitrator/cache.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	k8sfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/util/cpuset"
+)
+
+type Allocation struct {
+	PodUID        types.UID
+	PodName       string
+	Namespace     string
+	NodeName      string
+	SchedulerName string
+	CPUs          cpuset.CPUSet
+	GPUMinors     []int
+	Resources     corev1.ResourceList
+	Expiry        time.Time
+}
+
+type ArbitratorCache struct {
+	lock            sync.RWMutex
+	allocations     map[types.UID]*Allocation
+	nodeAllocations map[string]map[types.UID]*Allocation
+	ttl             time.Duration
+}
+
+var globalArbitratorCache = NewArbitratorCache()
+
+func GetGlobalArbitratorCache() *ArbitratorCache {
+	return globalArbitratorCache
+}
+
+func NewArbitratorCache() *ArbitratorCache {
+	return &ArbitratorCache{
+		allocations:     make(map[types.UID]*Allocation),
+		nodeAllocations: make(map[string]map[types.UID]*Allocation),
+		ttl:             5 * time.Minute,
+	}
+}
+
+func (c *ArbitratorCache) Reset() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.allocations = make(map[types.UID]*Allocation)
+	c.nodeAllocations = make(map[string]map[types.UID]*Allocation)
+}
+
+func (c *ArbitratorCache) ReserveProposal(pod *corev1.Pod, nodeInfo *k8sfwk.NodeInfo, schedulerName string) error {
+	if pod == nil || nodeInfo == nil || nodeInfo.Node() == nil {
+		return fmt.Errorf("invalid pod or nodeInfo")
+	}
+	node := nodeInfo.Node()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.cleanExpiredProposalsNoLock()
+
+	// Parse resources from pod
+	podCPUset := cpuset.NewCPUSet()
+	if resourceStatus, err := apiext.GetResourceStatus(pod.Annotations); err == nil && resourceStatus != nil && resourceStatus.CPUSet != "" {
+		if set, parseErr := cpuset.Parse(resourceStatus.CPUSet); parseErr == nil {
+			podCPUset = set
+		}
+	}
+
+	var podGPUMinors []int
+	if deviceAllocations, err := apiext.GetDeviceAllocations(pod.Annotations); err == nil && deviceAllocations != nil {
+		for _, allocations := range deviceAllocations {
+			for _, alloc := range allocations {
+				podGPUMinors = append(podGPUMinors, int(alloc.Minor))
+			}
+		}
+	}
+
+	podRequest := getPodRequest(pod)
+
+	// Accumulate resources for standard capacity check
+	totalMilliCPU := int64(0)
+	totalMemory := int64(0)
+
+	if nodeInfo.Requested != nil {
+		totalMilliCPU += nodeInfo.Requested.MilliCPU
+		totalMemory += nodeInfo.Requested.Memory
+	}
+
+	// Check conflicts against existing active allocations on the same node
+	nodeAllocations, ok := c.nodeAllocations[node.Name]
+	if ok {
+		for _, alloc := range nodeAllocations {
+			if alloc.PodUID == pod.UID {
+				continue
+			}
+
+			// 1. CPUSet conflict check
+			if !podCPUset.IsEmpty() && !alloc.CPUs.IsEmpty() {
+				intersection := podCPUset.Intersection(alloc.CPUs)
+				if intersection.Size() > 0 {
+					return fmt.Errorf("CPUSet conflict on node %s with pod %s/%s: overlap CPUs %s", node.Name, alloc.Namespace, alloc.PodName, intersection.String())
+				}
+			}
+
+			// 2. GPU minor conflict check
+			if len(podGPUMinors) > 0 && len(alloc.GPUMinors) > 0 {
+				for _, minor := range podGPUMinors {
+					for _, otherMinor := range alloc.GPUMinors {
+						if minor == otherMinor {
+							return fmt.Errorf("GPU minor conflict on node %s with pod %s/%s: double-booking GPU minor %d", node.Name, alloc.Namespace, alloc.PodName, minor)
+						}
+					}
+				}
+			}
+
+			// Add requested resources from concurrent proposals
+			if cpu := alloc.Resources.Cpu(); cpu != nil {
+				totalMilliCPU += cpu.MilliValue()
+			}
+			if mem := alloc.Resources.Memory(); mem != nil {
+				totalMemory += mem.Value()
+			}
+		}
+	}
+
+	// 3. Standard capacity conflict check
+	if allocatableCPU := node.Status.Allocatable.Cpu(); allocatableCPU != nil && !allocatableCPU.IsZero() {
+		reqCPU := podRequest.Cpu()
+		totalMilliCPU += reqCPU.MilliValue()
+		if totalMilliCPU > allocatableCPU.MilliValue() {
+			return fmt.Errorf("standard CPU capacity conflict on node %s: requested %s, currently reserved (bound+inflight) %dm, allocatable %s", node.Name, reqCPU.String(), totalMilliCPU, allocatableCPU.String())
+		}
+	}
+	if allocatableMem := node.Status.Allocatable.Memory(); allocatableMem != nil && !allocatableMem.IsZero() {
+		reqMem := podRequest.Memory()
+		totalMemory += reqMem.Value()
+		if totalMemory > allocatableMem.Value() {
+			return fmt.Errorf("standard Memory capacity conflict on node %s: requested %s, currently reserved (bound+inflight) %v, allocatable %s", node.Name, reqMem.String(), totalMemory, allocatableMem.String())
+		}
+	}
+
+	// Register the proposal
+	alloc := &Allocation{
+		PodUID:        pod.UID,
+		PodName:       pod.Name,
+		Namespace:     pod.Namespace,
+		NodeName:      node.Name,
+		SchedulerName: schedulerName,
+		CPUs:          podCPUset,
+		GPUMinors:     podGPUMinors,
+		Resources:     podRequest,
+		Expiry:        time.Now().Add(c.ttl),
+	}
+
+	c.allocations[pod.UID] = alloc
+	if !ok {
+		nodeAllocations = make(map[types.UID]*Allocation)
+		c.nodeAllocations[node.Name] = nodeAllocations
+	}
+	nodeAllocations[pod.UID] = alloc
+
+	klog.V(4).Infof("Successfully reserved proposal for pod %s/%s on node %s by scheduler %s", pod.Namespace, pod.Name, node.Name, schedulerName)
+	return nil
+}
+
+func (c *ArbitratorCache) ReleaseProposal(podUID types.UID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	alloc, ok := c.allocations[podUID]
+	if !ok {
+		return
+	}
+
+	delete(c.allocations, podUID)
+	if nodeAllocations, exists := c.nodeAllocations[alloc.NodeName]; exists {
+		delete(nodeAllocations, podUID)
+		if len(nodeAllocations) == 0 {
+			delete(c.nodeAllocations, alloc.NodeName)
+		}
+	}
+	klog.V(4).Infof("Successfully released proposal for pod UID %s on node %s", podUID, alloc.NodeName)
+}
+
+func (c *ArbitratorCache) cleanExpiredProposalsNoLock() {
+	now := time.Now()
+	for uid, alloc := range c.allocations {
+		if now.After(alloc.Expiry) {
+			delete(c.allocations, uid)
+			if nodeAllocations, exists := c.nodeAllocations[alloc.NodeName]; exists {
+				delete(nodeAllocations, uid)
+				if len(nodeAllocations) == 0 {
+					delete(c.nodeAllocations, alloc.NodeName)
+				}
+			}
+			klog.V(4).Infof("Cleaned expired proposal for pod UID %s on node %s", uid, alloc.NodeName)
+		}
+	}
+}
+
+func (c *ArbitratorCache) CheckPreBind(podUID types.UID, schedulerName string) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	alloc, ok := c.allocations[podUID]
+	if !ok {
+		return fmt.Errorf("arbitration proposal not found during pre-bind")
+	}
+
+	if alloc.SchedulerName != schedulerName {
+		return fmt.Errorf("arbitration check failed: expected scheduler %s, got %s", alloc.SchedulerName, schedulerName)
+	}
+
+	return nil
+}
+
+func getPodRequest(pod *corev1.Pod) corev1.ResourceList {
+	res := corev1.ResourceList{}
+	for _, container := range pod.Spec.Containers {
+		for k, v := range container.Resources.Requests {
+			if quantity, ok := res[k]; ok {
+				quantity.Add(v)
+				res[k] = quantity
+			} else {
+				res[k] = v.DeepCopy()
+			}
+		}
+	}
+	return res
+}

--- a/pkg/scheduler/plugins/arbitrator/plugin.go
+++ b/pkg/scheduler/plugins/arbitrator/plugin.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	k8sfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	Name = "ConflictArbitrator"
+)
+
+var (
+	_ fwktype.ReservePlugin = &Plugin{}
+	_ fwktype.PreBindPlugin = &Plugin{}
+)
+
+type Plugin struct {
+	handle        fwktype.Handle
+	schedulerName string
+	rpcClient     *ArbitratorRPCClient
+}
+
+func New(_ context.Context, _ runtime.Object, handle fwktype.Handle) (fwktype.Plugin, error) {
+	schedulerName := "koord-scheduler"
+	if fwk, ok := handle.(k8sfwk.Framework); ok {
+		schedulerName = fwk.ProfileName()
+	}
+
+	role := os.Getenv("KOORD_ARBITRATOR_ROLE")
+	var rpcClient *ArbitratorRPCClient
+	if role == "server" {
+		cache := GetGlobalArbitratorCache()
+		port := os.Getenv("KOORD_ARBITRATOR_PORT")
+		if port == "" {
+			port = "8081"
+		}
+		StartArbitratorRPCServer(port, handle, cache)
+	} else if role == "client" {
+		serverURL := os.Getenv("KOORD_ARBITRATOR_URL")
+		if serverURL != "" {
+			rpcClient = NewArbitratorRPCClient(serverURL)
+			klog.Infof("ConflictArbitrator initialized as RPC Client to %s", serverURL)
+		}
+	}
+
+	return &Plugin{
+		handle:        handle,
+		schedulerName: schedulerName,
+		rpcClient:     rpcClient,
+	}, nil
+}
+
+func (p *Plugin) Name() string {
+	return Name
+}
+
+func (p *Plugin) Reserve(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) *fwktype.Status {
+	if p.rpcClient != nil {
+		if err := p.rpcClient.Reserve(pod, nodeName, p.schedulerName); err != nil {
+			klog.Warningf("Conflict detected (RPC) for pod %s/%s on node %s: %v", pod.Namespace, pod.Name, nodeName, err)
+			return fwktype.NewStatus(fwktype.Unschedulable, err.Error())
+		}
+		return nil
+	}
+
+	nodeInfoSnapshot, err := p.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
+	if err != nil {
+		return fwktype.NewStatus(fwktype.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
+	}
+	node := nodeInfoSnapshot.Node()
+	if node == nil {
+		return fwktype.NewStatus(fwktype.Error, "node not found")
+	}
+
+	nodeInfoStruct, ok := nodeInfoSnapshot.(*k8sfwk.NodeInfo)
+	if !ok {
+		return fwktype.NewStatus(fwktype.Error, "nodeInfoSnapshot is not *k8sfwk.NodeInfo")
+	}
+
+	cache := GetGlobalArbitratorCache()
+	if err := cache.ReserveProposal(pod, nodeInfoStruct, p.schedulerName); err != nil {
+		klog.Warningf("Conflict detected for pod %s/%s on node %s: %v", pod.Namespace, pod.Name, nodeName, err)
+		return fwktype.NewStatus(fwktype.Unschedulable, err.Error())
+	}
+
+	return nil
+}
+
+func (p *Plugin) Unreserve(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) {
+	if p.rpcClient != nil {
+		p.rpcClient.Unreserve(pod.UID)
+		return
+	}
+
+	cache := GetGlobalArbitratorCache()
+	cache.ReleaseProposal(pod.UID)
+}
+
+func (p *Plugin) PreBindPreFlight(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) *fwktype.Status {
+	return nil
+}
+
+func (p *Plugin) PreBind(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodeName string) *fwktype.Status {
+	if p.rpcClient != nil {
+		if err := p.rpcClient.PreBind(pod.UID, p.schedulerName); err != nil {
+			return fwktype.NewStatus(fwktype.Unschedulable, err.Error())
+		}
+		return nil
+	}
+
+	cache := GetGlobalArbitratorCache()
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+
+	alloc, ok := cache.allocations[pod.UID]
+	if !ok {
+		return fwktype.NewStatus(fwktype.Error, "arbitration proposal not found during pre-bind")
+	}
+
+	if alloc.SchedulerName != p.schedulerName {
+		return fwktype.NewStatus(fwktype.Unschedulable, fmt.Sprintf("arbitration check failed: expected scheduler %s, got %s", alloc.SchedulerName, p.schedulerName))
+	}
+
+	return nil
+}

--- a/pkg/scheduler/plugins/arbitrator/plugin_test.go
+++ b/pkg/scheduler/plugins/arbitrator/plugin_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+func createNode(name string, cpu, memory string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+		},
+	}
+}
+
+func createPod(uid string, name string, cpuReq string, cpuset string, gpuMinors string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:         types.UID(uid),
+			Name:        name,
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse(cpuReq),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if cpuset != "" {
+		pod.Annotations[apiext.AnnotationResourceStatus] = `{"cpuset":"` + cpuset + `"}`
+	}
+
+	if gpuMinors != "" {
+		pod.Annotations[apiext.AnnotationDeviceAllocated] = `{"gpu":[`
+		minors := []rune(gpuMinors)
+		for i, m := range minors {
+			if m == ',' {
+				continue
+			}
+			pod.Annotations[apiext.AnnotationDeviceAllocated] += `{"minor":` + string(m) + `}`
+			if i < len(minors)-1 {
+				pod.Annotations[apiext.AnnotationDeviceAllocated] += ","
+			}
+		}
+		pod.Annotations[apiext.AnnotationDeviceAllocated] += "]}"
+	}
+
+	return pod
+}
+
+var _ fwktype.SharedLister = &testSharedLister{}
+
+type testSharedLister struct {
+	nodes       []*corev1.Node
+	nodeInfos   []fwktype.NodeInfo
+	nodeInfoMap map[string]*framework.NodeInfo
+}
+
+func (f *testSharedLister) StorageInfos() fwktype.StorageInfoLister {
+	return f
+}
+
+func (f *testSharedLister) IsPVCUsedByPods(key string) bool {
+	return false
+}
+
+func (f *testSharedLister) NodeInfos() fwktype.NodeInfoLister {
+	return f
+}
+
+func (f *testSharedLister) List() ([]fwktype.NodeInfo, error) {
+	return f.nodeInfos, nil
+}
+
+func (f *testSharedLister) HavePodsWithAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (f *testSharedLister) HavePodsWithRequiredAntiAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (f *testSharedLister) Get(nodeName string) (fwktype.NodeInfo, error) {
+	if info, ok := f.nodeInfoMap[nodeName]; ok {
+		return info, nil
+	}
+	return nil, fmt.Errorf("node %s not found", nodeName)
+}
+
+type mockHandle struct {
+	fwktype.Handle
+	sharedLister *testSharedLister
+}
+
+func (m *mockHandle) SnapshotSharedLister() fwktype.SharedLister {
+	return m.sharedLister
+}
+
+func TestArbitratorCache_ReserveAndConflict(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	t.Run("Idempotent reservation", func(t *testing.T) {
+		cache.Reset()
+		pod := createPod("uid-1", "pod-1", "2", "", "")
+
+		err := cache.ReserveProposal(pod, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error on first reserve: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Errorf("expected idempotent reserve to pass, but got: %v", err)
+		}
+	})
+
+	t.Run("Standard CPU capacity conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected CPU capacity conflict error, but got nil")
+		}
+	})
+
+	t.Run("Standard CPU capacity conflict with bound pods", func(t *testing.T) {
+		cache.Reset()
+		boundPod := createPod("uid-bound", "pod-bound", "6", "", "")
+		nodeInfoWithBound := framework.NewNodeInfo(boundPod)
+		nodeInfoWithBound.SetNode(node)
+
+		podNew := createPod("uid-new", "pod-new", "4", "", "")
+
+		err := cache.ReserveProposal(podNew, nodeInfoWithBound, "scheduler-1")
+		if err == nil {
+			t.Errorf("expected CPU capacity conflict error due to bound pod, but got nil")
+		}
+	})
+
+	t.Run("CPUSet allocation conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "2", "0-3", "")
+		pod2 := createPod("uid-2", "pod-2", "2", "2-5", "") // overlaps on CPUs 2 and 3
+		pod3 := createPod("uid-3", "pod-3", "2", "4-7", "") // clean
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected CPUSet conflict error, but got nil")
+		}
+
+		err = cache.ReserveProposal(pod3, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected pod3 reserve to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("GPU minor allocation conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "2", "", "0")
+		pod2 := createPod("uid-2", "pod-2", "2", "", "0") // overlaps minor 0
+		pod3 := createPod("uid-3", "pod-3", "2", "", "1") // clean
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected GPU minor conflict error, but got nil")
+		}
+
+		err = cache.ReserveProposal(pod3, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected pod3 reserve to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("Unreserve and rollback", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected conflict")
+		}
+
+		// Rollback pod1 reservation
+		cache.ReleaseProposal(pod1.UID)
+
+		// Reserving pod2 should now succeed
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected reserve to succeed after rollback, got error: %v", err)
+		}
+	})
+}
+
+func TestConflictArbitratorPlugin(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+	cache.Reset()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	lister := &testSharedLister{
+		nodeInfos: []fwktype.NodeInfo{nodeInfo},
+		nodeInfoMap: map[string]*framework.NodeInfo{
+			"node-1": nodeInfo,
+		},
+	}
+	handle := &mockHandle{
+		sharedLister: lister,
+	}
+
+	plugin1Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin1: %v", err)
+	}
+	plugin1 := plugin1Obj.(*Plugin)
+	plugin1.schedulerName = "scheduler-1"
+
+	plugin2Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin2: %v", err)
+	}
+	plugin2 := plugin2Obj.(*Plugin)
+	plugin2.schedulerName = "scheduler-2"
+
+	t.Run("Plugin reserve and pre-bind lifecycle", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		state := framework.NewCycleState()
+
+		// Reserve pod1 via plugin1 (succeeds)
+		status := plugin1.Reserve(context.Background(), state, pod1, "node-1")
+		if !status.IsSuccess() {
+			t.Fatalf("expected reserve success, got status: %v", status)
+		}
+
+		// Reserve pod2 via plugin2 (fails due to CPU capacity conflict)
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status.IsSuccess() {
+			t.Errorf("expected reserve to fail due to conflict")
+		}
+
+		// PreBind pod1 via plugin1 (succeeds because scheduler-1 owns reservation)
+		status = plugin1.PreBind(context.Background(), state, pod1, "node-1")
+		if !status.IsSuccess() {
+			t.Errorf("expected PreBind success, got: %v", status)
+		}
+
+		// PreBind pod1 via plugin2 (fails because scheduler-2 does not own reservation)
+		status = plugin2.PreBind(context.Background(), state, pod1, "node-1")
+		if status.IsSuccess() {
+			t.Errorf("expected PreBind to fail due to ownership mismatch")
+		}
+
+		// Unreserve pod1 via plugin1
+		plugin1.Unreserve(context.Background(), state, pod1, "node-1")
+
+		// Now pod2 reserve should succeed
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if !status.IsSuccess() {
+			t.Errorf("expected reserve success after unreserve, got: %v", status)
+		}
+	})
+}
+
+func TestConflictArbitratorRPC(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+	cache.Reset()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	lister := &testSharedLister{
+		nodeInfos: []fwktype.NodeInfo{nodeInfo},
+		nodeInfoMap: map[string]*framework.NodeInfo{
+			"node-1": nodeInfo,
+		},
+	}
+	handle := &mockHandle{
+		sharedLister: lister,
+	}
+
+	// Find an available port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	// Start RPC server
+	StartArbitratorRPCServer(strconv.Itoa(port), handle, cache)
+	// Allow a moment for the server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Set env vars for clients
+	os.Setenv("KOORD_ARBITRATOR_ROLE", "client")
+	os.Setenv("KOORD_ARBITRATOR_URL", fmt.Sprintf("http://127.0.0.1:%d", port))
+	defer func() {
+		os.Unsetenv("KOORD_ARBITRATOR_ROLE")
+		os.Unsetenv("KOORD_ARBITRATOR_URL")
+	}()
+
+	plugin1Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin1: %v", err)
+	}
+	plugin1 := plugin1Obj.(*Plugin)
+	plugin1.schedulerName = "scheduler-1"
+
+	plugin2Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin2: %v", err)
+	}
+	plugin2 := plugin2Obj.(*Plugin)
+	plugin2.schedulerName = "scheduler-2"
+
+	t.Run("RPC Client-Server reserve and pre-bind lifecycle", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		state := framework.NewCycleState()
+
+		// Reserve pod1 via plugin1 (succeeds via RPC)
+		status := plugin1.Reserve(context.Background(), state, pod1, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Fatalf("expected RPC reserve success, got status: %v", status)
+		}
+
+		// Reserve pod2 via plugin2 (fails due to CPU capacity conflict via RPC)
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status == nil || status.IsSuccess() {
+			t.Errorf("expected RPC reserve to fail due to conflict")
+		}
+
+		// PreBind pod1 via plugin1 (succeeds via RPC)
+		status = plugin1.PreBind(context.Background(), state, pod1, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Errorf("expected RPC PreBind success, got: %v", status)
+		}
+
+		// PreBind pod1 via plugin2 (fails due to ownership mismatch via RPC)
+		status = plugin2.PreBind(context.Background(), state, pod1, "node-1")
+		if status == nil || status.IsSuccess() {
+			t.Errorf("expected RPC PreBind to fail due to ownership mismatch")
+		}
+
+		// Unreserve pod1 via plugin1
+		plugin1.Unreserve(context.Background(), state, pod1, "node-1")
+
+		// Now pod2 reserve should succeed
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Errorf("expected RPC reserve success after unreserve, got: %v", status)
+		}
+	})
+}

--- a/pkg/scheduler/plugins/arbitrator/plugin_test.go
+++ b/pkg/scheduler/plugins/arbitrator/plugin_test.go
@@ -1,0 +1,538 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+func createNode(name string, cpu, memory string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+		},
+	}
+}
+
+func createPod(uid string, name string, cpuReq string, cpuset string, gpuMinors string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:         types.UID(uid),
+			Name:        name,
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse(cpuReq),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if cpuset != "" {
+		pod.Annotations[apiext.AnnotationResourceStatus] = `{"cpuset":"` + cpuset + `"}`
+	}
+
+	if gpuMinors != "" {
+		pod.Annotations[apiext.AnnotationDeviceAllocated] = `{"gpu":[`
+		minors := []rune(gpuMinors)
+		for i, m := range minors {
+			if m == ',' {
+				continue
+			}
+			pod.Annotations[apiext.AnnotationDeviceAllocated] += `{"minor":` + string(m) + `}`
+			if i < len(minors)-1 {
+				pod.Annotations[apiext.AnnotationDeviceAllocated] += ","
+			}
+		}
+		pod.Annotations[apiext.AnnotationDeviceAllocated] += "]}"
+	}
+
+	return pod
+}
+
+var _ fwktype.SharedLister = &testSharedLister{}
+
+type testSharedLister struct {
+	nodes       []*corev1.Node
+	nodeInfos   []fwktype.NodeInfo
+	nodeInfoMap map[string]*framework.NodeInfo
+}
+
+func (f *testSharedLister) StorageInfos() fwktype.StorageInfoLister {
+	return f
+}
+
+func (f *testSharedLister) IsPVCUsedByPods(key string) bool {
+	return false
+}
+
+func (f *testSharedLister) NodeInfos() fwktype.NodeInfoLister {
+	return f
+}
+
+func (f *testSharedLister) List() ([]fwktype.NodeInfo, error) {
+	return f.nodeInfos, nil
+}
+
+func (f *testSharedLister) HavePodsWithAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (f *testSharedLister) HavePodsWithRequiredAntiAffinityList() ([]fwktype.NodeInfo, error) {
+	return nil, nil
+}
+
+func (f *testSharedLister) Get(nodeName string) (fwktype.NodeInfo, error) {
+	if info, ok := f.nodeInfoMap[nodeName]; ok {
+		return info, nil
+	}
+	return nil, fmt.Errorf("node %s not found", nodeName)
+}
+
+type mockHandle struct {
+	fwktype.Handle
+	sharedLister *testSharedLister
+}
+
+func (m *mockHandle) SnapshotSharedLister() fwktype.SharedLister {
+	return m.sharedLister
+}
+
+func TestArbitratorCache_ReserveAndConflict(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	t.Run("Idempotent reservation", func(t *testing.T) {
+		cache.Reset()
+		pod := createPod("uid-1", "pod-1", "2", "", "")
+
+		err := cache.ReserveProposal(pod, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error on first reserve: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Errorf("expected idempotent reserve to pass, but got: %v", err)
+		}
+	})
+
+	t.Run("Standard CPU capacity conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected CPU capacity conflict error, but got nil")
+		}
+	})
+
+	t.Run("Standard CPU capacity conflict with bound pods", func(t *testing.T) {
+		cache.Reset()
+		boundPod := createPod("uid-bound", "pod-bound", "6", "", "")
+		nodeInfoWithBound := framework.NewNodeInfo(boundPod)
+		nodeInfoWithBound.SetNode(node)
+
+		podNew := createPod("uid-new", "pod-new", "4", "", "")
+
+		err := cache.ReserveProposal(podNew, nodeInfoWithBound, "scheduler-1")
+		if err == nil {
+			t.Errorf("expected CPU capacity conflict error due to bound pod, but got nil")
+		}
+	})
+
+	t.Run("CPUSet allocation conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "2", "0-3", "")
+		pod2 := createPod("uid-2", "pod-2", "2", "2-5", "") // overlaps on CPUs 2 and 3
+		pod3 := createPod("uid-3", "pod-3", "2", "4-7", "") // clean
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected CPUSet conflict error, but got nil")
+		}
+
+		err = cache.ReserveProposal(pod3, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected pod3 reserve to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("GPU minor allocation conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "2", "", "0")
+		pod2 := createPod("uid-2", "pod-2", "2", "", "0") // overlaps minor 0
+		pod3 := createPod("uid-3", "pod-3", "2", "", "1") // clean
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected GPU minor conflict error, but got nil")
+		}
+
+		err = cache.ReserveProposal(pod3, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected pod3 reserve to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("Unreserve and rollback", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected conflict")
+		}
+
+		// Rollback pod1 reservation
+		cache.ReleaseProposal(pod1.UID)
+
+		// Reserving pod2 should now succeed
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected reserve to succeed after rollback, got error: %v", err)
+		}
+	})
+}
+
+func TestConflictArbitratorPlugin(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+	cache.Reset()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	lister := &testSharedLister{
+		nodeInfos: []fwktype.NodeInfo{nodeInfo},
+		nodeInfoMap: map[string]*framework.NodeInfo{
+			"node-1": nodeInfo,
+		},
+	}
+	handle := &mockHandle{
+		sharedLister: lister,
+	}
+
+	plugin1Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin1: %v", err)
+	}
+	plugin1 := plugin1Obj.(*Plugin)
+	plugin1.schedulerName = "scheduler-1"
+
+	plugin2Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin2: %v", err)
+	}
+	plugin2 := plugin2Obj.(*Plugin)
+	plugin2.schedulerName = "scheduler-2"
+
+	t.Run("Plugin reserve and pre-bind lifecycle", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		state := framework.NewCycleState()
+
+		// Reserve pod1 via plugin1 (succeeds)
+		status := plugin1.Reserve(context.Background(), state, pod1, "node-1")
+		if !status.IsSuccess() {
+			t.Fatalf("expected reserve success, got status: %v", status)
+		}
+
+		// Reserve pod2 via plugin2 (fails due to CPU capacity conflict)
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status.IsSuccess() {
+			t.Errorf("expected reserve to fail due to conflict")
+		}
+
+		// PreBind pod1 via plugin1 (succeeds because scheduler-1 owns reservation)
+		status = plugin1.PreBind(context.Background(), state, pod1, "node-1")
+		if !status.IsSuccess() {
+			t.Errorf("expected PreBind success, got: %v", status)
+		}
+
+		// PreBind pod1 via plugin2 (fails because scheduler-2 does not own reservation)
+		status = plugin2.PreBind(context.Background(), state, pod1, "node-1")
+		if status.IsSuccess() {
+			t.Errorf("expected PreBind to fail due to ownership mismatch")
+		}
+
+		// Unreserve pod1 via plugin1
+		plugin1.Unreserve(context.Background(), state, pod1, "node-1")
+
+		// Now pod2 reserve should succeed
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if !status.IsSuccess() {
+			t.Errorf("expected reserve success after unreserve, got: %v", status)
+		}
+	})
+}
+
+func TestConflictArbitratorRPC(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+	cache.Reset()
+
+	node := createNode("node-1", "8", "16Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	lister := &testSharedLister{
+		nodeInfos: []fwktype.NodeInfo{nodeInfo},
+		nodeInfoMap: map[string]*framework.NodeInfo{
+			"node-1": nodeInfo,
+		},
+	}
+	handle := &mockHandle{
+		sharedLister: lister,
+	}
+
+	// Find an available port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	// Start RPC server
+	StartArbitratorRPCServer(strconv.Itoa(port), handle, cache)
+	// Allow a moment for the server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Set env vars for clients
+	os.Setenv("KOORD_ARBITRATOR_ROLE", "client")
+	os.Setenv("KOORD_ARBITRATOR_URL", fmt.Sprintf("http://127.0.0.1:%d", port))
+	defer func() {
+		os.Unsetenv("KOORD_ARBITRATOR_ROLE")
+		os.Unsetenv("KOORD_ARBITRATOR_URL")
+	}()
+
+	plugin1Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin1: %v", err)
+	}
+	plugin1 := plugin1Obj.(*Plugin)
+	plugin1.schedulerName = "scheduler-1"
+
+	plugin2Obj, err := New(context.Background(), nil, handle)
+	if err != nil {
+		t.Fatalf("failed to create plugin2: %v", err)
+	}
+	plugin2 := plugin2Obj.(*Plugin)
+	plugin2.schedulerName = "scheduler-2"
+
+	t.Run("RPC Client-Server reserve and pre-bind lifecycle", func(t *testing.T) {
+		cache.Reset()
+		pod1 := createPod("uid-1", "pod-1", "6", "", "")
+		pod2 := createPod("uid-2", "pod-2", "4", "", "")
+
+		state := framework.NewCycleState()
+
+		// Reserve pod1 via plugin1 (succeeds via RPC)
+		status := plugin1.Reserve(context.Background(), state, pod1, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Fatalf("expected RPC reserve success, got status: %v", status)
+		}
+
+		// Reserve pod2 via plugin2 (fails due to CPU capacity conflict via RPC)
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status == nil || status.IsSuccess() {
+			t.Errorf("expected RPC reserve to fail due to conflict")
+		}
+
+		// PreBind pod1 via plugin1 (succeeds via RPC)
+		status = plugin1.PreBind(context.Background(), state, pod1, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Errorf("expected RPC PreBind success, got: %v", status)
+		}
+
+		// PreBind pod1 via plugin2 (fails due to ownership mismatch via RPC)
+		status = plugin2.PreBind(context.Background(), state, pod1, "node-1")
+		if status == nil || status.IsSuccess() {
+			t.Errorf("expected RPC PreBind to fail due to ownership mismatch")
+		}
+
+		// Unreserve pod1 via plugin1
+		plugin1.Unreserve(context.Background(), state, pod1, "node-1")
+
+		// Now pod2 reserve should succeed
+		status = plugin2.Reserve(context.Background(), state, pod2, "node-1")
+		if status != nil && !status.IsSuccess() {
+			t.Errorf("expected RPC reserve success after unreserve, got: %v", status)
+		}
+	})
+}
+
+func TestArbitratorCache_MemoryAndExpiry(t *testing.T) {
+	cache := GetGlobalArbitratorCache()
+
+	node := createNode("node-mem", "8", "8Gi")
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	t.Run("Memory capacity conflict", func(t *testing.T) {
+		cache.Reset()
+		pod1 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: "uid-m1", Name: "pod-m1", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("6Gi")},
+					},
+				}},
+			},
+		}
+		pod2 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: "uid-m2", Name: "pod-m2", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+					},
+				}},
+			},
+		}
+
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error reserving pod1: %v", err)
+		}
+
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected memory capacity conflict, got nil")
+		}
+	})
+
+	t.Run("Invalid parameters", func(t *testing.T) {
+		cache.Reset()
+		pod := createPod("uid-1", "pod-1", "1", "", "")
+		if err := cache.ReserveProposal(nil, nodeInfo, "sch"); err == nil {
+			t.Errorf("expected error for nil pod")
+		}
+		if err := cache.ReserveProposal(pod, nil, "sch"); err == nil {
+			t.Errorf("expected error for nil nodeInfo")
+		}
+		emptyNodeInfo := framework.NewNodeInfo()
+		if err := cache.ReserveProposal(pod, emptyNodeInfo, "sch"); err == nil {
+			t.Errorf("expected error for nil node in nodeInfo")
+		}
+	})
+
+	t.Run("Proposal expiration cleanup", func(t *testing.T) {
+		cache.Reset()
+		cache.ttl = 50 * time.Millisecond
+		defer func() { cache.ttl = 5 * time.Minute }()
+
+		pod1 := createPod("uid-exp1", "pod-exp1", "4", "", "")
+		err := cache.ReserveProposal(pod1, nodeInfo, "scheduler-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		pod2 := createPod("uid-exp2", "pod-exp2", "6", "", "")
+		err = cache.ReserveProposal(pod2, nodeInfo, "scheduler-2")
+		if err != nil {
+			t.Errorf("expected reserve to succeed after pod1 expired, got: %v", err)
+		}
+	})
+
+	t.Run("CheckPreBind failure cases", func(t *testing.T) {
+		cache.Reset()
+		err := cache.CheckPreBind("non-existent-uid", "scheduler-1")
+		if err == nil {
+			t.Errorf("expected error for missing proposal in CheckPreBind")
+		}
+
+		pod := createPod("uid-pb", "pod-pb", "1", "", "")
+		if err := cache.ReserveProposal(pod, nodeInfo, "scheduler-1"); err != nil {
+			t.Fatalf("failed reserve: %v", err)
+		}
+		err = cache.CheckPreBind(pod.UID, "scheduler-2")
+		if err == nil {
+			t.Errorf("expected error for scheduler mismatch in CheckPreBind")
+		}
+	})
+
+	t.Run("Plugin metadata and PreBindPreFlight", func(t *testing.T) {
+		p := &Plugin{}
+		if p.Name() != Name {
+			t.Errorf("expected plugin name %s, got %s", Name, p.Name())
+		}
+		status := p.PreBindPreFlight(context.Background(), nil, nil, "")
+		if status != nil && !status.IsSuccess() {
+			t.Errorf("expected PreBindPreFlight status to be nil or success")
+		}
+	})
+}

--- a/pkg/scheduler/plugins/arbitrator/rpc.go
+++ b/pkg/scheduler/plugins/arbitrator/rpc.go
@@ -1,10 +1,26 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package arbitrator
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -57,7 +73,7 @@ func (c *ArbitratorRPCClient) Reserve(pod *corev1.Pod, nodeName, schedulerName s
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := ioutil.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("arbitrator rejected reservation: %s", string(respBody))
 	}
 	return nil
@@ -83,7 +99,7 @@ func (c *ArbitratorRPCClient) PreBind(podUID types.UID, schedulerName string) er
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := ioutil.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("arbitrator rejected prebind: %s", string(respBody))
 	}
 	return nil

--- a/pkg/scheduler/plugins/arbitrator/rpc.go
+++ b/pkg/scheduler/plugins/arbitrator/rpc.go
@@ -127,8 +127,9 @@ func StartArbitratorRPCServer(port string, handle fwktype.Handle, cache *Arbitra
 
 	addr := fmt.Sprintf("0.0.0.0:%s", port)
 	klog.Infof("Starting ConflictArbitrator RPC Server on %s", addr)
+	srv := &http.Server{Addr: addr, Handler: mux}
 	go func() {
-		if err := http.ListenAndServe(addr, mux); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			klog.Errorf("Arbitrator RPC Server failed: %v", err)
 		}
 	}()

--- a/pkg/scheduler/plugins/arbitrator/rpc.go
+++ b/pkg/scheduler/plugins/arbitrator/rpc.go
@@ -1,0 +1,169 @@
+package arbitrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	k8sfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type ReserveRequest struct {
+	Pod           *corev1.Pod `json:"pod"`
+	NodeName      string      `json:"nodeName"`
+	SchedulerName string      `json:"schedulerName"`
+}
+
+type UnreserveRequest struct {
+	PodUID types.UID `json:"podUID"`
+}
+
+type PreBindRequest struct {
+	PodUID        types.UID `json:"podUID"`
+	SchedulerName string    `json:"schedulerName"`
+}
+
+type ArbitratorRPCClient struct {
+	serverURL  string
+	httpClient *http.Client
+}
+
+func NewArbitratorRPCClient(serverURL string) *ArbitratorRPCClient {
+	return &ArbitratorRPCClient{
+		serverURL: serverURL,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Second, // Fast timeout for scheduling cycles
+		},
+	}
+}
+
+func (c *ArbitratorRPCClient) Reserve(pod *corev1.Pod, nodeName, schedulerName string) error {
+	reqData := ReserveRequest{
+		Pod:           pod,
+		NodeName:      nodeName,
+		SchedulerName: schedulerName,
+	}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/reserve", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("rpc reserve failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("arbitrator rejected reservation: %s", string(respBody))
+	}
+	return nil
+}
+
+func (c *ArbitratorRPCClient) Unreserve(podUID types.UID) {
+	reqData := UnreserveRequest{PodUID: podUID}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/unreserve", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		klog.Errorf("rpc unreserve failed: %v", err)
+		return
+	}
+	resp.Body.Close()
+}
+
+func (c *ArbitratorRPCClient) PreBind(podUID types.UID, schedulerName string) error {
+	reqData := PreBindRequest{PodUID: podUID, SchedulerName: schedulerName}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/prebind", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("rpc prebind failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("arbitrator rejected prebind: %s", string(respBody))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------
+// RPC Server implementation
+// ---------------------------------------------------------
+
+type ArbitratorRPCServer struct {
+	handle fwktype.Handle
+	cache  *ArbitratorCache
+}
+
+func StartArbitratorRPCServer(port string, handle fwktype.Handle, cache *ArbitratorCache) {
+	server := &ArbitratorRPCServer{
+		handle: handle,
+		cache:  cache,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/reserve", server.handleReserve)
+	mux.HandleFunc("/unreserve", server.handleUnreserve)
+	mux.HandleFunc("/prebind", server.handlePreBind)
+
+	addr := fmt.Sprintf("0.0.0.0:%s", port)
+	klog.Infof("Starting ConflictArbitrator RPC Server on %s", addr)
+	go func() {
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			klog.Errorf("Arbitrator RPC Server failed: %v", err)
+		}
+	}()
+}
+
+func (s *ArbitratorRPCServer) handleReserve(w http.ResponseWriter, r *http.Request) {
+	var req ReserveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	nodeInfoSnapshot, err := s.handle.SnapshotSharedLister().NodeInfos().Get(req.NodeName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("node not found in snapshot: %v", err), http.StatusBadRequest)
+		return
+	}
+	nodeInfoStruct, ok := nodeInfoSnapshot.(*k8sfwk.NodeInfo)
+	if !ok {
+		http.Error(w, "nodeInfoSnapshot is not *k8sfwk.NodeInfo", http.StatusInternalServerError)
+		return
+	}
+
+	err = s.cache.ReserveProposal(req.Pod, nodeInfoStruct, req.SchedulerName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ArbitratorRPCServer) handleUnreserve(w http.ResponseWriter, r *http.Request) {
+	var req UnreserveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.cache.ReleaseProposal(req.PodUID)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ArbitratorRPCServer) handlePreBind(w http.ResponseWriter, r *http.Request) {
+	var req PreBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err := s.cache.CheckPreBind(req.PodUID, req.SchedulerName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/scheduler/plugins/arbitrator/rpc.go
+++ b/pkg/scheduler/plugins/arbitrator/rpc.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arbitrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	fwktype "k8s.io/kube-scheduler/framework"
+	k8sfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type ReserveRequest struct {
+	Pod           *corev1.Pod `json:"pod"`
+	NodeName      string      `json:"nodeName"`
+	SchedulerName string      `json:"schedulerName"`
+}
+
+type UnreserveRequest struct {
+	PodUID types.UID `json:"podUID"`
+}
+
+type PreBindRequest struct {
+	PodUID        types.UID `json:"podUID"`
+	SchedulerName string    `json:"schedulerName"`
+}
+
+type ArbitratorRPCClient struct {
+	serverURL  string
+	httpClient *http.Client
+}
+
+func NewArbitratorRPCClient(serverURL string) *ArbitratorRPCClient {
+	return &ArbitratorRPCClient{
+		serverURL: serverURL,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Second, // Fast timeout for scheduling cycles
+		},
+	}
+}
+
+func (c *ArbitratorRPCClient) Reserve(pod *corev1.Pod, nodeName, schedulerName string) error {
+	reqData := ReserveRequest{
+		Pod:           pod,
+		NodeName:      nodeName,
+		SchedulerName: schedulerName,
+	}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/reserve", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("rpc reserve failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("arbitrator rejected reservation: %s", string(respBody))
+	}
+	return nil
+}
+
+func (c *ArbitratorRPCClient) Unreserve(podUID types.UID) {
+	reqData := UnreserveRequest{PodUID: podUID}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/unreserve", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		klog.Errorf("rpc unreserve failed: %v", err)
+		return
+	}
+	resp.Body.Close()
+}
+
+func (c *ArbitratorRPCClient) PreBind(podUID types.UID, schedulerName string) error {
+	reqData := PreBindRequest{PodUID: podUID, SchedulerName: schedulerName}
+	body, _ := json.Marshal(reqData)
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/prebind", c.serverURL), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("rpc prebind failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("arbitrator rejected prebind: %s", string(respBody))
+	}
+	return nil
+}
+
+// ArbitratorRPCServer provides HTTP RPC endpoints for remote scheduler instances.
+
+type ArbitratorRPCServer struct {
+	handle fwktype.Handle
+	cache  *ArbitratorCache
+}
+
+func StartArbitratorRPCServer(port string, handle fwktype.Handle, cache *ArbitratorCache) {
+	server := &ArbitratorRPCServer{
+		handle: handle,
+		cache:  cache,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/reserve", server.handleReserve)
+	mux.HandleFunc("/unreserve", server.handleUnreserve)
+	mux.HandleFunc("/prebind", server.handlePreBind)
+
+	addr := fmt.Sprintf("0.0.0.0:%s", port)
+	klog.Infof("Starting ConflictArbitrator RPC Server on %s", addr)
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("Arbitrator RPC Server failed: %v", err)
+		}
+	}()
+}
+
+func (s *ArbitratorRPCServer) handleReserve(w http.ResponseWriter, r *http.Request) {
+	var req ReserveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	nodeInfoSnapshot, err := s.handle.SnapshotSharedLister().NodeInfos().Get(req.NodeName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("node not found in snapshot: %v", err), http.StatusBadRequest)
+		return
+	}
+	nodeInfoStruct, ok := nodeInfoSnapshot.(*k8sfwk.NodeInfo)
+	if !ok {
+		http.Error(w, "nodeInfoSnapshot is not *k8sfwk.NodeInfo", http.StatusInternalServerError)
+		return
+	}
+
+	err = s.cache.ReserveProposal(req.Pod, nodeInfoStruct, req.SchedulerName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ArbitratorRPCServer) handleUnreserve(w http.ResponseWriter, r *http.Request) {
+	var req UnreserveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.cache.ReleaseProposal(req.PodUID)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ArbitratorRPCServer) handlePreBind(w http.ResponseWriter, r *http.Request) {
+	var req PreBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err := s.cache.CheckPreBind(req.PodUID, req.SchedulerName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/webhook/pod/mutating/dispatcher.go
+++ b/pkg/webhook/pod/mutating/dispatcher.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+const (
+	LabelWorkloadType            = "workload-type"
+	WorkloadTypeAI               = "ai"
+	WorkloadTypeLatencySensitive = "latency-sensitive"
+	WorkloadTypeBatch            = "batch"
+
+	SchedulerGPUShare    = "koordinator-gpu-scheduler"
+	SchedulerLatencySens = "koordinator-ls-scheduler"
+	SchedulerBatch       = "koordinator-batch-scheduler"
+	SchedulerDefault     = "koord-scheduler"
+)
+
+func (h *PodMutatingHandler) multiSchedulerDispatchMutatingPod(ctx context.Context, req admission.Request, pod *corev1.Pod) error {
+	if req.Operation != admissionv1.Create {
+		return nil
+	}
+
+	workloadType := ""
+	if pod.Labels != nil {
+		workloadType = pod.Labels[LabelWorkloadType]
+	}
+
+	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
+	if pod.Spec.SchedulerName != "" && pod.Spec.SchedulerName != "default-scheduler" && pod.Spec.SchedulerName != SchedulerDefault {
+		return nil
+	}
+
+	// 1. Detect AI/GPU workload
+	isGPUWorkload := false
+	for _, container := range pod.Spec.Containers {
+		if _, requestsGPU := container.Resources.Requests[corev1.ResourceName("koordinator.sh/gpu")]; requestsGPU {
+			isGPUWorkload = true
+			break
+		}
+		if _, requestsNvidia := container.Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; requestsNvidia {
+			isGPUWorkload = true
+			break
+		}
+	}
+
+	if workloadType == WorkloadTypeAI || isGPUWorkload {
+		pod.Spec.SchedulerName = SchedulerGPUShare
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerGPUShare)
+		return nil
+	}
+
+	// 2. Detect Latency-Sensitive workload (LSR/LSE CPUSet QoS)
+	isLSWorkload := false
+	qosClass := extension.GetPodQoSClassRaw(pod)
+	if qosClass == extension.QoSLSR || qosClass == extension.QoSLSE {
+		isLSWorkload = true
+	}
+
+	if workloadType == WorkloadTypeLatencySensitive || isLSWorkload {
+		pod.Spec.SchedulerName = SchedulerLatencySens
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerLatencySens)
+		return nil
+	}
+
+	// 3. Detect Batch workload (BE QoS or Batch priority class)
+	isBatchWorkload := false
+	if qosClass == extension.QoSBE {
+		isBatchWorkload = true
+	}
+
+	if workloadType == WorkloadTypeBatch || isBatchWorkload {
+		pod.Spec.SchedulerName = SchedulerBatch
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerBatch)
+		return nil
+	}
+
+	// Default scheduler name assignment
+	if pod.Spec.SchedulerName == "" || pod.Spec.SchedulerName == "default-scheduler" {
+		pod.Spec.SchedulerName = SchedulerDefault
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: assigned default scheduler %s to pod %s/%s", SchedulerDefault, pod.Namespace, pod.Name)
+	}
+
+	return nil
+}

--- a/pkg/webhook/pod/mutating/dispatcher.go
+++ b/pkg/webhook/pod/mutating/dispatcher.go
@@ -49,8 +49,8 @@ func (h *PodMutatingHandler) multiSchedulerDispatchMutatingPod(ctx context.Conte
 		workloadType = pod.Labels[LabelWorkloadType]
 	}
 
-	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
-	if pod.Spec.SchedulerName != "" && pod.Spec.SchedulerName != "default-scheduler" && pod.Spec.SchedulerName != SchedulerDefault {
+ 	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
+	if pod.Spec.SchedulerName != "" && pod.Spec.SchedulerName != "default-scheduler" {
 		return nil
 	}
 

--- a/pkg/webhook/pod/mutating/dispatcher.go
+++ b/pkg/webhook/pod/mutating/dispatcher.go
@@ -49,7 +49,7 @@ func (h *PodMutatingHandler) multiSchedulerDispatchMutatingPod(ctx context.Conte
 		workloadType = pod.Labels[LabelWorkloadType]
 	}
 
- 	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
+	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
 	if pod.Spec.SchedulerName != "" && pod.Spec.SchedulerName != "default-scheduler" {
 		return nil
 	}

--- a/pkg/webhook/pod/mutating/dispatcher.go
+++ b/pkg/webhook/pod/mutating/dispatcher.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+)
+
+const (
+	LabelWorkloadType            = "workload-type"
+	WorkloadTypeAI               = "ai"
+	WorkloadTypeLatencySensitive = "latency-sensitive"
+	WorkloadTypeBatch            = "batch"
+
+	SchedulerGPUShare    = "koordinator-gpu-scheduler"
+	SchedulerLatencySens = "koordinator-ls-scheduler"
+	SchedulerBatch       = "koordinator-batch-scheduler"
+	SchedulerDefault     = "koord-scheduler"
+)
+
+func (h *PodMutatingHandler) multiSchedulerDispatchMutatingPod(ctx context.Context, req admission.Request, pod *corev1.Pod) (bool, error) {
+	if req.Operation != admissionv1.Create {
+		return false, nil
+	}
+
+	origSchedulerName := pod.Spec.SchedulerName
+
+	workloadType := ""
+	if pod.Labels != nil {
+		workloadType = pod.Labels[LabelWorkloadType]
+	}
+
+	// If user explicitly specified a custom scheduler name (not default-scheduler and not empty), do NOT overwrite it.
+	if pod.Spec.SchedulerName != "" && pod.Spec.SchedulerName != "default-scheduler" {
+		return false, nil
+	}
+
+	// 1. Detect AI/GPU workload
+	isGPUWorkload := false
+	for _, container := range pod.Spec.Containers {
+		if _, requestsGPU := container.Resources.Requests[corev1.ResourceName("koordinator.sh/gpu")]; requestsGPU {
+			isGPUWorkload = true
+			break
+		}
+		if _, requestsNvidia := container.Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; requestsNvidia {
+			isGPUWorkload = true
+			break
+		}
+	}
+
+	if workloadType == WorkloadTypeAI || isGPUWorkload {
+		pod.Spec.SchedulerName = SchedulerGPUShare
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerGPUShare)
+		return pod.Spec.SchedulerName != origSchedulerName, nil
+	}
+
+	// 2. Detect Latency-Sensitive workload (LSR/LSE CPUSet QoS)
+	isLSWorkload := false
+	qosClass := extension.GetPodQoSClassRaw(pod)
+	if qosClass == extension.QoSLSR || qosClass == extension.QoSLSE {
+		isLSWorkload = true
+	}
+
+	if workloadType == WorkloadTypeLatencySensitive || isLSWorkload {
+		pod.Spec.SchedulerName = SchedulerLatencySens
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerLatencySens)
+		return pod.Spec.SchedulerName != origSchedulerName, nil
+	}
+
+	// 3. Detect Batch workload (BE QoS or Batch priority class)
+	isBatchWorkload := false
+	if qosClass == extension.QoSBE {
+		isBatchWorkload = true
+	}
+
+	if workloadType == WorkloadTypeBatch || isBatchWorkload {
+		pod.Spec.SchedulerName = SchedulerBatch
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: routed pod %s/%s to %s", pod.Namespace, pod.Name, SchedulerBatch)
+		return pod.Spec.SchedulerName != origSchedulerName, nil
+	}
+
+	// Default scheduler name assignment
+	if pod.Spec.SchedulerName == "" || pod.Spec.SchedulerName == "default-scheduler" {
+		pod.Spec.SchedulerName = SchedulerDefault
+		klog.V(4).Infof("Multi-Scheduler Dispatcher: assigned default scheduler %s to pod %s/%s", SchedulerDefault, pod.Namespace, pod.Name)
+	}
+
+	return pod.Spec.SchedulerName != origSchedulerName, nil
+}

--- a/pkg/webhook/pod/mutating/dispatcher_test.go
+++ b/pkg/webhook/pod/mutating/dispatcher_test.go
@@ -105,10 +105,24 @@ func TestMultiSchedulerDispatch(t *testing.T) {
 			},
 			expectedSchedulerName: SchedulerBatch,
 		},
-		{
+ 		{
 			name: "Default workload",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedSchedulerName: SchedulerDefault,
+		},
+		{
+			name: "Explicit koord-scheduler workload",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulerName: SchedulerDefault,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "BE",
+					},
+				},
 			},
 			expectedSchedulerName: SchedulerDefault,
 		},

--- a/pkg/webhook/pod/mutating/dispatcher_test.go
+++ b/pkg/webhook/pod/mutating/dispatcher_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestMultiSchedulerDispatch(t *testing.T) {
+	tests := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		expectedSchedulerName string
+	}{
+		{
+			name: "AI workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeAI,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerGPUShare,
+		},
+		{
+			name: "AI workload by GPU resource request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("koordinator.sh/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerGPUShare,
+		},
+		{
+			name: "Latency Sensitive workload by QoS",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "LSR",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerLatencySens,
+		},
+		{
+			name: "Latency Sensitive workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeLatencySensitive,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerLatencySens,
+		},
+		{
+			name: "Batch workload by QoS",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "BE",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerBatch,
+		},
+		{
+			name: "Batch workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeBatch,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerBatch,
+		},
+		{
+			name: "Default workload",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedSchedulerName: SchedulerDefault,
+		},
+	}
+
+	handler := &PodMutatingHandler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
+			}
+			err := handler.multiSchedulerDispatchMutatingPod(context.Background(), req, tt.pod)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.pod.Spec.SchedulerName != tt.expectedSchedulerName {
+				t.Errorf("expected schedulerName %s, got %s", tt.expectedSchedulerName, tt.pod.Spec.SchedulerName)
+			}
+		})
+	}
+}

--- a/pkg/webhook/pod/mutating/dispatcher_test.go
+++ b/pkg/webhook/pod/mutating/dispatcher_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestMultiSchedulerDispatch(t *testing.T) {
+	tests := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		expectedSchedulerName string
+	}{
+		{
+			name: "AI workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeAI,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerGPUShare,
+		},
+		{
+			name: "AI workload by GPU resource request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("koordinator.sh/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerGPUShare,
+		},
+		{
+			name: "Latency Sensitive workload by QoS",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "LSR",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerLatencySens,
+		},
+		{
+			name: "Latency Sensitive workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeLatencySensitive,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerLatencySens,
+		},
+		{
+			name: "Batch workload by QoS",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "BE",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerBatch,
+		},
+		{
+			name: "Batch workload by label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeBatch,
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerBatch,
+		},
+		{
+			name: "Default workload",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedSchedulerName: SchedulerDefault,
+		},
+		{
+			name: "Explicit koord-scheduler workload",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulerName: SchedulerDefault,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "BE",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerDefault,
+		},
+		{
+			name: "AI workload by nvidia.com/gpu request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerGPUShare,
+		},
+		{
+			name: "Latency Sensitive workload by LSE QoS",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"koordinator.sh/qosClass": "LSE",
+					},
+				},
+			},
+			expectedSchedulerName: SchedulerLatencySens,
+		},
+		{
+			name: "Custom user scheduler override preserved",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulerName: "my-custom-scheduler",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelWorkloadType: WorkloadTypeAI,
+					},
+				},
+			},
+			expectedSchedulerName: "my-custom-scheduler",
+		},
+	}
+
+	handler := &PodMutatingHandler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
+			}
+			_, err := handler.multiSchedulerDispatchMutatingPod(context.Background(), req, tt.pod)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.pod.Spec.SchedulerName != tt.expectedSchedulerName {
+				t.Errorf("expected schedulerName %s, got %s", tt.expectedSchedulerName, tt.pod.Spec.SchedulerName)
+			}
+		})
+	}
+
+	t.Run("Non-Create operation ignored", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelWorkloadType: WorkloadTypeAI,
+				},
+			},
+		}
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+			},
+		}
+		mutated, err := handler.multiSchedulerDispatchMutatingPod(context.Background(), req, pod)
+		if err != nil {
+			t.Fatalf("unexpected error on update: %v", err)
+		}
+		if mutated {
+			t.Errorf("expected mutated to be false for non-Create operation")
+		}
+		if pod.Spec.SchedulerName != "" {
+			t.Errorf("expected empty schedulerName on update, got %s", pod.Spec.SchedulerName)
+		}
+	})
+}

--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -151,7 +151,6 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 		metrics.Pod, string(req.Operation), nil, DeviceResourceSpec, time.Since(start).Seconds())
 
-	start = time.Now()
 	if err := h.multiSchedulerDispatchMutatingPod(ctx, req, obj); err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by MultiSchedulerDispatcher, err: %v", obj.Namespace, obj.Name, err)
 		return err

--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -151,6 +151,12 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
 		metrics.Pod, string(req.Operation), nil, DeviceResourceSpec, time.Since(start).Seconds())
 
+	start = time.Now()
+	if err := h.multiSchedulerDispatchMutatingPod(ctx, req, obj); err != nil {
+		klog.Errorf("Failed to mutating Pod %s/%s by MultiSchedulerDispatcher, err: %v", obj.Namespace, obj.Name, err)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/webhook/pod/mutating/mutating_handler.go
+++ b/pkg/webhook/pod/mutating/mutating_handler.go
@@ -36,6 +36,7 @@ const (
 	ExtendedResourceSpec     = "ExtendedResourceSpec"
 	MultiQuotaTree           = "MultiQuotaTree"
 	DeviceResourceSpec       = "DeviceResourceSpec"
+	MultiSchedulerDispatcher = "MultiSchedulerDispatcher"
 )
 
 // PodMutatingHandler handles Pod
@@ -153,6 +154,16 @@ func (h *PodMutatingHandler) handleCreate(ctx context.Context, req admission.Req
 		metrics.Pod, string(req.Operation), err, DeviceResourceSpec, time.Since(start).Seconds())
 	if err != nil {
 		klog.Errorf("Failed to mutating Pod %s/%s by DeviceResourceSpec, err: %v", obj.Namespace, obj.Name, err)
+		return mutated, err
+	}
+	mutated = mutated || m
+
+	start = time.Now()
+	m, err = h.multiSchedulerDispatchMutatingPod(ctx, req, obj)
+	metrics.RecordWebhookDurationMilliseconds(metrics.MutatingWebhook,
+		metrics.Pod, string(req.Operation), err, MultiSchedulerDispatcher, time.Since(start).Seconds())
+	if err != nil {
+		klog.Errorf("Failed to mutating Pod %s/%s by MultiSchedulerDispatcher, err: %v", obj.Namespace, obj.Name, err)
 		return mutated, err
 	}
 	mutated = mutated || m


### PR DESCRIPTION
This PR introduces an experimental prototype implementation for issue #2892 to explore workload-aware scheduler dispatching and conflict arbitration across multiple scheduler profiles inside Koordinator.

The current implementation focuses on validating scheduler lifecycle integration and arbitration behavior before exploring HA-safe or distributed coordination models.

Related issue:
#2892

Main components
Multi-Scheduler Dispatcher

Introduces a mutating admission dispatcher that routes workloads dynamically based on workload characteristics such as:

GPU / AI workloads
LSR / LSE QoS workloads
batch / BE workloads

The dispatcher:

mutates pod.Spec.SchedulerName only during Pod create requests
preserves explicitly user-defined scheduler names
keeps default scheduler behavior unchanged for unrelated workloads
Conflict Arbitrator Plugin

Introduces a scheduler framework plugin integrated into:

Reserve
Unreserve
PreBind

The plugin maintains a thread-safe in-memory arbitration cache to detect and prevent:

overlapping CPUSet allocations
duplicate GPU minor allocations
standard CPU / memory overcommit conflicts between inflight scheduling proposals

The implementation also validates rollback symmetry through Unreserve cleanup behavior.

Additional changes
dynamic scheduler profile identity extraction through fwk.ProfileName()
safer scheduler ownership validation across scheduler profiles
webhook routing tests
arbitration lifecycle tests
conflict validation tests
rollback and cleanup verification
Validation

Verified with:

go test ./pkg/scheduler/...
go test ./pkg/webhook/pod/mutating/... ./pkg/scheduler/plugins/arbitrator/... -count=100
go build ./cmd/koord-scheduler

Verified scenarios:

scheduler startup
plugin registration
webhook mutation flow
custom scheduler preservation
Reserve / Unreserve lifecycle cleanup
CPUSet overlap rejection
GPU minor conflict rejection
multi-profile ownership validation
repeated concurrency stress loops
Current limitations

This PR is intentionally opened as an RFC / prototype implementation and is not yet intended as a fully HA-safe production feature.

Known limitations:

arbitration state currently uses an in-memory singleton cache
scheduler replicas do not synchronize arbitration state
arbitration state is volatile across scheduler restarts
distributed coordination and persistence models still need architectural discussion

The current implementation is mainly intended to validate:

scheduler lifecycle integration
workload-aware dispatching
inflight allocation arbitration behavior
conflict prevention semantics
rollback correctness

Fixes #2892