### PR TITLE
descheduler: add ranker and unit tests for scaledownbinpack

### DIFF
--- a/pkg/descheduler/framework/plugins/scaledownbinpack/ranker.go
+++ b/pkg/descheduler/framework/plugins/scaledownbinpack/ranker.go
@@ -78,9 +78,9 @@ func RankPods(nodes []*corev1.Node, eligibleTargetPods []*corev1.Pod, skippedTar
 
 		var num, den float64
 		for resName, weight := range resourceWeights {
-			capacity := node.Status.Capacity[resName]
-			capMilli := capacity.MilliValue()
-			if capMilli <= 0 {
+			allocatable := node.Status.Allocatable[resName]
+			allocMilli := allocatable.MilliValue()
+			if allocMilli <= 0 {
 				continue
 			}
 
@@ -98,8 +98,8 @@ func RankPods(nodes []*corev1.Node, eligibleTargetPods []*corev1.Pod, skippedTar
 				ntReq += q.MilliValue()
 			}
 
-			uNt := float64(ntReq) / float64(capMilli)
-			uT := float64(tReq) / float64(capMilli)
+			uNt := float64(ntReq) / float64(allocMilli)
+			uT := float64(tReq) / float64(allocMilli)
 
 			num += weight * uNt
 			den += weight * uT
@@ -144,8 +144,8 @@ func RankPods(nodes []*corev1.Node, eligibleTargetPods []*corev1.Pod, skippedTar
 	for _, info := range nodeInfos {
 		sort.Slice(info.EligibleTargetPods, func(i, j int) bool {
 			pi, pj := info.EligibleTargetPods[i], info.EligibleTargetPods[j]
-			sizeI := getPodSize(pi, resourceWeights)
-			sizeJ := getPodSize(pj, resourceWeights)
+			sizeI := getPodSize(pi, info.Node.Status.Allocatable, resourceWeights)
+			sizeJ := getPodSize(pj, info.Node.Status.Allocatable, resourceWeights)
 
 			if sizeI != sizeJ {
 				return sizeI > sizeJ // descending
@@ -174,11 +174,15 @@ func RankPods(nodes []*corev1.Node, eligibleTargetPods []*corev1.Pod, skippedTar
 	return globalRanked
 }
 
-func getPodSize(pod *corev1.Pod, weights map[corev1.ResourceName]float64) float64 {
+func getPodSize(pod *corev1.Pod, allocatable corev1.ResourceList, weights map[corev1.ResourceName]float64) float64 {
 	var size float64
 	for resName, weight := range weights {
 		q := util.GetPodRequest(pod, resName)[resName]
-		size += weight * float64(q.MilliValue())
+		alloc := allocatable[resName]
+		allocMilli := alloc.MilliValue()
+		if allocMilli > 0 {
+			size += weight * (float64(q.MilliValue()) / float64(allocMilli))
+		}
 	}
 	return size
 }

--- a/pkg/descheduler/framework/plugins/scaledownbinpack/ranker_test.go
+++ b/pkg/descheduler/framework/plugins/scaledownbinpack/ranker_test.go
@@ -35,6 +35,10 @@ func makeNode(name string, cpu, mem string) *corev1.Node {
 				corev1.ResourceCPU:    resource.MustParse(cpu),
 				corev1.ResourceMemory: resource.MustParse(mem),
 			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(mem),
+			},
 		},
 	}
 }
@@ -221,4 +225,40 @@ func TestRankPods_ZeroRequestTargetPod(t *testing.T) {
 
 	// Validate the Infinity trap worked
 	assert.True(t, math.IsInf(ranked[2].EvacuationScore, 1), "Expected +Inf score for zero-request target on a taxed node")
+}
+
+func TestRankPods_ResourceDomination(t *testing.T) {
+	now := time.Now()
+
+	// A node with 4 CPU and 8Gi Memory.
+	node := makeNode("node1", "4", "8Gi")
+
+	// CPU heavy pod: 2 CPU, 100Mi Memory
+	// CPU usage: 2 / 4 = 0.5
+	// Mem usage: 100Mi / 8Gi = 100 * 2^20 / (8 * 2^30) = 100 / 8192 = 0.012
+	// Normalized size = 0.5 + 0.012 = 0.512
+	pCpuHeavy := makePod("default", "p-cpu-heavy", "node1", "2", "100Mi", now)
+
+	// Memory heavy pod: 100m CPU, 3Gi Memory
+	// CPU usage: 0.1 / 4 = 0.025
+	// Mem usage: 3Gi / 8Gi = 0.375
+	// Normalized size = 0.025 + 0.375 = 0.4
+	pMemHeavy := makePod("default", "p-mem-heavy", "node1", "100m", "3Gi", now)
+
+	nodes := []*corev1.Node{node}
+	targetPods := []*corev1.Pod{pCpuHeavy, pMemHeavy}
+
+	weights := map[corev1.ResourceName]float64{
+		corev1.ResourceCPU:    1.0,
+		corev1.ResourceMemory: 1.0,
+	}
+
+	ranked := RankPods(nodes, targetPods, nil, nil, weights)
+
+	assert.Equal(t, 2, len(ranked))
+
+	// cpu-heavy normalized size (0.512) > mem-heavy normalized size (0.4)
+	// So cpu-heavy pod should be ranked first (largest size first).
+	assert.Equal(t, "p-cpu-heavy", ranked[0].Pod.Name)
+	assert.Equal(t, "p-mem-heavy", ranked[1].Pod.Name)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds the initial `Scale-Down Binpack` ranker implementation under `pkg/descheduler/framework/plugins/scaledownbinpack/`.

It introduces:

- `RankPods(...)` to compute a per-node evacuation score.
- Node grouping for target pods and non-target pods.
- Node-level sorting based on evacuation score, target pod count, and node name for deterministic ordering.
- Pod-level sorting within each node by weighted size, then creation timestamp, then namespace/name.
- A global rank assignment for all target pods, which can later be used for pod-deletion-cost annotation or direct eviction flow.

This logic is designed to improve scale-down packing by preferring victims whose removal helps consolidate remaining workload onto fewer nodes.

### Ⅱ. Does this pull request fix one issue?

Refers #2790

### Ⅲ. Describe how to verify it

Run the unit tests for the new ranker package:
```bash
go test ./pkg/descheduler/framework/plugins/scaledownbinpack/...
```

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
