### PR TITLE
fix(descheduler): fix PreEvictionFilter delegation in k8s plugin evictor adaptor

### DIFF
--- a/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor.go
@@ -41,10 +41,7 @@ func (a *evictorAdaptor) Filter(pod *corev1.Pod) bool {
 
 // PreEvictionFilter checks if pod can be evicted right before eviction
 func (a *evictorAdaptor) PreEvictionFilter(pod *corev1.Pod) bool {
-	if evictorPlugin, ok := a.evictor.(k8sdeschedulerframework.EvictorPlugin); ok {
-		return evictorPlugin.PreEvictionFilter(pod)
-	}
-	return a.evictor.Filter(pod)
+	return a.evictor.PreEvictionFilter(pod)
 }
 
 // Evict evicts a pod (no pre-check performed)

--- a/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor_test.go
+++ b/pkg/descheduler/framework/plugins/kubernetes/adaptor/evictor_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adaptor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/descheduler/framework"
+)
+
+// mockEvictor implements framework.Evictor with independently-controlled return
+// values for Filter and PreEvictionFilter so that the two methods can be
+// distinguished in tests.
+type mockEvictor struct {
+	filterResult            bool
+	preEvictionFilterResult bool
+}
+
+var _ framework.Evictor = &mockEvictor{}
+
+func (m *mockEvictor) Filter(_ *corev1.Pod) bool            { return m.filterResult }
+func (m *mockEvictor) PreEvictionFilter(_ *corev1.Pod) bool { return m.preEvictionFilterResult }
+func (m *mockEvictor) Evict(_ context.Context, _ *corev1.Pod, _ framework.EvictOptions) bool {
+	return false
+}
+
+func TestEvictorAdaptor_Filter(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}}
+
+	tests := []struct {
+		name         string
+		filterResult bool
+		want         bool
+	}{
+		{name: "filter allows", filterResult: true, want: true},
+		{name: "filter denies", filterResult: false, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &evictorAdaptor{evictor: &mockEvictor{filterResult: tc.filterResult}}
+			assert.Equal(t, tc.want, a.Filter(pod))
+		})
+	}
+}
+
+func TestEvictorAdaptor_PreEvictionFilter(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}}
+
+	tests := []struct {
+		name                    string
+		filterResult            bool
+		preEvictionFilterResult bool
+		want                    bool
+	}{
+		{
+			// Key test case: pod is structurally evictable (Filter=true)
+			// but NodeFit says no room on other nodes (PreEvictionFilter=false).
+			// The adaptor must return false, not the Filter value.
+			name:                    "passes Filter but fails PreEvictionFilter (NodeFit blocked)",
+			filterResult:            true,
+			preEvictionFilterResult: false,
+			want:                    false,
+		},
+		{
+			name:                    "passes both Filter and PreEvictionFilter",
+			filterResult:            true,
+			preEvictionFilterResult: true,
+			want:                    true,
+		},
+		{
+			name:                    "fails both Filter and PreEvictionFilter",
+			filterResult:            false,
+			preEvictionFilterResult: false,
+			want:                    false,
+		},
+		{
+			// Inverse: structurally blocked but pre-eviction says ok.
+			// Unusual in practice but the adaptor must still delegate faithfully.
+			name:                    "fails Filter but passes PreEvictionFilter",
+			filterResult:            false,
+			preEvictionFilterResult: true,
+			want:                    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &evictorAdaptor{
+				evictor: &mockEvictor{
+					filterResult:            tc.filterResult,
+					preEvictionFilterResult: tc.preEvictionFilterResult,
+				},
+			}
+			assert.Equal(t, tc.want, a.PreEvictionFilter(pod))
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

`evictorAdaptor.PreEvictionFilter` type-asserted `a.evictor` against the upstream `k8sdeschedulerframework.EvictorPlugin` interface, which `evictorProxy` never satisfies; it implements Koordinator's `framework.Evictor` but is missing the `Name() string` method that `EvictorPlugin` requires. The assertion always failed, so every call fell through to `return a.evictor.Filter(pod)`.

`Filter` and `PreEvictionFilter` serve different purposes: 
- `Filter` performs cheap structural checks (static pod, DaemonSet, terminating), 
- while `PreEvictionFilter` performs runtime checks immediately before eviction, most importantly **NodeFit**, which verifies the pod can actually be scheduled on another node. 

All in-tree upstream plugins call `handle.Evictor().PreEvictionFilter(pod)` before evicting, so NodeFit was silently bypassed for all of them, producing permanently-pending pods in loaded clusters.

**Fix:**
Delegate directly to `a.evictor.PreEvictionFilter(pod)`. Since `a.evictor` is typed as `framework.Evictor`, which mandates `PreEvictionFilter`, no assertion or fallback is needed. This mirrors how `Filter` and `Evict` are already implemented on the same struct.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #3054

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/descheduler/framework/plugins/kubernetes/adaptor/... -run TestEvictorAdaptor -v
```

All 6 sub-tests pass, including the key regression case in `TestEvictorAdaptor_PreEvictionFilter`:

- `passes Filter but fails PreEvictionFilter (NodeFit blocked)`, mock returns `Filter=true`, `PreEvictionFilter=false`; the adaptor must return `false`. Before this fix it returned `true`.

### Ⅳ. Special notes for reviews

The removed type assertion (`a.evictor.(k8sdeschedulerframework.EvictorPlugin)`) was never reachable. Adding `Name() string` to `evictorProxy` to make it satisfy `EvictorPlugin` was considered and rejected: `evictorProxy` is an internal runtime multiplexer, not a named plugin, and satisfying `EvictorPlugin` would expose it to upstream plugin-registry code (profile registration, strategy metrics) that was never intended to touch it.

### V. Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `make test`
