### PR TITLE
scheduler: fix unchecked type assertions in elasticquota event handlers

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/node_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/node_handler.go
@@ -36,8 +36,14 @@ func (g *Plugin) OnNodeAdd(obj interface{}) {
 }
 
 func (g *Plugin) OnNodeUpdate(oldObj, newObj interface{}) {
-	newNode := newObj.(*corev1.Node)
-	oldNode := oldObj.(*corev1.Node)
+	newNode, ok := newObj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	oldNode, ok := oldObj.(*corev1.Node)
+	if !ok {
+		return
+	}
 
 	if newNode.ResourceVersion == oldNode.ResourceVersion {
 		klog.Warningf("update node warning, update version for the same, nodeName:%v", newNode.Name)

--- a/pkg/scheduler/plugins/elasticquota/pod_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/pod_handler.go
@@ -45,8 +45,14 @@ func (g *Plugin) OnPodAdd(obj interface{}) {
 }
 
 func (g *Plugin) OnPodUpdate(oldObj, newObj interface{}) {
-	oldPod := oldObj.(*corev1.Pod)
-	newPod := newObj.(*corev1.Pod)
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
 
 	if oldPod.ResourceVersion == newPod.ResourceVersion {
 		return

--- a/pkg/scheduler/plugins/elasticquota/quota_handler.go
+++ b/pkg/scheduler/plugins/elasticquota/quota_handler.go
@@ -65,7 +65,11 @@ func (g *Plugin) OnQuotaAdd(obj interface{}) {
 }
 
 func (g *Plugin) OnQuotaUpdate(oldObj, newObj interface{}) {
-	newQuota := newObj.(*schedulerv1alpha1.ElasticQuota)
+	newQuota, ok := newObj.(*schedulerv1alpha1.ElasticQuota)
+	if !ok {
+		klog.Errorf("quota is nil")
+		return
+	}
 
 	if newQuota.DeletionTimestamp != nil {
 		klog.Warningf("update quota warning, update is deleting: %v", newQuota.Name)
@@ -137,7 +141,10 @@ func (g *Plugin) OnQuotaDelete(obj interface{}) {
 func (g *Plugin) ReplaceQuotas(objs []interface{}) error {
 	quotas := make(map[string]*schedulerv1alpha1.ElasticQuota, len(objs))
 	for _, obj := range objs {
-		quota := obj.(*schedulerv1alpha1.ElasticQuota)
+		quota, ok := obj.(*schedulerv1alpha1.ElasticQuota)
+		if !ok {
+			continue
+		}
 		quotas[quota.Name] = quota
 	}
 


### PR DESCRIPTION
OnNodeUpdate, OnPodUpdate, OnQuotaUpdate and ReplaceQuotas used bare type assertions on informer callback objects. If an unexpected object type is received, these assertions may panic at runtime. The corresponding Add and Delete handlers in the same files already use the safe comma-ok pattern; this change aligns the Update paths with that existing defensive style.

### Ⅰ. Describe what this PR does

 Add safe comma-ok type assertion checks to `OnNodeUpdate`, `OnPodUpdate`, `OnQuotaUpdate`, and `ReplaceQuotas` in the elasticquota scheduler plugin. These four locations used bare type assertions like `obj.(*corev1.Node)` while their corresponding Add and Delete handlers (`OnNodeAdd`, `OnPodAdd`, `OnQuotaAdd`, `OnNodeDelete`, `OnPodDelete`, `OnQuotaDelete`) in the same files already used the safe `obj, ok := ...` pattern. When an informer delivers a `cache.DeletedFinalStateUnknown` tombstone object, bare assertions cause a runtime panic that kills the scheduler process.

### Ⅱ. Does this pull request fix one issue?

 NONE

### Ⅲ. Describe how to verify it

`go test ./pkg/scheduler/plugins/elasticquota/...` passes.

### Ⅳ. Special notes for reviews

The fix follows the exact same pattern already established in `OnNodeAdd`, `OnPodAdd`, `OnQuotaAdd` in the same files — no new conventions introduced.

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
