### PR TITLE
test: add unit tests for pkg/util/parallelize/parallelism.go

### DIFF
--- a/pkg/util/parallelize/parallelism_test.go
+++ b/pkg/util/parallelize/parallelism_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallelize
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestChunkSizeFor(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want int
+	}{
+		{
+			name: "0 items",
+			n:    0,
+			want: 1,
+		},
+		{
+			name: "small n",
+			n:    4,
+			want: 1,
+		},
+		{
+			name: "exact boundaries",
+			n:    16 * 16,
+			want: 16,
+		},
+		{
+			name: "large values",
+			n:    1000,
+			want: 31,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chunkSizeFor(tt.n); got != tt.want {
+				t.Errorf("chunkSizeFor(%v) = %v, want %v", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUntil(t *testing.T) {
+	t.Run("exactly once", func(t *testing.T) {
+		pieces := 100
+		var count int32
+
+		Until(context.Background(), pieces, func(piece int) {
+			atomic.AddInt32(&count, 1)
+		})
+
+		if count != int32(pieces) {
+			t.Errorf("Until executed %d times, want %d", count, pieces)
+		}
+	})
+
+	t.Run("0 pieces", func(t *testing.T) {
+		var count int32
+
+		Until(context.Background(), 0, func(piece int) {
+			atomic.AddInt32(&count, 1)
+		})
+
+		if count != 0 {
+			t.Errorf("Until executed %d times on 0 pieces, want 0", count)
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var count int32
+
+		Until(ctx, 100, func(piece int) {
+			// This might execute a few items before the worker checks the context,
+			// or items that are sent before cancellation takes full effect,
+			// but we can definitely test that it doesn't do all the work
+			// or we can simulate a long running task that checks the context.
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt32(&count, 1)
+		})
+
+		if count == 100 {
+			t.Errorf("Until executed all pieces despite cancelled context")
+		}
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds missing unit test coverage for `pkg/util/parallelize/parallelism.go`. The test file `parallelism_test.go` exercises the pure utility logic in the package:
- `chunkSizeFor(n int)`: Tested against zero, small, exact-boundary, and large `n` values to ensure optimal chunk boundaries.
- `Until(...)`: Tested to ensure it executes each work item exactly once, safely handles `pieces == 0` without invoking the worker, and properly respects context cancellation.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Run the added unit tests for the package:
```bash
go test -v ./pkg/util/parallelize
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
