### PR TITLE
fix: remove redundant fmt.Sprintf no-ops across four packages

### DIFF
--- a/pkg/descheduler/controllers/migration/controller.go
+++ b/pkg/descheduler/controllers/migration/controller.go
@@ -514,7 +514,7 @@ func getLimiterKeyAndProcessScope(pod *corev1.Pod, limiterType deschedulerconfig
 		}
 	case deschedulerconfig.MigrationLimitObjectNamespace:
 		limiterKey = pod.Namespace
-		processScope = fmt.Sprintf("%s", pod.Namespace)
+		processScope = pod.Namespace
 	}
 	return limiterKey, processScope
 }
@@ -571,7 +571,7 @@ func (r *Reconciler) abortJobIfTimeout(ctx context.Context, job *sev1alpha1.PodM
 func (r *Reconciler) abortJobByInvalidPodRef(ctx context.Context, job *sev1alpha1.PodMigrationJob) error {
 	job.Status.Phase = sev1alpha1.PodMigrationJobFailed
 	job.Status.Reason = "InvalidPodRef"
-	job.Status.Message = fmt.Sprintf("Abort job caused by invalid PodRef")
+	job.Status.Message = "Abort job caused by invalid PodRef"
 	err := r.Status().Update(ctx, job)
 	if err == nil {
 		r.eventRecorder.Eventf(job, nil, corev1.EventTypeWarning, "InvalidPodRef", "Migrating", job.Status.Message)

--- a/pkg/device-daemon/resource/utils.go
+++ b/pkg/device-daemon/resource/utils.go
@@ -295,7 +295,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 
 		results = strings.ReplaceAll(results, "MiB", "Mi")
 
-		return fmt.Sprintf("%s", results), nil
+		return results, nil
 	case NPU:
 		klog.Info("GetNPUMemory, start to get npu memory")
 
@@ -343,7 +343,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 
 		results = strings.ReplaceAll(results, "MiB", "Mi")
 
-		return fmt.Sprintf("%s", results), nil
+		return results, nil
 	case XPU:
 		klog.Info("GetXPUMemory, start to get xpu memory")
 		cmd := exec.Command(ChangeRootCmd, HostRootDir, XPUSmiCmd, QueryXPUMachineReadbleArgs)
@@ -381,7 +381,7 @@ func GetXPUMemory(deviceType string) (string, error) {
 
 		realResults = fmt.Sprintf("%sMi", realResults)
 
-		return fmt.Sprintf("%s", realResults), nil
+		return realResults, nil
 	case MX:
 		klog.Info("GetMXMemory, start to get mx memory")
 		// mx-smi --show-hwinfo | grep -i "Memory Capacity" | awk '{print $4}' | head -1
@@ -633,7 +633,7 @@ func GetDeviceInfo(deviceType, index string) (koordletuti.DeviceTopology, koordl
 				if faultCount > 0 {
 					status.Healthy = false
 					status.ErrMessage = fmt.Sprintf("NPU index %s has %d chip faults", index, faultCount)
-					status.ErrCode = fmt.Sprintf("chip error")
+					status.ErrCode = "chip error"
 				}
 			}
 		}
@@ -763,7 +763,7 @@ func GetDeviceInfo(deviceType, index string) (koordletuti.DeviceTopology, koordl
 		if errCount > 0 {
 			deviceStatus.Healthy = false
 			deviceStatus.ErrMessage = fmt.Sprintf("MX index %s has %d SRAM/DRAM Uncorrectable or Double Bit  ECC errors", index, errCount)
-			deviceStatus.ErrCode = fmt.Sprintf("ECC error")
+			deviceStatus.ErrCode = "ECC error"
 		}
 		return topo, deviceStatus, uuid, nil
 	default:

--- a/pkg/koordlet/util/system/cgroup_driver.go
+++ b/pkg/koordlet/util/system/cgroup_driver.go
@@ -192,7 +192,7 @@ var cgroupPathFormatterInCgroupfs = Formatter{
 			return RuntimeTypeUnknown, "", fmt.Errorf("parse container id %s failed", id)
 		}
 		if hashID[0] == RuntimeTypeDocker || hashID[0] == RuntimeTypeContainerd || hashID[0] == RuntimeTypePouch || hashID[0] == RuntimeTypeCrio {
-			return hashID[0], fmt.Sprintf("%s", hashID[1]), nil
+			return hashID[0], hashID[1], nil
 		} else {
 			return RuntimeTypeUnknown, "", fmt.Errorf("unknown container protocol %s", id)
 		}

--- a/pkg/koordlet/util/system/core_sched.go
+++ b/pkg/koordlet/util/system/core_sched.go
@@ -395,7 +395,7 @@ func SetCoreSchedFeatureEnabled() (bool, string) {
 	content, err := os.ReadFile(featurePath)
 	if err != nil {
 		klog.V(5).Infof("Core Sched is unsupported by sched_features %s, read err: %s", featurePath, err)
-		return false, fmt.Sprintf("failed to read sched_features")
+		return false, "failed to read sched_features"
 	}
 
 	features := strings.Fields(string(content))

--- a/pkg/koordlet/util/system/validator.go
+++ b/pkg/koordlet/util/system/validator.go
@@ -37,7 +37,7 @@ type RangeValidator struct {
 
 func (r *RangeValidator) Validate(value string) (bool, string) {
 	if value == "" {
-		return false, fmt.Sprintf("value is nil")
+		return false, "value is nil"
 	}
 	var v int64
 	var err error

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -269,7 +269,7 @@ func (g *Plugin) PreFilter(ctx context.Context, cycleState fwktype.CycleState, p
 	}
 	quotaInfo := mgr.GetQuotaInfoByName(quotaName)
 	if quotaInfo == nil {
-		return nil, fwktype.NewStatus(fwktype.Error, fmt.Sprintf("Could not find the specified ElasticQuota"))
+		return nil, fwktype.NewStatus(fwktype.Error, "Could not find the specified ElasticQuota")
 	}
 	state := g.snapshotPostFilterState(quotaInfo, cycleState)
 

--- a/pkg/scheduler/plugins/reservation/preemption.go
+++ b/pkg/scheduler/plugins/reservation/preemption.go
@@ -164,7 +164,7 @@ func (pm *PreemptionMgr) SelectVictimsOnNode(
 
 	// No potential victims are found, and so we don't need to evaluate the node again since its state didn't change.
 	if len(potentialVictims) == 0 {
-		message := fmt.Sprintf("No preemption victims found for incoming pod")
+		message := "No preemption victims found for incoming pod"
 		return nil, 0, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable, message)
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Removes 12 call sites across four packages that pass a plain string to `fmt.Sprintf` with no format directives. Five calls use `fmt.Sprintf("%s", x)` — equivalent to `x` with an unnecessary allocation. Seven calls use `fmt.Sprintf("literal")` — equivalent to the string literal itself. These are no-ops that add allocations and mislead readers into thinking formatting is happening. Changes are split one commit per package.

### Ⅱ. Does this pull request fix one issue?

fixes #3022 

### Ⅲ. Describe how to verify it

All changes are mechanical string substitutions with no logic changes:

- `pkg/device-daemon/resource/utils.go` — 3 `fmt.Sprintf("%s", x)`  calls replaced with `x`, 2 string-literal wraps removed
- `pkg/descheduler/controllers/migration/controller.go` — 1  `fmt.Sprintf("%s", pod.Namespace)` replaced with `pod.Namespace`,  1 string-literal wrap removed
- `pkg/koordlet/util/system/cgroup_driver.go` — 1  `fmt.Sprintf("%s", hashID[1])` replaced with `hashID[1]`
- `pkg/koordlet/util/system/core_sched.go` and `validator.go` — 2  string-literal wraps removed
- `pkg/scheduler/plugins/elasticquota/plugin.go` and  `reservation/preemption.go` — 2 string-literal wraps removed

```bash
go vet ./pkg/device-daemon/... ./pkg/descheduler/... ./pkg/koordlet/... ./pkg/scheduler/...
go test ./pkg/device-daemon/... ./pkg/descheduler/... ./pkg/koordlet/... ./pkg/scheduler/...
```

All pass with no failures.

### Ⅳ. Special notes for reviews

No behavioral changes in any file. The `fmt` import remains used in all affected files — no import removals needed. Each package is a separate commit for easier review.

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`