### PR TITLE
scheduler: fix potential deadlock caused by double RLock in GetQuotaSnapshot

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
+++ b/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go
@@ -682,9 +682,7 @@ func (gqm *GroupQuotaManager) GetQuotaSnapshot() *QuotaSnapshot {
 
 	for name, quotaInfo := range gqm.quotaInfoMap {
 		// Deep copy QuotaInfo for snapshot
-		quotaInfo.lock.RLock()
 		snapshot.quotaInfoMap[name] = quotaInfo.DeepCopy()
-		quotaInfo.lock.RUnlock()
 	}
 	return snapshot
 }


### PR DESCRIPTION
  Ⅰ. Describe what this PR does

  GetQuotaSnapshot acquires quotaInfo.lock.RLock() before calling quotaInfo.DeepCopy(), but DeepCopy() internally acquires quotaInfo.lock.RLock() as well. This double RLock on the same sync.RWMutex from the same goroutine can cause a self-deadlock. The outer RLock/RUnlock was introduced by #2742.

  Scenario: while the outer RLock is held, if a concurrent writer (e.g., UpdateUsed from the scheduling loop) is waiting for the write lock, the inner RLock in DeepCopy() blocks because the writer is queued, but the writer cannot proceed until the outer RLock is released — a classic self-deadlock.

  The following goroutine dump from a cluster confirms this deadlock (both goroutines stuck for 322 minutes):

  - Goroutine 507 (writer): OnPodUpdate → updatePodUsedNoLock → updateGroupDeltaUsedNoLock → scopedLockForQuotaInfo → Lock() — waiting for the write lock on the same QuotaInfo.
  - Goroutine 479 (reader): updateQuotaSnapshot → GetQuotaSnapshot → DeepCopy → RLock() — the outer RLock on line 685 was already held, the writer queued for Lock in between, and the inner RLock in DeepCopy (line 119) blocks because a writer is pending.

```
goroutine 479 [sync.RWMutex.RLock, 322 minutes]:
sync.runtime_SemacquireRWMutexR(0x127ba93?, 0x4f?, 0x127b83f?)
        /usr/local/go/src/runtime/sema.go:82 +0x25
sync.(*RWMutex).RLock(...)
        /usr/local/go/src/sync/rwmutex.go:71
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*QuotaInfo).DeepCopy(0xc006320a80)
        /go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/quota_info.go:119 +0x6d
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*GroupQuotaManager).GetQuotaSnapshot(0xc0070f03c0)
        /go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go:686 +0x18f
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota.(*Plugin).updateQuotaSnapshot(0xc0083ba700)
        /go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/plugin.go:602 +0x14d
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc014391f00?)
        /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00b8f8900?, {0x3320fc0, 0xc00da29a70}, 0x1, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00b8f8900?, 0x1bf08eb000, 0x0, 0xc0?, 0xc00c536fd0?)
        /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(0x127e540?, 0xc003b4cc18?, 0xc00c536fb8?)
        /go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:161 +0x1e
created by github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota.(*Plugin).Start in goroutine 907
        /go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/plugin.go:221 +0x185


goroutine 507 [sync.RWMutex.Lock, 322 minutes]:
sync.runtime_SemacquireRWMutex(0xc012c92958?, 0xe0?, 0x2?)
	/usr/local/go/src/runtime/sema.go:87 +0x25
sync.(*RWMutex).Lock(0x0?)
	/usr/local/go/src/sync/rwmutex.go:152 +0x6a
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*GroupQuotaManager).scopedLockForQuotaInfo(0xc01fa5a540?, {0xc016bf5710, 0x2, 0x2})
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go:396 +0x3d
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*GroupQuotaManager).updateGroupDeltaUsedNoLock(0xc0070f03c0, {0xc02151c520, 0x1f}, 0x2b?, 0x2932320?, 0x0)
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go:251 +0x12a
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*GroupQuotaManager).updatePodUsedNoLock(0xc0070f03c0, {0xc02151c520, 0x1f}, 0xc00bfc7b00, 0x0)
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go:806 +0xad5
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core.(*GroupQuotaManager).OnPodUpdate(0xc0070f03c0, {0xc00d13e300, 0x1f}, {0xc02151c520, 0x1f}, 0xc004e15b00, 0x15f8be9?)
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/core/group_quota_manager.go:961 +0x49c
github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota.(*Plugin).OnPodUpdate(0xc022574720?, {0x2e37ba0?, 0xc00bfc7b00}, {0x2e37ba0?, 0xc004e15b00})
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/elasticquota/pod_handler.go:68 +0x9e5
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/pkg/mod/k8s.io/client-go@v0.28.7/tools/cache/controller.go:246
github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper.(*forceSyncEventHandler).OnUpdate(0xc00ebaafc0, {0x2e37ba0, 0xc00bfc7b00}, {0x2e37ba0, 0xc004e15b00})
	/go/src/github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper/forcesync_eventhandler.go:83 +0x89
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/pkg/mod/k8s.io/client-go@v0.28.7/tools/cache/shared_informer.go:972 +0xea
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00b1f1738?, {0x3320fc0, 0xc00eb4e150}, 0x1, 0xc00acc2180)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0xc00b1f1788?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc00b906000)
	/go/pkg/mod/k8s.io/client-go@v0.28.7/tools/cache/shared_informer.go:968 +0x69
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/wait.go:72 +0x4f
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 1
	/go/pkg/mod/k8s.io/apimachinery@v0.28.7/pkg/util/wait/wait.go:70 +0x73
```


  Fix: DeepCopy() already handles its own locking (RLock + defer RUnlock), so the redundant outer RLock/RUnlock pair is removed.

  Ⅱ. Does this pull request fix one issue?

Fixes a potential deadlock in GetQuotaSnapshot where double RLock on the same sync.RWMutex from the same goroutine can cause a self-deadlock when a concurrent writer is waiting for the write lock.

  Ⅲ. Describe how to verify it

  1. Build passes: go build ./pkg/scheduler/plugins/elasticquota/core/...
  2. Unit tests pass: go test ./pkg/scheduler/plugins/elasticquota/core/...
  3. Existing TestQuotaInfo_DeepCopy already covers lock safety of DeepCopy, no new tests needed.

  Ⅳ. Special notes for reviews

  DeepCopy() already handles nil check and locking internally. The outer gqm.hierarchyUpdateLock.RLock() protects quotaInfoMap from add/delete, and each QuotaInfo's data consistency is guaranteed by DeepCopy's internal lock. Removing the outer RLock is safe.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
