### PR TITLE
fix(scheduler): fix loadaware ghost load when pod spec.nodeName changes

### DIFF
--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache.go
@@ -375,6 +375,14 @@ func (p *podAssignCache) OnUpdate(oldObj, newObj interface{}) {
 	if !ok || pod == nil {
 		return
 	}
+	// When spec.nodeName changes, remove the pod from the old node's cache to
+	// prevent ghost load: the old node would otherwise permanently retain the
+	// pod's estimated resources in nodeDelta/nodeEstimated, inflating Filter
+	// and Score results for new pods targeting that node.
+	if oldPod, ok := oldObj.(*corev1.Pod); ok && oldPod != nil &&
+		oldPod.Spec.NodeName != "" && oldPod.Spec.NodeName != pod.Spec.NodeName {
+		p.unAssign(oldPod.Spec.NodeName, pod)
+	}
 	switch oldPodInfo := p.getPodAssignInfo(pod.Spec.NodeName, pod); {
 	case oldPodInfo == nil: // pod was not cached
 		p.assign(pod.Spec.NodeName, pod)

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -326,8 +326,98 @@ func TestPodAssignCache_OnUpdate(t *testing.T) {
 				assignCache.OnAdd(pod, true)
 			}
 			assignCache.OnUpdate(nil, tt.pod)
-			actual, _ := assignCache.getNodeInfo(node)
-			tt.want(t, actual)
+		actual, _ := assignCache.getNodeInfo(node)
+		tt.want(t, actual)
+	})
+}
+}
+
+func TestPodAssignCache_OnUpdate_NodeNameChange(t *testing.T) {
+	vectorizer := NewResourceVectorizer(corev1.ResourceCPU, corev1.ResourceMemory)
+	now := metav1.Now().Rfc3339Copy().Time
+	nodeA := "node-a"
+	nodeB := "node-b"
+	tests := []struct {
+		name        string
+		existingPod *corev1.Pod
+		updatedPod  *corev1.Pod
+		wantSrcNode func(*testing.T, *nodeInfo)
+		wantDstNode func(*testing.T, *nodeInfo)
+	}{
+		{
+		name:        "pod moves from node-a to node-b: source node cache must be cleared",
+		existingPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeA).Phase(corev1.PodRunning).Obj(),
+		updatedPod:  st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeB).Phase(corev1.PodRunning).Obj(),
+		wantSrcNode: func(t *testing.T, n *nodeInfo) {
+			assert.Equal(t, 0, len(n.podInfos))
+			empty := sets.New[NamespacedName]()
+			assert.Equal(t, vectorizer.EmptyVec(), n.nodeDelta)
+			assert.Equal(t, vectorizer.EmptyVec(), n.nodeEstimated)
+			assert.Equal(t, empty, n.nodeDeltaPods)
+			assert.Equal(t, empty, n.nodeEstimatedPods)
+		},
+		wantDstNode: func(t *testing.T, n *nodeInfo) {
+			assert.Equal(t, 1, len(n.podInfos))
+			v := vectorizer.ToFactorVec(map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    estimator.DefaultMilliCPURequest,
+				corev1.ResourceMemory: estimator.DefaultMemoryRequest,
+			})
+			s := sets.New(NamespacedName{Namespace: "default", Name: "test-pod"})
+			assert.Equal(t, v, n.nodeDelta)
+			assert.Equal(t, v, n.nodeEstimated)
+			assert.Equal(t, s, n.nodeDeltaPods)
+			assert.Equal(t, s, n.nodeEstimatedPods)
+		},
+	},
+	{
+		name: "pod with resources moves from node-a to node-b: source node cache must be cleared",
+			existingPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeA).Phase(corev1.PodRunning).
+				Req(map[corev1.ResourceName]string{corev1.ResourceCPU: "1", corev1.ResourceMemory: "4Gi"}).Obj(),
+			updatedPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeB).Phase(corev1.PodRunning).
+				Req(map[corev1.ResourceName]string{corev1.ResourceCPU: "1", corev1.ResourceMemory: "4Gi"}).Obj(),
+			wantSrcNode: func(t *testing.T, n *nodeInfo) {
+				assert.Equal(t, 0, len(n.podInfos))
+				empty := sets.New[NamespacedName]()
+				assert.Equal(t, vectorizer.EmptyVec(), n.nodeDelta)
+				assert.Equal(t, vectorizer.EmptyVec(), n.prodDelta)
+				assert.Equal(t, vectorizer.EmptyVec(), n.nodeEstimated)
+				assert.Equal(t, empty, n.nodeDeltaPods)
+				assert.Equal(t, empty, n.prodDeltaPods)
+				assert.Equal(t, empty, n.nodeEstimatedPods)
+			},
+			wantDstNode: func(t *testing.T, n *nodeInfo) {
+				assert.Equal(t, 1, len(n.podInfos))
+				v := vectorizer.ToVec(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				})
+				s := sets.New(NamespacedName{Namespace: "default", Name: "test-pod"})
+				assert.Equal(t, v, n.nodeDelta)
+				assert.Equal(t, v, n.prodDelta)
+				assert.Equal(t, v, n.nodeEstimated)
+				assert.Equal(t, s, n.nodeDeltaPods)
+				assert.Equal(t, s, n.prodDeltaPods)
+				assert.Equal(t, s, n.nodeEstimatedPods)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := &config.LoadAwareSchedulingArgs{EstimatedScalingFactors: map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    100,
+				corev1.ResourceMemory: 100,
+			}}
+			e, _ := estimator.NewDefaultEstimator(args, nil)
+			assignCache := newPodAssignCache(e, vectorizer, args)
+			assignCache.clock = clock.NewFakeClock(now)
+			assignCache.AddOrUpdateNodeMetric(&slov1alpha1.NodeMetric{ObjectMeta: metav1.ObjectMeta{Name: nodeA}})
+			assignCache.AddOrUpdateNodeMetric(&slov1alpha1.NodeMetric{ObjectMeta: metav1.ObjectMeta{Name: nodeB}})
+			assignCache.OnAdd(tt.existingPod, true)
+			assignCache.OnUpdate(tt.existingPod, tt.updatedPod)
+			srcInfo, _ := assignCache.getNodeInfo(nodeA)
+			dstInfo, _ := assignCache.getNodeInfo(nodeB)
+			tt.wantSrcNode(t, srcInfo)
+			tt.wantDstNode(t, dstInfo)
 		})
 	}
 }

--- a/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
+++ b/pkg/scheduler/plugins/loadaware/pod_assign_cache_test.go
@@ -326,10 +326,10 @@ func TestPodAssignCache_OnUpdate(t *testing.T) {
 				assignCache.OnAdd(pod, true)
 			}
 			assignCache.OnUpdate(nil, tt.pod)
-		actual, _ := assignCache.getNodeInfo(node)
-		tt.want(t, actual)
-	})
-}
+			actual, _ := assignCache.getNodeInfo(node)
+			tt.want(t, actual)
+		})
+	}
 }
 
 func TestPodAssignCache_OnUpdate_NodeNameChange(t *testing.T) {
@@ -345,32 +345,32 @@ func TestPodAssignCache_OnUpdate_NodeNameChange(t *testing.T) {
 		wantDstNode func(*testing.T, *nodeInfo)
 	}{
 		{
-		name:        "pod moves from node-a to node-b: source node cache must be cleared",
-		existingPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeA).Phase(corev1.PodRunning).Obj(),
-		updatedPod:  st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeB).Phase(corev1.PodRunning).Obj(),
-		wantSrcNode: func(t *testing.T, n *nodeInfo) {
-			assert.Equal(t, 0, len(n.podInfos))
-			empty := sets.New[NamespacedName]()
-			assert.Equal(t, vectorizer.EmptyVec(), n.nodeDelta)
-			assert.Equal(t, vectorizer.EmptyVec(), n.nodeEstimated)
-			assert.Equal(t, empty, n.nodeDeltaPods)
-			assert.Equal(t, empty, n.nodeEstimatedPods)
+			name:        "pod moves from node-a to node-b: source node cache must be cleared",
+			existingPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeA).Phase(corev1.PodRunning).Obj(),
+			updatedPod:  st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeB).Phase(corev1.PodRunning).Obj(),
+			wantSrcNode: func(t *testing.T, n *nodeInfo) {
+				assert.Equal(t, 0, len(n.podInfos))
+				empty := sets.New[NamespacedName]()
+				assert.Equal(t, vectorizer.EmptyVec(), n.nodeDelta)
+				assert.Equal(t, vectorizer.EmptyVec(), n.nodeEstimated)
+				assert.Equal(t, empty, n.nodeDeltaPods)
+				assert.Equal(t, empty, n.nodeEstimatedPods)
+			},
+			wantDstNode: func(t *testing.T, n *nodeInfo) {
+				assert.Equal(t, 1, len(n.podInfos))
+				v := vectorizer.ToFactorVec(map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    estimator.DefaultMilliCPURequest,
+					corev1.ResourceMemory: estimator.DefaultMemoryRequest,
+				})
+				s := sets.New(NamespacedName{Namespace: "default", Name: "test-pod"})
+				assert.Equal(t, v, n.nodeDelta)
+				assert.Equal(t, v, n.nodeEstimated)
+				assert.Equal(t, s, n.nodeDeltaPods)
+				assert.Equal(t, s, n.nodeEstimatedPods)
+			},
 		},
-		wantDstNode: func(t *testing.T, n *nodeInfo) {
-			assert.Equal(t, 1, len(n.podInfos))
-			v := vectorizer.ToFactorVec(map[corev1.ResourceName]int64{
-				corev1.ResourceCPU:    estimator.DefaultMilliCPURequest,
-				corev1.ResourceMemory: estimator.DefaultMemoryRequest,
-			})
-			s := sets.New(NamespacedName{Namespace: "default", Name: "test-pod"})
-			assert.Equal(t, v, n.nodeDelta)
-			assert.Equal(t, v, n.nodeEstimated)
-			assert.Equal(t, s, n.nodeDeltaPods)
-			assert.Equal(t, s, n.nodeEstimatedPods)
-		},
-	},
-	{
-		name: "pod with resources moves from node-a to node-b: source node cache must be cleared",
+		{
+			name: "pod with resources moves from node-a to node-b: source node cache must be cleared",
 			existingPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeA).Phase(corev1.PodRunning).
 				Req(map[corev1.ResourceName]string{corev1.ResourceCPU: "1", corev1.ResourceMemory: "4Gi"}).Obj(),
 			updatedPod: st.MakePod().UID("aaa").Namespace("default").Name("test-pod").Node(nodeB).Phase(corev1.PodRunning).


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

`podAssignCache.OnUpdate` declared `oldObj` as a parameter but never read it. When a pod's `spec.nodeName` changes from `node-A` to `node-B`, as triggered by migration controllers that patch `spec.nodeName` directly, the handler called `assign("node-B", pod)` correctly but never called `unAssign("node-A", pod)`. 
The source node permanently retained the pod's estimated CPU and memory in `nodeDelta` and `nodeEstimated`, making it appear busier than it really is to `LoadAware` `Filter` and `Score`.

Fix: before the existing switch, cast `oldObj` to `*corev1.Pod` and call `unAssign(oldNode, pod)` when `oldPod.Spec.NodeName` is non-empty and differs from the new node. This mirrors the existing behaviour of `OnDelete` and `Unreserve`, both of which already call `unAssign` correctly.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #3049

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/scheduler/plugins/loadaware/... -run TestPodAssignCache_OnUpdate -v
```

All 8 sub-tests pass, including the two new cases in `TestPodAssignCache_OnUpdate_NodeNameChange`:
- `pod moves from node-a to node-b: source node cache must be cleared`
- `pod with resources moves from node-a to node-b: source node cache must be cleared`

Both cases confirm that after `OnUpdate`, `node-a` holds zero pods, empty `nodeDelta`, and empty `nodeEstimated`.

### Ⅳ. Special notes for reviews

- The guard `oldPod.Spec.NodeName != ""` ensures pending pods (never assigned to a node) are a no-op, consistent with the early-return in `unAssign` itself.
- The guard `oldPod.Spec.NodeName != pod.Spec.NodeName` prevents same-node updates (conditions, labels, resource changes) from triggering an unnecessary `unAssign` + `assign` round-trip on the same node.
