### PR TITLE
fix(descheduler): fail PodMigrationJob when target pod is missing in arbitrator

### DIFF
--- a/pkg/descheduler/controllers/migration/arbitrator/arbitrator.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/arbitrator.go
@@ -155,16 +155,18 @@ func (a *arbitratorImpl) sort(jobs []*v1alpha1.PodMigrationJob, podOfJob map[*v1
 
 // filtering calls nonRetryablePodFilter and retryablePodFilter to filter one PodMigrationJob.
 func (a *arbitratorImpl) filtering(pod *corev1.Pod) (isFailed, isPassed bool) {
-	if pod != nil {
-		markPodArbitrating(pod)
-		if a.filter.nonRetryablePodFilter != nil && !a.filter.nonRetryablePodFilter(pod) {
-			isFailed = true
-			return
-		}
-		if a.filter.retryablePodFilter != nil && !a.filter.retryablePodFilter(pod) {
-			isPassed = false
-			return
-		}
+	if pod == nil {
+		isFailed = true
+		return
+	}
+	markPodArbitrating(pod)
+	if a.filter.nonRetryablePodFilter != nil && !a.filter.nonRetryablePodFilter(pod) {
+		isFailed = true
+		return
+	}
+	if a.filter.retryablePodFilter != nil && !a.filter.retryablePodFilter(pod) {
+		isPassed = false
+		return
 	}
 	isPassed = true
 	return
@@ -230,11 +232,20 @@ func (a *arbitratorImpl) copyJobs() []*v1alpha1.PodMigrationJob {
 func (a *arbitratorImpl) updateFailedJob(job *v1alpha1.PodMigrationJob, pod *corev1.Pod) {
 	// change phase to Failed
 	job.Status.Phase = v1alpha1.PodMigrationJobFailed
-	job.Status.Reason = v1alpha1.PodMigrationJobReasonForbiddenMigratePod
-	job.Status.Message = fmt.Sprintf("Pod %q is forbidden to migrate because it does not meet the requirements", klog.KObj(pod))
+	if pod == nil {
+		podRefKey := "<nil>"
+		if job.Spec.PodRef != nil {
+			podRefKey = fmt.Sprintf("%s/%s", job.Spec.PodRef.Namespace, job.Spec.PodRef.Name)
+		}
+		job.Status.Reason = v1alpha1.PodMigrationJobReasonMissingPod
+		job.Status.Message = fmt.Sprintf("Pod %q is missing for PodMigrationJob", podRefKey)
+	} else {
+		job.Status.Reason = v1alpha1.PodMigrationJobReasonForbiddenMigratePod
+		job.Status.Message = fmt.Sprintf("Pod %q is forbidden to migrate because it does not meet the requirements", klog.KObj(pod))
+	}
 	err := a.client.Status().Update(context.TODO(), job)
 	if err == nil {
-		a.eventRecorder.Eventf(job, nil, corev1.EventTypeWarning, v1alpha1.PodMigrationJobReasonForbiddenMigratePod, "Migrating", job.Status.Message)
+		a.eventRecorder.Eventf(job, nil, corev1.EventTypeWarning, job.Status.Reason, "Migrating", job.Status.Message)
 	}
 
 	// delete from waitingCollection

--- a/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
@@ -149,8 +149,8 @@ func TestFiltering(t *testing.T) {
 			nil,
 			false,
 			false,
-			false,
 			true,
+			false,
 		},
 		{
 			"testCase2: nonRetryable:failed, retryable: passed",
@@ -232,6 +232,51 @@ func TestAdd(t *testing.T) {
 	}
 	expectedJobs := []string{"test-job-1", "test-job-2", "test-job-3", "test-job-4", "test-job-5"}
 	assert.ElementsMatchf(t, expectedJobs, actualJobs, "failed")
+}
+
+func TestDoOnceArbitrateMissingPodFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithStatusSubresource(&v1alpha1.PodMigrationJob{}).WithScheme(scheme).Build()
+
+	job := makePodMigrationJob("test-job", time.Now(), nil)
+	assert.Nil(t, fakeClient.Create(context.TODO(), job))
+
+	a := &arbitratorImpl{
+		waitingCollection: map[types.UID]*v1alpha1.PodMigrationJob{job.UID: job},
+		sorts: []SortFn{func(jobs []*v1alpha1.PodMigrationJob, podOfJob map[*v1alpha1.PodMigrationJob]*corev1.Pod) []*v1alpha1.PodMigrationJob {
+			return jobs
+		}},
+		filter: &filter{
+			nonRetryablePodFilter: func(pod *corev1.Pod) bool {
+				return true
+			},
+			retryablePodFilter: func(pod *corev1.Pod) bool {
+				return true
+			},
+			arbitratedPodMigrationJobs: map[types.UID]bool{},
+		},
+		client:        fakeClient,
+		mu:            sync.Mutex{},
+		eventRecorder: &events.FakeRecorder{},
+		interval:      0,
+	}
+
+	a.doOnceArbitrate()
+
+	assert.Equal(t, 0, len(a.waitingCollection))
+
+	actualJob := &v1alpha1.PodMigrationJob{}
+	assert.Nil(t, fakeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: job.Namespace,
+		Name:      job.Name,
+	}, actualJob))
+	assert.Equal(t, v1alpha1.PodMigrationJobFailed, actualJob.Status.Phase)
+	assert.Equal(t, v1alpha1.PodMigrationJobReasonMissingPod, actualJob.Status.Reason)
+	if actualJob.Annotations != nil {
+		assert.NotEqual(t, "true", actualJob.Annotations[AnnotationPassedArbitration])
+	}
 }
 
 func TestRequeueJobIfRetryablePodFilterFailed(t *testing.T) {

--- a/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
+++ b/pkg/descheduler/controllers/migration/arbitrator/arbitrator_test.go
@@ -235,47 +235,81 @@ func TestAdd(t *testing.T) {
 }
 
 func TestDoOnceArbitrateMissingPodFails(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = v1alpha1.AddToScheme(scheme)
-	_ = clientgoscheme.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithStatusSubresource(&v1alpha1.PodMigrationJob{}).WithScheme(scheme).Build()
-
-	job := makePodMigrationJob("test-job", time.Now(), nil)
-	assert.Nil(t, fakeClient.Create(context.TODO(), job))
-
-	a := &arbitratorImpl{
-		waitingCollection: map[types.UID]*v1alpha1.PodMigrationJob{job.UID: job},
-		sorts: []SortFn{func(jobs []*v1alpha1.PodMigrationJob, podOfJob map[*v1alpha1.PodMigrationJob]*corev1.Pod) []*v1alpha1.PodMigrationJob {
-			return jobs
-		}},
-		filter: &filter{
-			nonRetryablePodFilter: func(pod *corev1.Pod) bool {
-				return true
-			},
-			retryablePodFilter: func(pod *corev1.Pod) bool {
-				return true
-			},
-			arbitratedPodMigrationJobs: map[types.UID]bool{},
+	testCases := []struct {
+		name            string
+		job             *v1alpha1.PodMigrationJob
+		expectedMessage string
+	}{
+		{
+			name:            "podRef nil",
+			job:             makePodMigrationJob("test-job-nil-podref", time.Now(), nil),
+			expectedMessage: `Pod "<nil>" is missing for PodMigrationJob`,
 		},
-		client:        fakeClient,
-		mu:            sync.Mutex{},
-		eventRecorder: &events.FakeRecorder{},
-		interval:      0,
+		{
+			name: "podRef set but pod not found",
+			job: &v1alpha1.PodMigrationJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-job-missing-pod",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					UID:               types.UID("test-job-missing-pod-uid"),
+				},
+				Spec: v1alpha1.PodMigrationJobSpec{
+					PodRef: &corev1.ObjectReference{
+						Namespace: "default",
+						Name:      "missing-pod",
+					},
+				},
+			},
+			expectedMessage: `Pod "default/missing-pod" is missing for PodMigrationJob`,
+		},
 	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = v1alpha1.AddToScheme(scheme)
+			_ = clientgoscheme.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithStatusSubresource(&v1alpha1.PodMigrationJob{}).WithScheme(scheme).Build()
 
-	a.doOnceArbitrate()
+			job := testCase.job
+			assert.Nil(t, fakeClient.Create(context.TODO(), job))
 
-	assert.Equal(t, 0, len(a.waitingCollection))
+			a := &arbitratorImpl{
+				waitingCollection: map[types.UID]*v1alpha1.PodMigrationJob{job.UID: job},
+				sorts: []SortFn{func(jobs []*v1alpha1.PodMigrationJob, podOfJob map[*v1alpha1.PodMigrationJob]*corev1.Pod) []*v1alpha1.PodMigrationJob {
+					return jobs
+				}},
+				filter: &filter{
+					nonRetryablePodFilter: func(pod *corev1.Pod) bool {
+						return true
+					},
+					retryablePodFilter: func(pod *corev1.Pod) bool {
+						return true
+					},
+					arbitratedPodMigrationJobs: map[types.UID]bool{},
+				},
+				client:        fakeClient,
+				mu:            sync.Mutex{},
+				eventRecorder: &events.FakeRecorder{},
+				interval:      0,
+			}
 
-	actualJob := &v1alpha1.PodMigrationJob{}
-	assert.Nil(t, fakeClient.Get(context.TODO(), types.NamespacedName{
-		Namespace: job.Namespace,
-		Name:      job.Name,
-	}, actualJob))
-	assert.Equal(t, v1alpha1.PodMigrationJobFailed, actualJob.Status.Phase)
-	assert.Equal(t, v1alpha1.PodMigrationJobReasonMissingPod, actualJob.Status.Reason)
-	if actualJob.Annotations != nil {
-		assert.NotEqual(t, "true", actualJob.Annotations[AnnotationPassedArbitration])
+			a.doOnceArbitrate()
+
+			assert.Equal(t, 0, len(a.waitingCollection))
+
+			actualJob := &v1alpha1.PodMigrationJob{}
+			assert.Nil(t, fakeClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: job.Namespace,
+				Name:      job.Name,
+			}, actualJob))
+			assert.Equal(t, v1alpha1.PodMigrationJobFailed, actualJob.Status.Phase)
+			assert.Equal(t, v1alpha1.PodMigrationJobReasonMissingPod, actualJob.Status.Reason)
+			assert.Equal(t, testCase.expectedMessage, actualJob.Status.Message)
+			if actualJob.Annotations != nil {
+				assert.NotEqual(t, "true", actualJob.Annotations[AnnotationPassedArbitration])
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When the migration arbitrator cannot resolve the target pod, fail the PodMigrationJob with MissingPod instead of approving it for migration.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

The migration controller’s arbitrator resolves each PodMigrationJob’s target pod via getPodForJob. When the pod is missing (deleted, not yet created, or PodRef cannot be resolved), the job is absent from podOfJob, so filtering receives nil.

Previously, filtering(nil) skipped filter checks and returned isPassed = true, which led to updatePassedJob and set descheduler.koordinator.sh/passed-arbitration. That incorrectly approved migration for a job with no resolvable pod.

This PR:

1. `filtering`: Treats a `nil` pod as failure (`isFailed = true`) and returns early, so the job never receives the passed-arbitration annotation.
2. `updateFailedJob`: When `pod == nil`, sets `Status.Phase = Failed`, `Status.Reason = MissingPod`, and a message naming the pod reference (aligned with the migration controller’s existing missing-pod handling). Filter failures on a real pod still use `ForbiddenMigratePod`.
3. Tests: Updates `TestFiltering` for the nil-pod case and adds `TestDoOnceArbitrateMissingPodFails` for the end-to-end arbitrate path.

### Ⅱ. Does this pull request fix one issue?

fixes #3039

### Ⅲ. Describe how to verify it
Run the relevant tests

```bash
go test ./pkg/descheduler/controllers/migration/arbitrator -run 'TestFiltering|TestDoOnceArbitrateMissingPodFails' -v
```

### Ⅳ. Special notes for reviews

- **Scope**: Only the arbitrator path when `getPodForJob` leaves `podOfJob[job]` unset (`PodRef` nil, `Get` error, or pod not in API). Transient API errors still omit the pod from the map; this change fails the job instead of approving it. If retry-on-transient-error is desired, that would be a separate follow-up.
- **Consistency**: `PodMigrationJobReasonMissingPod` is already used in `pkg/descheduler/controllers/migration/controller.go` for missing pods; this PR aligns arbitrator behavior with that.
- **Event reason**: `updateFailedJob` now uses `job.Status.Reason` in the event (so missing-pod jobs emit `MissingPod`, not always `ForbiddenMigratePod`).

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
