### PR TITLE
scheduler: fix swapped total/free args in deviceshare shared-GPU scoring

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu.go
@@ -409,7 +409,7 @@ func allocateFromScope(requirements *GPURequirements, scope *GPUTopologyScope, a
 			_, belongToTotal := allocateContext.deviceTotal[minor]
 			contextOfDevice.satisfied = contextOfDevice.satisfied && belongToTotal
 			if contextOfDevice.satisfied && requirements.gpuShared && allocateContext.allocationScorer != nil {
-				contextOfDevice.score = allocateContext.allocationScorer.scoreDevice(requirements.requestsPerGPU, freeResources, totalResources)
+				contextOfDevice.score = allocateContext.allocationScorer.scoreDevice(requirements.requestsPerGPU, totalResources, freeResources)
 			}
 		}
 		if !contextOfDevice.satisfied {

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
@@ -1690,6 +1690,58 @@ func TestAllocateSharedGPU(t *testing.T) {
 	}
 }
 
+func TestAllocateFromScopeSharedGPUScoreUsesTotalAndFree(t *testing.T) {
+	// Two shared-GPU minors in the same scope, both able to satisfy the request
+	// but at different utilization levels:
+	//   minor 6: 75 free out of 100 (25 used)
+	//   minor 7: 50 free out of 100 (50 used)
+	// With the MostAllocated strategy the scorer must prefer the more-utilized
+	// minor (7) to bin-pack shared GPUs. This only holds when scoreDevice is
+	// called as scoreDevice(request, total, free); if total and free are swapped,
+	// every partially-used minor collapses to an identical score and the lower
+	// minor (6) wins by iteration order instead. This test guards that regression.
+	scorer := deviceResourceStrategyTypeMap[schedulerconfig.MostAllocated](&schedulerconfig.DeviceShareArgs{
+		ScoringStrategy: &schedulerconfig.ScoringStrategy{
+			Type: schedulerconfig.MostAllocated,
+			Resources: []schedconfig.ResourceSpec{
+				{
+					Name:   string(apiext.ResourceGPUMemoryRatio),
+					Weight: 1,
+				},
+			},
+		},
+	})
+
+	total := corev1.ResourceList{apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(100, resource.DecimalSI)}
+	deviceTotal := deviceResources{6: total.DeepCopy(), 7: total.DeepCopy()}
+	deviceFree := deviceResources{
+		6: corev1.ResourceList{apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(75, resource.DecimalSI)},
+		7: corev1.ResourceList{apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI)},
+	}
+	scope := &GPUTopologyScope{
+		scopeLevel:      0,
+		minors:          []int{6, 7},
+		minorsResources: deviceResources{6: total.DeepCopy(), 7: total.DeepCopy()},
+	}
+	requirements := &GPURequirements{
+		numberOfGPUs:   1,
+		gpuShared:      true,
+		requestsPerGPU: corev1.ResourceList{apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(50, resource.DecimalSI)},
+	}
+	allocateContext := &AllocateContext{
+		deviceFree:       deviceFree,
+		deviceTotal:      deviceTotal,
+		allocationScorer: scorer,
+	}
+
+	result := allocateFromScope(requirements, scope, allocateContext, ScopeLevelContext{
+		contextOfDevices: make(map[int]*DeviceLevelContext, len(scope.minors)),
+	})
+	if assert.NotNil(t, result) && assert.Len(t, result.allocations, 1) {
+		assert.Equal(t, int32(7), result.allocations[0].Minor, "MostAllocated should pick the more-utilized shared GPU minor")
+	}
+}
+
 func TestAllocateByTemplate(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`allocateFromScope` scored shared-GPU candidate minors by calling `scoreDevice(requestsPerGPU, freeResources, totalResources)`, but the method signature is `scoreDevice(podRequest, total, free)` — `total` and `free` were passed in swapped order. The correct usage is in `device_resources.go`. With the swap, every partially-used minor produces an identical "fully allocated" score, so the scoring strategy (MostAllocated / LeastAllocated) can no longer differentiate minors and selection degenerates to iteration order, placing shared-GPU pods on the wrong minor.

This PR passes the arguments in the correct order and adds a regression test.

### Ⅱ. Does this pull request fix one issue?

fixes #3073

### Ⅲ. Describe how to verify it

```
go test ./pkg/scheduler/plugins/deviceshare/ -run TestAllocateFromScopeSharedGPUScoreUsesTotalAndFree
```

The new test sets up two shared-GPU minors (minor 6: 75/100 free, minor 7: 50/100 free) under MostAllocated and asserts the more-utilized minor (7) is chosen. It fails on the current code (selects minor 6) and passes with this fix.

### Ⅳ. Special notes for reviews

Single-line production change; the rest is the regression test.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
