### PR TITLE
chore: fix frameworkext flaky test

### DIFF
--- a/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
+++ b/pkg/scheduler/frameworkext/helper/forcesync_eventhandler_test.go
@@ -85,6 +85,21 @@ func TestSyncedEventHandler(t *testing.T) {
 	mu.Unlock()
 
 	sharedInformerFactory.WaitForCacheSync(stopCh)
+
+	// Ensure the reflector's Watch has been established before mutating.
+	// WaitForCacheSync only guarantees the initial List was consumed by the
+	// FIFO; the Watch registration with the fake tracker may lag behind,
+	// causing the Update event to be silently dropped.
+	err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		for _, action := range fakeClientSet.Actions() {
+			if action.GetVerb() == "watch" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	assert.NoError(t, err, "timed out waiting for watch to be established")
+
 	node, err := nodeInformer.Lister().Get("node-0")
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
@@ -92,12 +107,12 @@ func TestSyncedEventHandler(t *testing.T) {
 	node.ResourceVersion = "100"
 	_, err = fakeClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	assert.NoError(t, err)
-	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		node, err := nodeInformer.Lister().Get("node-0")
 		assert.NoError(t, err)
 		assert.NotNil(t, node)
 		return node.ResourceVersion == "100", nil
-	}, wait.NeverStop)
+	})
 	assert.NoError(t, err)
 }
 
@@ -298,6 +313,18 @@ func TestSyncedEventHandlerWithReplace(t *testing.T) {
 	}
 
 	sharedInformerFactory.WaitForCacheSync(stopCh)
+
+	// Ensure the reflector's Watch has been established before mutating.
+	err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		for _, action := range fakeClientSet.Actions() {
+			if action.GetVerb() == "watch" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	assert.NoError(t, err, "timed out waiting for watch to be established")
+
 	node, err := nodeInformer.Lister().Get("node-0")
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
@@ -305,11 +332,11 @@ func TestSyncedEventHandlerWithReplace(t *testing.T) {
 	node.ResourceVersion = "100"
 	_, err = fakeClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	assert.NoError(t, err)
-	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		node, err := nodeInformer.Lister().Get("node-0")
 		assert.NoError(t, err)
 		assert.NotNil(t, node)
 		return node.ResourceVersion == "100", nil
-	}, wait.NeverStop)
+	})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

Fix a flaky test introduced in #3105 and #2875, triggered at https://github.com/koordinator-sh/koordinator/actions/runs/28513975135/job/84520928833.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
