### PR TITLE
fix(koordlet): exit runtimehooks reconcile goroutines on stopCh

### DIFF
--- a/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/host_app_reconciler.go
@@ -98,6 +98,7 @@ func (r *hostReconciler) reconcile(stopCh <-chan struct{}) {
 			timer.Reset(r.reconcileInterval)
 		case <-stopCh:
 			klog.V(1).Infof("stop reconcile for host application")
+			return
 		}
 	}
 }

--- a/pkg/koordlet/runtimehooks/reconciler/reconcile_stop_test.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconcile_stop_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+	"time"
+)
+
+// a large interval keeps the timer branch from firing so the test only exercises the stopCh path.
+const stopTestInterval = time.Hour
+
+// assertReturnsBeforeTimeout fails if fn does not return once stopCh is closed.
+func assertReturnsBeforeTimeout(t *testing.T, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reconcile loop did not return after stopCh was closed")
+	}
+}
+
+func Test_hostReconciler_reconcile_exitsOnStop(t *testing.T) {
+	r := &hostReconciler{
+		appUpdated:        make(chan struct{}, 1),
+		reconcileInterval: stopTestInterval,
+	}
+	stopCh := make(chan struct{})
+	close(stopCh)
+	assertReturnsBeforeTimeout(t, func() { r.reconcile(stopCh) })
+}
+
+func Test_reconciler_reconcileKubeQOSCgroup_exitsOnStop(t *testing.T) {
+	c := &reconciler{
+		reconcileInterval: stopTestInterval,
+	}
+	stopCh := make(chan struct{})
+	close(stopCh)
+	assertReturnsBeforeTimeout(t, func() { c.reconcileKubeQOSCgroup(stopCh) })
+}

--- a/pkg/koordlet/runtimehooks/reconciler/reconciler.go
+++ b/pkg/koordlet/runtimehooks/reconciler/reconciler.go
@@ -400,6 +400,7 @@ func (c *reconciler) reconcileKubeQOSCgroup(stopCh <-chan struct{}) {
 			timer.Reset(c.reconcileInterval)
 		case <-stopCh:
 			klog.V(1).Infof("stop reconcile kube qos cgroup")
+			return
 		}
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The host application reconcile loop (`host_app_reconciler.go`) and the kubeqos cgroup reconcile loop (`reconciler.go`) log on `stopCh` but never `return`, so the `for`/`select` keeps running after shutdown is signalled. Once `stopCh` is closed the closed channel is always ready, so the select fires the `<-stopCh` case on every iteration — the goroutine busy-spins instead of exiting.

This adds the missing `return`, matching the sibling loops in the same package (`doHostAppCgroup` and `reconcilePodCgroup`) that already return on `stopCh`. These two were the only `case <-stopCh:` in `pkg/` that didn't return.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```
go test ./pkg/koordlet/runtimehooks/reconciler/ -run exitsOnStop
```

The added tests close `stopCh` and assert the loop returns within a deadline. They time out on the old behaviour and pass once the loops return.

### Ⅳ. Special notes for reviews

Minimal change: one `return` per loop plus the tests.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
