### PR TITLE
fix: use NUMA node ID instead of slice index in addPodAllocation

### DIFF
--- a/pkg/scheduler/plugins/nodenumaresource/node_allocation.go
+++ b/pkg/scheduler/plugins/nodenumaresource/node_allocation.go
@@ -142,11 +142,11 @@ func (n *NodeAllocation) addPodAllocation(request *PodAllocation, cpuTopology *C
 		}
 	}
 
-	for nodeID, numaNodeRes := range request.NUMANodeResources {
+	for _, numaNodeRes := range request.NUMANodeResources {
 		res := n.allocatedResources[numaNodeRes.Node]
 		if res == nil {
 			res = &NUMANodeResource{
-				Node:      nodeID,
+				Node:      numaNodeRes.Node,
 				Resources: make(corev1.ResourceList),
 			}
 			n.allocatedResources[numaNodeRes.Node] = res

--- a/pkg/scheduler/plugins/nodenumaresource/node_allocation_test.go
+++ b/pkg/scheduler/plugins/nodenumaresource/node_allocation_test.go
@@ -96,6 +96,40 @@ func TestNodeAllocationAddCPUs(t *testing.T) {
 	assert.Equal(t, expectAllocatedCPUs, allocationState.allocatedCPUs)
 }
 
+func TestNodeAllocation_addPodAllocation(t *testing.T) {
+	allocationState := NewNodeAllocation("test-node-1")
+	assert.NotNil(t, allocationState)
+
+	podUID := uuid.NewUUID()
+	request := &PodAllocation{
+		UID: podUID,
+		NUMANodeResources: []NUMANodeResource{
+			{
+				Node: 1, // Start from 1 to test the slice index bug
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			{
+				Node: 2,
+				Resources: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+
+	// Add pod allocation
+	allocationState.addPodAllocation(request, nil)
+
+	// Verify that the allocatedResources map keys match the Node field in the values
+	for _, numaNodeRes := range request.NUMANodeResources {
+		storedRes := allocationState.allocatedResources[numaNodeRes.Node]
+		assert.NotNil(t, storedRes)
+		assert.Equal(t, numaNodeRes.Node, storedRes.Node, "stored node ID should match the map key and the requested node ID")
+	}
+}
+
 func TestNodeAllocationStateReleaseCPUs(t *testing.T) {
 	cpuTopology := buildCPUTopologyForTest(2, 1, 4, 2)
 	for _, v := range cpuTopology.CPUDetails {


### PR DESCRIPTION
Ⅰ. **Describe what this PR does**
This PR fixes a bug in `NodeAllocation.addPodAllocation` within the `nodenumaresource` scheduler plugin. 

Previously, when iterating over the pod's `NUMANodeResources` slice, the loop used the slice index (`nodeID`) rather than the actual NUMA node ID (`numaNodeRes.Node`) when constructing the new `NUMANodeResource` struct. If a pod was allocated on NUMA nodes `[1, 2]`, the resulting map entries would incorrectly store `Node: 0` and `Node: 1` as their internal IDs, despite being keyed correctly in the `n.allocatedResources` map.

This PR corrects the loop to assign `numaNodeRes.Node` to the `.Node` field, aligning it with the behavior in `release()` and preventing future bugs when this field is read by metrics or debugging endpoints.

Ⅱ. **Does this pull request fix one issue?**
Fixes #3081 

Ⅲ. **Describe how to verify it**
A new unit test `TestNodeAllocation_addPodAllocation` has been added to `pkg/scheduler/plugins/nodenumaresource/node_allocation_test.go`.

Run the unit test to verify the fix:
```bash
go test -v ./pkg/scheduler/plugins/nodenumaresource/... -run TestNodeAllocation_addPodAllocation
```

Ⅳ. **Special notes for reviewers**
None. This is a targeted, single-line bug fix.

Ⅴ. **Checklist**
- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
