### PR TITLE
fix: report all missing EstimatedScalingFactors in ValidateLoadAwareSchedulingArgs

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -55,7 +55,6 @@ func ValidateLoadAwareSchedulingArgs(args *config.LoadAwareSchedulingArgs) error
 	for resourceName := range args.ResourceWeights {
 		if _, ok := args.EstimatedScalingFactors[resourceName]; !ok {
 			allErrs = append(allErrs, field.NotFound(field.NewPath("estimatedScalingFactors"), resourceName))
-			break
 		}
 	}
 

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -212,6 +212,21 @@ func TestValidateLoadAwareSchedulingArgs(t *testing.T) {
 	}
 }
 
+func TestValidateLoadAwareSchedulingArgs_ReportsAllMissingScalingFactors(t *testing.T) {
+	args := &config.LoadAwareSchedulingArgs{
+		ResourceWeights: map[corev1.ResourceName]int64{
+			corev1.ResourceCPU:    1,
+			corev1.ResourceMemory: 1,
+		},
+		EstimatedScalingFactors: map[corev1.ResourceName]int64{},
+	}
+	err := ValidateLoadAwareSchedulingArgs(args)
+	assert.Error(t, err)
+	errStr := err.Error()
+	assert.Contains(t, errStr, string(corev1.ResourceCPU))
+	assert.Contains(t, errStr, string(corev1.ResourceMemory))
+}
+
 func TestValidateElasticQuotaArgs(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`ValidateLoadAwareSchedulingArgs` in `pkg/scheduler/apis/config/validation/validation_pluginargs.go` validates that every key in `ResourceWeights` has a corresponding entry in `EstimatedScalingFactors`. The loop had a `break` after the first `field.NotFound` error, so validation stopped at the first missing entry. Operators with multiple missing scaling factors had to fix and restart the scheduler repeatedly to discover each one.

Removes the `break` so the loop runs to completion and all missing entries are reported in a single validation call, consistent with every other loop in the same function and with `field.ErrorList` semantics across the Kubernetes ecosystem.

### Ⅱ. Does this pull request fix one issue?

fixes #3033 

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/scheduler/apis/config/validation/... -v -run TestValidateLoadAwareSchedulingArgs
```

New test `TestValidateLoadAwareSchedulingArgs_ReportsAllMissingScalingFactors` configures `ResourceWeights` with both `cpu` and `memory` while leaving `EstimatedScalingFactors` empty. Before the fix only one resource name appeared in the error; after the fix both appear. All existing tests continue to pass.

### Ⅳ. Special notes for reviews

One `break` removed — no other logic change. The existing `"resourceWeight missing estimatedScalingFactor"` table case only checks `wantErr: true` so it passes either way; the new test is what specifically exercises the all-errors path.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`