### PR TITLE
descheduler: Added fragmentation-aware scoring files

### DIFF
--- a/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fragmentationaware
+
+import (
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	resourcehelper "k8s.io/component-helpers/resource"
+)
+
+// nodeRequests returns the total requests of a group of pods.
+func nodeRequests(pods []*corev1.Pod, resources []corev1.ResourceName) corev1.ResourceList {
+	totalReq := make(corev1.ResourceList)
+	for _, r := range resources {
+		totalReq[r] = resource.Quantity{}
+	}
+
+	for _, pod := range pods {
+		reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+		for _, r := range resources {
+			if q, ok := reqs[r]; ok {
+				qty := totalReq[r]
+				qty.Add(q)
+				totalReq[r] = qty
+			}
+		}
+	}
+	return totalReq
+}
+
+// allocationFractions calculates requested / allocatable fractions for resources.
+// It skips resources mapped to 0 allocatable to prevent divide-by-zero.
+func allocationFractions(requests corev1.ResourceList, allocatable corev1.ResourceList, resources []corev1.ResourceName) []float64 {
+	var fractions []float64
+	for _, r := range resources {
+		alloc := allocatable[r]
+		if alloc.IsZero() {
+			continue
+		}
+		req := requests[r]
+		fraction := float64(req.MilliValue()) / float64(alloc.MilliValue())
+		fractions = append(fractions, fraction)
+	}
+	return fractions
+}
+
+// stdDev computes the population standard deviation of the values list.
+func stdDev(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	mean := sum / float64(len(values))
+
+	var varianceSum float64
+	for _, v := range values {
+		diff := v - mean
+		varianceSum += diff * diff
+	}
+	return math.Sqrt(varianceSum / float64(len(values)))
+}
+
+// scoreNodeImbalance computes the standard deviation of allocation fractions across resources.
+func scoreNodeImbalance(node *corev1.Node, pods []*corev1.Pod, resources []corev1.ResourceName) float64 {
+	if node == nil {
+		return 0
+	}
+	requests := nodeRequests(pods, resources)
+	fractions := allocationFractions(requests, node.Status.Allocatable, resources)
+	return stdDev(fractions)
+}
+
+// scorePodRemovalGain computes the gain (before - after) in standard deviation when a given pod is removed.
+// A higher, positive gain means removing the pod decreases the standard deviation significantly.
+func scorePodRemovalGain(node *corev1.Node, pods []*corev1.Pod, pod *corev1.Pod, resources []corev1.ResourceName) float64 {
+	if node == nil || pod == nil {
+		return 0
+	}
+	stdBefore := scoreNodeImbalance(node, pods, resources)
+
+	var podsAfter []*corev1.Pod
+	for _, p := range pods {
+		if p.UID != pod.UID {
+			podsAfter = append(podsAfter, p)
+		}
+	}
+
+	stdAfter := scoreNodeImbalance(node, podsAfter, resources)
+	return stdBefore - stdAfter
+}

--- a/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
@@ -20,29 +20,9 @@ import (
 	"math"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	resourcehelper "k8s.io/component-helpers/resource"
+
+	deschedulernode "github.com/koordinator-sh/koordinator/pkg/descheduler/node"
 )
-
-// nodeRequests returns the total requests of a group of pods.
-func nodeRequests(pods []*corev1.Pod, resources []corev1.ResourceName) corev1.ResourceList {
-	totalReq := make(corev1.ResourceList)
-	for _, r := range resources {
-		totalReq[r] = resource.Quantity{}
-	}
-
-	for _, pod := range pods {
-		reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
-		for _, r := range resources {
-			if q, ok := reqs[r]; ok {
-				qty := totalReq[r]
-				qty.Add(q)
-				totalReq[r] = qty
-			}
-		}
-	}
-	return totalReq
-}
 
 // allocationFractions calculates requested / allocatable fractions for resources.
 // It skips resources mapped to 0 allocatable to prevent divide-by-zero.
@@ -84,22 +64,28 @@ func scoreNodeImbalance(node *corev1.Node, pods []*corev1.Pod, resources []corev
 	if node == nil {
 		return 0
 	}
-	requests := nodeRequests(pods, resources)
+	utilization := deschedulernode.NodeUtilization(pods, resources)
+	requests := make(corev1.ResourceList, len(utilization))
+	for res, qty := range utilization {
+		if qty != nil {
+			requests[res] = *qty
+		}
+	}
 	fractions := allocationFractions(requests, node.Status.Allocatable, resources)
 	return stdDev(fractions)
 }
 
 // scorePodRemovalGain computes the gain (before - after) in standard deviation when a given pod is removed.
 // A higher, positive gain means removing the pod decreases the standard deviation significantly.
-func scorePodRemovalGain(node *corev1.Node, pods []*corev1.Pod, pod *corev1.Pod, resources []corev1.ResourceName) float64 {
-	if node == nil || pod == nil {
+func scorePodRemovalGain(node *corev1.Node, pods []*corev1.Pod, targetPod *corev1.Pod, resources []corev1.ResourceName) float64 {
+	if node == nil || targetPod == nil {
 		return 0
 	}
 	stdBefore := scoreNodeImbalance(node, pods, resources)
 
 	var podsAfter []*corev1.Pod
 	for _, p := range pods {
-		if p.UID != pod.UID {
+		if p.UID != targetPod.UID {
 			podsAfter = append(podsAfter, p)
 		}
 	}

--- a/pkg/descheduler/framework/plugins/fragmentationaware/scoring_test.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/scoring_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fragmentationaware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func makePod(uid string, cpu int64, mem int64) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID(uid),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.DecimalSI),
+							corev1.ResourceMemory: *resource.NewQuantity(mem, resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeNode(cpu int64, mem int64) *corev1.Node {
+	return &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(mem, resource.BinarySI),
+			},
+		},
+	}
+}
+
+func TestScoreNodeImbalance(t *testing.T) {
+	resources := []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+
+	t.Run("nil node returns zero", func(t *testing.T) {
+		stdDev := scoreNodeImbalance(nil, nil, resources)
+		assert.Equal(t, 0.0, stdDev)
+	})
+
+	t.Run("no scored resources returns zero", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+
+		stdDev := scoreNodeImbalance(node, nil, nil)
+		assert.Equal(t, 0.0, stdDev)
+	})
+
+	t.Run("balanced CPU/memory node gives low stddev", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		pods := []*corev1.Pod{
+			makePod("p1", 500, 512),
+		}
+
+		stdDev := scoreNodeImbalance(node, pods, resources)
+		assert.True(t, stdDev < 0.01)
+	})
+
+	t.Run("CPU-heavy node gives high stddev", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		pods := []*corev1.Pod{
+			makePod("p1", 900, 100),
+		}
+
+		stdDev := scoreNodeImbalance(node, pods, resources)
+		assert.True(t, stdDev > 0.1)
+	})
+
+	t.Run("zero allocatable resource is skipped", func(t *testing.T) {
+		node := makeNode(1000, 0) // Memory is 0
+		pods := []*corev1.Pod{
+			makePod("p1", 500, 512),
+		}
+
+		stdDev := scoreNodeImbalance(node, pods, resources)
+		assert.True(t, stdDev == 0, "only CPU is considered, variance of 1 element is 0")
+	})
+
+	t.Run("custom resource works if configured", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		node.Status.Allocatable["example.com/gpu"] = *resource.NewQuantity(2, resource.DecimalSI)
+		pods := []*corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{UID: types.UID("p1")},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"example.com/gpu": *resource.NewQuantity(1, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		customRes := []corev1.ResourceName{"example.com/gpu", corev1.ResourceCPU}
+		stdDev := scoreNodeImbalance(node, pods, customRes)
+		// GPU = 1/2 = 0.5, CPU = 0/1000 = 0
+		// mean = 0.25
+		// std = sqrt((0.5-0.25)^2 + (0-0.25)^2) / 2 = sqrt(0.0625) = 0.25
+		assert.Equal(t, 0.25, stdDev)
+	})
+}
+
+func TestScorePodRemovalGain(t *testing.T) {
+	resources := []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+
+	t.Run("nil node returns zero", func(t *testing.T) {
+		pod := makePod("p1", 100, 100)
+
+		gain := scorePodRemovalGain(nil, nil, pod, resources)
+		assert.Equal(t, 0.0, gain)
+	})
+
+	t.Run("nil pod returns zero", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+
+		gain := scorePodRemovalGain(node, nil, nil, resources)
+		assert.Equal(t, 0.0, gain)
+	})
+
+	t.Run("removing CPU-heavy pod improves stddev", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		podCPUHeavy := makePod("cpu-heavy", 800, 100)
+		podBalanced := makePod("balanced", 100, 100)
+
+		pods := []*corev1.Pod{podCPUHeavy, podBalanced}
+
+		gain := scorePodRemovalGain(node, pods, podCPUHeavy, resources)
+		assert.True(t, gain > 0, "Gain should be positive for removing imbalanced pod")
+	})
+
+	t.Run("removing wrong pod gives low/negative gain", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		// Together they balance the node
+		podA := makePod("podA", 200, 800)
+		podB := makePod("podB", 600, 100)
+
+		pods := []*corev1.Pod{podA, podB}
+
+		gain := scorePodRemovalGain(node, pods, podB, resources)
+		assert.True(t, gain < 0, "Gain should be negative for removing a pod that balances or keeps it worse")
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR implements and tests the pure scoring logic will be used by the planned FragmentationAware descheduler plugin.
It introduces the core helper functions used to score node fragmentation:

- `nodeRequests(...)` aggregates total resource requests across a set of pods
- `allocationFractions(...)` computes requested/allocatable fractions for the configured resources
- `stdDev(...)` calculates the population standard deviation of those fractions
- `scoreNodeImbalance(...)` scores how imbalanced a node is across resources
- `scorePodRemovalGain(...)` measures how much the imbalance improves when a candidate pod is removed

### Ⅱ. Does this pull request fix one issue?

Refers #2332

### Ⅲ. Describe how to verify it

Run the unit tests for the fragmentation-aware package:

```bash
go test ./pkg/descheduler/framework/plugins/fragmentationaware/...
```

### Ⅳ. Special notes for reviews

This PR is intentionally limited to pure scoring logic.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
