### PR TITLE
fix: stop hostReconciler cleanly after stopCh closes

### DIFF
--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
@@ -98,6 +98,7 @@ func (r *hostReconciler) reconcile(stopCh <-chan struct{}) {
 			timer.Reset(r.reconcileInterval)
 		case <-stopCh:
 			klog.V(1).Infof("stop reconcile for host application")
+			return
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler_test.go
@@ -335,3 +335,26 @@ func TestNewHostAppReconciler(t *testing.T) {
 	defer close(stop)
 	assert.NoError(t, r.Run(stop))
 }
+func TestHostReconcilerStopsOnStopCh(t *testing.T) {
+	r := &hostReconciler{
+		appUpdated:        make(chan struct{}, 1),
+		reconcileInterval: 10 * time.Millisecond,
+	}
+
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		r.reconcile(stopCh)
+		close(done)
+	}()
+
+	close(stopCh)
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("hostReconciler.reconcile did not stop after stopCh closed")
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a goroutine lifecycle issue in hostReconciler.reconcile().
Previously, when stopCh was closed, the reconciler logged the shutdown event but continued looping instead of exiting, As a result, the reconcile goroutine could remain alive indefinitely after shutdown.

Fix:

- add return in the stop channel case so the goroutine exits cleanly
- add a unit test verifying the reconciler stops correctly after stopCh closes

The new test reproduces the issue deterministically and validates the shutdown behavior.

### Ⅱ. Does this pull request fix one issue?

fixes #3018 

### Ⅲ. Describe how to verify it

Run:

```bash
go test ./pkg/koordlet/runtimehooks/reconciler \
  -run TestHostReconcilerStopsOnStopCh \
  -count=1 \
  -v
```

Expected result:

before fix: test fails by timeout
after fix: test passes successfully

### Ⅳ. Special notes for reviews

- This change only affects shutdown behavior.
- No reconcile logic or scheduling behavior was modified.
- The fix prevents leaked background goroutines during shutdown and testing.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
