### PR TITLE
scheduler: patch gangPod condition in parallel and add more gang audit info

### DIFF
--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -134,6 +134,12 @@ const (
 	// resource overcommitment caused by scheduling pods based on a stale cache from the
 	// previous leader's final moments.
 	SyncBarrier featuregate.Feature = "SyncBarrier"
+
+	// GangPendingPodsConditionPatch enables patching PodScheduled=False conditions on
+	// unattempted pending pods in a gang group when a non-root-cause pod fails PostFilter.
+	// This provides earlier scheduling failure visibility for pods that haven't been
+	// individually attempted by the scheduler yet.
+	GangPendingPodsConditionPatch featuregate.Feature = "GangPendingPodsConditionPatch"
 )
 
 var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -162,6 +168,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	PodDisruptionBudget:                       {Default: true, PreRelease: featuregate.GA},
 	SyncBarrier:                               {Default: false, PreRelease: featuregate.Alpha},
 	CrossSchedulerNomination:                  {Default: false, PreRelease: featuregate.Alpha},
+	GangPendingPodsConditionPatch:             {Default: true, PreRelease: featuregate.Beta},
 }
 
 func init() {

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -456,7 +456,7 @@ func (ext *frameworkExtenderImpl) RunPostFilterPlugins(ctx context.Context, stat
 	defer func() {
 		for _, transformer := range ext.postFilterTransformersEnabled {
 			startTime := time.Now()
-			transformer.AfterPostFilter(ctx, state, pod, filteredNodeStatusMap)
+			transformer.AfterPostFilter(ctx, state, pod, filteredNodeStatusMap, status)
 			ext.metricsRecorder.ObservePluginDurationAsync("AfterPostFilter", transformer.Name(), "", metrics.SinceInSeconds(startTime))
 		}
 		diagnosis := GetDiagnosis(state)

--- a/pkg/scheduler/frameworkext/framework_extender_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_test.go
@@ -286,7 +286,7 @@ func (h *TestTransformer) ScoreExtensions() fwktype.ScoreExtensions {
 	return nil
 }
 
-func (h *TestTransformer) AfterPostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) {
+func (h *TestTransformer) AfterPostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status) {
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -149,7 +149,7 @@ type ScoreTransformer interface {
 // PostFilterTransformer is executed before PostFilter.
 type PostFilterTransformer interface {
 	SchedulingTransformer
-	AfterPostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader)
+	AfterPostFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status)
 }
 
 // PluginToReservationRestoreStates declares a map from plugin name to its ReservationRestoreState.

--- a/pkg/scheduler/frameworkext/workloadauditor/event_handlers_test.go
+++ b/pkg/scheduler/frameworkext/workloadauditor/event_handlers_test.go
@@ -87,7 +87,7 @@ func (m *mockWorkloadAuditor) RecordPod(_ *corev1.Pod, _ RecordType, _ string)  
 func (m *mockWorkloadAuditor) RecordPodGating(_ *corev1.Pod, _ bool)                           {}
 func (m *mockWorkloadAuditor) RecordAttemptPod(_ *corev1.Pod)                                  {}
 func (m *mockWorkloadAuditor) RecordPodScheduleResult(_ *corev1.Pod, _ RecordType, _ string)   {}
-func (m *mockWorkloadAuditor) AddGangGroup(_ string)                                           {}
+func (m *mockWorkloadAuditor) AddGangGroup(_ string, _ int)                                    {}
 func (m *mockWorkloadAuditor) DeleteGangGroup(_ string)                                        {}
 func (m *mockWorkloadAuditor) RecordGangGroup(_ string, _ *corev1.Pod, _ RecordType, _ string) {}
 func (m *mockWorkloadAuditor) RecordGangGating(_ string, _ *corev1.Pod, _ bool)                {}

--- a/pkg/scheduler/frameworkext/workloadauditor/types.go
+++ b/pkg/scheduler/frameworkext/workloadauditor/types.go
@@ -52,6 +52,10 @@ type WorkloadRecord struct {
 	// has already been recorded, used to deduplicate ScheduleFailure records.
 	lastRecordedAttempt int
 
+	// Gang group sizing info (set via AddGangGroup)
+	gangMinMember       int
+	gangMinMemberBucket string
+
 	// Preemption state tracking (for anomaly detection)
 	lastPreemptNominatedInvalidated    bool
 	lastPreemptNominatedTime           *time.Time

--- a/pkg/scheduler/frameworkext/workloadauditor/workload_auditor.go
+++ b/pkg/scheduler/frameworkext/workloadauditor/workload_auditor.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulermetrics "github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
 )
 
 // PodIsGated determines whether a pod is considered gated.
@@ -43,7 +44,7 @@ type WorkloadAuditor interface {
 	RecordAttemptPod(pod *corev1.Pod)
 	RecordPodScheduleResult(pod *corev1.Pod, recordType RecordType, message string)
 
-	AddGangGroup(gangGroupID string)
+	AddGangGroup(gangGroupID string, minMember int)
 	DeleteGangGroup(gangGroupID string)
 	RecordGangGroup(gangGroupID string, pod *corev1.Pod, recordType RecordType, message string)
 	RecordGangGating(gangGroupID string, pod *corev1.Pod, gated bool)
@@ -74,7 +75,7 @@ func (w *workloadAuditorImpl) getRecord(key string) *WorkloadRecord {
 	return val.(*WorkloadRecord)
 }
 
-func (w *workloadAuditorImpl) AddGangGroup(gangGroupID string) {
+func (w *workloadAuditorImpl) AddGangGroup(gangGroupID string, minMember int) {
 	if !w.Config.Enabled {
 		return
 	}
@@ -83,10 +84,12 @@ func (w *workloadAuditorImpl) AddGangGroup(gangGroupID string) {
 		RecordMethodDurationSeconds.WithLabelValues("AddGangGroup").Observe(time.Since(start).Seconds())
 	}()
 	record := &WorkloadRecord{
-		WorkloadKey:      gangGroupID,
-		recordTypeCounts: map[RecordType]int{RecordTypeCreate: 1},
-		labelValues:      make([]string, len(w.Config.MetricLabelNames)),
-		labelDetail:      formatLabelDetail(w.Config.MetricLabelNames, make([]string, len(w.Config.MetricLabelNames))),
+		WorkloadKey:         gangGroupID,
+		gangMinMember:       minMember,
+		gangMinMemberBucket: schedulermetrics.GangJobSizeBucket(minMember),
+		recordTypeCounts:    map[RecordType]int{RecordTypeCreate: 1},
+		labelValues:         make([]string, len(w.Config.MetricLabelNames)),
+		labelDetail:         formatLabelDetail(w.Config.MetricLabelNames, make([]string, len(w.Config.MetricLabelNames))),
 	}
 	w.records.LoadOrStore(gangGroupID, record)
 }
@@ -106,8 +109,8 @@ func (w *workloadAuditorImpl) DeleteGangGroup(gangGroupID string) {
 	record := val.(*WorkloadRecord)
 	record.mu.Lock()
 	defer record.mu.Unlock()
-	klog.V(4).Infof("WorkloadAuditor delete(gangDeleted): workloadKey=%s %s, attempts=%d",
-		record.WorkloadKey, record.labelDetail, record.Attempts)
+	klog.V(4).Infof("WorkloadAuditor delete(gangDeleted): workloadKey=%s %s, gangMinMember=%d(%s), attempts=%d",
+		record.WorkloadKey, record.labelDetail, record.gangMinMember, record.gangMinMemberBucket, record.Attempts)
 	finalizeWorkloadRecord(record, outcomeGangDeleted)
 }
 
@@ -357,8 +360,8 @@ func (w *workloadAuditorImpl) RecordGangScheduleResult(gangKey string, recordTyp
 	w.appendRecord(record, recordType, message)
 	// On successful gang schedule, remove the gang record.
 	if recordType == RecordTypeScheduled {
-		klog.V(4).Infof("WorkloadAuditor delete(gangScheduled): workloadKey=%s %s, attempts=%d",
-			record.WorkloadKey, record.labelDetail, record.Attempts)
+		klog.V(4).Infof("WorkloadAuditor delete(gangScheduled): workloadKey=%s %s, gangMinMember=%d(%s), attempts=%d",
+			record.WorkloadKey, record.labelDetail, record.gangMinMember, record.gangMinMemberBucket, record.Attempts)
 		finalizeWorkloadRecord(record, outcomeGangScheduled)
 		record.mu.Unlock()
 		w.records.Delete(gangKey)
@@ -370,8 +373,13 @@ func (w *workloadAuditorImpl) RecordGangScheduleResult(gangKey string, recordTyp
 // appendRecord increments the record-type count, logs the event, and runs anomaly detection.
 func (w *workloadAuditorImpl) appendRecord(wr *WorkloadRecord, recordType RecordType, message string) {
 	wr.recordTypeCounts[recordType]++
-	klog.V(4).Infof("WorkloadAuditor record: workloadKey=%s %s, type=%s, message=%q, attempts=%d",
-		wr.WorkloadKey, wr.labelDetail, recordType, message, wr.Attempts)
+	if wr.gangMinMember > 0 {
+		klog.V(4).Infof("WorkloadAuditor record: workloadKey=%s %s, gangMinMember=%d(%s), type=%s, message=%q, attempts=%d",
+			wr.WorkloadKey, wr.labelDetail, wr.gangMinMember, wr.gangMinMemberBucket, recordType, message, wr.Attempts)
+	} else {
+		klog.V(4).Infof("WorkloadAuditor record: workloadKey=%s %s, type=%s, message=%q, attempts=%d",
+			wr.WorkloadKey, wr.labelDetail, recordType, message, wr.Attempts)
+	}
 	checkRecordAnomaly(&w.Config, wr, recordType, message)
 }
 

--- a/pkg/scheduler/frameworkext/workloadauditor/workload_auditor_test.go
+++ b/pkg/scheduler/frameworkext/workloadauditor/workload_auditor_test.go
@@ -304,38 +304,40 @@ func TestRecordPodGating_NotFound(t *testing.T) {
 
 func TestAddGangGroup(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	record := w.getRecord("gang-1")
 	assert.NotNil(t, record)
 	assert.Equal(t, 1, record.recordTypeCounts[RecordTypeCreate])
 	assert.False(t, record.labelsExtracted)
+	assert.Equal(t, 3, record.gangMinMember)
+	assert.Equal(t, "1-100", record.gangMinMemberBucket)
 }
 
 func TestAddGangGroup_Disabled(t *testing.T) {
 	w := newTestAuditor()
 	w.Config.Enabled = false
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	assert.Nil(t, w.getRecord("gang-1"))
 }
 
 func TestAddGangGroup_Duplicate(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
+	w.AddGangGroup("gang-1", 3)
 	record := w.getRecord("gang-1")
 	assert.Equal(t, 1, record.recordTypeCounts[RecordTypeCreate])
 }
 
 func TestDeleteGangGroup(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	w.DeleteGangGroup("gang-1")
 	assert.Nil(t, w.getRecord("gang-1"))
 }
 
 func TestDeleteGangGroup_Disabled(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	w.Config.Enabled = false
 	w.DeleteGangGroup("gang-1")
 	assert.NotNil(t, w.getRecord("gang-1"))
@@ -348,7 +350,7 @@ func TestDeleteGangGroup_NotFound(t *testing.T) {
 
 func TestRecordGangGroup(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	pod := newPod("ns", "p1", "u1")
 	w.RecordGangGroup("gang-1", pod, RecordTypeGangMinMemberSatisfied, "test")
 	record := w.getRecord("gang-1")
@@ -369,7 +371,7 @@ func TestRecordGangGroup_NotFound(t *testing.T) {
 
 func TestRecordGangGating(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	pod := newPod("ns", "p1", "u1")
 
 	w.RecordGangGating("gang-1", pod, true)
@@ -385,7 +387,7 @@ func TestRecordGangGating(t *testing.T) {
 
 func TestRecordGangGating_NoChange(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	w.RecordGangGating("gang-1", newPod("ns", "p1", "u1"), false)
 	record := w.getRecord("gang-1")
 	assert.Equal(t, 0, record.recordTypeCounts[RecordTypeAdmissionPassed])
@@ -404,7 +406,7 @@ func TestRecordGangGating_NotFound(t *testing.T) {
 
 func TestRecordGangScheduleResult_Scheduled(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	w.RecordGangScheduleResult("gang-1", RecordTypeScheduleFailure, "no fit")
 	w.RecordGangScheduleResult("gang-1", RecordTypeScheduled, "")
 	// Record is deleted on scheduled.
@@ -413,7 +415,7 @@ func TestRecordGangScheduleResult_Scheduled(t *testing.T) {
 
 func TestRecordGangScheduleResult_Failure(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-1")
+	w.AddGangGroup("gang-1", 3)
 	w.RecordGangScheduleResult("gang-1", RecordTypeScheduleFailure, "")
 	record := w.getRecord("gang-1")
 	assert.NotNil(t, record)
@@ -446,7 +448,7 @@ func TestRecordDiagnosis_NonGang(t *testing.T) {
 
 func TestRecordDiagnosis_Gang(t *testing.T) {
 	w := newTestAuditor()
-	w.AddGangGroup("gang-key")
+	w.AddGangGroup("gang-key", 5)
 	pod := newGangPod("ns", "p1", "u1")
 	w.RecordDiagnosis(pod, "gang-key", RecordTypeScheduleFailure, "")
 	record := w.getRecord("gang-key")

--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -422,7 +422,8 @@ func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype
 }
 
 // patchGangPendingPodsCondition patches a PodScheduled=False condition on unattempted pending pods
-// (plus the current pod) in the gang group in parallel, without modifying NominatedNodeName.
+// (excluding the current pod, which is patched by the scheduler) in the gang group in parallel,
+// without modifying NominatedNodeName.
 func (pgMgr *PodGroupManager) patchGangPendingPodsCondition(ctx context.Context, handle fwktype.Handle, currentPod *corev1.Pod, gang *Gang, gangSchedulingContext *GangSchedulingContext, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status) {
 	if postFilterStatus == nil {
 		return
@@ -430,9 +431,7 @@ func (pgMgr *PodGroupManager) patchGangPendingPodsCondition(ctx context.Context,
 	startTime := time.Now()
 
 	// Get the set of already attempted pods to exclude
-	gangSchedulingContext.RLock()
 	attemptedPods := gangSchedulingContext.alreadyAttemptedPods
-	gangSchedulingContext.RUnlock()
 
 	// Collect all pending pods from the gang group, excluding already attempted ones
 	// and the current pod (which already gets its condition patched by the scheduler).

--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -26,18 +26,22 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	pgclientset "github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/generated/clientset/versioned"
 	pgformers "github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/generated/informers/externalversions"
 	pglister "github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/generated/listers/scheduling/v1alpha1"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+	"github.com/koordinator-sh/koordinator/pkg/features"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/apis/config"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
@@ -74,7 +78,7 @@ type Manager interface {
 	Permit(context.Context, *corev1.Pod) (time.Duration, Status)
 	PostBind(context.Context, *corev1.Pod, string)
 	PostFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, m fwktype.NodeToStatusReader) (*fwktype.PostFilterResult, *fwktype.Status)
-	AfterPostFilter(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.Handle, string, fwktype.NodeToStatusReader) (*fwktype.PostFilterResult, *fwktype.Status)
+	AfterPostFilter(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.Handle, string, fwktype.NodeToStatusReader, *fwktype.Status) (*fwktype.PostFilterResult, *fwktype.Status)
 	GetAllPodsFromGang(string) []*corev1.Pod
 	AllowGangGroup(*corev1.Pod, fwktype.Handle, string)
 	Unreserve(context.Context, fwktype.CycleState, *corev1.Pod, string, fwktype.Handle, string)
@@ -372,7 +376,7 @@ func (pgMgr *PodGroupManager) PostFilter(ctx context.Context, state fwktype.Cycl
 // AfterPostFilter
 // i. If strict-mode, we will set scheduleCycleValid to false and release all assumed pods.
 // ii. If non-strict mode, we will do nothing.
-func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, handle fwktype.Handle, pluginName string, filteredNodeStatusMap fwktype.NodeToStatusReader) (*fwktype.PostFilterResult, *fwktype.Status) {
+func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, handle fwktype.Handle, pluginName string, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status) (*fwktype.PostFilterResult, *fwktype.Status) {
 	if !util.IsPodNeedGang(pod) {
 		return &fwktype.PostFilterResult{}, fwktype.NewStatus(fwktype.Unschedulable)
 	}
@@ -396,6 +400,17 @@ func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype
 			}
 		}
 	}
+
+	// Patch scheduling failure condition for unattempted pending pods in the gang group.
+	// Only execute for non-root-cause pods and only once per GangSchedulingContext.
+	if k8sfeature.DefaultFeatureGate.Enabled(features.GangPendingPodsConditionPatch) && diagnosis != nil && !diagnosis.IsRootCausePod {
+		gangSchedulingContext := pgMgr.holder.getCurrentGangSchedulingContext()
+		if gangSchedulingContext != nil && !gangSchedulingContext.pendingPodsConditionPatched {
+			gangSchedulingContext.pendingPodsConditionPatched = true
+			pgMgr.patchGangPendingPodsCondition(ctx, handle, pod, gang, gangSchedulingContext, filteredNodeStatusMap, postFilterStatus)
+		}
+	}
+
 	if gang.getGangMode() == extension.GangModeStrict {
 		gang.clearWaitingGang()
 		pgMgr.rejectGangGroupById(handle, pluginName, gang.Name, message)
@@ -404,6 +419,76 @@ func (pgMgr *PodGroupManager) AfterPostFilter(ctx context.Context, state fwktype
 	}
 
 	return &fwktype.PostFilterResult{}, fwktype.NewStatus(fwktype.Unschedulable)
+}
+
+// patchGangPendingPodsCondition patches a PodScheduled=False condition on unattempted pending pods
+// (plus the current pod) in the gang group in parallel, without modifying NominatedNodeName.
+func (pgMgr *PodGroupManager) patchGangPendingPodsCondition(ctx context.Context, handle fwktype.Handle, currentPod *corev1.Pod, gang *Gang, gangSchedulingContext *GangSchedulingContext, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status) {
+	if postFilterStatus == nil {
+		return
+	}
+	startTime := time.Now()
+
+	// Get the set of already attempted pods to exclude
+	gangSchedulingContext.RLock()
+	attemptedPods := gangSchedulingContext.alreadyAttemptedPods
+	gangSchedulingContext.RUnlock()
+
+	// Collect all pending pods from the gang group, excluding already attempted ones
+	// and the current pod (which already gets its condition patched by the scheduler).
+	currentPodKey := util.GetId(currentPod.Namespace, currentPod.Name)
+	var pendingPods []*corev1.Pod
+	gangGroup := gang.getGangGroup()
+	for _, groupGangId := range gangGroup {
+		groupGang := pgMgr.cache.getGangFromCacheByGangId(groupGangId, false)
+		if groupGang == nil {
+			continue
+		}
+		pods := groupGang.getPendingChildrenFromGang()
+		for _, pod := range pods {
+			podKey := util.GetId(pod.Namespace, pod.Name)
+			if podKey != currentPodKey && !attemptedPods.Has(podKey) {
+				pendingPods = append(pendingPods, pod)
+			}
+		}
+	}
+
+	if len(pendingPods) == 0 {
+		klog.Infof("patchGangPendingPodsCondition skipped (no pending pods): currentPod=%s/%s, gangGroupID=%s, gangMinMember=%d, alreadyAttempted=%d, duration=%v",
+			currentPod.Namespace, currentPod.Name, gangSchedulingContext.gangGroupID, gang.MinRequiredNumber, attemptedPods.Len(), time.Since(startTime))
+		return
+	}
+
+	nodeInfos, _ := handle.SnapshotSharedLister().NodeInfos().List()
+	fitErr := &framework.FitError{
+		Pod:         currentPod,
+		NumAllNodes: len(nodeInfos),
+		Diagnosis: framework.Diagnosis{
+			PreFilterMsg:  gangSchedulingContext.failedMessage,
+			PostFilterMsg: postFilterStatus.Message(),
+		},
+	}
+	errMsg := fitErr.Error()
+
+	cs := handle.ClientSet()
+	handle.Parallelizer().Until(ctx, len(pendingPods), func(i int) {
+		pod := pendingPods[i]
+		condition := &corev1.PodCondition{
+			Type:    corev1.PodScheduled,
+			Status:  corev1.ConditionFalse,
+			Reason:  corev1.PodReasonUnschedulable,
+			Message: errMsg,
+		}
+		podStatusCopy := pod.Status.DeepCopy()
+		if !podutil.UpdatePodCondition(podStatusCopy, condition) {
+			return
+		}
+		if err := schedulerutil.PatchPodStatus(ctx, cs, pod.Name, pod.Namespace, &pod.Status, podStatusCopy); err != nil {
+			klog.Warningf("Failed to patch scheduling failure condition for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
+	}, "PatchGangPendingPodsCondition")
+	klog.Infof("patchGangPendingPodsCondition completed: currentPod=%s/%s, gangGroupID=%s, gangMinMember=%d, alreadyAttempted=%d, pendingPodsPatched=%d, duration=%v",
+		currentPod.Namespace, currentPod.Name, gangSchedulingContext.gangGroupID, gang.MinRequiredNumber, attemptedPods.Len(), len(pendingPods), time.Since(startTime))
 }
 
 func (pgMgr *PodGroupManager) summaryAndRecordFailedMessage(state fwktype.CycleState, triggerPod *corev1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) string {

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -29,6 +29,7 @@ import (
 	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -677,7 +678,7 @@ func TestAfterPostFilter_SuggestionPropagation(t *testing.T) {
 				diagnosis.SetSuggestion(tt.suggestion)
 			}
 
-			pgMgr.AfterPostFilter(context.TODO(), cycleState, tt.pod, pgMgr.handle, "coscheduling", nil)
+			pgMgr.AfterPostFilter(context.TODO(), cycleState, tt.pod, pgMgr.handle, "coscheduling", nil, nil)
 			assert.Equal(t, tt.wantSuggestion, tt.gangSchedulingContext.suggestion, "suggestion propagation")
 		})
 	}
@@ -854,4 +855,170 @@ func TestGetGangBindingInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPatchGangPendingPodsCondition(t *testing.T) {
+	gangCreatedTime := time.Now()
+
+	tests := []struct {
+		name                 string
+		currentPod           *corev1.Pod
+		pendingPods          []*corev1.Pod
+		alreadyAttemptedPods sets.Set[string]
+		postFilterStatus     *fwktype.Status
+		wantPatchCount       int
+	}{
+		{
+			name:             "nil postFilterStatus does nothing",
+			currentPod:       st.MakePod().Name("pod1").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+			postFilterStatus: nil,
+			wantPatchCount:   0,
+		},
+		{
+			name:       "excludes current pod and already attempted pods",
+			currentPod: st.MakePod().Name("pod1").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+			pendingPods: []*corev1.Pod{
+				st.MakePod().Name("pod2").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+				st.MakePod().Name("pod3").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+				st.MakePod().Name("pod4").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+			},
+			alreadyAttemptedPods: sets.New[string]("ns/pod1", "ns/pod2"),
+			postFilterStatus:     fwktype.NewStatus(fwktype.Unschedulable, "PostFilter failed"),
+			wantPatchCount:       2, // pod3 + pod4 (current pod excluded, pod2 attempted)
+		},
+		{
+			name:                 "no patches when all others are attempted",
+			currentPod:           st.MakePod().Name("pod1").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj(),
+			pendingPods:          []*corev1.Pod{},
+			alreadyAttemptedPods: sets.New[string]("ns/pod1"),
+			postFilterStatus:     fwktype.NewStatus(fwktype.Unschedulable, "PostFilter failed"),
+			wantPatchCount:       0, // current pod excluded, no other pending pods
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := makePg("gangA", "ns", 4, &gangCreatedTime, nil)
+
+			// Create handle with fake framework
+			handle := NewFakeExtendedFramework(t, []*corev1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			}, nil, nil, nil, nil)
+
+			// Create PodGroupManager
+			args := &config.CoschedulingArgs{DefaultTimeout: metav1.Duration{Duration: 300 * time.Second}}
+			gangCache := NewGangCache(args, nil, nil, nil, handle)
+			pgMgr := &PodGroupManager{
+				handle: handle,
+				cache:  gangCache,
+				args:   args,
+			}
+
+			// Set up gang
+			gangCache.onPodGroupAdd(pg)
+			gang := gangCache.getGangFromCacheByGangId("ns/gangA", false)
+			assert.NotNil(t, gang)
+
+			// Add pending pods to gang
+			for _, pod := range tt.pendingPods {
+				gang.setChild(pod)
+			}
+			gang.setChild(tt.currentPod)
+
+			// Set up gangSchedulingContext
+			gangSchedulingContext := &GangSchedulingContext{
+				gangGroupID:          "ns/gangA",
+				alreadyAttemptedPods: tt.alreadyAttemptedPods,
+				failedMessage:        "test failed message",
+			}
+
+			// Call the function
+			pgMgr.patchGangPendingPodsCondition(context.TODO(), handle, tt.currentPod, gang, gangSchedulingContext, nil, tt.postFilterStatus)
+
+			// Verify patch actions
+			fakeClient := handle.ClientSet().(*clientsetfake.Clientset)
+			patchCount := 0
+			for _, action := range fakeClient.Actions() {
+				if action.GetVerb() == "patch" && action.GetResource().Resource == "pods" {
+					patchAction := action.(k8stesting.PatchAction)
+					assert.Equal(t, "status", patchAction.GetSubresource())
+					patchCount++
+				}
+			}
+			assert.Equal(t, tt.wantPatchCount, patchCount, "unexpected number of patch actions")
+		})
+	}
+}
+
+func TestAfterPostFilter_PatchConditionOnlyOnce(t *testing.T) {
+	gangCreatedTime := time.Now()
+	pg := makePg("gangA", "ns", 3, &gangCreatedTime, nil)
+	pg.Annotations = map[string]string{
+		extension.AnnotationGangMode: string(extension.GangModeStrict),
+	}
+
+	// Create handle with fake framework
+	handle := NewFakeExtendedFramework(t, []*corev1.Node{
+		st.MakeNode().Name("node1").Obj(),
+	}, nil, nil, nil, nil)
+
+	// Create PodGroupManager with holder
+	args := &config.CoschedulingArgs{DefaultTimeout: metav1.Duration{Duration: 300 * time.Second}}
+	gangCache := NewGangCache(args, nil, nil, nil, handle)
+	pgMgr := &PodGroupManager{
+		handle: handle,
+		cache:  gangCache,
+		args:   args,
+	}
+
+	// Set up gang
+	gangCache.onPodGroupAdd(pg)
+	gang := gangCache.getGangFromCacheByGangId("ns/gangA", false)
+	assert.NotNil(t, gang)
+
+	pod := st.MakePod().Name("pod1").Namespace("ns").Label(v1alpha1.PodGroupLabel, "gangA").Obj()
+	gang.setChild(pod)
+
+	// Set up gangSchedulingContext with IsRootCausePod=false in diagnosis
+	gangSchedulingContext := &GangSchedulingContext{
+		gangGroupID:          "ns/gangA",
+		gangGroup:            sets.New[string]("ns/gangA"),
+		alreadyAttemptedPods: sets.New[string]("ns/pod1"),
+		failedMessage:        "test failed message",
+	}
+	pgMgr.holder.gangSchedulingContext = gangSchedulingContext
+
+	// Create cycleState with diagnosis where IsRootCausePod=false
+	cycleState := framework.NewCycleState()
+	frameworkext.InitDiagnosis(cycleState, pod)
+	diagnosis := frameworkext.GetDiagnosis(cycleState)
+	diagnosis.IsRootCausePod = false
+
+	postFilterStatus := fwktype.NewStatus(fwktype.Unschedulable, "PostFilter failed")
+
+	// First call: should patch
+	pgMgr.AfterPostFilter(context.TODO(), cycleState, pod, handle, "coscheduling", nil, postFilterStatus)
+	assert.True(t, gangSchedulingContext.pendingPodsConditionPatched, "flag should be set after first call")
+
+	// Count patches from first call
+	fakeClient := handle.ClientSet().(*clientsetfake.Clientset)
+	firstCallPatches := 0
+	for _, action := range fakeClient.Actions() {
+		if action.GetVerb() == "patch" && action.GetResource().Resource == "pods" {
+			firstCallPatches++
+		}
+	}
+
+	// Second call: should NOT patch again (flag already set)
+	gangSchedulingContext.failedMessage = "" // reset to allow re-entry into AfterPostFilter
+	pgMgr.AfterPostFilter(context.TODO(), cycleState, pod, handle, "coscheduling", nil, postFilterStatus)
+
+	// Count total patches - should be same as after first call
+	secondCallPatches := 0
+	for _, action := range fakeClient.Actions() {
+		if action.GetVerb() == "patch" && action.GetResource().Resource == "pods" {
+			secondCallPatches++
+		}
+	}
+	assert.Equal(t, firstCallPatches, secondCallPatches, "no additional patches should be made on second call")
 }

--- a/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_cache.go
@@ -149,7 +149,7 @@ func (gangCache *GangCache) onPodAddInternal(obj interface{}, action string) {
 		gangGroupInfo, created := gangCache.getGangGroupInfo(gangGroupId, gangGroup, true)
 		gang.SetGangGroupInfo(gangGroupInfo)
 		if created && pod.Spec.NodeName == "" && gangCache.isResponsibleForPod(pod) && gangCache.workloadAuditor != nil {
-			gangCache.workloadAuditor.AddGangGroup(gangGroupId)
+			gangCache.workloadAuditor.AddGangGroup(gangGroupId, gang.MinRequiredNumber)
 		}
 	}
 
@@ -267,7 +267,7 @@ func (gangCache *GangCache) onPodGroupAdd(obj interface{}) {
 	if gangCache.workloadAuditor != nil {
 		phase := pg.Status.Phase
 		if isPodGroupPendingPhase(phase) {
-			gangCache.workloadAuditor.AddGangGroup(gang.GangGroupId)
+			gangCache.workloadAuditor.AddGangGroup(gang.GangGroupId, gang.MinRequiredNumber)
 		}
 	}
 	if gang.isGangWorthRequeue() {

--- a/pkg/scheduler/plugins/coscheduling/core/gang_context.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang_context.go
@@ -108,6 +108,8 @@ type GangSchedulingContext struct {
 	preemptionMessage string
 	suggestion        *frameworkext.ScheduleSuggestion
 
+	pendingPodsConditionPatched bool
+
 	networkTopologySpec         *extension.NetworkTopologySpec
 	networkTopologySnapshot     *networktopology.TreeSnapshot
 	networkTopologyPlannedNodes map[string]string // podKey -> nodeName

--- a/pkg/scheduler/plugins/coscheduling/coscheduling.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling.go
@@ -165,8 +165,8 @@ func (cs *Coscheduling) AfterPreFilter(ctx context.Context, cycleState fwktype.C
 	return nil
 }
 
-func (cs *Coscheduling) AfterPostFilter(ctx context.Context, state fwktype.CycleState, pod *v1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader) {
-	cs.pgMgr.AfterPostFilter(ctx, state, pod, cs.frameworkHandler, Name, filteredNodeStatusMap)
+func (cs *Coscheduling) AfterPostFilter(ctx context.Context, state fwktype.CycleState, pod *v1.Pod, filteredNodeStatusMap fwktype.NodeToStatusReader, postFilterStatus *fwktype.Status) {
+	cs.pgMgr.AfterPostFilter(ctx, state, pod, cs.frameworkHandler, Name, filteredNodeStatusMap, postFilterStatus)
 }
 
 // PostFilter

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -384,7 +384,7 @@ func TestPostFilter(t *testing.T) {
 				}
 			}
 			// reject waitingPods
-			_, code := gp.pgMgr.AfterPostFilter(context.Background(), cycleState, tt.pod, suit.Handle, Name, nil)
+			_, code := gp.pgMgr.AfterPostFilter(context.Background(), cycleState, tt.pod, suit.Handle, Name, nil, nil)
 			if code.Message() == "" != tt.expectedEmptyMsg {
 				t.Errorf("expectedEmptyMsg %v, got %v", tt.expectedEmptyMsg, code.Message() == "")
 			}


### PR DESCRIPTION
… pending pods

After PostFilter, patch a PodScheduled=False condition on all unattempted pending pods in the gang group (plus the current pod) in parallel. This enriches pod status with scheduling failure information without modifying NominatedNodeName.

Key changes:
- Pass PostFilter status as parameter to AfterPostFilter interface
- Add patchGangPendingPodsCondition: collects pending pods excluding already attempted ones (always includes current pod), generates error message via framework.FitError, patches conditions in parallel
- Only executes when IsRootCausePod==false, once per GangSchedulingContext
- Add timing log with gangGroupID, gang size, pending pods count, duration
- Add unit tests for patchGangPendingPodsCondition and only-once behavior

### Ⅰ. Describe what this PR does

Patch a `PodScheduled=False` condition on all unattempted pending pods in the gang group after PostFilter, enriching pod status with scheduling failure information.

### Ⅱ. Does this pull request fix one issue?

Fixes #3088

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
