### PR TITLE
webhook: validate quota on pod update when quota label changes

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -91,6 +91,9 @@ const (
 	// EnableQuotaAdmission enables quota admission.
 	EnableQuotaAdmission featuregate.Feature = "EnableQuotaAdmission"
 
+	// EnableQuotaAdmissionOnUpdate enables quota admission on pod update when quota label changes.
+	EnableQuotaAdmissionOnUpdate featuregate.Feature = "EnableQuotaAdmissionOnUpdate"
+
 	// EnablePodEnhancedValidator enables enhanced validator for pods with configurable rules.
 	EnablePodEnhancedValidator featuregate.Feature = "EnablePodEnhancedValidator"
 
@@ -134,6 +137,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisableDefaultQuota:                     {Default: false, PreRelease: featuregate.Alpha},
 	SupportParentQuotaSubmitPod:             {Default: false, PreRelease: featuregate.Alpha},
 	EnableQuotaAdmission:                    {Default: false, PreRelease: featuregate.Alpha},
+	EnableQuotaAdmissionOnUpdate:            {Default: false, PreRelease: featuregate.Alpha},
 	EnableSyncGPUSharedResource:             {Default: false, PreRelease: featuregate.Alpha},
 	ColocationProfileController:             {Default: false, PreRelease: featuregate.Alpha},
 	ValidatePodDeviceResource:               {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/webhook/pod/validating/evaluate_quota.go
+++ b/pkg/webhook/pod/validating/evaluate_quota.go
@@ -39,27 +39,17 @@ var podTransformersForQuotaEvaluation = []func(pod *corev1.Pod){
 	transformer.TransformReplaceResources,
 }
 
-func (h *PodValidatingHandler) evaluateQuota(ctx context.Context, req admission.Request, newPod *corev1.Pod) (bool, string, error) {
+func (h *PodValidatingHandler) evaluateQuota(ctx context.Context, req admission.Request, newPod, oldPod *corev1.Pod) (bool, string, error) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.EnableQuotaAdmission) {
 		return true, "", nil
 	}
 	var quotaName string
 	switch req.Operation {
 	case admissionv1.Create:
-		if err := h.Decoder.DecodeRaw(req.Object, newPod); err != nil {
-			return false, "", err
-		}
 		quotaName = elasticquota.GetQuotaName(newPod, h.Client)
 	case admissionv1.Update:
 		if !utilfeature.DefaultFeatureGate.Enabled(features.EnableQuotaAdmissionOnUpdate) {
 			return true, "", nil
-		}
-		oldPod := &corev1.Pod{}
-		if err := h.Decoder.DecodeRaw(req.OldObject, oldPod); err != nil {
-			return false, "", err
-		}
-		if err := h.Decoder.DecodeRaw(req.Object, newPod); err != nil {
-			return false, "", err
 		}
 		oldQuotaName := elasticquota.GetQuotaName(oldPod, h.Client)
 		quotaName = elasticquota.GetQuotaName(newPod, h.Client)

--- a/pkg/webhook/pod/validating/evaluate_quota.go
+++ b/pkg/webhook/pod/validating/evaluate_quota.go
@@ -43,15 +43,34 @@ func (h *PodValidatingHandler) evaluateQuota(ctx context.Context, req admission.
 	if !utilfeature.DefaultFeatureGate.Enabled(features.EnableQuotaAdmission) {
 		return true, "", nil
 	}
-
+	var quotaName string
 	switch req.Operation {
 	case admissionv1.Create:
+		if err := h.Decoder.DecodeRaw(req.Object, newPod); err != nil {
+			return false, "", err
+		}
+		quotaName = elasticquota.GetQuotaName(newPod, h.Client)
+	case admissionv1.Update:
+		if !utilfeature.DefaultFeatureGate.Enabled(features.EnableQuotaAdmissionOnUpdate) {
+			return true, "", nil
+		}
+		oldPod := &corev1.Pod{}
+		if err := h.Decoder.DecodeRaw(req.OldObject, oldPod); err != nil {
+			return false, "", err
+		}
+		if err := h.Decoder.DecodeRaw(req.Object, newPod); err != nil {
+			return false, "", err
+		}
+		oldQuotaName := elasticquota.GetQuotaName(oldPod, h.Client)
+		quotaName = elasticquota.GetQuotaName(newPod, h.Client)
+		if oldQuotaName == quotaName {
+			return true, "", nil
+		}
 	default:
 		return true, "", nil
 	}
 
 	// quota is system quota or empty, skip it.
-	quotaName := elasticquota.GetQuotaName(newPod, h.Client)
 	if quotaName == "" || quotaName == extension.DefaultQuotaName ||
 		quotaName == extension.SystemQuotaName || quotaName == extension.RootQuotaName {
 		return true, "", nil

--- a/pkg/webhook/pod/validating/evaluate_quota_test.go
+++ b/pkg/webhook/pod/validating/evaluate_quota_test.go
@@ -328,6 +328,112 @@ func TestEvaluateQuota(t *testing.T) {
 			},
 		},
 		{
+			name:      "update with feature gate disabled, skip",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota2").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota1").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).Obj(),
+			wantAllowed: true,
+			wantReason:  "",
+			wantErr:     false,
+			wantUsed:    corev1.ResourceList{},
+		},
+		{
+			name:      "update with quota label unchanged, skip",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota1").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).Obj(),
+			prepareFn: func() func() {
+				return utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate,
+					features.EnableQuotaAdmissionOnUpdate, true)
+			},
+			wantAllowed: true,
+			wantReason:  "",
+			wantErr:     false,
+			wantUsed:    corev1.ResourceList{},
+		},
+		{
+			name:      "update quota label to a quota with capacity, allowed",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota2").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota2").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).Obj(),
+			prepareFn: func() func() {
+				return utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate,
+					features.EnableQuotaAdmissionOnUpdate, true)
+			},
+			wantAllowed: true,
+			wantReason:  "",
+			wantErr:     false,
+			wantUsed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+		{
+			name:      "update quota label to a full quota, denied",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota2").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota2").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).ChildRequest(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).Obj(),
+			prepareFn: func() func() {
+				return utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate,
+					features.EnableQuotaAdmissionOnUpdate, true)
+			},
+			wantAllowed: false,
+			wantReason:  "exceeded quota: kube-system/quota2, requested: cpu=2,memory=4Gi, used: cpu=4,memory=8Gi, limited: cpu=4,memory=8Gi",
+			wantErr:     true,
+			wantUsed:    corev1.ResourceList{},
+		},
+		{
 			name:      "pod with replace-resources annotation, should replace or erase specified resources",
 			operation: admissionv1.Create,
 			newPod: func() *corev1.Pod {

--- a/pkg/webhook/pod/validating/evaluate_quota_test.go
+++ b/pkg/webhook/pod/validating/evaluate_quota_test.go
@@ -519,7 +519,7 @@ func TestEvaluateQuota(t *testing.T) {
 			}
 
 			req := newAdmissionRequest(tc.operation, objRawExt, oldObjRawExt, "pods")
-			gotAllowed, gotReason, err := h.evaluateQuota(context.TODO(), admission.Request{AdmissionRequest: req}, tc.newPod)
+			gotAllowed, gotReason, err := h.evaluateQuota(context.TODO(), admission.Request{AdmissionRequest: req}, tc.newPod, tc.oldPod)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/webhook/pod/validating/validating_handler.go
+++ b/pkg/webhook/pod/validating/validating_handler.go
@@ -114,7 +114,7 @@ func (h *PodValidatingHandler) validatingPodFn(ctx context.Context, req admissio
 		metrics.Pod, string(req.Operation), nil, plugin.Name(), time.Since(start).Seconds())
 
 	start = time.Now()
-	_, reason, err = h.evaluateQuota(ctx, req, newPod)
+	_, reason, err = h.evaluateQuota(ctx, req, newPod, oldPod)
 	metrics.RecordWebhookDurationMilliseconds(metrics.ValidatingWebhook,
 		metrics.Pod, string(req.Operation), err, EvaluateQuota, time.Since(start).Seconds())
 

--- a/pkg/webhook/quotaevaluate/evaluator.go
+++ b/pkg/webhook/quotaevaluate/evaluator.go
@@ -448,8 +448,11 @@ func (e *quotaEvaluator) initCtx(ctx *quotaCheckContext, quota *v1alpha1.Elastic
 	return ctx
 }
 
+// Handles returns true if the evaluator should process this operation.
+// For Update, the caller (evaluateQuota) has already checked the EnableQuotaAdmissionOnUpdate feature gate
+// before constructing the Attributes, so no redundant gate check is needed here.
 func (e *quotaEvaluator) Handles(a *Attributes) bool {
-	if a.Operation == admissionv1.Create {
+	if a.Operation == admissionv1.Create || a.Operation == admissionv1.Update {
 		return true
 	}
 	return false

--- a/pkg/webhook/quotaevaluate/evaluator_test.go
+++ b/pkg/webhook/quotaevaluate/evaluator_test.go
@@ -117,7 +117,7 @@ func TestCheckRequest(t *testing.T) {
 			expectDelta: corev1.ResourceList{},
 		},
 		{
-			name: "non-create operation is no-op",
+			name: "update operation is handled and counts resources",
 			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
 				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}).Obj(),
 			ctx: &quotaCheckContext{
@@ -128,6 +128,49 @@ func TestCheckRequest(t *testing.T) {
 			},
 			attr: &Attributes{
 				Operation: admissionv1.Update,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).Obj(),
+			},
+			expectErr:   false,
+			expectUsed:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			expectDelta: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+		},
+		{
+			name: "update operation exceeds quota returns error",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+				admission: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(corev1.ResourceCPU),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Update,
+				Pod: elasticquota.MakePod("ns", "pod1").Container(
+					corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					}).Obj(),
+			},
+			expectErr:   true,
+			errContains: "exceeded quota",
+			expectUsed:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+			expectDelta: corev1.ResourceList{},
+		},
+		{
+			name: "delete operation is no-op",
+			quota: elasticquota.MakeQuota("test").Namespace("ns").Max(
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}).Obj(),
+			ctx: &quotaCheckContext{
+				used:      corev1.ResourceList{},
+				admission: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")},
+				delta:     corev1.ResourceList{},
+				names:     sets.New(corev1.ResourceCPU),
+			},
+			attr: &Attributes{
+				Operation: admissionv1.Delete,
 				Pod: elasticquota.MakePod("ns", "pod1").Container(
 					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).Obj(),
 			},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

  Support quota admission validation on pod update when the quota label changes.

  When a pod is created, the webhook validates its quota usage via `evaluateQuota`. However, the quota name is derived from the pod label `quota.scheduling.koordinator.sh/name`, which can be modified via Update
  operations. Currently, `evaluateQuota` only handles Create and skips Update, allowing users to bypass quota limits by changing the quota label after creation — moving a pod into a full quota without any admission
   check.

  This PR:
  - Adds `admissionv1.Update` handling in `evaluateQuota`: decodes old/new pod, compares quota labels, and evaluates the target quota capacity if the label changed.
  - Extends `Handles()` in the evaluator to accept Update operations.
  - Introduces a new `EnableQuotaAdmissionOnUpdate` feature gate (Alpha, default off) to control the behavior independently.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

  1. Run existing tests to confirm no regression:
     ```bash
     go test ./pkg/webhook/pod/validating/ -run TestEvaluateQuota -v
     go test ./pkg/webhook/quotaevaluate/ -v
  2. New test cases cover:
    - Update with feature gate disabled — allowed (skip)
    - Update with quota label unchanged — allowed (skip)
    - Update with quota label changed, target quota has capacity — allowed
    - Update with quota label changed, target quota is full — denied

### Ⅳ. Special notes for reviews

  - The feature is gated behind EnableQuotaAdmissionOnUpdate (Alpha, default off), so it has zero impact when not explicitly enabled.
  - The Handles() method in the evaluator accepts Update unconditionally; the feature gate check is performed by the caller (evaluateQuota) before constructing the Attributes. A comment documents this contract.
  - The scheduler's GroupQuotaManager.OnPodUpdate already handles quota label migration (adjusts used/request accounting), so the quota state will reconcile correctly after the webhook validates the update.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
