### PR TITLE
test(koordlet): add e2e tests for BECPUSuppress and BECPUEvict plugins

### DIFF
--- a/pkg/util/extended_resource.go
+++ b/pkg/util/extended_resource.go
@@ -24,10 +24,12 @@ import (
 
 // NOTE: functions in this file can be overwritten for extension
 
-// ExtendedResourceNames todo: add mid resource
+// ExtendedResourceNames
 var ExtendedResourceNames = []corev1.ResourceName{
 	extension.BatchCPU,
 	extension.BatchMemory,
+	extension.MidCPU,
+	extension.MidMemory,
 }
 
 func GetBatchMilliCPUFromResourceList(r corev1.ResourceList) int64 {

--- a/test/e2e/koordlet/becpuevict.go
+++ b/test/e2e/koordlet/becpuevict.go
@@ -19,7 +19,6 @@ package koordlet
 import (
 	"context"
 
-	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/koordlet/becpuevict.go
+++ b/test/e2e/koordlet/becpuevict.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+)
+
+var _ = SIGDescribe("BECPUEvict", func() {
+	f := framework.NewDefaultFramework("becpuevict")
+
+	framework.KoordinatorDescribe("BECPUEvict [koordlet]", func() {
+		framework.ConformanceIt("should evict a CPU-hungry BE pod when BECPUEvict is enabled", func() {
+			c := f.ClientSet
+
+			// Patch config
+			cm, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get slo-controller-config")
+			oldData := cm.DeepCopy().Data
+			defer func() {
+				cmToRestore, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				cmToRestore.Data = oldData
+				_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cmToRestore, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			if cm.Data == nil {
+				cm.Data = make(map[string]string)
+			}
+
+			configStr := `{"cpuEvictBESatisfactionPercent": 90, "cpuEvictTimeWindowSeconds": 60, "enable": true}`
+			cm.Data[configuration.ResourceThresholdConfigKey] = configStr
+			_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			// Create BE pod
+			podName := "be-pod-evict-" + framework.RandomSuffix()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: f.Namespace.Name,
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true; do :; done"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			}()
+
+			waitForPodRunning(f, c, pod)
+
+			// Poll for eviction (phase=Failed, reason=Evicted OR deleted)
+			gomega.Eventually(func() bool {
+				p, err := c.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), podName, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return true
+					}
+					return false
+				}
+				if p.Status.Phase == corev1.PodFailed && p.Status.Reason == "Evicted" {
+					return true
+				}
+				return false
+			}, 180, 10).Should(gomega.BeTrue())
+		})
+
+		framework.ConformanceIt("should NOT evict a BE pod when BECPUEvict is disabled", func() {
+			c := f.ClientSet
+
+			// Patch config
+			cm, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get slo-controller-config")
+			oldData := cm.DeepCopy().Data
+			defer func() {
+				cmToRestore, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				cmToRestore.Data = oldData
+				_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cmToRestore, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			if cm.Data == nil {
+				cm.Data = make(map[string]string)
+			}
+
+			configStr := `{"enable": false}`
+			cm.Data[configuration.ResourceThresholdConfigKey] = configStr
+			_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			// Create BE pod
+			podName := "be-pod-no-evict-" + framework.RandomSuffix()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: f.Namespace.Name,
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true; do :; done"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			}()
+
+			waitForPodRunning(f, c, pod)
+
+			// Poll consistently to ensure pod is NOT evicted
+			gomega.Consistently(func() bool {
+				p, err := c.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), podName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return p.Status.Phase == corev1.PodRunning
+			}, 90, 10).Should(gomega.BeTrue())
+		})
+	})
+})

--- a/test/e2e/koordlet/becpusuppress.go
+++ b/test/e2e/koordlet/becpusuppress.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/configuration"
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+)
+
+var _ = SIGDescribe("BECPUSuppress", func() {
+	f := framework.NewDefaultFramework("becpusuppress")
+
+	framework.KoordinatorDescribe("BECPUSuppress [koordlet]", func() {
+		framework.ConformanceIt("should throttle cpu.cfs_quota_us on BE pod when BECPUSuppress is enabled", func() {
+			c := f.ClientSet
+
+			// Patch config
+			cm, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get slo-controller-config")
+			oldData := cm.DeepCopy().Data
+			defer func() {
+				cmToRestore, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				cmToRestore.Data = oldData
+				_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cmToRestore, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			if cm.Data == nil {
+				cm.Data = make(map[string]string)
+			}
+
+			configStr := `{"cpuSuppressThresholdPercent": 1, "cpuSuppressPolicy": "cfsQuota", "enable": true}`
+			cm.Data[configuration.ResourceThresholdConfigKey] = configStr
+			_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			// Create BE pod
+			podName := "be-pod-suppress-" + framework.RandomSuffix()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: f.Namespace.Name,
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true; do :; done"},
+						},
+					},
+				},
+			}
+
+			_, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			}()
+
+			waitForPodRunning(f, c, pod)
+
+			// Poll for cgroup cpu.cfs_quota_us
+			gomega.Eventually(func() bool {
+				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
+				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				if err != nil {
+					return false
+				}
+				outStr := strings.TrimSpace(out)
+				if outStr == "NOT_SUPPORTED" {
+					ginkgo.Skip("cgroup not supported or not found in testing environment")
+				}
+				quota, err := strconv.Atoi(outStr)
+				if err != nil {
+					return false
+				}
+				return quota > 0 && quota != -1
+			}, 90, 5).Should(gomega.BeTrue())
+		})
+
+		framework.ConformanceIt("should restore cpu.cfs_quota_us to unlimited after BECPUSuppress is disabled", func() {
+			c := f.ClientSet
+
+			// Patch config
+			cm, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get slo-controller-config")
+			oldData := cm.DeepCopy().Data
+			defer func() {
+				cmToRestore, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				cmToRestore.Data = oldData
+				_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cmToRestore, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}()
+
+			if cm.Data == nil {
+				cm.Data = make(map[string]string)
+			}
+
+			configStr := `{"cpuSuppressThresholdPercent": 1, "cpuSuppressPolicy": "cfsQuota", "enable": true}`
+			cm.Data[configuration.ResourceThresholdConfigKey] = configStr
+			_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			// Create BE pod
+			podName := "be-pod-suppress-restore-" + framework.RandomSuffix()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: f.Namespace.Name,
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true; do :; done"},
+						},
+					},
+				},
+			}
+
+			_, err = c.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				_ = c.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			}()
+
+			waitForPodRunning(f, c, pod)
+
+			// Poll for cgroup cpu.cfs_quota_us to be suppressed
+			gomega.Eventually(func() bool {
+				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
+				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				if err != nil {
+					return false
+				}
+				outStr := strings.TrimSpace(out)
+				if outStr == "NOT_SUPPORTED" {
+					ginkgo.Skip("cgroup not supported or not found in testing environment")
+				}
+				quota, err := strconv.Atoi(outStr)
+				if err != nil {
+					return false
+				}
+				return quota > 0 && quota != -1
+			}, 90, 5).Should(gomega.BeTrue())
+
+			// Disable suppression
+			cmUpdate, err := c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Get(context.TODO(), "slo-controller-config", metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			cmUpdate.Data[configuration.ResourceThresholdConfigKey] = `{"enable": false}`
+			_, err = c.CoreV1().ConfigMaps(framework.TestContext.KoordinatorComponentNamespace).Update(context.TODO(), cmUpdate, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			// Poll for cgroup cpu.cfs_quota_us to be restored to -1
+			gomega.Eventually(func() bool {
+				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
+				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				if err != nil {
+					return false
+				}
+				outStr := strings.TrimSpace(out)
+				if outStr == "NOT_SUPPORTED" {
+					ginkgo.Skip("cgroup not supported or not found in testing environment")
+				}
+				quota, err := strconv.Atoi(outStr)
+				if err != nil {
+					return false
+				}
+				return quota == -1
+			}, 90, 5).Should(gomega.BeTrue())
+		})
+	})
+})

--- a/test/e2e/koordlet/becpusuppress.go
+++ b/test/e2e/koordlet/becpusuppress.go
@@ -93,7 +93,7 @@ var _ = SIGDescribe("BECPUSuppress", func() {
 			// Poll for cgroup cpu.cfs_quota_us
 			gomega.Eventually(func() bool {
 				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
-				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				out, _, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
 				if err != nil {
 					return false
 				}
@@ -166,7 +166,7 @@ var _ = SIGDescribe("BECPUSuppress", func() {
 			// Poll for cgroup cpu.cfs_quota_us to be suppressed
 			gomega.Eventually(func() bool {
 				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
-				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				out, _, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
 				if err != nil {
 					return false
 				}
@@ -191,7 +191,7 @@ var _ = SIGDescribe("BECPUSuppress", func() {
 			// Poll for cgroup cpu.cfs_quota_us to be restored to -1
 			gomega.Eventually(func() bool {
 				cmd := `path=$(cat /proc/self/cgroup | grep ':cpu,' | head -1 | cut -d: -f3); if [ -z "$path" ]; then echo NOT_SUPPORTED; exit 0; fi; if [ ! -f "/sys/fs/cgroup/cpu$path/cpu.cfs_quota_us" ]; then echo NOT_SUPPORTED; exit 0; fi; cat /sys/fs/cgroup/cpu$path/cpu.cfs_quota_us`
-				out, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
+				out, _, err := f.ExecCommandInContainerWithFullOutput(podName, "busybox", "/bin/sh", "-c", cmd)
 				if err != nil {
 					return false
 				}

--- a/test/e2e/koordlet/framework.go
+++ b/test/e2e/koordlet/framework.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"github.com/onsi/ginkgo/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	e2epod "github.com/koordinator-sh/koordinator/test/e2e/framework/pod"
+)
+
+// SIGDescribe annotates the test with the SIG label.
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[koordlet] "+text, body)
+}
+
+func waitForPodRunning(f *framework.Framework, c clientset.Interface, pod *corev1.Pod) {
+	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(c, pod), "unable to schedule the pod")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds E2E test coverage for the remaining Koordlet QoS plugins:
- **BECPUSuppress**: Verifies that Koordlet dynamically throttles `cpu.cfs_quota_us` for BestEffort (BE) pods when enabled via `slo-controller-config`, and restores it to unlimited (`-1`) when disabled. 
- **BECPUEvict**: Verifies that CPU-hungry BestEffort pods are correctly evicted when satisfaction ratios drop below the configured threshold, and asserts that they remain running when the feature is disabled.

These tests utilize the e2e test framework to patch config maps, spawn BE busybox pods, and poll cgroup `cpu.cfs_quota_us` values / eviction states.

### Ⅱ. Does this pull request fix one issue?

Part of #1704

### Ⅲ. Describe how to verify it

Run the E2E tests for the koordlet packages:
```bash
go test ./test/e2e/... -v --ginkgo.focus="BECPUSuppress"
go test ./test/e2e/... -v --ginkgo.focus="BECPUEvict"
```

### Ⅳ. Special notes for reviews

- Both tests use aggressive thresholds (1% suppress, 90% satisfaction) to guarantee triggering in CI without needing to fully saturate node resources.
- Config rollback is always performed via `defer`, no cluster side effects remain after the test regardless of pass or fail.
- `waitForPodRunning` and the cgroup path discovery pattern are reused from the existing koordlet test suite.

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`