### PR TITLE
fix: add schema validation for quotaLabels in ElasticQuotaProfile

### DIFF
--- a/apis/quota/v1alpha1/elastic_quota_profile_types.go
+++ b/apis/quota/v1alpha1/elastic_quota_profile_types.go
@@ -28,6 +28,7 @@ type ElasticQuotaProfileSpec struct {
 	// +required
 	QuotaName string `json:"quotaName"`
 	// QuotaLabels defines the labels of the quota.
+	// +kubebuilder:validation:XValidation:rule="self.values().all(v, v.matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$') && size(v) <= 63)"
 	QuotaLabels map[string]string `json:"quotaLabels,omitempty"`
 	// ResourceRatio is a ratio, we will use it to fix the resource fragmentation problem.
 	// If the total resource is 100 and the resource ratio is 0.9, the allocable resource is 100*0.9=90

--- a/config/crd/bases/quota.koordinator.sh_elasticquotaprofiles.yaml
+++ b/config/crd/bases/quota.koordinator.sh_elasticquotaprofiles.yaml
@@ -90,6 +90,9 @@ spec:
                   type: string
                 description: QuotaLabels defines the labels of the quota.
                 type: object
+                x-kubernetes-validations:
+                - rule: self.values().all(v, v.matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$')
+                    && size(v) <= 63)
               quotaName:
                 description: QuotaName defines the associated quota name of the profile.
                 type: string


### PR DESCRIPTION
### Describe what this PR does

- **Summary of changes:** Added schema-level OpenAPI validation for the `Spec.QuotaLabels` map in `ElasticQuotaProfile`.
- **How it works:** Uses Kubebuilder CEL markers (`+kubebuilder:validation:XValidation`) to enforce that every label value under `quotaLabels` satisfies standard Kubernetes label formatting constraints (max 63 characters, must start and end with an alphanumeric, and contain only `-`, `_`, `.`, or alphanumerics).
- **Why this is needed:** Previously, arbitrary strings were accepted by the API server. When the profile controller reconciled the resource and attempted to copy these into metadata labels for the downstream `ElasticQuota` resource, the API server rejected the `ElasticQuota` update. This caused persistent reconciliation failures in the profile controller.

### Does this pull request fix one issue?

fixes #3116

### Note
This change is fully backward-compatible as it only rejects invalid Kubernetes label inputs at schema level, matching constraints that are already implicitly required at runtime by the API server.

### Describe how to verify it

- **Compilation check:**
  ```bash
  go build ./apis/...
  go build ./pkg/...

**Unit Test:**
  ```bash
go test ./pkg/quota-controller/profile/...

