### PR TITLE
scheduler: key required device resources by minor value in deviceshare

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -445,7 +445,7 @@ func calcRequiredDeviceResources(alloc *reusableAlloc, preemptibleInRR map[sched
 		}
 		for deviceType, minors := range minorHints {
 			resources := deviceResources{}
-			for minor := range minors.UnsortedList() {
+			for _, minor := range minors.UnsortedList() {
 				resources[minor] = corev1.ResourceList{}
 			}
 			required[deviceType] = resources

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -1464,3 +1464,29 @@ func Test_isDeviceAllocationsInclude(t *testing.T) {
 		})
 	}
 }
+
+func TestCalcRequiredDeviceResourcesKeyedByMinor(t *testing.T) {
+	// A fully consumed reservation produces an empty-capacity required map.
+	// The map must be keyed by the real device minors. With non-contiguous
+	// minors (3 and 5) this only holds if we range over the minor values; if
+	// we range over the slice itself we get the indices 0 and 1 instead, which
+	// keys the constraint to the wrong devices.
+	alloc := &reusableAlloc{
+		allocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+			schedulingv1alpha1.GPU: {
+				3: corev1.ResourceList{},
+				5: corev1.ResourceList{},
+			},
+		},
+		remained: map[schedulingv1alpha1.DeviceType]deviceResources{},
+	}
+
+	required := calcRequiredDeviceResources(alloc, map[schedulingv1alpha1.DeviceType]deviceResources{})
+
+	gpu := required[schedulingv1alpha1.GPU]
+	assert.Len(t, gpu, 2)
+	_, has3 := gpu[3]
+	_, has5 := gpu[5]
+	assert.True(t, has3, "required map should be keyed by minor 3")
+	assert.True(t, has5, "required map should be keyed by minor 5")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

calcRequiredDeviceResources builds an empty capacity required map for a fully consumed reservation. It ranged over minors.UnsortedList() with a single loop variable, which iterates the slice indices rather than the minor values, so the map was keyed by 0..n-1 instead of the real device minors. With non contiguous minors the reservation constraint was then applied to the wrong devices.

This change ranges over the minor values and adds a regression test.

### Ⅱ. Does this pull request fix one issue?

fixes #3077

### Ⅲ. Describe how to verify it

```
go test ./pkg/scheduler/plugins/deviceshare/ -run TestCalcRequiredDeviceResourcesKeyedByMinor
```

The new test uses a reservation with non contiguous GPU minors 3 and 5 and asserts the required map is keyed by 3 and 5. It fails on the current code (keys 0 and 1) and passes after this change.

### Ⅳ. Special notes for reviews

One line production change. The rest is the test.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
