### PR TITLE
fix: remove stale feature gate TODO comments

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -172,7 +172,6 @@ var transformerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultDeschedulerFeatureGates))
-	// TODO: use a unified feature-gate
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(transformerFeatureGates))
 }
 

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -173,6 +173,5 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 
 func init() {
 	runtime.Must(k8sfeature.DefaultMutableFeatureGate.Add(defaultSchedulerFeatureGates))
-	// TODO: use a unified feature-gate
 	runtime.Must(k8sfeature.DefaultMutableFeatureGate.Add(transformerFeatureGates))
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Removes two stale `// TODO: use a unified feature-gate` comments from `pkg/features/features.go` and `pkg/features/scheduler_features.go`. No code logic changes; feature gate registration is unchanged.

### Ⅱ. Does this pull request fix one issue?

fixes #2965

### Ⅲ. Describe how to verify it

```bash
grep -rn "TODO: use a unified feature-gate" pkg/features/
go test -race ./pkg/features/...
go test -race ./pkg/util/transformer/...
```

Expected: grep returns no matches; tests pass.

### Ⅳ. Special notes for reviews

The three separate feature gate instances (`utilfeature.DefaultMutableFeatureGate`, `k8sfeature.DefaultMutableFeatureGate`, `DefaultMutableKoordletFeatureGate`) are intentional — each binary runs in its own process. The removed TODOs referred to an unimplemented local refactor (merging multiple `Add()` calls), not cross-binary unification.

### V. Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`