### PR TITLE
fix(descheduler): remove deleted PodMigrationJobs from arbitrator waiting queue

### DIFF
--- a/pkg/descheduler/controllers/migration/arbitrator/arbitrator.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/arbitrator.go
@@ -111,6 +111,10 @@ func (a *arbitratorImpl) AddPodMigrationJob(job *v1alpha1.PodMigrationJob) {
 // It is safe to be called concurrently by multiple goroutines.
 func (a *arbitratorImpl) DeletePodMigrationJob(job *v1alpha1.PodMigrationJob) {
 	a.filter.removeJobPassedArbitration(job.UID)
+	// remove from waitingCollection if it's still there
+	a.mu.Lock()
+	delete(a.waitingCollection, job.UID)
+	a.mu.Unlock()
 }
 
 // Start starts the goroutine to arbitrate jobs periodically.

--- a/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
@@ -234,6 +234,28 @@ func TestAdd(t *testing.T) {
 	assert.ElementsMatchf(t, expectedJobs, actualJobs, "failed")
 }
 
+func TestDeletePodMigrationJobRemovesFromWaitingCollection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	job := makePodMigrationJob("test-job", time.Now(), nil)
+	arbitrator := &arbitratorImpl{
+		waitingCollection: map[types.UID]*v1alpha1.PodMigrationJob{job.UID: job},
+		client:            fakeClient,
+		filter: &filter{
+			arbitratedPodMigrationJobs: map[types.UID]bool{job.UID: true},
+		},
+		mu: sync.Mutex{},
+	}
+
+	arbitrator.DeletePodMigrationJob(job)
+
+	assert.False(t, arbitrator.filter.checkJobPassedArbitration(job.UID))
+	assert.Len(t, arbitrator.waitingCollection, 0)
+}
+
 func TestRequeueJobIfRetryablePodFilterFailed(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(scheme)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

- Fixes the arbitrator delete path to remove deleted PodMigrationJobs from the in‑memory waiting queue, preventing repeated update attempts on deleted objects.
- Adds a unit test to ensure `DeletePodMigrationJob` clears the queue and arbitration map state.

### Ⅱ. Does this pull request fix one issue?
fixes #3030

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

- Unit test:
  - `go test ./pkg/descheduler/controllers/migration/arbitrator -run TestDeletePodMigrationJobRemovesFromWaitingCollection`
- Manual repro: (check issue for bug details)
  1. Create a Deployment with 2 replicas and a PodMigrationJob targeting one pod.
  2. Immediately delete the PodMigrationJob before arbitration.
  3. Confirm no repeated `failed to update job` errors appear in descheduler logs.

### Ⅳ. Special notes for reviews

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
