### PR TITLE
apis: fix ExactMatchReservation returning early on absent resource

### DIFF
--- a/apis/extension/reservation.go
+++ b/apis/extension/reservation.go
@@ -262,7 +262,10 @@ func ExactMatchReservation(podRequests, reservationAllocatable corev1.ResourceLi
 		request, existsInPod := podRequests[resourceName]
 		if !existsInReservation || !existsInPod {
 			if !existsInReservation && !existsInPod {
-				return true
+				// This resource is absent on both sides, so it trivially
+				// matches. Continue checking the remaining resources instead
+				// of returning early, otherwise a later mismatch is missed.
+				continue
 			}
 			return false
 		}

--- a/apis/extension/reservation_test.go
+++ b/apis/extension/reservation_test.go
@@ -251,6 +251,22 @@ func TestExactMatchReservation(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "resource absent on both sides must not skip a later mismatch",
+			spec: &ExactMatchReservationSpec{
+				ResourceNames: []corev1.ResourceName{
+					corev1.ResourceMemory,
+					corev1.ResourceCPU,
+				},
+			},
+			podRequests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			},
+			reservationAllocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

ExactMatchReservation checks every resource name in the spec and must confirm each one matches. When a resource was absent on both the pod and the reservation it returned true immediately, which ended the loop and skipped the resources listed after it. A pod could then be treated as an exact match even when a later resource did not match.

This change skips the absent on both sides resource with continue so the rest of the list is still checked, and adds a regression test.

### Ⅱ. Does this pull request fix one issue?

fixes #3075

### Ⅲ. Describe how to verify it

```
go test ./apis/extension/ -run TestExactMatchReservation
```

The new case lists memory then cpu, with memory absent on both sides and cpu mismatched. It expects false. The case fails on the current code and passes after this change.

### Ⅳ. Special notes for reviews

One line production change. The rest is the test.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
