### PR TITLE
koordlet: fix perf group cpu error accumulation

### DIFF
--- a/pkg/koordlet/util/perf_group/perf_group_linux.go
+++ b/pkg/koordlet/util/perf_group/perf_group_linux.go
@@ -246,8 +246,8 @@ func GetContainerPerfResult(collector *PerfGroupCollector) (map[string]float64, 
 	var err error
 	for _, cpu := range collector.cpus {
 		if pc, ok := collector.perfCollectors[cpu]; ok {
-			if err = pc.collect(collector.valueCh); err != nil {
-				err = multierr.Append(err, err)
+			if collectErr := pc.collect(collector.valueCh); collectErr != nil {
+				err = multierr.Append(err, collectErr)
 			}
 		}
 	}

--- a/pkg/koordlet/util/perf_group/perf_group_linux_test.go
+++ b/pkg/koordlet/util/perf_group/perf_group_linux_test.go
@@ -141,3 +141,81 @@ func Test_GetContainerCyclesAndInstructions(t *testing.T) {
 	//assert.Nil(t, err)
 	//LibFinalize()
 }
+
+func TestGetContainerPerfResultPreservesErrors(t *testing.T) {
+	InitBufferPool(map[int]struct{}{1: {}})
+	oldNew := perfValuePool.New
+	perfValuePool.New = func() interface{} {
+		return &value{}
+	}
+	defer func() {
+		perfValuePool.New = oldNew
+	}()
+
+	tempDir := t.TempDir()
+	cgroupFile, err := os.OpenFile(tempDir, os.O_RDONLY, os.ModeDir)
+	assert.NoError(t, err)
+
+	failedCPUFile := newPerfValueFile(t, tempDir, "failed-cpu", 1, 10)
+	successCPUFile := newPerfValueFile(t, tempDir, "success-cpu", 1, 10)
+
+	collector := &PerfGroupCollector{
+		cgroupFile: cgroupFile,
+		cpus:       []int{0, 1},
+		perfCollectors: map[int]*perfCollector{
+			0: {
+				cpu:      0,
+				leaderFd: failedCPUFile,
+				syscall6: func(uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr) (uintptr, uintptr, syscall.Errno) {
+					return 0, 0, syscall.EINVAL
+				},
+			},
+			1: {
+				cpu:      1,
+				leaderFd: successCPUFile,
+				syscall6: func(uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr) (uintptr, uintptr, syscall.Errno) {
+					return 0, 0, 0
+				},
+			},
+		},
+		idEventMap: map[uint64]string{
+			1: CYCLES,
+		},
+		resultMap: map[string]float64{},
+		valueCh:   make(chan perfValue),
+		closeCh:   make(chan struct{}),
+	}
+
+	go func() {
+		for value := range collector.valueCh {
+			collector.resultMap[collector.idEventMap[value.ID]] += value.Value
+		}
+		close(collector.closeCh)
+	}()
+
+	_, err = GetContainerPerfResult(collector)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "EINVAL")
+	}
+}
+
+func newPerfValueFile(t *testing.T, dir, name string, id, sampleValue uint64) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(dir, name)
+	assert.NoError(t, err)
+
+	assert.NoError(t, binary.Write(file, binary.LittleEndian, &perfValueHeader{
+		Nr:          1,
+		TimeEnabled: 10,
+		TimeRunning: 10,
+	}))
+	assert.NoError(t, binary.Write(file, binary.LittleEndian, value{
+		ID:    id,
+		Value: sampleValue,
+	}))
+	_, err = file.Seek(0, 0)
+	assert.NoError(t, err)
+
+	return file
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Preserves per-cpu collection errors in the perf-group cpi collector.

`GetContainerPerfResult` was reusing the same `err` variable inside the cpu loop. If one cpu collection failed and a later cpu collection succeeded, the later success could overwrite the earlier error. That made it possible to return partial cycle and instruction totals as if collection had fully succeeded.

This keeps the accumulated error separate from each per-cpu `collectErr`, so any cpu collection failure is still returned to the caller.

### Ⅱ. Does this pull request fix one issue?

fixes #3060

### Ⅲ. Describe how to verify it

```bash
docker run --rm \
  -v "$PWD":/workspace \
  -w /workspace \
  golang:1.25-bookworm \
  bash -c 'apt-get update >/dev/null && \
    apt-get install -y libpfm4-dev >/dev/null && \
    go test ./pkg/koordlet/util/perf_group \
      -run TestGetContainerPerfResultPreservesErrors \
      -count=1 \
      -v && \
    go test ./pkg/koordlet/util/perf_group -count=1'
```

### Ⅳ. Special notes for reviews

The perf-group package is linux-only and depends on libpfm4, so I verified the test in a linux container.

No screenshots are needed for this PR. The regression test covers the failing path directly.

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`