### PR TITLE
test: fix TestSyncedEventHandler hanging indefinitely in unit tests

### DIFF
--- a/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
@@ -72,7 +72,16 @@ func TestSyncedEventHandler(t *testing.T) {
 	defer close(stopCh)
 	sharedInformerFactory.Start(stopCh)
 
-	wg.Wait()
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+	select {
+	case <-wgDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for informer to deliver initial list events")
+	}
 
 	mu.Lock()
 	for _, v := range addTimes {
@@ -92,12 +101,14 @@ func TestSyncedEventHandler(t *testing.T) {
 	node.ResourceVersion = "100"
 	_, err = fakeClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	assert.NoError(t, err)
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer pollCancel()
 	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
 		node, err := nodeInformer.Lister().Get("node-0")
 		assert.NoError(t, err)
 		assert.NotNil(t, node)
 		return node.ResourceVersion == "100", nil
-	}, wait.NeverStop)
+	}, pollCtx.Done())
 	assert.NoError(t, err)
 }
 
@@ -258,7 +269,16 @@ func TestSyncedEventHandlerWithReplace(t *testing.T) {
 	defer close(stopCh)
 	sharedInformerFactory.Start(stopCh)
 
-	wg.Wait()
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+	select {
+	case <-wgDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for informer to deliver initial list events")
+	}
 
 	mu.Lock()
 	for _, v := range addTimes {
@@ -305,11 +325,13 @@ func TestSyncedEventHandlerWithReplace(t *testing.T) {
 	node.ResourceVersion = "100"
 	_, err = fakeClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	assert.NoError(t, err)
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer pollCancel()
 	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
 		node, err := nodeInformer.Lister().Get("node-0")
 		assert.NoError(t, err)
 		assert.NotNil(t, node)
 		return node.ResourceVersion == "100", nil
-	}, wait.NeverStop)
+	}, pollCtx.Done())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #2957

The TestSyncedEventHandler and TestSyncedEventHandlerWithReplace tests were
using wait.NeverStop as the stop channel for wait.PollUntil. This meant that
if the fake clientset's watch event was ever delayed or not delivered (which
can happen under CI load), the poll would run forever with no way out, causing
the entire unit-tests job to hang until the runner was killed after 10 minutes.

Replaced wait.NeverStop with a context.WithTimeout(10s).Done() channel. The
tests still pass immediately when the watch event arrives normally (~1s), but
now fail fast and cleanly instead of blocking the CI queue when something goes
wrong.

Tested locally — both tests pass consistently.