### PR TITLE
test: add HugePageReport e2e coverage for koordlet

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/koordinator-sh/koordinator/test/utils/image"
 
 	// test sources
+	_ "github.com/koordinator-sh/koordinator/test/e2e/koordlet"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/quota"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/scheduling"
 	_ "github.com/koordinator-sh/koordinator/test/e2e/slocontroller"

--- a/test/e2e/koordlet/framework.go
+++ b/test/e2e/koordlet/framework.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import "github.com/onsi/ginkgo/v2"
+
+// SIGDescribe describes SIG information
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[koordlet] "+text, body)
+}

--- a/test/e2e/koordlet/hugepage_report.go
+++ b/test/e2e/koordlet/hugepage_report.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package koordlet
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	topov1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	nrtclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	koordutil "github.com/koordinator-sh/koordinator/pkg/util"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	e2enode "github.com/koordinator-sh/koordinator/test/e2e/framework/node"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework/skipper"
+)
+
+var hugepageResourceNames = []corev1.ResourceName{
+	corev1.ResourceName(string(corev1.ResourceHugePagesPrefix) + "2Mi"),
+	corev1.ResourceName(string(corev1.ResourceHugePagesPrefix) + "1Gi"),
+}
+
+var _ = SIGDescribe("HugePageReport", func() {
+	f := framework.NewDefaultFramework("hugepage-report")
+
+	var (
+		c         clientset.Interface
+		nrtClient nrtclientset.Interface
+	)
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+
+		var err error
+		nrtClient, err = nrtclientset.NewForConfig(f.ClientConfig())
+		framework.ExpectNoError(err, "unable to create NRT client")
+	})
+
+	framework.KoordinatorDescribe("HugePageReport NodeResourceTopology", func() {
+		framework.ConformanceIt("report hugepage capacity in NRT zones", func() {
+			nodeList, err := e2enode.GetReadySchedulableNodes(c)
+			framework.ExpectNoError(err)
+			gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty())
+
+			node, resourceNames := findNodeWithHugepages(nodeList.Items)
+			if node == nil {
+				skipper.Skipf("no nodes with hugepage capacity > 0; skipping HugePageReport e2e test")
+			}
+
+			expected := map[corev1.ResourceName]resource.Quantity{}
+			for _, resName := range resourceNames {
+				expected[resName] = node.Status.Capacity[resName]
+			}
+
+			ginkgo.By(fmt.Sprintf("Using node %s to verify hugepage reporting", node.Name))
+
+			gomega.Eventually(func() error {
+				nrt, err := nrtClient.TopologyV1alpha1().NodeResourceTopologies().Get(context.TODO(), node.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if len(nrt.Zones) == 0 {
+					return fmt.Errorf("node resource topology has no zones")
+				}
+
+				for resName, expectedQty := range expected {
+					actual := sumZoneResource(nrt, resName)
+					if actual.Cmp(expectedQty) != 0 {
+						return fmt.Errorf("resource %s mismatch: expected %s, got %s", resName, expectedQty.String(), actual.String())
+					}
+				}
+
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+		})
+	})
+})
+
+func findNodeWithHugepages(nodes []corev1.Node) (*corev1.Node, []corev1.ResourceName) {
+	for i := range nodes {
+		node := &nodes[i]
+		var resourceNames []corev1.ResourceName
+		for _, resName := range hugepageResourceNames {
+			quantity, ok := node.Status.Capacity[resName]
+			if !ok || quantity.Value() <= 0 {
+				continue
+			}
+			resourceNames = append(resourceNames, resName)
+		}
+		if len(resourceNames) > 0 {
+			return node, resourceNames
+		}
+	}
+
+	return nil, nil
+}
+
+func sumZoneResource(nrt *topov1alpha1.NodeResourceTopology, resourceName corev1.ResourceName) resource.Quantity {
+	total := resource.NewQuantity(0, resource.BinarySI)
+	for _, zone := range nrt.Zones {
+		if zone.Type != koordutil.NodeZoneType {
+			continue
+		}
+		for _, res := range zone.Resources {
+			if res.Name == string(resourceName) {
+				total.Add(res.Capacity)
+			}
+		}
+	}
+
+	return *total
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds e2e test coverage for the `koordlet` `HugePageReport` functionality and follows the existing E2E testing patterns already used in the repository.

### Ⅱ. Does this pull request fix one issue?

Refers #1704 

### Ⅲ. Describe how to verify it
Run:
```bash
ginkgo -focus="HugePageReport" ./test/e2e/...
```
### Ⅳ. Special notes for reviews

- No production logic was modified.
- This PR only adds E2E coverage for HugePageReport validation.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
