### PR TITLE
scheduler: add optional BatchResetAware interface for elastic-quota hook plugin.

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
@@ -88,8 +88,8 @@ type QuotaHookPlugin interface {
 // BatchResetAware is an optional capability for hook plugins that want to
 // distinguish a batched reset from per-quota updates. ResetQuotasForHookPlugins
 // brackets its loop with OnBatchResetBegin / OnBatchResetEnd while holding
-// hierarchyUpdateLock. Plugins that don't implement this interface keep the
-// original per-call behavior.
+// hierarchyUpdateLock in write mode. Plugins that don't implement this interface
+// keep the original per-call behavior.
 type BatchResetAware interface {
 	OnBatchResetBegin()
 	OnBatchResetEnd()
@@ -332,14 +332,16 @@ func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alp
 	defer gqm.hierarchyUpdateLock.Unlock()
 
 	batchAwarePlugins := collectBatchResetAware(gqm.hookPlugins)
-	for _, p := range batchAwarePlugins {
-		p.OnBatchResetBegin()
-	}
+	begun := 0
 	defer func() {
-		for _, p := range batchAwarePlugins {
-			p.OnBatchResetEnd()
+		for i := 0; i < begun; i++ {
+			batchAwarePlugins[i].OnBatchResetEnd()
 		}
 	}()
+	for _, p := range batchAwarePlugins {
+		begun++
+		p.OnBatchResetBegin()
+	}
 
 	for quotaName, quotaInfo := range gqm.quotaInfoMap {
 		quota := quotas[quotaInfo.Name]

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
@@ -339,8 +339,8 @@ func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alp
 		}
 	}()
 	for _, p := range batchAwarePlugins {
-		begun++
 		p.OnBatchResetBegin()
+		begun++
 	}
 
 	for quotaName, quotaInfo := range gqm.quotaInfoMap {

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin.go
@@ -85,6 +85,16 @@ type QuotaHookPlugin interface {
 	CheckPod(quotaName string, pod *v1.Pod) error
 }
 
+// BatchResetAware is an optional capability for hook plugins that want to
+// distinguish a batched reset from per-quota updates. ResetQuotasForHookPlugins
+// brackets its loop with OnBatchResetBegin / OnBatchResetEnd while holding
+// hierarchyUpdateLock. Plugins that don't implement this interface keep the
+// original per-call behavior.
+type BatchResetAware interface {
+	OnBatchResetBegin()
+	OnBatchResetEnd()
+}
+
 type HookPluginFactory func(qiProvider *QuotaInfoReader, key, args string) (QuotaHookPlugin, error)
 
 // hookPluginFactories is a global map of registered hook-plugin factories, keyed by factory key.
@@ -321,6 +331,16 @@ func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alp
 	gqm.hierarchyUpdateLock.Lock()
 	defer gqm.hierarchyUpdateLock.Unlock()
 
+	batchAwarePlugins := collectBatchResetAware(gqm.hookPlugins)
+	for _, p := range batchAwarePlugins {
+		p.OnBatchResetBegin()
+	}
+	defer func() {
+		for _, p := range batchAwarePlugins {
+			p.OnBatchResetEnd()
+		}
+	}()
+
 	for quotaName, quotaInfo := range gqm.quotaInfoMap {
 		quota := quotas[quotaInfo.Name]
 		if quota == nil {
@@ -330,4 +350,20 @@ func (gqm *GroupQuotaManager) ResetQuotasForHookPlugins(quotas map[string]*v1alp
 		hookState := gqm.runPreQuotaUpdateHooks(nil, quotaInfo, quota)
 		gqm.runPostQuotaUpdateHooks(nil, quotaInfo, quota, hookState)
 	}
+}
+
+// collectBatchResetAware unwraps MetricsWrapper and returns inner plugins
+// that implement BatchResetAware. Order is preserved.
+func collectBatchResetAware(hooks []QuotaHookPlugin) []BatchResetAware {
+	var out []BatchResetAware
+	for _, h := range hooks {
+		inner := h
+		if w, ok := h.(*MetricsWrapper); ok {
+			inner = w.GetPlugin()
+		}
+		if br, ok := inner.(BatchResetAware); ok {
+			out = append(out, br)
+		}
+	}
+	return out
 }

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
@@ -596,3 +596,169 @@ func TestResetQuotasForHookPlugins(t *testing.T) {
 	assert.Equal(t, 0, len(preUpdateQuotas), "No PreQuotaUpdate quotas expected")
 	assert.Equal(t, 0, len(postUpdateQuotas), "No PostQuotaUpdate quotas expected")
 }
+
+// batchEventLog records the sequence of hook callbacks across one or more
+// plugins so tests can assert ordering of OnBatchResetBegin/End relative to
+// PreQuotaUpdate/PostQuotaUpdate.
+type batchEventLog struct {
+	sync.Mutex
+	events []string
+}
+
+func (l *batchEventLog) record(ev string) {
+	l.Lock()
+	defer l.Unlock()
+	l.events = append(l.events, ev)
+}
+
+func (l *batchEventLog) snapshot() []string {
+	l.Lock()
+	defer l.Unlock()
+	out := make([]string, len(l.events))
+	copy(out, l.events)
+	return out
+}
+
+// batchAwareMockHook is a MockHookPlugin that additionally implements
+// BatchResetAware. It records events into a shared log to verify ordering.
+type batchAwareMockHook struct {
+	*MockHookPlugin
+	log *batchEventLog
+}
+
+var _ BatchResetAware = &batchAwareMockHook{}
+
+func (b *batchAwareMockHook) OnBatchResetBegin() {
+	b.log.record(b.GetKey() + ":begin")
+}
+
+func (b *batchAwareMockHook) OnBatchResetEnd() {
+	b.log.record(b.GetKey() + ":end")
+}
+
+func (b *batchAwareMockHook) PreQuotaUpdate(oldQ, newQ *QuotaInfo, q *v1alpha1.ElasticQuota,
+	state *QuotaUpdateState) {
+	b.log.record(b.GetKey() + ":pre")
+	b.MockHookPlugin.PreQuotaUpdate(oldQ, newQ, q, state)
+}
+
+func (b *batchAwareMockHook) PostQuotaUpdate(oldQ, newQ *QuotaInfo, q *v1alpha1.ElasticQuota,
+	state *QuotaUpdateState) {
+	b.log.record(b.GetKey() + ":post")
+	b.MockHookPlugin.PostQuotaUpdate(oldQ, newQ, q, state)
+}
+
+// loggingMockHook is a MockHookPlugin that does NOT implement BatchResetAware,
+// used to verify collectBatchResetAware correctly skips non-aware plugins.
+type loggingMockHook struct {
+	*MockHookPlugin
+	log *batchEventLog
+}
+
+func (l *loggingMockHook) PreQuotaUpdate(oldQ, newQ *QuotaInfo, q *v1alpha1.ElasticQuota,
+	state *QuotaUpdateState) {
+	l.log.record(l.GetKey() + ":pre")
+	l.MockHookPlugin.PreQuotaUpdate(oldQ, newQ, q, state)
+}
+
+func (l *loggingMockHook) PostQuotaUpdate(oldQ, newQ *QuotaInfo, q *v1alpha1.ElasticQuota,
+	state *QuotaUpdateState) {
+	l.log.record(l.GetKey() + ":post")
+	l.MockHookPlugin.PostQuotaUpdate(oldQ, newQ, q, state)
+}
+
+// TestResetQuotasForHookPlugins_BatchResetAware asserts that
+// ResetQuotasForHookPlugins:
+//  1. Calls OnBatchResetBegin on every BatchResetAware plugin BEFORE the loop.
+//  2. Calls OnBatchResetEnd on every BatchResetAware plugin AFTER the loop.
+//  3. Does not invoke Begin/End on plugins that don't implement BatchResetAware.
+func TestResetQuotasForHookPlugins_BatchResetAware(t *testing.T) {
+	log := &batchEventLog{}
+	const (
+		awareKey   = "awareHook"
+		plainKey   = "plainHook"
+		awareFK    = "awareFactory"
+		plainFK    = "plainFactory"
+	)
+	RegisterHookPluginFactory(awareFK,
+		func(_ *QuotaInfoReader, key, _ string) (QuotaHookPlugin, error) {
+			return &batchAwareMockHook{MockHookPlugin: &MockHookPlugin{key: key}, log: log}, nil
+		})
+	RegisterHookPluginFactory(plainFK,
+		func(_ *QuotaInfoReader, key, _ string) (QuotaHookPlugin, error) {
+			return &loggingMockHook{MockHookPlugin: &MockHookPlugin{key: key}, log: log}, nil
+		})
+
+	gqm := NewGroupQuotaManager("", true, nil, nil)
+	err := gqm.InitHookPlugins(&config.ElasticQuotaArgs{
+		HookPlugins: []config.HookPluginConf{
+			{Key: awareKey, FactoryKey: awareFK},
+			{Key: plainKey, FactoryKey: plainFK},
+		},
+	})
+	assert.NoError(t, err)
+
+	// register two quotas so the loop body fires more than once
+	parent := CreateQuota("p", extension.RootQuotaName, 100, 100, 0, 0, false, false)
+	assert.NoError(t, gqm.UpdateQuota(parent))
+	c1 := CreateQuota("c1", parent.Name, 40, 40, 10, 10, false, false)
+	assert.NoError(t, gqm.UpdateQuota(c1))
+
+	// reset log to ignore events from the registration phase above
+	log.Lock()
+	log.events = nil
+	log.Unlock()
+
+	quotas := map[string]*v1alpha1.ElasticQuota{
+		parent.Name: parent,
+		c1.Name:     c1,
+	}
+	gqm.ResetQuotasForHookPlugins(quotas)
+
+	events := log.snapshot()
+
+	// extract events for the aware hook and verify ordering
+	var awareEvents []string
+	for _, ev := range events {
+		if len(ev) >= len(awareKey) && ev[:len(awareKey)] == awareKey {
+			awareEvents = append(awareEvents, ev[len(awareKey)+1:])
+		}
+	}
+	assert.GreaterOrEqual(t, len(awareEvents), 5, "aware hook should record begin + (pre+post)*N + end")
+	assert.Equal(t, "begin", awareEvents[0], "first aware event must be begin")
+	assert.Equal(t, "end", awareEvents[len(awareEvents)-1], "last aware event must be end")
+	for _, ev := range awareEvents[1 : len(awareEvents)-1] {
+		assert.Contains(t, []string{"pre", "post"}, ev,
+			"events between begin and end must be pre/post only")
+	}
+
+	// plain hook should NOT receive begin/end (it doesn't implement BatchResetAware)
+	for _, ev := range events {
+		if len(ev) >= len(plainKey) && ev[:len(plainKey)] == plainKey {
+			suffix := ev[len(plainKey)+1:]
+			assert.NotEqual(t, "begin", suffix, "plain hook must not receive begin")
+			assert.NotEqual(t, "end", suffix, "plain hook must not receive end")
+		}
+	}
+}
+
+// TestCollectBatchResetAware_UnwrapsMetricsWrapper verifies that
+// collectBatchResetAware correctly unwraps MetricsWrapper before checking
+// for the BatchResetAware capability.
+func TestCollectBatchResetAware_UnwrapsMetricsWrapper(t *testing.T) {
+	log := &batchEventLog{}
+	aware := &batchAwareMockHook{MockHookPlugin: &MockHookPlugin{key: "aware"}, log: log}
+	plain := &MockHookPlugin{key: "plain"}
+	wrapped := []QuotaHookPlugin{
+		NewMetricsWrapper(aware),
+		NewMetricsWrapper(plain),
+	}
+
+	got := collectBatchResetAware(wrapped)
+	assert.Equal(t, 1, len(got), "only the aware plugin should be collected")
+
+	// invoke to confirm the right plugin was collected
+	got[0].OnBatchResetBegin()
+	got[0].OnBatchResetEnd()
+	assert.Equal(t, []string{"aware:begin", "aware:end"}, log.snapshot())
+}

--- a/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/core/hook_plugin_test.go
@@ -675,10 +675,10 @@ func (l *loggingMockHook) PostQuotaUpdate(oldQ, newQ *QuotaInfo, q *v1alpha1.Ela
 func TestResetQuotasForHookPlugins_BatchResetAware(t *testing.T) {
 	log := &batchEventLog{}
 	const (
-		awareKey   = "awareHook"
-		plainKey   = "plainHook"
-		awareFK    = "awareFactory"
-		plainFK    = "plainFactory"
+		awareKey = "awareHook"
+		plainKey = "plainHook"
+		awareFK  = "awareFactory"
+		plainFK  = "plainFactory"
 	)
 	RegisterHookPluginFactory(awareFK,
 		func(_ *QuotaInfoReader, key, _ string) (QuotaHookPlugin, error) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

**Motivation**:
   Hook plugins that maintain derived state across the entire quota tree currently pay O(N²) cost during a batched reset, because every `PostQuotaUpdate` runs a full subtree rebuild even though most descendants have not yet been registered. The expensive plugins also have no way to tell "I am being initialized in bulk" apart from "this is a single quota update".
  
  This PR adds the minimum interface contract needed for such plugins to defer expensive per-quota work and run one consolidated rebuild at the end of the batch.

  - Add `BatchResetAware` interface (`OnBatchResetBegin()` / `OnBatchResetEnd()`) next to `QuotaHookPlugin`. `QuotaHookPlugin` itself is unchanged.
  - `ResetQuotasForHookPlugins` now brackets its per-quota loop with `OnBatchResetBegin` / `OnBatchResetEnd` for plugins that opt in, while continuing to hold `hierarchyUpdateLock` in write mode for the whole window. `OnBatchResetEnd` is invoked via `defer` so it still fires if a hook panics.
  - Add `collectBatchResetAware` helper that unwraps a single layer of `*MetricsWrapper` before checking the interface, so opt-in works transparently regardless of metrics
  wrapping at plugin construction time.


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

UT

### Ⅳ. Special notes for reviews

  - **Opt-in by design**: Adding the capability does not modify `QuotaHookPlugin`. Plugins gain it purely by declaring the two methods. No existing in-tree or out-of-tree  plugin needs to change.
  - **Lock contract**: Both Begin and End run while `hierarchyUpdateLock` is held in write mode, so implementations may freely call `*NoLock` accessors on the GQM during  their hook. This is documented on both methods.
  - **MetricsWrapper unwrap**: `collectBatchResetAware` unwraps one level. If wrapping is ever nested in the future, this helper should be revisited.
  - **No behavior change for current users**: With no in-tree plugin implementing `BatchResetAware`, `ResetQuotasForHookPlugins` is functionally identical to before this PR.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
