### PR TITLE
opt: move nodenumaresource NUMA hint checking to Filter phase(3070)

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/plugin.go
+++ b/pkg/scheduler/plugins/nodenumaresource/plugin.go
@@ -369,6 +369,7 @@ func (p *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod 
 	if err != nil {
 		return fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable, ErrNotMatchNUMATopology)
 	}
+
 	if state.designatedAllocation != nil {
 		status = p.allocate(ctx, cycleState, pod, nodeInfo.Node(), numaTopologyPolicy)
 		if !status.IsSuccess() {
@@ -376,6 +377,21 @@ func (p *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod 
 		}
 		return nil
 	}
+
+	// Filter by NUMA Node early
+	if numaTopologyPolicy != extension.NUMATopologyPolicyNone && numaTopologyPolicy != extension.NUMATopologyPolicyBestEffort {
+		// when numa topology policy is set on node, we should maintain the same behavior as before, so we only
+		// set default podNUMAExclusive when podNUMATopologyPolicy is not none
+		podNUMAExclusive := state.podNUMAExclusive
+		if podNUMAExclusive == "" && podNUMATopologyPolicy != "" {
+			podNUMAExclusive = extension.NumaTopologyExclusiveRequired
+		}
+		status := p.FilterByNUMANode(ctx, cycleState, pod, node, numaTopologyPolicy, podNUMAExclusive, topologyOptions)
+		if !status.IsSuccess() {
+			return status
+		}
+	}
+
 	nodeCPUBindPolicy := extension.GetNodeCPUBindPolicy(node.Labels, topologyOptions.Policy)
 	requestCPUBind, status := requestCPUBind(state, nodeCPUBindPolicy)
 	if !status.IsSuccess() {
@@ -432,17 +448,6 @@ func (p *Plugin) Filter(ctx context.Context, cycleState fwktype.CycleState, pod 
 			}
 			return nil
 		}
-	}
-
-	// FIXME: move it ahead the resourceManager.Allocate so that we can check with NUMA hints almost in the Filter
-	if numaTopologyPolicy != extension.NUMATopologyPolicyNone && numaTopologyPolicy != extension.NUMATopologyPolicyBestEffort {
-		// when numa topology policy is set on node, we should maintain the same behavior as before, so we only
-		// set default podNUMAExclusive when podNUMATopologyPolicy is not none
-		podNUMAExclusive := state.podNUMAExclusive
-		if podNUMAExclusive == "" && podNUMATopologyPolicy != "" {
-			podNUMAExclusive = extension.NumaTopologyExclusiveRequired
-		}
-		return p.FilterByNUMANode(ctx, cycleState, pod, node, numaTopologyPolicy, podNUMAExclusive, topologyOptions)
 	}
 
 	return nil


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR resolves a `FIXME` comment in `pkg/scheduler/plugins/nodenumaresource/plugin.go`. 

Previously, the plugin waited until relatively late in the scheduling cycle to check if a node actually matches a Pod's NUMA topology hints using `FilterByNUMANode`. Because this check happened so late, the scheduler would perform heavy resource allocation calculations for nodes that were ultimately going to be thrown out anyway.

I shifted the `FilterByNUMANode` check earlier into the `Filter` phase (specifically right after the `designatedAllocation` short-circuit). Now, nodes that fail the NUMA topology check are dropped immediately, saving the scheduler from doing wasted math and speeding up scheduling throughput.

### Ⅱ. Does this pull request fix one issue?

fixes #3070

### Ⅲ. Describe how to verify it

You can run the existing unit tests for the nodenumaresource plugin. Everything passes cleanly, which confirms that the new placement still perfectly respects the `designatedAllocation` logic while dropping unsuitable nodes earlier.

### Ⅳ. Special notes for reviews

This is a straightforward cleanup that just moves the existing validation logic up to resolve the `FIXME`!

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`