### PR TITLE
fix: add webhook validation for quotaLabels in ElasticQuotaProfile

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -161,6 +161,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-quota-koordinator-sh-v1alpha1-elasticquotaprofile
+  failurePolicy: Fail
+  name: velasticquotaprofile.koordinator.sh
+  rules:
+  - apiGroups:
+    - quota.koordinator.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - elasticquotaprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-node
   failurePolicy: Ignore
   name: vnode.koordinator.sh

--- a/pkg/webhook/elasticquota/validating/profile_validating_handler.go
+++ b/pkg/webhook/elasticquota/validating/profile_validating_handler.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	v1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	quotav1alpha1 "github.com/koordinator-sh/koordinator/apis/quota/v1alpha1"
+)
+
+type ElasticQuotaProfileValidatingHandler struct {
+	Decoder admission.Decoder
+}
+
+var _ admission.Handler = &ElasticQuotaProfileValidatingHandler{}
+
+func (h *ElasticQuotaProfileValidatingHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
+	if request.AdmissionRequest.Resource.Resource != "elasticquotaprofiles" {
+		return admission.Allowed("")
+	}
+
+	obj := &quotav1alpha1.ElasticQuotaProfile{}
+
+	var err error
+	if request.Operation != v1.Delete {
+		if err = h.Decoder.Decode(request, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	} else {
+		return admission.Allowed("")
+	}
+
+	allErrs := h.ValidateElasticQuotaProfile(obj)
+	if len(allErrs) > 0 {
+		return admission.Denied(allErrs.ToAggregate().Error())
+	}
+
+	return admission.Allowed("")
+}
+
+func (h *ElasticQuotaProfileValidatingHandler) ValidateElasticQuotaProfile(profile *quotav1alpha1.ElasticQuotaProfile) field.ErrorList {
+	var allErrs field.ErrorList
+	fldPath := field.NewPath("spec", "quotaLabels")
+
+	for k, v := range profile.Spec.QuotaLabels {
+		for _, msg := range validation.IsQualifiedName(k) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(k), k, msg))
+		}
+		for _, msg := range validation.IsValidLabelValue(v) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(k), v, fmt.Sprintf("invalid label value: %s", msg)))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/webhook/elasticquota/validating/profile_validating_handler_test.go
+++ b/pkg/webhook/elasticquota/validating/profile_validating_handler_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	quotav1alpha1 "github.com/koordinator-sh/koordinator/apis/quota/v1alpha1"
+)
+
+func TestElasticQuotaProfileValidatingHandler(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = quotav1alpha1.AddToScheme(scheme)
+	decoder := admission.NewDecoder(scheme)
+
+	handler := &ElasticQuotaProfileValidatingHandler{
+		Decoder: decoder,
+	}
+
+	tests := []struct {
+		name            string
+		req             admission.Request
+		expectedAllowed bool
+	}{
+		{
+			name: "valid labels",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "elasticquotaprofiles"},
+					Operation: v1.Create,
+					Object: runtime.RawExtension{
+						Raw: marshalObj(&quotav1alpha1.ElasticQuotaProfile{
+							Spec: quotav1alpha1.ElasticQuotaProfileSpec{
+								QuotaLabels: map[string]string{
+									"valid-key":   "valid-value",
+									"foo.bar/baz": "value123",
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "invalid label keys",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "elasticquotaprofiles"},
+					Operation: v1.Create,
+					Object: runtime.RawExtension{
+						Raw: marshalObj(&quotav1alpha1.ElasticQuotaProfile{
+							Spec: quotav1alpha1.ElasticQuotaProfileSpec{
+								QuotaLabels: map[string]string{
+									"invalid key with spaces": "value",
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedAllowed: false,
+		},
+		{
+			name: "invalid label values",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "elasticquotaprofiles"},
+					Operation: v1.Create,
+					Object: runtime.RawExtension{
+						Raw: marshalObj(&quotav1alpha1.ElasticQuotaProfile{
+							Spec: quotav1alpha1.ElasticQuotaProfileSpec{
+								QuotaLabels: map[string]string{
+									"valid-key": "invalid value with spaces",
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedAllowed: false,
+		},
+		{
+			name: "ignore other resources",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "pods"},
+					Operation: v1.Create,
+				},
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "allow delete operation",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "elasticquotaprofiles"},
+					Operation: v1.Delete,
+				},
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "invalid object decode error",
+			req: admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Resource:  metav1.GroupVersionResource{Resource: "elasticquotaprofiles"},
+					Operation: v1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte("invalid json"),
+					},
+				},
+			},
+			expectedAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := handler.Handle(context.TODO(), tt.req)
+			assert.Equal(t, tt.expectedAllowed, resp.Allowed)
+		})
+	}
+}
+
+func marshalObj(obj interface{}) []byte {
+	b, _ := json.Marshal(obj)
+	return b
+}

--- a/pkg/webhook/elasticquota/validating/webhooks.go
+++ b/pkg/webhook/elasticquota/validating/webhooks.go
@@ -26,11 +26,13 @@ import (
 )
 
 // +kubebuilder:webhook:path=/validate-scheduling-sigs-k8s-io-v1alpha1-elasticquota,mutating=false,failurePolicy=fail,sideEffects=None,admissionReviewVersions=v1;v1beta1,groups=scheduling.sigs.k8s.io,resources=elasticquotas,verbs=create;update;delete,versions=v1alpha1,name=velasticquota.koordinator.sh
+// +kubebuilder:webhook:path=/validate-quota-koordinator-sh-v1alpha1-elasticquotaprofile,mutating=false,failurePolicy=fail,sideEffects=None,admissionReviewVersions=v1;v1beta1,groups=quota.koordinator.sh,resources=elasticquotaprofiles,verbs=create;update,versions=v1alpha1,name=velasticquotaprofile.koordinator.sh
 
 var (
 	// HandlerBuilderMap contains admission webhook handlers builder
 	HandlerBuilderMap = map[string]framework.HandlerBuilder{
-		"validate-scheduling-sigs-k8s-io-v1alpha1-elasticquota": &quotaValidateBuilder{},
+		"validate-scheduling-sigs-k8s-io-v1alpha1-elasticquota":      &quotaValidateBuilder{},
+		"validate-quota-koordinator-sh-v1alpha1-elasticquotaprofile": &profileValidateBuilder{},
 	}
 )
 
@@ -55,4 +57,21 @@ func (b *quotaValidateBuilder) Build() admission.Handler {
 		klog.Fatalf("failed to inject cache for quotaValidateBuilder: %v", err)
 	}
 	return h
+}
+
+var _ framework.HandlerBuilder = &profileValidateBuilder{}
+
+type profileValidateBuilder struct {
+	mgr manager.Manager
+}
+
+func (b *profileValidateBuilder) WithControllerManager(mgr ctrl.Manager) framework.HandlerBuilder {
+	b.mgr = mgr
+	return b
+}
+
+func (b *profileValidateBuilder) Build() admission.Handler {
+	return &ElasticQuotaProfileValidatingHandler{
+		Decoder: admission.NewDecoder(b.mgr.GetScheme()),
+	}
 }

--- a/pkg/webhook/elasticquota/validating/webhooks_test.go
+++ b/pkg/webhook/elasticquota/validating/webhooks_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type mockManager struct {
+	ctrl.Manager
+	scheme *runtime.Scheme
+}
+
+func (m *mockManager) GetScheme() *runtime.Scheme {
+	return m.scheme
+}
+
+func TestProfileValidateBuilder(t *testing.T) {
+	scheme := runtime.NewScheme()
+	mgr := &mockManager{scheme: scheme}
+
+	builder := &profileValidateBuilder{}
+	builder.WithControllerManager(mgr)
+
+	handler := builder.Build()
+	assert.NotNil(t, handler)
+	assert.IsType(t, &ElasticQuotaProfileValidatingHandler{}, handler)
+}


### PR DESCRIPTION
Ⅰ. **Describe what this PR does**
This PR adds validating admission webhook logic to reject malformed keys and values in `quotaLabels` for the `ElasticQuotaProfile` CRD. It utilizes `k8s.io/apimachinery/pkg/util/validation` to enforce that keys are qualified names and values are valid label values.

Ⅱ. **Does this pull request fix one issue?**
Fixes #3116

Ⅲ. **Describe how to verify it**
1. Install the CRD and run the webhook locally or in a cluster.
2. Attempt to create an `ElasticQuotaProfile` with an invalid `quotaLabels` format (e.g. `label: test-wec1, test-wec2` or spaces in the label keys).
3. The webhook should successfully reject the resource creation, returning the specific validation error.

Ⅳ. **Special notes for reviews**
This approach validates `quotaLabels` proactively at admission time and leverages the standard `validation.IsQualifiedName` and `validation.IsValidLabelValue` utilities from `k8s.io/apimachinery`. 

V. **Checklist**
- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
