### PR TITLE
feat: share NodeDeviceCache across scheduler profiles

### DIFF
--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -553,7 +553,9 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	// StartSharedCaches wires the unified pod/node dispatcher on cc.InformerFactory and
 	// invokes Start on every SharedPluginCache registered by plugins during New(). Must
 	// run before cc.InformerFactory.Start() so no event fires before its handler is wired.
-	frameworkExtenderFactory.StartSharedCaches(ctx, cc.InformerFactory)
+	if err := frameworkExtenderFactory.StartSharedCaches(ctx, cc.InformerFactory); err != nil {
+		return nil, nil, nil, nil, err
+	}
 	workloadauditor.AddEventHandler(sched, workloadAuditor, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
 	reservationErrorHandler := eventhandlers.MakeReservationErrorHandler(
 		sched,

--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -550,6 +550,10 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	schedAdapter := frameworkExtenderFactory.Scheduler()
 
 	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory, crossSchedulerNominator)
+	// StartSharedCaches wires the unified pod/node dispatcher on cc.InformerFactory and
+	// invokes Start on every SharedPluginCache registered by plugins during New(). Must
+	// run before cc.InformerFactory.Start() so no event fires before its handler is wired.
+	frameworkExtenderFactory.StartSharedCaches(ctx, cc.InformerFactory)
 	workloadauditor.AddEventHandler(sched, workloadAuditor, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
 	reservationErrorHandler := eventhandlers.MakeReservationErrorHandler(
 		sched,

--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -241,6 +241,16 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 	}
 
 	startInformersAndWaitForSync := func(ctx context.Context) error {
+		// Start the opt-in shared plugin caches before any informer factory: this wires the
+		// unified pod/node dispatcher on cc.InformerFactory and invokes Start on every
+		// SharedPluginCache registered by plugins during New(). Doing it here (rather than in
+		// Setup) keeps all runtime startup in Run, and runs it in both the immediate and the
+		// leader-election paths (StartSharedCaches is idempotent). It must precede
+		// cc.InformerFactory.Start() below so no event fires before its handler is wired.
+		if err := extenderFactory.StartSharedCaches(ctx, cc.InformerFactory); err != nil {
+			return err
+		}
+
 		// Startup order matters for data-race freedom: some plugins register
 		// AfterPluginInformersSynced hooks (via frameworkexthelper) that rebuild
 		// internal state from an initial-list snapshot of their private informers
@@ -272,6 +282,14 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		}
 
 		// Step 3: start the remaining informer factories.
+		// Defensive invariant: the shared plugin caches (and their unified pod/node
+		// dispatcher registered on cc.InformerFactory) must be started before this factory
+		// starts, or events would be missed and shared caches read while unpopulated — the
+		// regression class this PR guards against. In the current structure StartSharedCaches
+		// above always runs first; this check fails loudly if a future edit ever reorders it.
+		if !extenderFactory.SharedCachesStarted() {
+			return fmt.Errorf("shared plugin caches must be started before the main informer factory (StartSharedCaches not called)")
+		}
 		cc.InformerFactory.Start(ctx.Done())
 		// DynInformerFactory can be nil in tests.
 		if cc.DynInformerFactory != nil {
@@ -550,12 +568,6 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	schedAdapter := frameworkExtenderFactory.Scheduler()
 
 	eventhandlers.AddScheduleEventHandler(sched, schedAdapter, cc.InformerFactory, cc.KoordinatorSharedInformerFactory, crossSchedulerNominator)
-	// StartSharedCaches wires the unified pod/node dispatcher on cc.InformerFactory and
-	// invokes Start on every SharedPluginCache registered by plugins during New(). Must
-	// run before cc.InformerFactory.Start() so no event fires before its handler is wired.
-	if err := frameworkExtenderFactory.StartSharedCaches(ctx, cc.InformerFactory); err != nil {
-		return nil, nil, nil, nil, err
-	}
 	workloadauditor.AddEventHandler(sched, workloadAuditor, cc.InformerFactory, cc.KoordinatorSharedInformerFactory)
 	reservationErrorHandler := eventhandlers.MakeReservationErrorHandler(
 		sched,

--- a/pkg/scheduler/frameworkext/framework_extender.go
+++ b/pkg/scheduler/frameworkext/framework_extender.go
@@ -106,6 +106,8 @@ type frameworkExtenderImpl struct {
 	metricsRecorder *metrics.MetricAsyncRecorder
 
 	crossSchedulerNominator *CrossSchedulerPodNominator
+
+	factory *FrameworkExtenderFactory
 }
 
 func NewFrameworkExtender(f *FrameworkExtenderFactory, fw framework.Framework) FrameworkExtender {
@@ -116,6 +118,7 @@ func NewFrameworkExtender(f *FrameworkExtenderFactory, fw framework.Framework) F
 	frameworkExtender := &frameworkExtenderImpl{
 		Framework:                           fw,
 		errorHandlerDispatcher:              f.errorHandlerDispatcher,
+		factory:                             f,
 		schedulerFn:                         schedulerFn,
 		monitor:                             f.monitor,
 		koordinatorClientSet:                f.KoordinatorClientSet(),
@@ -298,6 +301,10 @@ func (ext *frameworkExtenderImpl) GetCrossSchedulerPodNominator() *CrossSchedule
 
 func (ext *frameworkExtenderImpl) GetWorkloadAuditor() workloadauditor.WorkloadAuditor {
 	return ext.workloadAuditor
+}
+
+func (ext *frameworkExtenderImpl) GetOrRegisterSharedCache(key string, create func(handle ExtendedHandle) SharedPluginCache) SharedPluginCache {
+	return ext.factory.getOrRegisterSharedCache(key, ext, create)
 }
 
 // RunPreFilterPlugins transforms the PreFilter phase of framework with pre-filter transformers.

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -628,6 +628,10 @@ func (f *FrameworkExtenderFactory) SharedCachesStarted() bool {
 // goal is parallel-by-default dispatch with an opt-in serial mode, so the shared dispatcher
 // does not regress event-handling latency compared to the original per-profile handler
 // pattern. Deferred to the unified event-dispatcher phase (PR-3).
+//
+// TODO: instrument per-handler dispatch latency (e.g. a histogram labeled by cache key and
+// event type) so the dispatcher's handler performance is observable and regressions are
+// caught once serial/parallel execution modes land. Deferred to the same PR-3 phase.
 func (f *FrameworkExtenderFactory) dispatchCaches() []SharedPluginCache {
 	if p := f.startedCaches.Load(); p != nil {
 		return *p

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -561,40 +561,40 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 		f.sharedCachesMu.Unlock()
 		return nil
 	}
-	f.sharedCachesStarted = true
 	caches := make([]SharedPluginCache, 0, len(f.sharedCachesOrder))
 	for _, key := range f.sharedCachesOrder {
 		caches = append(caches, f.sharedCaches[key])
 	}
 	f.sharedCachesMu.Unlock()
 
-	if len(caches) == 0 {
-		return nil
+	if len(caches) > 0 {
+		// Register the unified pod/node dispatchers before committing any state, so a
+		// registration failure leaves the factory un-started (sharedCachesStarted stays
+		// false, no snapshot published) and returns an error for the caller to fail fast
+		// on, rather than a partially-started state that later calls would skip.
+		if _, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    f.dispatchPodAdd,
+			UpdateFunc: f.dispatchPodUpdate,
+			DeleteFunc: f.dispatchPodDelete,
+		}); err != nil {
+			return fmt.Errorf("failed to register shared cache pod event handler, err: %w", err)
+		}
+		if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    f.dispatchNodeAdd,
+			UpdateFunc: f.dispatchNodeUpdate,
+			DeleteFunc: f.dispatchNodeDelete,
+		}); err != nil {
+			return fmt.Errorf("failed to register shared cache node event handler, err: %w", err)
+		}
+		// Publish the immutable snapshot for lock-free dispatch. Events cannot arrive until
+		// the informer factory is started (after this returns), so it is safe to publish
+		// after the handlers are registered.
+		f.startedCaches.Store(&caches)
 	}
 
-	// Publish the immutable snapshot before wiring the dispatcher so events (which cannot
-	// arrive until the informer factory is started, after this returns) always read it.
-	f.startedCaches.Store(&caches)
-
-	// Register unified pod/node dispatchers before invoking Start so plugin-specific
-	// CRD handlers registered inside Start observe the same "handlers wired before
-	// factory started" invariant. A registration failure means the dispatcher is not
-	// wired and the caches would never receive pod/node events, so fail fast rather than
-	// starting into a silently broken state.
-	if _, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    f.dispatchPodAdd,
-		UpdateFunc: f.dispatchPodUpdate,
-		DeleteFunc: f.dispatchPodDelete,
-	}); err != nil {
-		return fmt.Errorf("failed to register shared cache pod event handler, err: %w", err)
-	}
-	if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    f.dispatchNodeAdd,
-		UpdateFunc: f.dispatchNodeUpdate,
-		DeleteFunc: f.dispatchNodeDelete,
-	}); err != nil {
-		return fmt.Errorf("failed to register shared cache node event handler, err: %w", err)
-	}
+	f.sharedCachesMu.Lock()
+	f.sharedCachesStarted = true
+	f.sharedCachesMu.Unlock()
 
 	for _, c := range caches {
 		c.Start(ctx)

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
@@ -173,6 +174,10 @@ type FrameworkExtenderFactory struct {
 	sharedCaches        map[string]SharedPluginCache
 	sharedCachesOrder   []string
 	sharedCachesStarted bool
+	// startedCaches is the immutable, registration-ordered snapshot of shared caches
+	// published once by StartSharedCaches. The unified dispatcher reads it lock-free on
+	// every pod/node event, avoiding a mutex acquisition and slice allocation per event.
+	startedCaches atomic.Pointer[[]SharedPluginCache]
 }
 
 func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, error) {
@@ -550,11 +555,11 @@ func (f *FrameworkExtenderFactory) getOrRegisterSharedCache(key string, handle E
 // after all profiles are built (all Plugin.New() calls completed) and before
 // informerFactory.Start() so no event is delivered before its handler is registered.
 // Idempotent — subsequent calls after the first are no-ops.
-func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, informerFactory informers.SharedInformerFactory) {
+func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, informerFactory informers.SharedInformerFactory) error {
 	f.sharedCachesMu.Lock()
 	if f.sharedCachesStarted {
 		f.sharedCachesMu.Unlock()
-		return
+		return nil
 	}
 	f.sharedCachesStarted = true
 	caches := make([]SharedPluginCache, 0, len(f.sharedCachesOrder))
@@ -564,40 +569,46 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 	f.sharedCachesMu.Unlock()
 
 	if len(caches) == 0 {
-		return
+		return nil
 	}
+
+	// Publish the immutable snapshot before wiring the dispatcher so events (which cannot
+	// arrive until the informer factory is started, after this returns) always read it.
+	f.startedCaches.Store(&caches)
 
 	// Register unified pod/node dispatchers before invoking Start so plugin-specific
 	// CRD handlers registered inside Start observe the same "handlers wired before
-	// factory started" invariant.
+	// factory started" invariant. A registration failure means the dispatcher is not
+	// wired and the caches would never receive pod/node events, so fail fast rather than
+	// starting into a silently broken state.
 	if _, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    f.dispatchPodAdd,
 		UpdateFunc: f.dispatchPodUpdate,
 		DeleteFunc: f.dispatchPodDelete,
 	}); err != nil {
-		klog.ErrorS(err, "failed to register shared cache pod event handler")
+		return fmt.Errorf("failed to register shared cache pod event handler, err: %w", err)
 	}
 	if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    f.dispatchNodeAdd,
 		UpdateFunc: f.dispatchNodeUpdate,
 		DeleteFunc: f.dispatchNodeDelete,
 	}); err != nil {
-		klog.ErrorS(err, "failed to register shared cache node event handler")
+		return fmt.Errorf("failed to register shared cache node event handler, err: %w", err)
 	}
 
 	for _, c := range caches {
 		c.Start(ctx)
 	}
+	return nil
 }
 
-func (f *FrameworkExtenderFactory) snapshotCaches() []SharedPluginCache {
-	f.sharedCachesMu.Lock()
-	defer f.sharedCachesMu.Unlock()
-	caches := make([]SharedPluginCache, 0, len(f.sharedCachesOrder))
-	for _, key := range f.sharedCachesOrder {
-		caches = append(caches, f.sharedCaches[key])
+// dispatchCaches returns the immutable snapshot of registered shared caches published by
+// StartSharedCaches. Read lock-free on every event — no mutex, no allocation.
+func (f *FrameworkExtenderFactory) dispatchCaches() []SharedPluginCache {
+	if p := f.startedCaches.Load(); p != nil {
+		return *p
 	}
-	return caches
+	return nil
 }
 
 func (f *FrameworkExtenderFactory) dispatchPodAdd(obj interface{}) {
@@ -605,7 +616,7 @@ func (f *FrameworkExtenderFactory) dispatchPodAdd(obj interface{}) {
 	if !ok {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnPodAdd(pod)
 	}
 }
@@ -619,7 +630,7 @@ func (f *FrameworkExtenderFactory) dispatchPodUpdate(oldObj, newObj interface{})
 	if !ok {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnPodUpdate(oldPod, newPod)
 	}
 }
@@ -635,7 +646,7 @@ func (f *FrameworkExtenderFactory) dispatchPodDelete(obj interface{}) {
 	if pod == nil {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnPodDelete(pod)
 	}
 }
@@ -645,7 +656,7 @@ func (f *FrameworkExtenderFactory) dispatchNodeAdd(obj interface{}) {
 	if !ok {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnNodeAdd(node)
 	}
 }
@@ -659,7 +670,7 @@ func (f *FrameworkExtenderFactory) dispatchNodeUpdate(oldObj, newObj interface{}
 	if !ok {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnNodeUpdate(oldNode, newNode)
 	}
 }
@@ -675,7 +686,7 @@ func (f *FrameworkExtenderFactory) dispatchNodeDelete(obj interface{}) {
 	if node == nil {
 		return
 	}
-	for _, c := range f.snapshotCaches() {
+	for _, c := range f.dispatchCaches() {
 		c.OnNodeDelete(node)
 	}
 }

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -639,15 +639,6 @@ func (f *FrameworkExtenderFactory) SharedCachesStarted() bool {
 
 // dispatchCaches returns the immutable snapshot of registered shared caches published by
 // StartSharedCaches. Read lock-free on every event — no mutex, no allocation.
-//
-// TODO: the dispatch* methods below invoke each cache's handler sequentially. The end-state
-// goal is parallel-by-default dispatch with an opt-in serial mode, so the shared dispatcher
-// does not regress event-handling latency compared to the original per-profile handler
-// pattern. Deferred to the unified event-dispatcher phase (PR-3).
-//
-// TODO: instrument per-handler dispatch latency (e.g. a histogram labeled by cache key and
-// event type) so the dispatcher's handler performance is observable and regressions are
-// caught once serial/parallel execution modes land. Deferred to the same PR-3 phase.
 func (f *FrameworkExtenderFactory) dispatchCaches() []SharedPluginCache {
 	if p := f.startedCaches.Load(); p != nil {
 		return *p
@@ -655,6 +646,15 @@ func (f *FrameworkExtenderFactory) dispatchCaches() []SharedPluginCache {
 	return nil
 }
 
+// The dispatch* methods below invoke each registered cache's handler sequentially.
+//
+// TODO: the end-state goal is parallel-by-default dispatch with an opt-in serial mode, so the
+// shared dispatcher does not regress event-handling latency compared to the original per-profile
+// handler pattern. Deferred to the unified event-dispatcher phase (PR-3).
+//
+// TODO: instrument per-handler dispatch latency (e.g. a histogram labeled by cache key and event
+// type) so the dispatcher's handler performance is observable and regressions are caught once
+// serial/parallel execution modes land. Deferred to the same PR-3 phase.
 func (f *FrameworkExtenderFactory) dispatchPodAdd(obj interface{}) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -545,6 +545,13 @@ func (f *FrameworkExtenderFactory) getOrRegisterSharedCache(key string, handle E
 	if c, ok := f.sharedCaches[key]; ok {
 		return c
 	}
+	if f.sharedCachesStarted {
+		// Registering a new shared cache after StartSharedCaches has published the dispatch
+		// snapshot would leave it out of that snapshot: it never gets Start() and never
+		// receives an event. That is a wiring bug (registration must happen during plugin
+		// New(), before StartSharedCaches), not a recoverable state — fail loudly.
+		panic(fmt.Sprintf("frameworkext: shared cache %q registered after StartSharedCaches; register it during plugin New()", key))
+	}
 	c := create(handle)
 	f.sharedCaches[key] = c
 	f.sharedCachesOrder = append(f.sharedCachesOrder, key)

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -45,6 +45,7 @@ import (
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
 	"github.com/koordinator-sh/koordinator/pkg/features"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/indexer"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/networktopology"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/services"
@@ -572,18 +573,27 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 		// registration failure leaves the factory un-started (sharedCachesStarted stays
 		// false, no snapshot published) and returns an error for the caller to fail fast
 		// on, rather than a partially-started state that later calls would skip.
-		if _, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    f.dispatchPodAdd,
-			UpdateFunc: f.dispatchPodUpdate,
-			DeleteFunc: f.dispatchPodDelete,
-		}); err != nil {
+		//
+		// Use ForceSyncFromInformer (not a bare AddEventHandler) so the dispatcher's
+		// registrations are collected into WaitForHandlersSync: the scheduler then waits
+		// for these handlers to drain their initial pod/node list into the shared caches
+		// before the first scheduling cycle, so a shared cache is never read while still
+		// unpopulated. This preserves the sync guarantee the per-plugin handlers had before
+		// they were centralized here.
+		if _, err := frameworkexthelper.ForceSyncFromInformer(ctx.Done(), informerFactory,
+			informerFactory.Core().V1().Pods().Informer(), cache.ResourceEventHandlerFuncs{
+				AddFunc:    f.dispatchPodAdd,
+				UpdateFunc: f.dispatchPodUpdate,
+				DeleteFunc: f.dispatchPodDelete,
+			}); err != nil {
 			return fmt.Errorf("failed to register shared cache pod event handler, err: %w", err)
 		}
-		if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    f.dispatchNodeAdd,
-			UpdateFunc: f.dispatchNodeUpdate,
-			DeleteFunc: f.dispatchNodeDelete,
-		}); err != nil {
+		if _, err := frameworkexthelper.ForceSyncFromInformer(ctx.Done(), informerFactory,
+			informerFactory.Core().V1().Nodes().Informer(), cache.ResourceEventHandlerFuncs{
+				AddFunc:    f.dispatchNodeAdd,
+				UpdateFunc: f.dispatchNodeUpdate,
+				DeleteFunc: f.dispatchNodeDelete,
+			}); err != nil {
 			return fmt.Errorf("failed to register shared cache node event handler, err: %w", err)
 		}
 		// Publish the immutable snapshot for lock-free dispatch. Events cannot arrive until
@@ -604,6 +614,11 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 
 // dispatchCaches returns the immutable snapshot of registered shared caches published by
 // StartSharedCaches. Read lock-free on every event — no mutex, no allocation.
+//
+// TODO: the dispatch* methods below invoke each cache's handler sequentially. The end-state
+// goal is parallel-by-default dispatch with an opt-in serial mode, so the shared dispatcher
+// does not regress event-handling latency compared to the original per-profile handler
+// pattern. Deferred to the unified event-dispatcher phase (PR-3).
 func (f *FrameworkExtenderFactory) dispatchCaches() []SharedPluginCache {
 	if p := f.startedCaches.Load(); p != nil {
 		return *p

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
@@ -31,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -165,6 +168,11 @@ type FrameworkExtenderFactory struct {
 	pluginInformerFactories []SharedInformerFactory
 
 	metricsRecorder *metrics.MetricAsyncRecorder
+
+	sharedCachesMu      sync.Mutex
+	sharedCaches        map[string]SharedPluginCache
+	sharedCachesOrder   []string
+	sharedCachesStarted bool
 }
 
 func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, error) {
@@ -192,6 +200,7 @@ func NewFrameworkExtenderFactory(options ...Option) (*FrameworkExtenderFactory, 
 		crossSchedulerNominator:             handleOptions.crossSchedulerNominator,
 		workloadAuditor:                     handleOptions.workloadAuditor,
 		metricsRecorder:                     metrics.NewMetricsAsyncRecorder(1000, time.Second, wait.NeverStop),
+		sharedCaches:                        map[string]SharedPluginCache{},
 	}, nil
 }
 
@@ -517,5 +526,156 @@ func PluginFactoryProxy(extenderFactory *FrameworkExtenderFactory, factoryFn fra
 		extenderFactory.updatePlugins(plugin, fw.ProfileName())
 		frameworkExtender.(*frameworkExtenderImpl).updatePlugins(plugin)
 		return plugin, nil
+	}
+}
+
+// getOrRegisterSharedCache is the factory-side implementation behind
+// ExtendedHandle.GetOrRegisterSharedCache. First call for a given key invokes create(handle)
+// and stores the result; subsequent calls return the stored instance and do not call
+// create. Registration order is preserved for deterministic event dispatch.
+func (f *FrameworkExtenderFactory) getOrRegisterSharedCache(key string, handle ExtendedHandle, create func(ExtendedHandle) SharedPluginCache) SharedPluginCache {
+	f.sharedCachesMu.Lock()
+	defer f.sharedCachesMu.Unlock()
+	if c, ok := f.sharedCaches[key]; ok {
+		return c
+	}
+	c := create(handle)
+	f.sharedCaches[key] = c
+	f.sharedCachesOrder = append(f.sharedCachesOrder, key)
+	return c
+}
+
+// StartSharedCaches wires up the unified pod/node event dispatcher on informerFactory and
+// invokes Start(ctx) on every registered SharedPluginCache exactly once. Must be called
+// after all profiles are built (all Plugin.New() calls completed) and before
+// informerFactory.Start() so no event is delivered before its handler is registered.
+// Idempotent — subsequent calls after the first are no-ops.
+func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, informerFactory informers.SharedInformerFactory) {
+	f.sharedCachesMu.Lock()
+	if f.sharedCachesStarted {
+		f.sharedCachesMu.Unlock()
+		return
+	}
+	f.sharedCachesStarted = true
+	caches := make([]SharedPluginCache, 0, len(f.sharedCachesOrder))
+	for _, key := range f.sharedCachesOrder {
+		caches = append(caches, f.sharedCaches[key])
+	}
+	f.sharedCachesMu.Unlock()
+
+	if len(caches) == 0 {
+		return
+	}
+
+	// Register unified pod/node dispatchers before invoking Start so plugin-specific
+	// CRD handlers registered inside Start observe the same "handlers wired before
+	// factory started" invariant.
+	if _, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    f.dispatchPodAdd,
+		UpdateFunc: f.dispatchPodUpdate,
+		DeleteFunc: f.dispatchPodDelete,
+	}); err != nil {
+		klog.ErrorS(err, "failed to register shared cache pod event handler")
+	}
+	if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    f.dispatchNodeAdd,
+		UpdateFunc: f.dispatchNodeUpdate,
+		DeleteFunc: f.dispatchNodeDelete,
+	}); err != nil {
+		klog.ErrorS(err, "failed to register shared cache node event handler")
+	}
+
+	for _, c := range caches {
+		c.Start(ctx)
+	}
+}
+
+func (f *FrameworkExtenderFactory) snapshotCaches() []SharedPluginCache {
+	f.sharedCachesMu.Lock()
+	defer f.sharedCachesMu.Unlock()
+	caches := make([]SharedPluginCache, 0, len(f.sharedCachesOrder))
+	for _, key := range f.sharedCachesOrder {
+		caches = append(caches, f.sharedCaches[key])
+	}
+	return caches
+}
+
+func (f *FrameworkExtenderFactory) dispatchPodAdd(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnPodAdd(pod)
+	}
+}
+
+func (f *FrameworkExtenderFactory) dispatchPodUpdate(oldObj, newObj interface{}) {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnPodUpdate(oldPod, newPod)
+	}
+}
+
+func (f *FrameworkExtenderFactory) dispatchPodDelete(obj interface{}) {
+	var pod *corev1.Pod
+	switch t := obj.(type) {
+	case *corev1.Pod:
+		pod = t
+	case cache.DeletedFinalStateUnknown:
+		pod, _ = t.Obj.(*corev1.Pod)
+	}
+	if pod == nil {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnPodDelete(pod)
+	}
+}
+
+func (f *FrameworkExtenderFactory) dispatchNodeAdd(obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnNodeAdd(node)
+	}
+}
+
+func (f *FrameworkExtenderFactory) dispatchNodeUpdate(oldObj, newObj interface{}) {
+	oldNode, ok := oldObj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	newNode, ok := newObj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnNodeUpdate(oldNode, newNode)
+	}
+}
+
+func (f *FrameworkExtenderFactory) dispatchNodeDelete(obj interface{}) {
+	var node *corev1.Node
+	switch t := obj.(type) {
+	case *corev1.Node:
+		node = t
+	case cache.DeletedFinalStateUnknown:
+		node, _ = t.Obj.(*corev1.Node)
+	}
+	if node == nil {
+		return
+	}
+	for _, c := range f.snapshotCaches() {
+		c.OnNodeDelete(node)
 	}
 }

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -575,6 +575,15 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 	}
 	f.sharedCachesMu.Unlock()
 
+	// INVARIANT: no getOrRegisterSharedCache runs concurrently with this function. sharedCachesStarted
+	// is not set until after the dispatchers register below (deliberately, so a registration failure
+	// leaves the factory un-started for fail-fast), so a cache registered in the window between the
+	// snapshot above and the flag set below would miss BOTH the snapshot and the post-start panic
+	// guard. This is unreachable today because profiles are constructed serially and every
+	// getOrRegisterSharedCache (from Plugin.New()) completes before StartSharedCaches is called.
+	// Future hardening (only if that ordering ever changes) must preserve the fail-fast property —
+	// e.g. fold the flag into a critical section that also covers registration.
+
 	if len(caches) > 0 {
 		// Register the unified pod/node dispatchers before committing any state, so a
 		// registration failure leaves the factory un-started (sharedCachesStarted stays

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -612,6 +612,15 @@ func (f *FrameworkExtenderFactory) StartSharedCaches(ctx context.Context, inform
 	return nil
 }
 
+// SharedCachesStarted reports whether StartSharedCaches has already run. Used by the
+// scheduler startup pipeline to assert that the shared caches (and their pod/node dispatcher)
+// are wired before the main informer factory is started.
+func (f *FrameworkExtenderFactory) SharedCachesStarted() bool {
+	f.sharedCachesMu.Lock()
+	defer f.sharedCachesMu.Unlock()
+	return f.sharedCachesStarted
+}
+
 // dispatchCaches returns the immutable snapshot of registered shared caches published by
 // StartSharedCaches. Read lock-free on every event — no mutex, no allocation.
 //

--- a/pkg/scheduler/frameworkext/framework_extender_factory_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory_test.go
@@ -520,3 +520,51 @@ func TestInterceptSchedulerErrorWiresSchedulingQueue(t *testing.T) {
 	// failure handler (see TestErrorHandlerDispatcherReleasesInFlightPodOnSuppression)
 	assert.NotNil(t, f.errorHandlerDispatcher.schedulingQueue)
 }
+
+// TestGetOrRegisterSharedCache_SharedAcrossProfiles simulates two scheduler profiles built
+// from the same FrameworkExtenderFactory, each calling GetOrRegisterSharedCache via its own
+// ExtendedHandle. Both must receive the same cache instance (created exactly once), proving
+// the opt-in cache is shared across profiles rather than duplicated per profile.
+func TestGetOrRegisterSharedCache_SharedAcrossProfiles(t *testing.T) {
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(koordClientSet, 0)
+	extenderFactory, err := NewFrameworkExtenderFactory(
+		WithKoordinatorClientSet(koordClientSet),
+		WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	)
+	assert.NoError(t, err)
+
+	fakeClient := kubefake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	newProfile := func(schedulerName string) FrameworkExtender {
+		fh, err := schedulertesting.NewFramework(
+			context.TODO(),
+			registeredPlugins,
+			schedulerName,
+			frameworkruntime.WithClientSet(fakeClient),
+			frameworkruntime.WithInformerFactory(sharedInformerFactory),
+		)
+		assert.NoError(t, err)
+		return extenderFactory.NewFrameworkExtender(fh)
+	}
+
+	profileA := newProfile("profile-a")
+	profileB := newProfile("profile-b")
+
+	rec := &orderRecorder{}
+	createCalls := 0
+	create := func(ExtendedHandle) SharedPluginCache {
+		createCalls++
+		return newRecordingCache("deviceshare", rec)
+	}
+
+	cacheA := profileA.GetOrRegisterSharedCache("deviceshare", create)
+	cacheB := profileB.GetOrRegisterSharedCache("deviceshare", create)
+
+	assert.Same(t, cacheA, cacheB, "both profiles must share a single cache instance")
+	assert.Equal(t, 1, createCalls, "the cache must be created exactly once across profiles")
+}

--- a/pkg/scheduler/frameworkext/interface.go
+++ b/pkg/scheduler/frameworkext/interface.go
@@ -64,6 +64,11 @@ type ExtendedHandle interface {
 	// It returns nil when the feature is not enabled or not configured.
 	GetCrossSchedulerPodNominator() *CrossSchedulerPodNominator
 	GetWorkloadAuditor() workloadauditor.WorkloadAuditor
+	// GetOrRegisterSharedCache registers a plugin's SharedPluginCache under key, or returns
+	// the previously-registered instance if key is already taken. Guarantees exactly-once
+	// creation across scheduling profiles. Plugins call this from their New() to opt into
+	// the shared cache mechanism instead of building a per-profile cache.
+	GetOrRegisterSharedCache(key string, create func(handle ExtendedHandle) SharedPluginCache) SharedPluginCache
 }
 
 // FrameworkExtender extends the K8s Scheduling Framework interface to provide more extension methods to support Koordinator.

--- a/pkg/scheduler/frameworkext/shared_plugin_cache.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SharedPluginCache is implemented by a plugin's cache object when the cache should be
+// shared as a single instance across all scheduler profiles. The framework extender
+// manages its lifecycle via StartSharedCaches and routes pod/node events to it centrally
+// through the unified dispatcher on FrameworkExtenderFactory. Plugins that need
+// Koordinator-specific CRD events (e.g. DeviceShare's Device CRD) register those handlers
+// themselves inside Start, since those events are plugin-specific.
+type SharedPluginCache interface {
+	Start(ctx context.Context)
+
+	OnPodAdd(pod *corev1.Pod)
+	OnPodUpdate(oldPod, newPod *corev1.Pod)
+	OnPodDelete(pod *corev1.Pod)
+
+	OnNodeAdd(node *corev1.Node)
+	OnNodeUpdate(oldNode, newNode *corev1.Node)
+	OnNodeDelete(node *corev1.Node)
+}
+
+// CacheReserver is an optional interface for SharedPluginCache implementations that write
+// assumed allocations during the Reserve scheduling phase. Implementers must uphold the
+// assume/forget contract: AssumePod records what Reserve wrote, ForgetPod (or the
+// reconcile path in OnPodAdd/Update/Delete) rolls it back. The informer event is always
+// authoritative — implementations reconcile rather than skip when it arrives for an
+// assumed pod, so the cache converges on the event's state even when the event's pod
+// object differs from what Reserve assumed.
+type CacheReserver interface {
+	SharedPluginCache
+	AssumePod(pod *corev1.Pod, nodeName string) error
+	ForgetPod(pod *corev1.Pod) error
+}

--- a/pkg/scheduler/frameworkext/shared_plugin_cache.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache.go
@@ -59,12 +59,17 @@ type SharedPluginCache interface {
 // for a racing ForgetPod on arbitration failure. Because the marker is not consumed on a
 // positive event, it lives for the whole lifetime of a successfully-bound pod.
 //
-// Two consequences implementers must accept: (1) rollback is against the Reserve-time snapshot,
-// not the pod's current annotation, so post-assume annotation changes are not reconciled while
-// the marker is live; (2) if a pod is genuinely bound to a node other than the one Reserve
-// assumed, that node is not credited until a later informer event arrives after the marker is
-// cleared. This is a deliberate departure from an annotation-authoritative "reconcile on every
-// event" model, chosen for arbitration safety.
+// This mirrors preemption nomination in the kube-scheduler framework: the assumed (Reserve)
+// node is accounted for immediately, and canceling that assumption — a reset of spec.nodeName
+// from a non-empty value back to "" — is the negative event that forgets the pod, rather than
+// the cache declining to account for the assumption in the first place. By design the
+// arbitrating node always equals the Reserve node, so a positive event never lands on a
+// different node and there is no divergent-bind undercount; this would be revisited only if a
+// future arbitration design introduces a genuine node change (a rare coalesced A→B update for a
+// pod whose marker has already cleared falls back to the plugin's ordinary nodeName-change
+// handling in updatePod). One consequence implementers must accept: rollback is against the
+// Reserve-time snapshot, not the pod's current annotation, so post-assume annotation changes are
+// not reconciled while the marker is live.
 type CacheReserver interface {
 	SharedPluginCache
 	AssumePod(pod *corev1.Pod, nodeName string) error

--- a/pkg/scheduler/frameworkext/shared_plugin_cache.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache.go
@@ -28,6 +28,14 @@ import (
 // through the unified dispatcher on FrameworkExtenderFactory. Plugins that need
 // Koordinator-specific CRD events (e.g. DeviceShare's Device CRD) register those handlers
 // themselves inside Start, since those events are plugin-specific.
+//
+// Start runs exactly once, on the ExtendedHandle of whichever profile first constructed the
+// shared cache, so it may only use factory-scoped (instance-singleton) dependencies — the
+// shared/koord informer factories, the scheduler cache, etc. Per-extender state must NOT be
+// registered here: a ForgetPod handler, for example, is per-extender (see
+// ExtendedHandle.RegisterForgetPodHandler), so registering it in Start would only wire the
+// one profile's extender and miss ForgetPod invoked through any other profile. Register such
+// per-profile hooks in the plugin's New() instead, where every profile runs.
 type SharedPluginCache interface {
 	Start(ctx context.Context)
 
@@ -41,12 +49,22 @@ type SharedPluginCache interface {
 }
 
 // CacheReserver is an optional interface for SharedPluginCache implementations that write
-// assumed allocations during the Reserve scheduling phase. Implementers must uphold the
-// assume/forget contract: AssumePod records what Reserve wrote, ForgetPod (or the
-// reconcile path in OnPodAdd/Update/Delete) rolls it back. The informer event is always
-// authoritative — implementations reconcile rather than skip when it arrives for an
-// assumed pod, so the cache converges on the event's state even when the event's pod
-// object differs from what Reserve assumed.
+// assumed allocations during the Reserve scheduling phase. Implementers uphold the
+// assume/forget contract: AssumePod records what Reserve wrote as a rollback marker, and the
+// marker is a pure rollback record — it is consumed ONLY by a negative event (ForgetPod, or a
+// delete / bound→unassigned / terminate through OnPodDelete/OnPodUpdate), which rolls back the
+// snapshot AssumePod recorded. A positive (assigned) event for an assumed pod must NOT re-add
+// or reconcile it: spec.nodeName is not a trustworthy bind signal (multi-scheduler arbitration
+// fakes it via a client-go transform and clears it back to ""), and the marker must survive
+// for a racing ForgetPod on arbitration failure. Because the marker is not consumed on a
+// positive event, it lives for the whole lifetime of a successfully-bound pod.
+//
+// Two consequences implementers must accept: (1) rollback is against the Reserve-time snapshot,
+// not the pod's current annotation, so post-assume annotation changes are not reconciled while
+// the marker is live; (2) if a pod is genuinely bound to a node other than the one Reserve
+// assumed, that node is not credited until a later informer event arrives after the marker is
+// cleared. This is a deliberate departure from an annotation-authoritative "reconcile on every
+// event" model, chosen for arbitration safety.
 type CacheReserver interface {
 	SharedPluginCache
 	AssumePod(pod *corev1.Pod, nodeName string) error

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_bench_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_bench_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// noopSharedCache is a zero-work SharedPluginCache used to isolate the dispatcher's own cost
+// (atomic snapshot load + fan-out) from any per-cache handler work.
+type noopSharedCache struct{}
+
+var _ SharedPluginCache = noopSharedCache{}
+
+func (noopSharedCache) Start(context.Context)          {}
+func (noopSharedCache) OnPodAdd(*corev1.Pod)           {}
+func (noopSharedCache) OnPodUpdate(_, _ *corev1.Pod)   {}
+func (noopSharedCache) OnPodDelete(*corev1.Pod)        {}
+func (noopSharedCache) OnNodeAdd(*corev1.Node)         {}
+func (noopSharedCache) OnNodeUpdate(_, _ *corev1.Node) {}
+func (noopSharedCache) OnNodeDelete(*corev1.Node)      {}
+
+func benchDispatchFactory(b *testing.B, numCaches int) *FrameworkExtenderFactory {
+	factory, err := NewFrameworkExtenderFactory()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < numCaches; i++ {
+		factory.getOrRegisterSharedCache(fmt.Sprintf("c%d", i), nil,
+			func(ExtendedHandle) SharedPluginCache { return noopSharedCache{} })
+	}
+	if err := factory.StartSharedCaches(context.TODO(), newTestInformerFactory()); err != nil {
+		b.Fatal(err)
+	}
+	return factory
+}
+
+// BenchmarkDispatchPodAdd measures the per-event dispatch cost (lock-free snapshot load +
+// fan-out to every registered cache) that replaced the per-event mutex + slice allocation.
+func BenchmarkDispatchPodAdd(b *testing.B) {
+	factory := benchDispatchFactory(b, 3)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		factory.dispatchPodAdd(pod)
+	}
+}
+
+// BenchmarkDispatchPodAddParallel confirms the dispatch read path scales under concurrency:
+// dispatchCaches() is an atomic load with no lock, so concurrent events do not contend.
+func BenchmarkDispatchPodAddParallel(b *testing.B) {
+	factory := benchDispatchFactory(b, 3)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			factory.dispatchPodAdd(pod)
+		}
+	})
+}

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_ordering_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_ordering_test.go
@@ -49,7 +49,7 @@ func Test_StartSharedCaches_NoEventBeforeStartReturns(t *testing.T) {
 	defer cancel()
 
 	// Phase 2: register dispatcher + Start() (records "a:Start"). Informer not started yet.
-	factory.StartSharedCaches(ctx, informerFactory)
+	assert.NoError(t, factory.StartSharedCaches(ctx, informerFactory))
 	// Phase 3: start the informer so the pre-existing pod/node are delivered as Add events.
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_ordering_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_ordering_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+// Test_StartSharedCaches_NoEventBeforeStartReturns pins the four-phase initialization order:
+// StartSharedCaches registers the unified dispatcher and invokes Start(ctx) BEFORE the shared
+// informer factory is started, so no pod/node event can be observed by a cache before its
+// Start() has returned. Pre-existing objects are created before startup and delivered only
+// once the informer starts, letting us assert Start is the first recorded call.
+func Test_StartSharedCaches_NoEventBeforeStartReturns(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+	c := newRecordingCache("a", rec)
+	factory.getOrRegisterSharedCache("a", nil, func(ExtendedHandle) SharedPluginCache { return c })
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "p1", UID: "p1"}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	client := kubefake.NewSimpleClientset(pod, node)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	// Phase 2: register dispatcher + Start() (records "a:Start"). Informer not started yet.
+	factory.StartSharedCaches(ctx, informerFactory)
+	// Phase 3: start the informer so the pre-existing pod/node are delivered as Add events.
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	// Wait until at least one pod/node event has been dispatched to the cache.
+	assert.Eventually(t, func() bool {
+		for _, e := range rec.snapshot() {
+			if e == "a:OnPodAdd:p1" || e == "a:OnNodeAdd:n1" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "expected pod/node events to be dispatched")
+
+	seq := rec.snapshot()
+	assert.Equal(t, "a:Start", seq[0], "Start must be the first recorded call")
+
+	startIdx := -1
+	for i, e := range seq {
+		if e == "a:Start" {
+			startIdx = i
+			break
+		}
+	}
+	for i, e := range seq {
+		if strings.HasPrefix(e, "a:OnPod") || strings.HasPrefix(e, "a:OnNode") {
+			assert.Greater(t, i, startIdx, "event %q must be observed after Start() returned", e)
+		}
+	}
+}

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
@@ -48,6 +48,12 @@ func (r *orderRecorder) snapshot() []string {
 	return append([]string(nil), r.seq...)
 }
 
+func (r *orderRecorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq = nil
+}
+
 // recordingCache is a mock SharedPluginCache that records how many times Start was called
 // and appends "<key>:<event>" to a shared orderRecorder for every dispatched event.
 type recordingCache struct {
@@ -142,8 +148,8 @@ func Test_StartSharedCaches_StartsEachCacheExactlyOnce(t *testing.T) {
 	informerFactory := newTestInformerFactory()
 	// Called twice to prove idempotency: the second call is a no-op guarded by
 	// sharedCachesStarted, so Start still runs exactly once per cache.
-	factory.StartSharedCaches(context.TODO(), informerFactory)
-	factory.StartSharedCaches(context.TODO(), informerFactory)
+	assert.NoError(t, factory.StartSharedCaches(context.TODO(), informerFactory))
+	assert.NoError(t, factory.StartSharedCaches(context.TODO(), informerFactory))
 
 	assert.Equal(t, 1, a.starts())
 	assert.Equal(t, 1, b.starts())
@@ -153,7 +159,7 @@ func Test_StartSharedCaches_NoCachesIsNoOp(t *testing.T) {
 	factory := newTestFactory(t)
 	// No registered caches — must not panic and must remain a no-op.
 	assert.NotPanics(t, func() {
-		factory.StartSharedCaches(context.TODO(), newTestInformerFactory())
+		assert.NoError(t, factory.StartSharedCaches(context.TODO(), newTestInformerFactory()))
 	})
 }
 
@@ -167,6 +173,10 @@ func Test_dispatch_FanOutInRegistrationOrder(t *testing.T) {
 			return newRecordingCache(k, rec)
 		})
 	}
+	// The dispatcher reads the snapshot published by StartSharedCaches; reset the recorder
+	// afterwards to drop the Start() entries so we assert only the dispatched events.
+	assert.NoError(t, factory.StartSharedCaches(context.TODO(), newTestInformerFactory()))
+	rec.reset()
 
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
 	newPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2"}}
@@ -195,6 +205,8 @@ func Test_dispatch_IgnoresUnexpectedTypesAndUnwrapsTombstones(t *testing.T) {
 	rec := &orderRecorder{}
 	c := newRecordingCache("a", rec)
 	factory.getOrRegisterSharedCache("a", nil, func(ExtendedHandle) SharedPluginCache { return c })
+	assert.NoError(t, factory.StartSharedCaches(context.TODO(), newTestInformerFactory()))
+	rec.reset()
 
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frameworkext
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+// orderRecorder collects a shared, ordered log of dispatch calls across multiple caches so
+// tests can assert the unified dispatcher fans out in registration order.
+type orderRecorder struct {
+	mu  sync.Mutex
+	seq []string
+}
+
+func (r *orderRecorder) add(s string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq = append(r.seq, s)
+}
+
+func (r *orderRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.seq...)
+}
+
+// recordingCache is a mock SharedPluginCache that records how many times Start was called
+// and appends "<key>:<event>" to a shared orderRecorder for every dispatched event.
+type recordingCache struct {
+	key string
+	rec *orderRecorder
+
+	mu         sync.Mutex
+	startCalls int
+}
+
+var _ SharedPluginCache = &recordingCache{}
+
+func newRecordingCache(key string, rec *orderRecorder) *recordingCache {
+	return &recordingCache{key: key, rec: rec}
+}
+
+func (c *recordingCache) starts() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.startCalls
+}
+
+func (c *recordingCache) Start(ctx context.Context) {
+	c.mu.Lock()
+	c.startCalls++
+	c.mu.Unlock()
+	c.rec.add(c.key + ":Start")
+}
+
+func (c *recordingCache) OnPodAdd(pod *corev1.Pod) { c.rec.add(c.key + ":OnPodAdd:" + pod.Name) }
+func (c *recordingCache) OnPodUpdate(oldPod, newPod *corev1.Pod) {
+	c.rec.add(c.key + ":OnPodUpdate:" + newPod.Name)
+}
+func (c *recordingCache) OnPodDelete(pod *corev1.Pod) { c.rec.add(c.key + ":OnPodDelete:" + pod.Name) }
+func (c *recordingCache) OnNodeAdd(node *corev1.Node) { c.rec.add(c.key + ":OnNodeAdd:" + node.Name) }
+func (c *recordingCache) OnNodeUpdate(oldNode, newNode *corev1.Node) {
+	c.rec.add(c.key + ":OnNodeUpdate:" + newNode.Name)
+}
+func (c *recordingCache) OnNodeDelete(node *corev1.Node) {
+	c.rec.add(c.key + ":OnNodeDelete:" + node.Name)
+}
+
+func newTestFactory(t *testing.T) *FrameworkExtenderFactory {
+	factory, err := NewFrameworkExtenderFactory()
+	assert.NoError(t, err)
+	return factory
+}
+
+func newTestInformerFactory() informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
+}
+
+func Test_getOrRegisterSharedCache_SameKeyReturnsSameInstance(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+
+	createCalls := 0
+	create := func(ExtendedHandle) SharedPluginCache {
+		createCalls++
+		return newRecordingCache("deviceshare", rec)
+	}
+
+	first := factory.getOrRegisterSharedCache("deviceshare", nil, create)
+	second := factory.getOrRegisterSharedCache("deviceshare", nil, create)
+
+	assert.Same(t, first, second, "same key must return the same instance across profiles")
+	assert.Equal(t, 1, createCalls, "create must be invoked exactly once for a given key")
+}
+
+func Test_getOrRegisterSharedCache_DifferentKeysReturnDistinctInstances(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+
+	a := factory.getOrRegisterSharedCache("a", nil, func(ExtendedHandle) SharedPluginCache {
+		return newRecordingCache("a", rec)
+	})
+	b := factory.getOrRegisterSharedCache("b", nil, func(ExtendedHandle) SharedPluginCache {
+		return newRecordingCache("b", rec)
+	})
+
+	assert.NotSame(t, a, b, "different keys must return distinct instances")
+}
+
+func Test_StartSharedCaches_StartsEachCacheExactlyOnce(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+	a := newRecordingCache("a", rec)
+	b := newRecordingCache("b", rec)
+	factory.getOrRegisterSharedCache("a", nil, func(ExtendedHandle) SharedPluginCache { return a })
+	factory.getOrRegisterSharedCache("b", nil, func(ExtendedHandle) SharedPluginCache { return b })
+
+	informerFactory := newTestInformerFactory()
+	// Called twice to prove idempotency: the second call is a no-op guarded by
+	// sharedCachesStarted, so Start still runs exactly once per cache.
+	factory.StartSharedCaches(context.TODO(), informerFactory)
+	factory.StartSharedCaches(context.TODO(), informerFactory)
+
+	assert.Equal(t, 1, a.starts())
+	assert.Equal(t, 1, b.starts())
+}
+
+func Test_StartSharedCaches_NoCachesIsNoOp(t *testing.T) {
+	factory := newTestFactory(t)
+	// No registered caches — must not panic and must remain a no-op.
+	assert.NotPanics(t, func() {
+		factory.StartSharedCaches(context.TODO(), newTestInformerFactory())
+	})
+}
+
+func Test_dispatch_FanOutInRegistrationOrder(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+	// Register in the order a, b, c; dispatch must fan out in that exact order.
+	for _, key := range []string{"a", "b", "c"} {
+		k := key
+		factory.getOrRegisterSharedCache(k, nil, func(ExtendedHandle) SharedPluginCache {
+			return newRecordingCache(k, rec)
+		})
+	}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	newPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2"}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	newNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n2"}}
+
+	factory.dispatchPodAdd(pod)
+	factory.dispatchPodUpdate(pod, newPod)
+	factory.dispatchPodDelete(pod)
+	factory.dispatchNodeAdd(node)
+	factory.dispatchNodeUpdate(node, newNode)
+	factory.dispatchNodeDelete(node)
+
+	assert.Equal(t, []string{
+		"a:OnPodAdd:p1", "b:OnPodAdd:p1", "c:OnPodAdd:p1",
+		"a:OnPodUpdate:p2", "b:OnPodUpdate:p2", "c:OnPodUpdate:p2",
+		"a:OnPodDelete:p1", "b:OnPodDelete:p1", "c:OnPodDelete:p1",
+		"a:OnNodeAdd:n1", "b:OnNodeAdd:n1", "c:OnNodeAdd:n1",
+		"a:OnNodeUpdate:n2", "b:OnNodeUpdate:n2", "c:OnNodeUpdate:n2",
+		"a:OnNodeDelete:n1", "b:OnNodeDelete:n1", "c:OnNodeDelete:n1",
+	}, rec.snapshot())
+}
+
+func Test_dispatch_IgnoresUnexpectedTypesAndUnwrapsTombstones(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+	c := newRecordingCache("a", rec)
+	factory.getOrRegisterSharedCache("a", nil, func(ExtendedHandle) SharedPluginCache { return c })
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+
+	// Non-pod / non-node objects are ignored, not dispatched.
+	factory.dispatchPodAdd("not-a-pod")
+	factory.dispatchNodeAdd(42)
+	assert.Empty(t, rec.snapshot(), "unexpected object types must be ignored")
+
+	// DeletedFinalStateUnknown tombstones are unwrapped to the underlying object.
+	factory.dispatchPodDelete(cache.DeletedFinalStateUnknown{Key: "default/p1", Obj: pod})
+	factory.dispatchNodeDelete(cache.DeletedFinalStateUnknown{Key: "n1", Obj: node})
+	assert.Equal(t, []string{"a:OnPodDelete:p1", "a:OnNodeDelete:n1"}, rec.snapshot())
+}

--- a/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
+++ b/pkg/scheduler/frameworkext/shared_plugin_cache_test.go
@@ -155,6 +155,30 @@ func Test_StartSharedCaches_StartsEachCacheExactlyOnce(t *testing.T) {
 	assert.Equal(t, 1, b.starts())
 }
 
+// Registering a NEW shared cache after StartSharedCaches would leave it out of the published
+// dispatch snapshot, never getting Start() and silently receiving no events. That is a wiring
+// bug, so it panics rather than no-oping; an already-registered key stays safe to look up.
+func Test_getOrRegisterSharedCache_PanicsOnRegisterAfterStart(t *testing.T) {
+	factory := newTestFactory(t)
+	rec := &orderRecorder{}
+	factory.getOrRegisterSharedCache("existing", nil, func(ExtendedHandle) SharedPluginCache {
+		return newRecordingCache("existing", rec)
+	})
+	assert.NoError(t, factory.StartSharedCaches(context.TODO(), newTestInformerFactory()))
+
+	assert.NotPanics(t, func() {
+		factory.getOrRegisterSharedCache("existing", nil, func(ExtendedHandle) SharedPluginCache {
+			return newRecordingCache("existing", rec)
+		})
+	}, "looking up an already-registered cache after start must not panic")
+
+	assert.Panics(t, func() {
+		factory.getOrRegisterSharedCache("late", nil, func(ExtendedHandle) SharedPluginCache {
+			return newRecordingCache("late", rec)
+		})
+	}, "registering a new shared cache after start must panic")
+}
+
 func Test_StartSharedCaches_NoCachesIsNoOp(t *testing.T) {
 	factory := newTestFactory(t)
 	// No registered caches — must not panic and must remain a no-op.

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -179,9 +179,10 @@ var (
 	// endpoint) against live pods rather than by watching the raw count.
 	SharedCacheAssumedPods = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
-			Subsystem: schedulermetrics.SchedulerSubsystem,
-			Name:      "shared_cache_assumed_pods",
-			Help:      "Size of a shared plugin cache's assumed-allocation ledger (labeled by cache name); tracks assumed pods still alive, not a pure leak gauge.",
+			Subsystem:      schedulermetrics.SchedulerSubsystem,
+			Name:           "shared_cache_assumed_pods",
+			Help:           "Size of a shared plugin cache's assumed-allocation ledger (labeled by cache name); tracks assumed pods still alive, not a pure leak gauge.",
+			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{sharedCacheNameKey},
 	)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -168,6 +168,19 @@ var (
 		[]string{"result"},
 	)
 
+	// SharedCacheAssumedPods tracks the size of a shared plugin cache's assumed-allocation
+	// ledger (assumedPods), labeled by cache name so every opt-in shared cache — DeviceShare
+	// now, NodeNUMAResource / Reservation in follow-ups — reports on the same metric without
+	// redesign. A steadily climbing value signals an assume/forget leak.
+	SharedCacheAssumedPods = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem: schedulermetrics.SchedulerSubsystem,
+			Name:      "shared_cache_assumed_pods",
+			Help:      "The number of pods currently held in a shared plugin cache's assumed-allocation ledger, labeled by cache name.",
+		},
+		[]string{sharedCacheNameKey},
+	)
+
 	metricsList = []metrics.Registerable{
 		SchedulingTimeout,
 		ReservationStatusPhase,
@@ -183,6 +196,7 @@ var (
 		ReservationSelectorIndexQueryTotal,
 		ReservationSelectorIndexCandidates,
 		InlineBatchScheduleDuration,
+		SharedCacheAssumedPods,
 	}
 
 	gcMetricsList = []prometheus.Collector{
@@ -196,6 +210,7 @@ const (
 	reservationResourceKey     = "resource"
 	reservationResourceTypeKey = "type"
 	reservationResourceUnitKey = "unit"
+	sharedCacheNameKey         = "cache"
 )
 
 const (
@@ -268,6 +283,16 @@ func RecordReservationResourceByTypeWithUnit(name, resource, typ, unit string, v
 
 func RecordElasticQuotaProcessLatency(operation string, latency time.Duration) {
 	ElasticQuotaProcessLatency.WithLabelValues(operation).Observe(latency.Seconds())
+}
+
+// RecordSharedCacheAssumedPods sets the assumed-allocation ledger size for the named shared
+// plugin cache. Reused across shared caches via the cache label.
+func RecordSharedCacheAssumedPods(cache string, size int) {
+	if SharedCacheAssumedPods.MetricVec == nil {
+		// only for UT
+		return
+	}
+	SharedCacheAssumedPods.WithLabelValues(cache).Set(float64(size))
 }
 
 func RecordSecondaryDeviceNotWellPlanned(nodeName string, notWellPlanned bool) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -171,12 +171,17 @@ var (
 	// SharedCacheAssumedPods tracks the size of a shared plugin cache's assumed-allocation
 	// ledger (assumedPods), labeled by cache name so every opt-in shared cache — DeviceShare
 	// now, NodeNUMAResource / Reservation in follow-ups — reports on the same metric without
-	// redesign. A steadily climbing value signals an assume/forget leak.
+	// redesign. Note the ledger entry for a successfully-bound pod is cleared only when the pod
+	// leaves (delete / unassign / terminate / ForgetPod), so this value tracks "pods this
+	// process assumed that are still alive" and climbs with cluster occupancy during normal
+	// operation — it is NOT a simple leak gauge. A leak shows up as entries for pods that no
+	// longer exist; detect it by diffing the ledger (see the /assumedAllocations debug
+	// endpoint) against live pods rather than by watching the raw count.
 	SharedCacheAssumedPods = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: schedulermetrics.SchedulerSubsystem,
 			Name:      "shared_cache_assumed_pods",
-			Help:      "The number of pods currently held in a shared plugin cache's assumed-allocation ledger, labeled by cache name.",
+			Help:      "Size of a shared plugin cache's assumed-allocation ledger (labeled by cache name); tracks assumed pods still alive, not a pure leak gauge.",
 		},
 		[]string{sharedCacheNameKey},
 	)

--- a/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
+++ b/pkg/scheduler/plugins/deviceshare/allocator_gpu_test.go
@@ -896,9 +896,9 @@ func TestAllocateByPartition(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -1332,9 +1332,9 @@ func TestAllocateByTopology(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -1590,9 +1590,9 @@ func TestAllocateSharedGPU(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -1916,9 +1916,9 @@ func TestAllocateByTemplate(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()

--- a/pkg/scheduler/plugins/deviceshare/device_allocator_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_allocator_test.go
@@ -1197,9 +1197,9 @@ func TestAutopilotAllocator(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -2017,9 +2017,9 @@ func TestAutopilotAllocatorWithExclusivePolicyAndRequiredScope(t *testing.T) {
 			}
 
 			frameworkexthelper.ResetRegistrations()
-			deviceCache := newNodeDeviceCache()
+			deviceCache := newNodeDeviceCache(nil)
 			registerDeviceEventHandler(deviceCache, koordShareInformerFactory)
-			registerPodEventHandler(deviceCache, sharedInformerFactory, koordShareInformerFactory)
+			registerPodEventHandlerForTest(deviceCache, sharedInformerFactory, koordShareInformerFactory)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -18,6 +18,7 @@ package deviceshare
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/metrics"
 	"github.com/koordinator-sh/koordinator/pkg/util"
@@ -140,6 +142,32 @@ func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations,
 			n.updateAllocateSet(deviceType, allocations, pod, add)
 		}
 	}
+}
+
+// copyPodAllocations returns the DeviceAllocations recorded in allocateSet for pod. The
+// caller must hold n.lock.RLock or n.lock.Lock. The returned allocations are a snapshot
+// safe to hold beyond the lock; the underlying resource maps are shallow-copied.
+func (n *nodeDevice) copyPodAllocations(pod *corev1.Pod) apiext.DeviceAllocations {
+	podNamespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	var result apiext.DeviceAllocations
+	for deviceType, allocations := range n.allocateSet {
+		res, ok := allocations[podNamespacedName]
+		if !ok || len(res) == 0 {
+			continue
+		}
+		if result == nil {
+			result = apiext.DeviceAllocations{}
+		}
+		list := make([]*apiext.DeviceAllocation, 0, len(res))
+		for minor, resources := range res {
+			list = append(list, &apiext.DeviceAllocation{
+				Minor:     int32(minor),
+				Resources: resources.DeepCopy(),
+			})
+		}
+		result[deviceType] = list
+	}
+	return result
 }
 
 func (n *nodeDevice) getUsed(namespace, name string) map[schedulingv1alpha1.DeviceType]deviceResources {
@@ -452,16 +480,163 @@ func (n *nodeDevice) split(requestsPerInstance corev1.ResourceList, deviceType s
 	return r
 }
 
+var (
+	_ frameworkext.SharedPluginCache = &nodeDeviceCache{}
+	_ frameworkext.CacheReserver     = &nodeDeviceCache{}
+)
+
+// assumedAllocation snapshots what Plugin.Reserve wrote to the cache for one pod: the
+// node the write went to and the allocation itself. Held only until the authoritative
+// pod informer event arrives (or Unreserve fires). Used to reconcile the cache when the
+// event's pod object diverges from what Reserve assumed (different node, mutated
+// annotations, or deletion before binding).
+type assumedAllocation struct {
+	nodeName    string
+	allocations apiext.DeviceAllocations
+}
+
 type nodeDeviceCache struct {
 	lock sync.RWMutex
 	// nodeDeviceInfos stores nodeDevice for each node.
 	nodeDeviceInfos map[string]*nodeDevice
+	// assumedPods records what Reserve wrote to nodeDeviceInfos, keyed by pod UID. Used
+	// by OnPodAdd/OnPodUpdate/OnPodDelete to reconcile with the authoritative informer
+	// event: the assumed write is rolled back and the event's state is applied.
+	assumedPods map[types.UID]*assumedAllocation
+	handle      frameworkext.ExtendedHandle
 }
 
-func newNodeDeviceCache() *nodeDeviceCache {
+func newNodeDeviceCache(handle frameworkext.ExtendedHandle) *nodeDeviceCache {
 	return &nodeDeviceCache{
 		nodeDeviceInfos: make(map[string]*nodeDevice),
+		assumedPods:     make(map[types.UID]*assumedAllocation),
+		handle:          handle,
 	}
+}
+
+// Start implements frameworkext.SharedPluginCache. Called exactly once per scheduler
+// instance after all profiles are built and before the shared informer factory starts.
+// Registers Device CRD handlers (plugin-specific, not centrally dispatched) and starts
+// the single GC goroutine.
+func (n *nodeDeviceCache) Start(ctx context.Context) {
+	registerDeviceEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
+	registerReservationEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
+	n.handle.RegisterForgetPodHandler(n.deletePod)
+	go n.gcNodeDevice(ctx, n.handle.SharedInformerFactory(), defaultGCPeriod)
+}
+
+// OnPodAdd implements frameworkext.SharedPluginCache. If the pod was previously assumed,
+// reconciles against the authoritative event instead of skipping — see the CacheReserver
+// invariants in the proposal.
+func (n *nodeDeviceCache) OnPodAdd(pod *corev1.Pod) {
+	if assumed, ok := n.takeAssumed(pod.UID); ok {
+		n.reconcileAssumed(assumed, pod)
+		return
+	}
+	n.updatePod(nil, pod)
+}
+
+// OnPodUpdate implements frameworkext.SharedPluginCache.
+func (n *nodeDeviceCache) OnPodUpdate(oldPod, newPod *corev1.Pod) {
+	if assumed, ok := n.takeAssumed(newPod.UID); ok {
+		// Prior cache state is Reserve's assumed write, not oldPod's annotations, so
+		// reconcile against the assumed snapshot rather than treating oldPod as truth.
+		n.reconcileAssumed(assumed, newPod)
+		return
+	}
+	n.updatePod(oldPod, newPod)
+}
+
+// OnPodDelete implements frameworkext.SharedPluginCache.
+func (n *nodeDeviceCache) OnPodDelete(pod *corev1.Pod) {
+	if assumed, ok := n.takeAssumed(pod.UID); ok {
+		// Pod was assumed but got deleted before the informer add/update ever landed.
+		// Roll back the assumed write; annotations at this point may not carry the
+		// allocation Reserve wrote, so deletePod cannot be trusted to undo it.
+		n.rollbackAssumed(assumed, pod)
+		return
+	}
+	n.deletePod(pod)
+}
+
+// OnNodeAdd implements frameworkext.SharedPluginCache. nodeDeviceInfos is keyed by node
+// name and populated lazily by Device CRD events; the GC goroutine's node lister handles
+// stale-entry removal, so node events are no-ops here.
+func (n *nodeDeviceCache) OnNodeAdd(*corev1.Node) {}
+
+// OnNodeUpdate implements frameworkext.SharedPluginCache.
+func (n *nodeDeviceCache) OnNodeUpdate(_, _ *corev1.Node) {}
+
+// OnNodeDelete implements frameworkext.SharedPluginCache.
+func (n *nodeDeviceCache) OnNodeDelete(*corev1.Node) {}
+
+// AssumePod implements frameworkext.CacheReserver. Called by Plugin.Reserve after
+// allocations have been written to the per-node cache. Snapshots what Reserve wrote so a
+// later informer event or Unreserve can reconcile against it — the naive "remember the
+// UID only" approach cannot roll back Reserve's write if the informer event's pod object
+// disagrees with what Reserve assumed.
+func (n *nodeDeviceCache) AssumePod(pod *corev1.Pod, nodeName string) error {
+	info := n.getNodeDevice(nodeName, false)
+	if info == nil {
+		return fmt.Errorf("nodeDevice for %s is missing when assuming pod %s", nodeName, klog.KObj(pod))
+	}
+	info.lock.RLock()
+	allocations := info.copyPodAllocations(pod)
+	info.lock.RUnlock()
+
+	n.lock.Lock()
+	if n.assumedPods == nil {
+		n.assumedPods = make(map[types.UID]*assumedAllocation)
+	}
+	n.assumedPods[pod.UID] = &assumedAllocation{nodeName: nodeName, allocations: allocations}
+	n.lock.Unlock()
+	return nil
+}
+
+// ForgetPod implements frameworkext.CacheReserver. Called by Plugin.Unreserve. Idempotent
+// — safe to call even if AssumePod was never called for this pod. Only clears the assumed
+// marker; Plugin.Unreserve's existing updateCacheUsed(..., add=false) reverts the cache
+// write itself so behavior for non-CacheReserver code paths is unchanged.
+func (n *nodeDeviceCache) ForgetPod(pod *corev1.Pod) error {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	delete(n.assumedPods, pod.UID)
+	return nil
+}
+
+func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	assumed, ok := n.assumedPods[uid]
+	if !ok {
+		return nil, false
+	}
+	delete(n.assumedPods, uid)
+	return assumed, true
+}
+
+// reconcileAssumed rolls back what AssumePod recorded on assumed.nodeName, then applies
+// the informer event's authoritative state from pod.Spec.NodeName / pod.Annotations. When
+// the event agrees with Reserve this is a net-zero operation; when it diverges the cache
+// converges on the event's state.
+func (n *nodeDeviceCache) reconcileAssumed(assumed *assumedAllocation, pod *corev1.Pod) {
+	n.rollbackAssumed(assumed, pod)
+	n.updatePod(nil, pod)
+}
+
+// rollbackAssumed subtracts the assumed allocation from assumed.nodeName. Extracted so
+// OnPodDelete (nothing to apply afterward) can reuse it.
+func (n *nodeDeviceCache) rollbackAssumed(assumed *assumedAllocation, pod *corev1.Pod) {
+	if len(assumed.allocations) == 0 {
+		return
+	}
+	info := n.getNodeDevice(assumed.nodeName, false)
+	if info == nil {
+		return
+	}
+	info.lock.Lock()
+	defer info.lock.Unlock()
+	info.updateCacheUsed(assumed.allocations, pod, false)
 }
 
 func (n *nodeDeviceCache) getNodeDevice(nodeName string, needInit bool) *nodeDevice {

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -534,6 +534,15 @@ func (n *nodeDeviceCache) Start(context.Context) {
 	})
 }
 
+// The OnPod* handlers below are invoked serially by the shared pod informer (one event at a
+// time), so they never race one another. They intentionally do not hold a single lock across
+// the whole operation: assumedPods is always accessed under n.lock (AssumePod/ForgetPod/
+// takeAssumed), the node map under n.lock (getNodeDevice/gcNodeDevice), and per-node allocation
+// state under the per-node nodeDevice.lock — the same lock discipline every other caller uses,
+// so a concurrent Reserve/Unreserve (scheduling goroutine), Device event, or GC stays race-free
+// without a global write lock. takeAssumed atomically claims a pod's assumed marker, so exactly
+// one path reconciles it.
+
 // OnPodAdd implements frameworkext.SharedPluginCache. If the pod was previously assumed,
 // reconciles against the authoritative event instead of skipping — see the CacheReserver
 // invariants in the proposal.

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -518,11 +518,20 @@ func newNodeDeviceCache(handle frameworkext.ExtendedHandle) *nodeDeviceCache {
 // instance after all profiles are built and before the shared informer factory starts.
 // Registers Device CRD handlers (plugin-specific, not centrally dispatched) and starts
 // the single GC goroutine.
-func (n *nodeDeviceCache) Start(ctx context.Context) {
+func (n *nodeDeviceCache) Start(context.Context) {
 	registerDeviceEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
 	registerReservationEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
 	n.handle.RegisterForgetPodHandler(n.deletePod)
-	go n.gcNodeDevice(ctx, n.handle.SharedInformerFactory(), defaultGCPeriod)
+	// Launch GC only after all informer factories have started and synced, so its first
+	// tick reads a fully populated node lister. Registering it behind an
+	// AfterAllInformersSynced hook gives an explicit happens-after-sync guarantee that does
+	// not depend on the WaitForHandlersSync guard in gcNodeDevice lining up with the node
+	// handler registration collected in Plugin.New(). The hook's ctx is the scheduler's
+	// run-time context, so GC lives for the scheduler's lifetime.
+	frameworkexthelper.RegisterAfterAllInformersSynced(func(ctx context.Context) error {
+		go n.gcNodeDevice(ctx, n.handle.SharedInformerFactory(), defaultGCPeriod)
+		return nil
+	})
 }
 
 // OnPodAdd implements frameworkext.SharedPluginCache. If the pod was previously assumed,
@@ -766,18 +775,13 @@ func (n *nodeDeviceCache) getAllNodeDeviceSummary() map[string]*NodeDeviceSummar
 }
 
 func (n *nodeDeviceCache) gcNodeDevice(ctx context.Context, informerFactory informers.SharedInformerFactory, period time.Duration) {
-	// Wait for all koord plugin event handlers (pod / device / reservation /
-	// node, etc.) to finish processing their initial list before starting GC.
-	// A bare cache.WaitForCacheSync(nodeInformer.HasSynced) only guarantees the
-	// underlying store is populated; it does NOT guarantee that OnAdd callbacks
-	// (which build nodeDeviceInfos) have run to completion. Without this wait
-	// the first GC tick may operate on a half-populated nodeDeviceInfos map
-	// (or, worse, see a warm nodeDeviceInfos but an empty node lister) and
-	// mistakenly evict entries that are about to be recreated.
-	// WaitForHandlersSync defers on ResourceEventHandlerRegistration.HasSynced
-	// for every registration collected by ForceSyncFromInformer, which is the
-	// same signal the scheduler's Run() waits on before accepting scheduling
-	// cycles -- effectively delaying GC until "after scheduler Run".
+	// gcNodeDevice is launched from an AfterAllInformersSynced hook (see Start), so by the
+	// time it runs all informer factories have already started and their caches and handler
+	// registrations have synced. This WaitForHandlersSync call is therefore a defense-in-depth
+	// secondary guard, not the primary gate: it ensures every koord plugin event handler
+	// (pod / device / reservation / node) has drained its initial list before the first GC
+	// tick, so GC never observes a warm nodeDeviceInfos against a not-yet-populated node
+	// lister and evicts entries that are about to be recreated.
 	if err := frameworkexthelper.WaitForHandlersSync(ctx); err != nil {
 		return
 	}

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -546,21 +546,35 @@ func (n *nodeDeviceCache) Start(context.Context) {
 // OnPodAdd implements frameworkext.SharedPluginCache. If the pod was previously assumed,
 // reconciles against the authoritative event instead of skipping — see the CacheReserver
 // invariants in the proposal.
+//
+// The assumed marker is only reconciled once the pod is actually bound (Spec.NodeName set).
+// A pod's binding cycle emits an earlier informer event when DeviceShare's PreBind patches
+// the allocation annotation, and at that point the pod is not yet bound (NodeName==""):
+// consuming the marker there would roll back Reserve's write before the pod is bound, leaving
+// the node under-counted until the Bind event lands, and racing Unreserve on a failed bind.
+// While unbound, the assumed write already reflects reality, so the marker is left in place —
+// it is cleared by the bound event here, by Unreserve→ForgetPod on a failed/rejected bind, or
+// by OnPodDelete on deletion.
 func (n *nodeDeviceCache) OnPodAdd(pod *corev1.Pod) {
-	if assumed, ok := n.takeAssumed(pod.UID); ok {
-		n.reconcileAssumed(assumed, pod)
-		return
+	if pod.Spec.NodeName != "" {
+		if assumed, ok := n.takeAssumed(pod.UID); ok {
+			n.reconcileAssumed(assumed, pod)
+			return
+		}
 	}
 	n.updatePod(nil, pod)
 }
 
-// OnPodUpdate implements frameworkext.SharedPluginCache.
+// OnPodUpdate implements frameworkext.SharedPluginCache. Only reconciles the assumed marker
+// once the pod is bound — see OnPodAdd for why pre-bind (NodeName=="") events are skipped.
 func (n *nodeDeviceCache) OnPodUpdate(oldPod, newPod *corev1.Pod) {
-	if assumed, ok := n.takeAssumed(newPod.UID); ok {
-		// Prior cache state is Reserve's assumed write, not oldPod's annotations, so
-		// reconcile against the assumed snapshot rather than treating oldPod as truth.
-		n.reconcileAssumed(assumed, newPod)
-		return
+	if newPod.Spec.NodeName != "" {
+		if assumed, ok := n.takeAssumed(newPod.UID); ok {
+			// Prior cache state is Reserve's assumed write, not oldPod's annotations, so
+			// reconcile against the assumed snapshot rather than treating oldPod as truth.
+			n.reconcileAssumed(assumed, newPod)
+			return
+		}
 	}
 	n.updatePod(oldPod, newPod)
 }
@@ -650,10 +664,21 @@ func (n *nodeDeviceCache) ForgetPod(pod *corev1.Pod) error {
 }
 
 func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) {
+	// Fast path: the vast majority of pod events are for pods that were never assumed, so
+	// peek under a read lock and avoid taking the write lock (which blocks all readers) on
+	// the common miss.
+	n.lock.RLock()
+	_, present := n.assumedPods[uid]
+	n.lock.RUnlock()
+	if !present {
+		return nil, false
+	}
+
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	assumed, ok := n.assumedPods[uid]
 	if !ok {
+		// Another goroutine claimed it between the RUnlock and the Lock.
 		return nil, false
 	}
 	delete(n.assumedPods, uid)
@@ -661,13 +686,40 @@ func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) 
 	return assumed, true
 }
 
-// reconcileAssumed rolls back what AssumePod recorded on assumed.nodeName, then applies
-// the informer event's authoritative state from pod.Spec.NodeName / pod.Annotations. When
-// the event agrees with Reserve this is a net-zero operation; when it diverges the cache
-// converges on the event's state.
+// reconcileAssumed removes what AssumePod recorded on assumed.nodeName and applies the
+// informer event's authoritative state. The caller guarantees pod.Spec.NodeName != "".
+//
+// When the event stays on the assumed node (the common case), the subtract of Reserve's
+// write and the add of the event's allocation run under a SINGLE hold of the per-node lock,
+// so no concurrent Filter/Score observes the intermediate under-counted state (which would
+// let it over-allocate). When the pod diverged to a different node, the event's node is
+// credited first (a transient over-count is safe; an under-count is not) and the phantom is
+// then removed from the assumed node.
 func (n *nodeDeviceCache) reconcileAssumed(assumed *assumedAllocation, pod *corev1.Pod) {
-	n.rollbackAssumed(assumed, pod)
-	n.updatePod(nil, pod)
+	if assumed.nodeName != pod.Spec.NodeName {
+		n.updatePod(nil, pod)
+		n.rollbackAssumed(assumed, pod)
+		return
+	}
+
+	info := n.getNodeDevice(pod.Spec.NodeName, true)
+	info.lock.Lock()
+	defer info.lock.Unlock()
+	if len(assumed.allocations) > 0 {
+		info.updateCacheUsed(assumed.allocations, pod, false)
+	}
+	if util.IsPodTerminated(pod) {
+		// A bound pod that has already terminated holds no allocations; only roll back.
+		return
+	}
+	newAllocations, err := apiext.GetDeviceAllocations(pod.Annotations)
+	if err != nil {
+		klog.ErrorS(err, "failed to get device allocations while reconciling assumed pod", "pod", klog.KObj(pod))
+		return
+	}
+	if len(newAllocations) > 0 {
+		info.updateCacheUsed(newAllocations, pod, true)
+	}
 }
 
 // rollbackAssumed subtracts the assumed allocation from assumed.nodeName. Extracted so

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -131,23 +131,25 @@ func (n *nodeDevice) resetDeviceTotal(resources map[schedulingv1alpha1.DeviceTyp
 }
 
 // updateCacheUsed updates deviceUsed when a pod is created/deleted, and reports whether the
-// operation actually landed for this pod. An add is skipped by isValid when the pod's ns/name
-// slot in allocateSet is already held — e.g. a same-ns/name pod (a StatefulSet replica) not yet
-// deleted. Callers that publish an assumed marker (keyed by UID, but snapshotted by name) must
-// not do so when the add did not land, or the marker would snapshot the other pod's allocation.
-// Same-ns/name pods request the same device types in practice, so the add is all-or-nothing.
+// operation landed for every requested device type (all-or-nothing). A type is skipped by isValid
+// when the pod's ns/name slot in allocateSet is already held — e.g. a same-ns/name pod (a
+// StatefulSet replica) not yet deleted. Callers that publish an assumed marker (keyed by UID, but
+// snapshotted by name) must not do so unless every type landed, or the marker would snapshot the
+// other pod's allocation for the colliding type. The return value is "all", not "any": a partial
+// collision returns false even though the non-colliding types were applied.
 func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations, pod *corev1.Pod, add bool) bool {
-	applied := false
-	if len(deviceAllocations) > 0 {
-		for deviceType, allocations := range deviceAllocations {
-			if !n.isValid(deviceType, pod.Namespace, pod.Name, add) {
-				continue
-			}
-			n.updateDeviceUsed(deviceType, allocations, add)
-			n.resetDeviceFree(deviceType)
-			n.updateAllocateSet(deviceType, allocations, pod, add)
-			applied = true
+	if len(deviceAllocations) == 0 {
+		return false
+	}
+	applied := true
+	for deviceType, allocations := range deviceAllocations {
+		if !n.isValid(deviceType, pod.Namespace, pod.Name, add) {
+			applied = false
+			continue
 		}
+		n.updateDeviceUsed(deviceType, allocations, add)
+		n.resetDeviceFree(deviceType)
+		n.updateAllocateSet(deviceType, allocations, pod, add)
 	}
 	return applied
 }
@@ -689,7 +691,35 @@ func (n *nodeDeviceCache) getAssumedAllocationsSummary() map[string]*AssumedAllo
 	defer n.lock.RUnlock()
 	out := make(map[string]*AssumedAllocationSummary, len(n.assumedPods))
 	for uid, a := range n.assumedPods {
-		out[string(uid)] = &AssumedAllocationSummary{NodeName: a.nodeName, Allocations: a.allocations}
+		out[string(uid)] = &AssumedAllocationSummary{NodeName: a.nodeName, Allocations: deepCopyDeviceAllocations(a.allocations)}
+	}
+	return out
+}
+
+// deepCopyDeviceAllocations returns a deep copy of allocations so the lock-protected assumedPods
+// ledger state does not escape by reference to a caller reading it after the lock is released.
+func deepCopyDeviceAllocations(allocations apiext.DeviceAllocations) apiext.DeviceAllocations {
+	if allocations == nil {
+		return nil
+	}
+	out := make(apiext.DeviceAllocations, len(allocations))
+	for deviceType, list := range allocations {
+		cp := make([]*apiext.DeviceAllocation, 0, len(list))
+		for _, a := range list {
+			if a == nil {
+				cp = append(cp, nil)
+				continue
+			}
+			c := &apiext.DeviceAllocation{Minor: a.Minor, ID: a.ID, Resources: a.Resources.DeepCopy()}
+			if a.Extension != nil {
+				c.Extension = &apiext.DeviceAllocationExtension{
+					VirtualFunctions:          append([]apiext.VirtualFunction(nil), a.Extension.VirtualFunctions...),
+					GPUSharedResourceTemplate: a.Extension.GPUSharedResourceTemplate,
+				}
+			}
+			cp = append(cp, c)
+		}
+		out[deviceType] = cp
 	}
 	return out
 }

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -130,8 +130,14 @@ func (n *nodeDevice) resetDeviceTotal(resources map[schedulingv1alpha1.DeviceTyp
 	}
 }
 
-// updateCacheUsed is used to update deviceUsed when there is a new pod created/deleted
-func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations, pod *corev1.Pod, add bool) {
+// updateCacheUsed updates deviceUsed when a pod is created/deleted, and reports whether the
+// operation actually landed for this pod. An add is skipped by isValid when the pod's ns/name
+// slot in allocateSet is already held — e.g. a same-ns/name pod (a StatefulSet replica) not yet
+// deleted. Callers that publish an assumed marker (keyed by UID, but snapshotted by name) must
+// not do so when the add did not land, or the marker would snapshot the other pod's allocation.
+// Same-ns/name pods request the same device types in practice, so the add is all-or-nothing.
+func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations, pod *corev1.Pod, add bool) bool {
+	applied := false
 	if len(deviceAllocations) > 0 {
 		for deviceType, allocations := range deviceAllocations {
 			if !n.isValid(deviceType, pod.Namespace, pod.Name, add) {
@@ -140,8 +146,10 @@ func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations,
 			n.updateDeviceUsed(deviceType, allocations, add)
 			n.resetDeviceFree(deviceType)
 			n.updateAllocateSet(deviceType, allocations, pod, add)
+			applied = true
 		}
 	}
+	return applied
 }
 
 // copyPodAllocations returns the DeviceAllocations recorded in allocateSet for pod. The

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -521,7 +521,7 @@ func newNodeDeviceCache(handle frameworkext.ExtendedHandle) *nodeDeviceCache {
 func (n *nodeDeviceCache) Start(context.Context) {
 	registerDeviceEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
 	registerReservationEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
-	n.handle.RegisterForgetPodHandler(n.deletePod)
+	n.handle.RegisterForgetPodHandler(n.forgetPod)
 	// Launch GC only after all informer factories have started and synced, so its first
 	// tick reads a fully populated node lister. Registering it behind an
 	// AfterAllInformersSynced hook gives an explicit happens-after-sync guarantee that does
@@ -537,58 +537,72 @@ func (n *nodeDeviceCache) Start(context.Context) {
 // The OnPod* handlers below are invoked serially by the shared pod informer (one event at a
 // time), so they never race one another. They intentionally do not hold a single lock across
 // the whole operation: assumedPods is always accessed under n.lock (AssumePod/ForgetPod/
-// takeAssumed), the node map under n.lock (getNodeDevice/gcNodeDevice), and per-node allocation
-// state under the per-node nodeDevice.lock — the same lock discipline every other caller uses,
-// so a concurrent Reserve/Unreserve (scheduling goroutine), Device event, or GC stays race-free
-// without a global write lock. takeAssumed atomically claims a pod's assumed marker, so exactly
-// one path reconciles it.
-
-// OnPodAdd implements frameworkext.SharedPluginCache. If the pod was previously assumed,
-// reconciles against the authoritative event instead of skipping — see the CacheReserver
-// invariants in the proposal.
+// takeAssumed/isAssumed), the node map under n.lock (getNodeDevice/gcNodeDevice), and per-node
+// allocation state under the per-node nodeDevice.lock — the same lock discipline every other
+// caller uses, so a concurrent Reserve/Unreserve (scheduling goroutine), Device event, GC, or
+// framework ForgetPod stays race-free without a global write lock.
 //
-// The assumed marker is only reconciled once the pod is actually bound (Spec.NodeName set).
-// A pod's binding cycle emits an earlier informer event when DeviceShare's PreBind patches
-// the allocation annotation, and at that point the pod is not yet bound (NodeName==""):
-// consuming the marker there would roll back Reserve's write before the pod is bound, leaving
-// the node under-counted until the Bind event lands, and racing Unreserve on a failed bind.
-// While unbound, the assumed write already reflects reality, so the marker is left in place —
-// it is cleared by the bound event here, by Unreserve→ForgetPod on a failed/rejected bind, or
-// by OnPodDelete on deletion.
+// The assumed marker is a pure rollback record. It is consumed only by NEGATIVE events — a
+// delete, a bound->unassigned transition (multi-scheduler arbitration clears spec.nodeName back
+// to ""), a termination, or the framework ForgetPod — and never by a POSITIVE (assigned) event.
+// A pod's spec.nodeName is not a trustworthy "real bind" signal: arbitration fakes it via a
+// client-go transform, so a positive event for an assumed pod must not re-add the pod (Reserve
+// already accounted it) and must leave the marker in place, because ext.ForgetPod fires
+// asynchronously on arbitration failure and needs the marker to roll back. Rolling back via the
+// marker snapshot also works before PreBind wrote the allocation annotation, which the
+// annotation-based deletePod cannot. The negative paths are idempotent against a racing
+// ForgetPod: whichever runs second finds the pod already gone from allocateSet (isValid guard)
+// and subtracts nothing.
+
+// OnPodAdd implements frameworkext.SharedPluginCache.
 func (n *nodeDeviceCache) OnPodAdd(pod *corev1.Pod) {
-	if pod.Spec.NodeName != "" {
-		if assumed, ok := n.takeAssumed(pod.UID); ok {
-			n.reconcileAssumed(assumed, pod)
-			return
+	// A terminated pod is a negative event even on Add: a watch reconnect can relist an
+	// already-terminated Reserved pod, and the marker lives until a terminal event, so this
+	// must roll it back (from the snapshot) rather than fall through to the positive handling.
+	if util.IsPodTerminated(pod) {
+		if !n.releaseAssumed(pod) {
+			n.updatePod(nil, pod)
 		}
+		return
+	}
+	if pod.Spec.NodeName != "" && n.isAssumed(pod.UID) {
+		return
 	}
 	n.updatePod(nil, pod)
 }
 
-// OnPodUpdate implements frameworkext.SharedPluginCache. Only reconciles the assumed marker
-// once the pod is bound — see OnPodAdd for why pre-bind (NodeName=="") events are skipped.
+// OnPodUpdate implements frameworkext.SharedPluginCache.
 func (n *nodeDeviceCache) OnPodUpdate(oldPod, newPod *corev1.Pod) {
-	if newPod.Spec.NodeName != "" {
-		if assumed, ok := n.takeAssumed(newPod.UID); ok {
-			// Prior cache state is Reserve's assumed write, not oldPod's annotations, so
-			// reconcile against the assumed snapshot rather than treating oldPod as truth.
-			n.reconcileAssumed(assumed, newPod)
-			return
+	unassigned := oldPod != nil && oldPod.Spec.NodeName != "" && newPod.Spec.NodeName == ""
+	if unassigned || util.IsPodTerminated(newPod) {
+		if !n.releaseAssumed(newPod) {
+			n.updatePod(oldPod, newPod)
 		}
+		return
+	}
+	if newPod.Spec.NodeName != "" && n.isAssumed(newPod.UID) {
+		return
 	}
 	n.updatePod(oldPod, newPod)
 }
 
 // OnPodDelete implements frameworkext.SharedPluginCache.
 func (n *nodeDeviceCache) OnPodDelete(pod *corev1.Pod) {
-	if assumed, ok := n.takeAssumed(pod.UID); ok {
-		// Pod was assumed but got deleted before the informer add/update ever landed.
-		// Roll back the assumed write; annotations at this point may not carry the
-		// allocation Reserve wrote, so deletePod cannot be trusted to undo it.
-		n.rollbackAssumed(assumed, pod)
-		return
+	if !n.releaseAssumed(pod) {
+		n.deletePod(pod)
 	}
-	n.deletePod(pod)
+}
+
+// forgetPod is the framework ForgetPodHandler (registered in Start). Unlike the CacheReserver
+// ForgetPod — which clears only the marker because Plugin.Unreserve has already reverted the
+// ledger — the framework path must revert the ledger too. It mirrors OnPodDelete so the two
+// forget paths are symmetric and idempotent. This closes the leak where a Reserved pod forgotten
+// via the framework (e.g. multi-scheduler arbitration failure) left its marker dangling and its
+// Reserve write un-reverted.
+func (n *nodeDeviceCache) forgetPod(pod *corev1.Pod) {
+	if !n.releaseAssumed(pod) {
+		n.deletePod(pod)
+	}
 }
 
 // OnNodeAdd implements frameworkext.SharedPluginCache. nodeDeviceInfos is keyed by node
@@ -663,6 +677,16 @@ func (n *nodeDeviceCache) ForgetPod(pod *corev1.Pod) error {
 	return nil
 }
 
+// isAssumed reports whether pod uid currently has an assumed marker, without consuming it.
+// Used by the positive (assigned) event paths, which must not re-add an assumed pod nor
+// disturb its marker.
+func (n *nodeDeviceCache) isAssumed(uid types.UID) bool {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	_, ok := n.assumedPods[uid]
+	return ok
+}
+
 func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) {
 	// Fast path: the vast majority of pod events are for pods that were never assumed, so
 	// peek under a read lock and avoid taking the write lock (which blocks all readers) on
@@ -686,44 +710,23 @@ func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) 
 	return assumed, true
 }
 
-// reconcileAssumed removes what AssumePod recorded on assumed.nodeName and applies the
-// informer event's authoritative state. The caller guarantees pod.Spec.NodeName != "".
-//
-// When the event stays on the assumed node (the common case), the subtract of Reserve's
-// write and the add of the event's allocation run under a SINGLE hold of the per-node lock,
-// so no concurrent Filter/Score observes the intermediate under-counted state (which would
-// let it over-allocate). When the pod diverged to a different node, the event's node is
-// credited first (a transient over-count is safe; an under-count is not) and the phantom is
-// then removed from the assumed node.
-func (n *nodeDeviceCache) reconcileAssumed(assumed *assumedAllocation, pod *corev1.Pod) {
-	if assumed.nodeName != pod.Spec.NodeName {
-		n.updatePod(nil, pod)
+// releaseAssumed claims and rolls back the assumed marker for a negative event (delete,
+// bound->unassigned, terminate, or framework ForgetPod), reverting Reserve's write from the
+// snapshot. It reports whether a marker was present so callers fall back to the annotation-based
+// updatePod/deletePod for pods this scheduler never assumed. Idempotent against a racing negative
+// path: takeAssumed atomically claims the marker and rollbackAssumed's isValid guard makes a
+// second subtract a no-op.
+func (n *nodeDeviceCache) releaseAssumed(pod *corev1.Pod) bool {
+	assumed, ok := n.takeAssumed(pod.UID)
+	if ok {
 		n.rollbackAssumed(assumed, pod)
-		return
 	}
-
-	info := n.getNodeDevice(pod.Spec.NodeName, true)
-	info.lock.Lock()
-	defer info.lock.Unlock()
-	if len(assumed.allocations) > 0 {
-		info.updateCacheUsed(assumed.allocations, pod, false)
-	}
-	if util.IsPodTerminated(pod) {
-		// A bound pod that has already terminated holds no allocations; only roll back.
-		return
-	}
-	newAllocations, err := apiext.GetDeviceAllocations(pod.Annotations)
-	if err != nil {
-		klog.ErrorS(err, "failed to get device allocations while reconciling assumed pod", "pod", klog.KObj(pod))
-		return
-	}
-	if len(newAllocations) > 0 {
-		info.updateCacheUsed(newAllocations, pod, true)
-	}
+	return ok
 }
 
-// rollbackAssumed subtracts the assumed allocation from assumed.nodeName. Extracted so
-// OnPodDelete (nothing to apply afterward) can reuse it.
+// rollbackAssumed subtracts the assumed allocation from assumed.nodeName. Shared by every
+// negative path (delete, unassign, terminate, framework ForgetPod) — it reverts Reserve's
+// write from the snapshot, so it works even before PreBind wrote the allocation annotation.
 func (n *nodeDeviceCache) rollbackAssumed(assumed *assumedAllocation, pod *corev1.Pod) {
 	if len(assumed.allocations) == 0 {
 		return

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -560,6 +560,10 @@ func (n *nodeDeviceCache) Start(context.Context) {
 // annotation-based deletePod cannot. The negative paths are idempotent against a racing
 // ForgetPod: whichever runs second finds the pod already gone from allocateSet (isValid guard)
 // and subtracts nothing.
+//
+// This mirrors preemption nomination (per @saintube): the assumed node is accounted for
+// immediately, and resetting spec.nodeName back to "" is the negative event that forgets the
+// pod — the arbitrating node always equals the Reserve node, so a positive event never diverges.
 
 // OnPodAdd implements frameworkext.SharedPluginCache.
 func (n *nodeDeviceCache) OnPodAdd(pod *corev1.Pod) {

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -622,21 +622,31 @@ func (n *nodeDeviceCache) OnNodeDelete(*corev1.Node) {}
 // UID only" approach cannot roll back Reserve's write if the informer event's pod object
 // disagrees with what Reserve assumed.
 func (n *nodeDeviceCache) AssumePod(pod *corev1.Pod, nodeName string) error {
-	info := n.getNodeDevice(nodeName, false)
+	// Snapshot the pod's cache contribution and publish the marker under a single n.lock hold,
+	// so no event handler can mutate the pod's per-node allocation between the two. A handler
+	// reaches the cache only via getNodeDevice (n.lock) and mutates under nodeDevice.lock, so
+	// holding n.lock here makes snapshot+publish atomic against it — the marker always equals
+	// the pod's current cache contribution at publish time, closing the ledger-desync window.
+	// Lock order is n-before-node, matching invalidateNodeDevice/updateNodeDevice.
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	info := n.nodeDeviceInfos[nodeName]
 	if info == nil {
 		return fmt.Errorf("nodeDevice for %s is missing when assuming pod %s", nodeName, klog.KObj(pod))
 	}
 	info.lock.RLock()
 	allocations := info.copyPodAllocations(pod)
 	info.lock.RUnlock()
-
-	n.lock.Lock()
+	if len(allocations) == 0 {
+		// A concurrent event removed the pod's allocation before we published the marker;
+		// there is nothing to roll back later, so do not publish a stale/empty marker.
+		return nil
+	}
 	if n.assumedPods == nil {
 		n.assumedPods = make(map[types.UID]*assumedAllocation)
 	}
 	n.assumedPods[pod.UID] = &assumedAllocation{nodeName: nodeName, allocations: allocations}
 	n.recordAssumedPodsSizeLocked()
-	n.lock.Unlock()
 	return nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -607,8 +607,34 @@ func (n *nodeDeviceCache) AssumePod(pod *corev1.Pod, nodeName string) error {
 		n.assumedPods = make(map[types.UID]*assumedAllocation)
 	}
 	n.assumedPods[pod.UID] = &assumedAllocation{nodeName: nodeName, allocations: allocations}
+	n.recordAssumedPodsSizeLocked()
 	n.lock.Unlock()
 	return nil
+}
+
+// recordAssumedPodsSizeLocked publishes the current assumedPods ledger size to the shared-cache
+// metric so a leak is observable. Caller must hold n.lock.
+func (n *nodeDeviceCache) recordAssumedPodsSizeLocked() {
+	metrics.RecordSharedCacheAssumedPods(Name, len(n.assumedPods))
+}
+
+// AssumedAllocationSummary is the JSON-serializable view of one assumed-allocation ledger
+// entry, exposed by the DeviceShare debug service for live inspection.
+type AssumedAllocationSummary struct {
+	NodeName    string                   `json:"nodeName"`
+	Allocations apiext.DeviceAllocations `json:"allocations"`
+}
+
+// getAssumedAllocationsSummary returns a point-in-time snapshot of the assumedPods ledger,
+// keyed by pod UID, for the debug endpoint.
+func (n *nodeDeviceCache) getAssumedAllocationsSummary() map[string]*AssumedAllocationSummary {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	out := make(map[string]*AssumedAllocationSummary, len(n.assumedPods))
+	for uid, a := range n.assumedPods {
+		out[string(uid)] = &AssumedAllocationSummary{NodeName: a.nodeName, Allocations: a.allocations}
+	}
+	return out
 }
 
 // ForgetPod implements frameworkext.CacheReserver. Called by Plugin.Unreserve. Idempotent
@@ -619,6 +645,7 @@ func (n *nodeDeviceCache) ForgetPod(pod *corev1.Pod) error {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	delete(n.assumedPods, pod.UID)
+	n.recordAssumedPodsSizeLocked()
 	return nil
 }
 
@@ -630,6 +657,7 @@ func (n *nodeDeviceCache) takeAssumed(uid types.UID) (*assumedAllocation, bool) 
 		return nil, false
 	}
 	delete(n.assumedPods, uid)
+	n.recordAssumedPodsSizeLocked()
 	return assumed, true
 }
 

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -521,7 +521,12 @@ func newNodeDeviceCache(handle frameworkext.ExtendedHandle) *nodeDeviceCache {
 func (n *nodeDeviceCache) Start(context.Context) {
 	registerDeviceEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
 	registerReservationEventHandler(n, n.handle.KoordinatorSharedInformerFactory())
-	n.handle.RegisterForgetPodHandler(n.forgetPod)
+	// NOTE: the ForgetPod handler is registered per profile in Plugin.New(), NOT here.
+	// forgetPodHandlers is per-extender state, and n.handle is only the profile that first
+	// constructed the shared cache — registering here would miss ForgetPod invoked through
+	// any other profile's extender. Start() may only use factory-scoped dependencies (the
+	// koord/shared informer factories above are singletons); per-extender registration belongs
+	// in New(). See the SharedPluginCache doc.
 	// Launch GC only after all informer factories have started and synced, so its first
 	// tick reads a fully populated node lister. Registering it behind an
 	// AfterAllInformersSynced hook gives an explicit happens-after-sync guarantee that does
@@ -535,12 +540,14 @@ func (n *nodeDeviceCache) Start(context.Context) {
 }
 
 // The OnPod* handlers below are invoked serially by the shared pod informer (one event at a
-// time), so they never race one another. They intentionally do not hold a single lock across
-// the whole operation: assumedPods is always accessed under n.lock (AssumePod/ForgetPod/
-// takeAssumed/isAssumed), the node map under n.lock (getNodeDevice/gcNodeDevice), and per-node
-// allocation state under the per-node nodeDevice.lock — the same lock discipline every other
-// caller uses, so a concurrent Reserve/Unreserve (scheduling goroutine), Device event, GC, or
-// framework ForgetPod stays race-free without a global write lock.
+// time), so they never race one another. The event path does not hold the cache-wide n.lock in
+// write mode across a whole event: assumedPods is accessed under n.lock (AssumePod/ForgetPod/
+// takeAssumed/isAssumed hold it briefly — AssumePod in write mode for the snapshot+publish, the
+// event path only via isAssumed's read lock), the node map under n.lock (getNodeDevice/
+// gcNodeDevice), and per-node allocation state under the per-node nodeDevice.lock — the same
+// lock discipline every other caller uses, so a concurrent Reserve/Unreserve (scheduling
+// goroutine), Device event, GC, or framework ForgetPod stays race-free. The only cache-wide
+// write-lock holders are the per-Reserve/Unreserve assume/forget calls, not the per-event path.
 //
 // The assumed marker is a pure rollback record. It is consumed only by NEGATIVE events — a
 // delete, a bound->unassigned transition (multi-scheduler arbitration clears spec.nodeName back

--- a/pkg/scheduler/plugins/deviceshare/device_cache.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache.go
@@ -130,13 +130,13 @@ func (n *nodeDevice) resetDeviceTotal(resources map[schedulingv1alpha1.DeviceTyp
 	}
 }
 
-// updateCacheUsed updates deviceUsed when a pod is created/deleted, and reports whether the
-// operation landed for every requested device type (all-or-nothing). A type is skipped by isValid
-// when the pod's ns/name slot in allocateSet is already held — e.g. a same-ns/name pod (a
-// StatefulSet replica) not yet deleted. Callers that publish an assumed marker (keyed by UID, but
-// snapshotted by name) must not do so unless every type landed, or the marker would snapshot the
-// other pod's allocation for the colliding type. The return value is "all", not "any": a partial
-// collision returns false even though the non-colliding types were applied.
+// updateCacheUsed updates deviceUsed when a pod is created/deleted, applying each requested device
+// type best-effort: a type is skipped by isValid when the pod's ns/name slot in allocateSet is
+// already held — e.g. a same-ns/name pod (a StatefulSet replica) not yet deleted — while the rest
+// are still applied. This partial application is what the informer path wants (self-healing). The
+// return value reports whether every type landed, but callers that need an all-or-nothing write
+// (the Reserve path) must gate on canApplyAll first rather than rely on this return, because by the
+// time it reports false the non-colliding types have already been written.
 func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations, pod *corev1.Pod, add bool) bool {
 	if len(deviceAllocations) == 0 {
 		return false
@@ -152,6 +152,25 @@ func (n *nodeDevice) updateCacheUsed(deviceAllocations apiext.DeviceAllocations,
 		n.updateAllocateSet(deviceType, allocations, pod, add)
 	}
 	return applied
+}
+
+// canApplyAll reports whether every requested device type can be applied for this pod, i.e. no
+// ns/name slot in allocateSet is already held for any of them. Callers that need an
+// all-or-nothing write must gate on this instead of inspecting updateCacheUsed's return value:
+// updateCacheUsed applies the non-colliding types before reporting false, which is the desired
+// best-effort behavior on the informer path but leaves an unrevertable partial write on the
+// Reserve path. Must be called with n.lock held for write (isValid lazily initializes
+// allocateSet[deviceType]).
+func (n *nodeDevice) canApplyAll(deviceAllocations apiext.DeviceAllocations, pod *corev1.Pod, add bool) bool {
+	if len(deviceAllocations) == 0 {
+		return false
+	}
+	for deviceType := range deviceAllocations {
+		if !n.isValid(deviceType, pod.Namespace, pod.Name, add) {
+			return false
+		}
+	}
+	return true
 }
 
 // copyPodAllocations returns the DeviceAllocations recorded in allocateSet for pod. The

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+)
+
+// gpuAllocations builds a single-GPU DeviceAllocations on the given minor.
+func gpuAllocations(minor int32, core int64) apiext.DeviceAllocations {
+	return apiext.DeviceAllocations{
+		schedulingv1alpha1.GPU: []*apiext.DeviceAllocation{
+			{
+				Minor: minor,
+				Resources: corev1.ResourceList{
+					apiext.ResourceGPUCore:        *resource.NewQuantity(core, resource.DecimalSI),
+					apiext.ResourceGPUMemoryRatio: *resource.NewQuantity(core, resource.DecimalSI),
+				},
+			},
+		},
+	}
+}
+
+func assumeTestPod(uid, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uid),
+			Namespace: "default",
+			Name:      "pod-" + uid,
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+}
+
+// eventPodFrom clones base as an informer event object: sets the bound node and writes the
+// device-allocation annotation (updatePod reads allocations from annotations, not allocateSet).
+func eventPodFrom(base *corev1.Pod, node string, alloc apiext.DeviceAllocations) *corev1.Pod {
+	p := base.DeepCopy()
+	p.Spec.NodeName = node
+	if alloc != nil {
+		_ = apiext.SetDeviceAllocations(p, alloc)
+	}
+	return p
+}
+
+// gpuMinors returns the GPU minors currently recorded for pod ns/name on nd.
+func gpuMinors(nd *nodeDevice, ns, name string) []int {
+	nd.lock.RLock()
+	defer nd.lock.RUnlock()
+	res := nd.getUsed(ns, name)[schedulingv1alpha1.GPU]
+	minors := make([]int, 0, len(res))
+	for m := range res {
+		minors = append(minors, m)
+	}
+	return minors
+}
+
+// reserveInto simulates Plugin.Reserve writing an allocation to the per-node cache.
+func reserveInto(cache *nodeDeviceCache, node string, pod *corev1.Pod, alloc apiext.DeviceAllocations) {
+	nd := cache.getNodeDevice(node, true)
+	nd.lock.Lock()
+	nd.updateCacheUsed(alloc, pod, true)
+	nd.lock.Unlock()
+}
+
+func assumedEntry(cache *nodeDeviceCache, uid types.UID) (*assumedAllocation, bool) {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	a, ok := cache.assumedPods[uid]
+	return a, ok
+}
+
+func Test_nodeDeviceCache_AssumePod(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+
+	err := cache.AssumePod(pod, "node-1")
+	assert.NoError(t, err)
+
+	assumed, ok := assumedEntry(cache, pod.UID)
+	assert.True(t, ok, "pod must be recorded in assumedPods after AssumePod")
+	assert.Equal(t, "node-1", assumed.nodeName)
+	if assert.Len(t, assumed.allocations[schedulingv1alpha1.GPU], 1) {
+		assert.Equal(t, int32(0), assumed.allocations[schedulingv1alpha1.GPU][0].Minor)
+	}
+}
+
+func Test_nodeDeviceCache_AssumePod_MissingNode(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+
+	err := cache.AssumePod(pod, "node-1")
+	assert.Error(t, err, "AssumePod must error when the nodeDevice is missing")
+
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "no assumed entry must be recorded on error")
+}
+
+func Test_nodeDeviceCache_ForgetPod_Idempotent(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	assert.NoError(t, cache.ForgetPod(pod))
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "ForgetPod must clear the assumed marker")
+
+	// Idempotent: a second ForgetPod, and a ForgetPod for a never-assumed pod, are safe no-ops.
+	assert.NoError(t, cache.ForgetPod(pod))
+	assert.NoError(t, cache.ForgetPod(assumeTestPod("never", "node-1")))
+}
+
+func Test_nodeDeviceCache_OnPodAdd_Reconcile(t *testing.T) {
+	tests := []struct {
+		name         string
+		assumedNode  string
+		assumedAlloc apiext.DeviceAllocations
+		eventNode    string
+		eventAlloc   apiext.DeviceAllocations // nil => event carries no allocation
+		wantNode1    []int                    // GPU minors expected for the pod on node-1
+		wantNode2    []int                    // GPU minors expected for the pod on node-2
+	}{
+		{
+			name:         "event agrees with reserve: net-zero on the same node",
+			assumedNode:  "node-1",
+			assumedAlloc: gpuAllocations(0, 100),
+			eventNode:    "node-1",
+			eventAlloc:   gpuAllocations(0, 100),
+			wantNode1:    []int{0},
+			wantNode2:    nil,
+		},
+		{
+			name:         "event on a different node: phantom cleared, event's node credited",
+			assumedNode:  "node-1",
+			assumedAlloc: gpuAllocations(0, 100),
+			eventNode:    "node-2",
+			eventAlloc:   gpuAllocations(0, 100),
+			wantNode1:    nil,
+			wantNode2:    []int{0},
+		},
+		{
+			name:         "event with mutated allocation: cache converges on the event",
+			assumedNode:  "node-1",
+			assumedAlloc: gpuAllocations(0, 100),
+			eventNode:    "node-1",
+			eventAlloc:   gpuAllocations(1, 50),
+			wantNode1:    []int{1},
+			wantNode2:    nil,
+		},
+		{
+			name:         "event with empty allocation: assumed rollback only",
+			assumedNode:  "node-1",
+			assumedAlloc: gpuAllocations(0, 100),
+			eventNode:    "node-1",
+			eventAlloc:   nil,
+			wantNode1:    nil,
+			wantNode2:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newNodeDeviceCache(nil)
+			pod := assumeTestPod("1", tt.assumedNode)
+			reserveInto(cache, tt.assumedNode, pod, tt.assumedAlloc)
+			assert.NoError(t, cache.AssumePod(pod, tt.assumedNode))
+
+			cache.OnPodAdd(eventPodFrom(pod, tt.eventNode, tt.eventAlloc))
+
+			node1 := cache.getNodeDevice("node-1", false)
+			assert.ElementsMatch(t, tt.wantNode1, gpuMinors(node1, pod.Namespace, pod.Name))
+			if node2 := cache.getNodeDevice("node-2", false); node2 != nil {
+				assert.ElementsMatch(t, tt.wantNode2, gpuMinors(node2, pod.Namespace, pod.Name))
+			} else {
+				assert.Empty(t, tt.wantNode2)
+			}
+			_, ok := assumedEntry(cache, pod.UID)
+			assert.False(t, ok, "assumed marker must be cleared after the informer event")
+		})
+	}
+}
+
+func Test_nodeDeviceCache_OnPodDelete_DeleteBeforeBind(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// Delete arrives before any add/update landed; the delete object carries NO allocation
+	// annotation, proving the rollback relies on the assumed snapshot, not deletePod reading
+	// annotations.
+	deletePod := pod.DeepCopy()
+	cache.OnPodDelete(deletePod)
+
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name), "assumed write must be rolled back")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "assumed marker must be cleared")
+}
+
+func Test_nodeDeviceCache_OnPodAdd_NotAssumed_PassThrough(t *testing.T) {
+	// A pod that was never assumed follows the ordinary updatePod path from its annotations.
+	cache := newNodeDeviceCache(nil)
+	pod := eventPodFrom(assumeTestPod("1", "node-1"), "node-1", gpuAllocations(0, 100))
+
+	cache.OnPodAdd(pod)
+
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(node1, pod.Namespace, pod.Name))
+}
+
+func Test_nodeDeviceCache_OnPodUpdate_ReconcilesAgainstAssumedNotOldPod(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	// Reserve wrote minor 0; the assumed snapshot records that.
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// oldPod carries a stale, never-applied allocation (minor 5). The cache state is Reserve's
+	// assumed write (minor 0), so reconcile must roll back the assumed snapshot and apply
+	// newPod (minor 1) — oldPod's minor 5 must never be treated as truth.
+	oldPod := eventPodFrom(pod, "node-1", gpuAllocations(5, 100))
+	newPod := eventPodFrom(pod, "node-1", gpuAllocations(1, 50))
+	cache.OnPodUpdate(oldPod, newPod)
+
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{1}, gpuMinors(node1, pod.Namespace, pod.Name),
+		"cache must converge on newPod's allocation, ignoring oldPod")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "assumed marker must be cleared after the update event")
+}

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -235,6 +235,46 @@ func Test_nodeDeviceCache_AssumePod_MissingNode(t *testing.T) {
 	assert.False(t, ok, "no assumed entry must be recorded on error")
 }
 
+// AssumePod snapshots the pod's cache contribution and publishes the marker under a single
+// n.lock hold. If a concurrent event already removed the pod's allocation (empty snapshot),
+// there is nothing to roll back later, so no marker is published — avoiding an orphaned entry.
+func Test_nodeDeviceCache_AssumePod_SkipsEmptyMarker(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	// The node exists but the pod has no allocation recorded (simulating a concurrent removal
+	// between Reserve's write and AssumePod).
+	cache.getNodeDevice("node-1", true)
+
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "no marker must be published when the pod's cache contribution is empty")
+}
+
+// Pins the safety property the Reserve-error inline rollback relies on: rolling back Reserve's
+// cache write, then a subsequent Unreserve subtract for the same pod, nets exactly one subtract.
+// The isValid guard makes the second subtract a no-op, so the inline rollback cannot double-count
+// even when the framework also runs Unreserve. (Corrects the round-3 "would double-subtract".)
+func Test_nodeDeviceCache_ReserveErrorRollback_NoDoubleSubtract(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc) // Reserve's updateCacheUsed(+A)
+	nd := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name))
+
+	// Inline rollback on AssumePod error: updateCacheUsed(-A).
+	nd.lock.Lock()
+	nd.updateCacheUsed(alloc, pod, false)
+	nd.lock.Unlock()
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "inline rollback removes the write")
+
+	// Framework Unreserve also runs updateCacheUsed(-A): must be a no-op, not go negative.
+	nd.lock.Lock()
+	nd.updateCacheUsed(alloc, pod, false)
+	nd.lock.Unlock()
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "second subtract is a no-op via isValid")
+}
+
 func Test_nodeDeviceCache_ForgetPod_Idempotent(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := assumeTestPod("1", "node-1")

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -86,6 +86,92 @@ func reserveInto(cache *nodeDeviceCache, node string, pod *corev1.Pod, alloc api
 	nd.lock.Unlock()
 }
 
+// unboundPod builds a pod that is assumed/reserved but not yet bound (Spec.NodeName == ""),
+// matching the pod object as it exists through Reserve and the PreBind annotation patch.
+func unboundPod(uid string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uid),
+			Namespace: "default",
+			Name:      "pod-" + uid,
+		},
+	}
+}
+
+func Test_nodeDeviceCache_PreBindPatchEvent_KeepsAssumedMarker(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := unboundPod("1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// PreBind patches the allocation annotation while the pod is still unbound (NodeName=="").
+	prebindPod := pod.DeepCopy()
+	assert.NoError(t, apiext.SetDeviceAllocations(prebindPod, alloc))
+	cache.OnPodUpdate(pod, prebindPod)
+
+	// The marker must be preserved and the node must stay credited — no premature rollback.
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.True(t, ok, "PreBind (unbound) event must not consume the assumed marker")
+	nd := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name), "node stays credited while assumed")
+
+	// The authoritative bound event reconciles and clears the marker; the node stays credited.
+	boundPod := prebindPod.DeepCopy()
+	boundPod.Spec.NodeName = "node-1"
+	cache.OnPodUpdate(prebindPod, boundPod)
+	_, ok = assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "bound event must consume the assumed marker")
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name))
+}
+
+func Test_nodeDeviceCache_UnreserveAfterPreBind_NoDoubleCount(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := unboundPod("1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// PreBind patch (unbound): marker preserved, pod still in the ledger.
+	prebindPod := pod.DeepCopy()
+	assert.NoError(t, apiext.SetDeviceAllocations(prebindPod, alloc))
+	cache.OnPodUpdate(pod, prebindPod)
+
+	// Bind fails → Unreserve: updateCacheUsed(..., false) then ForgetPod (what Plugin.Unreserve does).
+	nd := cache.getNodeDevice("node-1", false)
+	nd.lock.Lock()
+	nd.updateCacheUsed(alloc, pod, false)
+	nd.lock.Unlock()
+	assert.NoError(t, cache.ForgetPod(pod))
+
+	// Exactly one subtract: node freed, marker cleared, no negative/leaked accounting.
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name))
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok)
+}
+
+func Test_nodeDeviceCache_ReconcileAssumed_TerminatedAtBind_NotCredited(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := unboundPod("1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// The bound event arrives for a pod that has already terminated (fast-failing pod). The
+	// atomic same-node reconcile must roll back Reserve's write and NOT re-credit the pod —
+	// a terminated pod holds no allocations. Mirrors updatePod's IsPodTerminated handling.
+	boundTerminated := pod.DeepCopy()
+	boundTerminated.Spec.NodeName = "node-1"
+	assert.NoError(t, apiext.SetDeviceAllocations(boundTerminated, alloc))
+	boundTerminated.Status.Phase = corev1.PodFailed
+	cache.OnPodUpdate(pod, boundTerminated)
+
+	nd := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "terminated pod must not be credited at reconcile")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "marker must be consumed on the bound event")
+}
+
 func assumedEntry(cache *nodeDeviceCache, uid types.UID) (*assumedAllocation, bool) {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -44,6 +44,19 @@ func gpuAllocations(minor int32, core int64) apiext.DeviceAllocations {
 	}
 }
 
+func gpuRdmaAllocations(gpuMinor int32, gpuCore int64, rdmaMinor int32) apiext.DeviceAllocations {
+	alloc := gpuAllocations(gpuMinor, gpuCore)
+	alloc[schedulingv1alpha1.RDMA] = []*apiext.DeviceAllocation{
+		{
+			Minor: rdmaMinor,
+			Resources: corev1.ResourceList{
+				apiext.ResourceRDMA: *resource.NewQuantity(100, resource.DecimalSI),
+			},
+		},
+	}
+	return alloc
+}
+
 func assumeTestPod(uid, node string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -98,31 +98,39 @@ func unboundPod(uid string) *corev1.Pod {
 	}
 }
 
-func Test_nodeDeviceCache_PreBindPatchEvent_KeepsAssumedMarker(t *testing.T) {
+// The assumed marker is a pure rollback record: positive (assigned) events — the PreBind
+// annotation patch and the bound event — never consume it or re-add the pod. It is cleared
+// only by a terminal negative event (here, delete).
+func Test_nodeDeviceCache_PositiveEvents_KeepMarkerAndDoNotReAdd(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := unboundPod("1")
 	alloc := gpuAllocations(0, 100)
 	reserveInto(cache, "node-1", pod, alloc)
 	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+	nd := cache.getNodeDevice("node-1", false)
 
 	// PreBind patches the allocation annotation while the pod is still unbound (NodeName=="").
 	prebindPod := pod.DeepCopy()
 	assert.NoError(t, apiext.SetDeviceAllocations(prebindPod, alloc))
 	cache.OnPodUpdate(pod, prebindPod)
-
-	// The marker must be preserved and the node must stay credited — no premature rollback.
 	_, ok := assumedEntry(cache, pod.UID)
 	assert.True(t, ok, "PreBind (unbound) event must not consume the assumed marker")
-	nd := cache.getNodeDevice("node-1", false)
 	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name), "node stays credited while assumed")
 
-	// The authoritative bound event reconciles and clears the marker; the node stays credited.
+	// The bound event is positive: it must NOT consume the marker and must NOT re-add the pod
+	// (spec.nodeName is not a trustworthy bind signal — arbitration fakes it).
 	boundPod := prebindPod.DeepCopy()
 	boundPod.Spec.NodeName = "node-1"
 	cache.OnPodUpdate(prebindPod, boundPod)
 	_, ok = assumedEntry(cache, pod.UID)
-	assert.False(t, ok, "bound event must consume the assumed marker")
-	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name))
+	assert.True(t, ok, "bound (positive) event must leave the marker for a terminal event")
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name), "no re-add, no double count")
+
+	// A terminal delete finally clears the marker and rolls the allocation back exactly once.
+	cache.OnPodDelete(boundPod)
+	_, ok = assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "delete must clear the marker")
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "delete rolls back the assumed write")
 }
 
 func Test_nodeDeviceCache_UnreserveAfterPreBind_NoDoubleCount(t *testing.T) {
@@ -150,16 +158,16 @@ func Test_nodeDeviceCache_UnreserveAfterPreBind_NoDoubleCount(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_nodeDeviceCache_ReconcileAssumed_TerminatedAtBind_NotCredited(t *testing.T) {
+func Test_nodeDeviceCache_TerminatedAtBind_NotCredited(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := unboundPod("1")
 	alloc := gpuAllocations(0, 100)
 	reserveInto(cache, "node-1", pod, alloc)
 	assert.NoError(t, cache.AssumePod(pod, "node-1"))
 
-	// The bound event arrives for a pod that has already terminated (fast-failing pod). The
-	// atomic same-node reconcile must roll back Reserve's write and NOT re-credit the pod —
-	// a terminated pod holds no allocations. Mirrors updatePod's IsPodTerminated handling.
+	// The bound event arrives for a pod that has already terminated (fast-failing pod).
+	// Termination is a negative event: roll Reserve's write back via the marker and do NOT
+	// credit the pod — a terminated pod holds no allocations.
 	boundTerminated := pod.DeepCopy()
 	boundTerminated.Spec.NodeName = "node-1"
 	assert.NoError(t, apiext.SetDeviceAllocations(boundTerminated, alloc))
@@ -167,9 +175,29 @@ func Test_nodeDeviceCache_ReconcileAssumed_TerminatedAtBind_NotCredited(t *testi
 	cache.OnPodUpdate(pod, boundTerminated)
 
 	nd := cache.getNodeDevice("node-1", false)
-	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "terminated pod must not be credited at reconcile")
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "terminated pod must not be credited")
 	_, ok := assumedEntry(cache, pod.UID)
-	assert.False(t, ok, "marker must be consumed on the bound event")
+	assert.False(t, ok, "marker must be consumed on the terminated event")
+}
+
+// A watch reconnect can relist an already-terminated Reserved pod as an Add (not an Update),
+// before any annotation was written. OnPodAdd must treat termination as a negative event and
+// roll back via the marker — not fall through to the annotation-based deletePod, which would
+// leak Reserve's write and leave the marker dangling.
+func Test_nodeDeviceCache_OnPodAdd_TerminatedWithMarker_RollsBack(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1") // bound, but carries no device-allocation annotation
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	terminated := pod.DeepCopy()
+	terminated.Status.Phase = corev1.PodFailed
+	cache.OnPodAdd(terminated)
+
+	nd := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "terminated relist Add must roll back the assumed write")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "terminated relist Add must clear the marker")
 }
 
 func assumedEntry(cache *nodeDeviceCache, uid types.UID) (*assumedAllocation, bool) {
@@ -222,73 +250,98 @@ func Test_nodeDeviceCache_ForgetPod_Idempotent(t *testing.T) {
 	assert.NoError(t, cache.ForgetPod(assumeTestPod("never", "node-1")))
 }
 
-func Test_nodeDeviceCache_OnPodAdd_Reconcile(t *testing.T) {
-	tests := []struct {
-		name         string
-		assumedNode  string
-		assumedAlloc apiext.DeviceAllocations
-		eventNode    string
-		eventAlloc   apiext.DeviceAllocations // nil => event carries no allocation
-		wantNode1    []int                    // GPU minors expected for the pod on node-1
-		wantNode2    []int                    // GPU minors expected for the pod on node-2
-	}{
-		{
-			name:         "event agrees with reserve: net-zero on the same node",
-			assumedNode:  "node-1",
-			assumedAlloc: gpuAllocations(0, 100),
-			eventNode:    "node-1",
-			eventAlloc:   gpuAllocations(0, 100),
-			wantNode1:    []int{0},
-			wantNode2:    nil,
-		},
-		{
-			name:         "event on a different node: phantom cleared, event's node credited",
-			assumedNode:  "node-1",
-			assumedAlloc: gpuAllocations(0, 100),
-			eventNode:    "node-2",
-			eventAlloc:   gpuAllocations(0, 100),
-			wantNode1:    nil,
-			wantNode2:    []int{0},
-		},
-		{
-			name:         "event with mutated allocation: cache converges on the event",
-			assumedNode:  "node-1",
-			assumedAlloc: gpuAllocations(0, 100),
-			eventNode:    "node-1",
-			eventAlloc:   gpuAllocations(1, 50),
-			wantNode1:    []int{1},
-			wantNode2:    nil,
-		},
-		{
-			name:         "event with empty allocation: assumed rollback only",
-			assumedNode:  "node-1",
-			assumedAlloc: gpuAllocations(0, 100),
-			eventNode:    "node-1",
-			eventAlloc:   nil,
-			wantNode1:    nil,
-			wantNode2:    nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cache := newNodeDeviceCache(nil)
-			pod := assumeTestPod("1", tt.assumedNode)
-			reserveInto(cache, tt.assumedNode, pod, tt.assumedAlloc)
-			assert.NoError(t, cache.AssumePod(pod, tt.assumedNode))
+// A positive event on a node other than the one Reserve wrote (a faked arbitration nodeName)
+// must not re-add the pod there, and must leave the reserved node's marker intact so a later
+// ForgetPod can still roll it back.
+func Test_nodeDeviceCache_PositiveEvent_DivergentNode_NotCredited(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
 
-			cache.OnPodAdd(eventPodFrom(pod, tt.eventNode, tt.eventAlloc))
+	// Arbitration transform fakes spec.nodeName as node-2 (not the reserved node).
+	cache.OnPodAdd(eventPodFrom(pod, "node-2", gpuAllocations(0, 100)))
 
-			node1 := cache.getNodeDevice("node-1", false)
-			assert.ElementsMatch(t, tt.wantNode1, gpuMinors(node1, pod.Namespace, pod.Name))
-			if node2 := cache.getNodeDevice("node-2", false); node2 != nil {
-				assert.ElementsMatch(t, tt.wantNode2, gpuMinors(node2, pod.Namespace, pod.Name))
-			} else {
-				assert.Empty(t, tt.wantNode2)
-			}
-			_, ok := assumedEntry(cache, pod.UID)
-			assert.False(t, ok, "assumed marker must be cleared after the informer event")
-		})
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(node1, pod.Namespace, pod.Name), "reserved node unchanged")
+	if node2 := cache.getNodeDevice("node-2", false); node2 != nil {
+		assert.Empty(t, gpuMinors(node2, pod.Namespace, pod.Name), "faked node must not be credited")
 	}
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.True(t, ok, "marker must survive a faked-nodeName event for ForgetPod to roll back")
+}
+
+// A bound->unassigned transition (arbitration clears spec.nodeName back to "") is a negative
+// event: it rolls Reserve's write back via the marker and clears the marker.
+func Test_nodeDeviceCache_UnassignRelease_RollsBackAndClearsMarker(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	oldBound := eventPodFrom(pod, "node-1", gpuAllocations(0, 100))
+	newUnassigned := unboundPod("1")
+	cache.OnPodUpdate(oldBound, newUnassigned)
+
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name), "unassign must roll back the reserved node")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "unassign must clear the marker")
+}
+
+// forgetPod is the framework ForgetPodHandler: it rolls back the assumed snapshot (Fix for the
+// leak where the framework forget path left the marker dangling) and is idempotent.
+func Test_nodeDeviceCache_ForgetPod_RollsBackAssumedAndIdempotent(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	cache.forgetPod(pod)
+	node1 := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name), "framework forget must roll back the assumed write")
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "framework forget must clear the marker")
+
+	// Idempotent: a second forget is a safe no-op, never a double subtract.
+	cache.forgetPod(pod)
+	assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name))
+}
+
+// The framework ForgetPod (arbitration failure) and the informer unassign event fire
+// asynchronously in either order; both must net exactly one subtract and never go negative.
+func Test_nodeDeviceCache_ForgetAndUnassign_IdempotentEitherOrder(t *testing.T) {
+	// forget first, then the unassign informer update.
+	t.Run("forget then unassign", func(t *testing.T) {
+		cache := newNodeDeviceCache(nil)
+		pod := assumeTestPod("1", "node-1")
+		reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+		assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+		cache.forgetPod(pod)
+		cache.OnPodUpdate(eventPodFrom(pod, "node-1", gpuAllocations(0, 100)), unboundPod("1"))
+
+		node1 := cache.getNodeDevice("node-1", false)
+		assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name))
+		_, ok := assumedEntry(cache, pod.UID)
+		assert.False(t, ok)
+	})
+
+	// unassign informer update first, then forget.
+	t.Run("unassign then forget", func(t *testing.T) {
+		cache := newNodeDeviceCache(nil)
+		pod := assumeTestPod("1", "node-1")
+		reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+		assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+		cache.OnPodUpdate(eventPodFrom(pod, "node-1", gpuAllocations(0, 100)), unboundPod("1"))
+		cache.forgetPod(pod)
+
+		node1 := cache.getNodeDevice("node-1", false)
+		assert.Empty(t, gpuMinors(node1, pod.Namespace, pod.Name))
+		_, ok := assumedEntry(cache, pod.UID)
+		assert.False(t, ok)
+	})
 }
 
 func Test_nodeDeviceCache_OnPodDelete_DeleteBeforeBind(t *testing.T) {
@@ -320,23 +373,24 @@ func Test_nodeDeviceCache_OnPodAdd_NotAssumed_PassThrough(t *testing.T) {
 	assert.ElementsMatch(t, []int{0}, gpuMinors(node1, pod.Namespace, pod.Name))
 }
 
-func Test_nodeDeviceCache_OnPodUpdate_ReconcilesAgainstAssumedNotOldPod(t *testing.T) {
+// While a pod is assumed, a positive update is suppressed: the ledger stays at Reserve's write
+// and the event's (untrusted) annotation is not applied. Reserve owns the accounting until a
+// negative event rolls it back.
+func Test_nodeDeviceCache_OnPodUpdate_PositiveWhileAssumed_Suppressed(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := assumeTestPod("1", "node-1")
 	// Reserve wrote minor 0; the assumed snapshot records that.
 	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
 	assert.NoError(t, cache.AssumePod(pod, "node-1"))
 
-	// oldPod carries a stale, never-applied allocation (minor 5). The cache state is Reserve's
-	// assumed write (minor 0), so reconcile must roll back the assumed snapshot and apply
-	// newPod (minor 1) — oldPod's minor 5 must never be treated as truth.
-	oldPod := eventPodFrom(pod, "node-1", gpuAllocations(5, 100))
+	// A bound update whose annotation claims a different minor must NOT be applied while assumed.
+	oldPod := eventPodFrom(pod, "node-1", gpuAllocations(0, 100))
 	newPod := eventPodFrom(pod, "node-1", gpuAllocations(1, 50))
 	cache.OnPodUpdate(oldPod, newPod)
 
 	node1 := cache.getNodeDevice("node-1", false)
-	assert.ElementsMatch(t, []int{1}, gpuMinors(node1, pod.Namespace, pod.Name),
-		"cache must converge on newPod's allocation, ignoring oldPod")
+	assert.ElementsMatch(t, []int{0}, gpuMinors(node1, pod.Namespace, pod.Name),
+		"positive update while assumed must not re-add or mutate the ledger")
 	_, ok := assumedEntry(cache, pod.UID)
-	assert.False(t, ok, "assumed marker must be cleared after the update event")
+	assert.True(t, ok, "positive update must leave the marker in place")
 }

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -275,6 +275,46 @@ func Test_nodeDeviceCache_ReserveErrorRollback_NoDoubleSubtract(t *testing.T) {
 	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "second subtract is a no-op via isValid")
 }
 
+// A reservation's reserve pod is Reserved (marker stored); its synthetic delete event flows
+// through the onPodDelete adapter, which now routes to OnPodDelete → releaseAssumed. The marker
+// must be cleared and the assumed allocation rolled back — the legacy annotation path left the
+// ledger entry to leak forever (ZiMengSheng review item 2).
+func Test_nodeDeviceCache_onPodDelete_ReleasesAssumedMarker(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("resv-1", "node-1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	cache.onPodDelete(pod) // synthetic reservation delete (ResourceEventHandler interface{} arg)
+
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "reservation delete must clear the assumed marker")
+	nd := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "reservation delete must roll back the assumed allocation")
+}
+
+// An expired/failed reservation surfaces as a synthetic reserve pod with Phase=PodFailed; its
+// update event through the onPodUpdate adapter must hit the terminate→releaseAssumed branch and
+// clear the marker (the legacy onPodUpdate→deletePod path did not).
+func Test_nodeDeviceCache_onPodUpdate_TerminatedReservation_ReleasesMarker(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("resv-1", "node-1")
+	alloc := gpuAllocations(0, 100)
+	reserveInto(cache, "node-1", pod, alloc)
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	oldPod := pod.DeepCopy()
+	newPod := pod.DeepCopy()
+	newPod.Status.Phase = corev1.PodFailed
+	cache.onPodUpdate(oldPod, newPod)
+
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "terminated reservation must clear the assumed marker")
+	nd := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name))
+}
+
 func Test_nodeDeviceCache_ForgetPod_Idempotent(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := assumeTestPod("1", "node-1")

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -330,16 +330,21 @@ func Test_nodeDeviceCache_ForgetPod_Idempotent(t *testing.T) {
 	assert.NoError(t, cache.ForgetPod(assumeTestPod("never", "node-1")))
 }
 
-// A positive event on a node other than the one Reserve wrote (a faked arbitration nodeName)
-// must not re-add the pod there, and must leave the reserved node's marker intact so a later
-// ForgetPod can still roll it back.
+// Defensive pin: a positive event landing on a node other than the one Reserve wrote must not
+// re-add the pod there, and must leave the reserved node's marker intact so a later negative
+// event (nodeName reset / ForgetPod) can roll it back. Per @saintube (2026-08-19) this case does
+// not occur by design — the arbitrating node always equals the Reserve node, so a positive event
+// never diverges; the assumed node is accounted for like a preemption nomination, and forgetting
+// happens on the nodeName reset, not on a divergent positive event. This test keeps the suppress
+// behavior honest even so.
 func Test_nodeDeviceCache_PositiveEvent_DivergentNode_NotCredited(t *testing.T) {
 	cache := newNodeDeviceCache(nil)
 	pod := assumeTestPod("1", "node-1")
 	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
 	assert.NoError(t, cache.AssumePod(pod, "node-1"))
 
-	// Arbitration transform fakes spec.nodeName as node-2 (not the reserved node).
+	// A positive event on node-2 (not the reserved node) — a degenerate case that does not occur
+	// by design; the suppress must hold regardless.
 	cache.OnPodAdd(eventPodFrom(pod, "node-2", gpuAllocations(0, 100)))
 
 	node1 := cache.getNodeDevice("node-1", false)

--- a/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_assume_test.go
@@ -91,6 +91,17 @@ func gpuMinors(nd *nodeDevice, ns, name string) []int {
 	return minors
 }
 
+func rdmaMinors(nd *nodeDevice, ns, name string) []int {
+	nd.lock.RLock()
+	defer nd.lock.RUnlock()
+	res := nd.getUsed(ns, name)[schedulingv1alpha1.RDMA]
+	minors := make([]int, 0, len(res))
+	for m := range res {
+		minors = append(minors, m)
+	}
+	return minors
+}
+
 // reserveInto simulates Plugin.Reserve writing an allocation to the per-node cache.
 func reserveInto(cache *nodeDeviceCache, node string, pod *corev1.Pod, alloc apiext.DeviceAllocations) {
 	nd := cache.getNodeDevice(node, true)

--- a/pkg/scheduler/plugins/deviceshare/device_cache_bench_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_bench_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkNodeDeviceCache_AssumeForget measures the per-call cost of the assume/forget
+// contract in isolation (AssumePod snapshots what Reserve wrote; ForgetPod clears the marker).
+func BenchmarkNodeDeviceCache_AssumeForget(b *testing.B) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.AssumePod(pod, "node-1")
+		_ = cache.ForgetPod(pod)
+	}
+}
+
+// BenchmarkNodeDeviceCache_ConcurrentReserveReconcile measures throughput of the new
+// assume/reconcile hot path under concurrency: each op runs Reserve's cache write + AssumePod,
+// then the informer OnPodAdd (reconcile) and OnPodDelete for a distinct pod, spread across
+// several nodes so per-node locks are contended. Correctness under this same concurrency is
+// covered by the -race stress tests; this benchmark tracks the performance dimension.
+func BenchmarkNodeDeviceCache_ConcurrentReserveReconcile(b *testing.B) {
+	cache := newNodeDeviceCache(nil)
+	const nodes = 8
+	for i := 0; i < nodes; i++ {
+		cache.getNodeDevice(fmt.Sprintf("node-%d", i), true)
+	}
+	var ctr int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := atomic.AddInt64(&ctr, 1)
+			node := fmt.Sprintf("node-%d", id%nodes)
+			pod := assumeTestPod(fmt.Sprintf("uid-%d", id), node)
+			alloc := gpuAllocations(int32(id%8), 100)
+			reserveInto(cache, node, pod, alloc)
+			_ = cache.AssumePod(pod, node)
+			event := eventPodFrom(pod, node, alloc)
+			cache.OnPodAdd(event)
+			cache.OnPodDelete(event)
+		}
+	})
+}

--- a/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceshare
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_nodeDeviceCache_ConcurrentReserveAndEvents stresses the assume/forget/reconcile paths
+// under concurrency to prove the lock model (top-level nodeDeviceCache.lock for the node map
+// and assumed set, per-node nodeDevice.lock for allocations) is free of data races and
+// deadlocks. Run with -race. Each iteration races Reserve's AssumePod against an informer
+// OnPodAdd for the same pod, plus an Unreserve (ForgetPod) or a delete-before-bind OnPodDelete.
+func Test_nodeDeviceCache_ConcurrentReserveAndEvents(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	const nodes = 4
+	const iterations = 300
+
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		node := fmt.Sprintf("node-%d", i%nodes)
+		pod := assumeTestPod(fmt.Sprintf("uid-%d", i), node)
+		alloc := gpuAllocations(int32(i%8), 100)
+
+		// Reserve writes the allocation to the per-node cache before AssumePod snapshots it.
+		reserveInto(cache, node, pod, alloc)
+
+		wg.Add(3)
+		go func() { defer wg.Done(); _ = cache.AssumePod(pod, node) }()
+		go func() { defer wg.Done(); cache.OnPodAdd(eventPodFrom(pod, node, alloc)) }()
+		go func() {
+			defer wg.Done()
+			if i%2 == 0 {
+				_ = cache.ForgetPod(pod)
+			} else {
+				cache.OnPodDelete(eventPodFrom(pod, node, alloc))
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent reserve/event operations deadlocked")
+	}
+}
+
+// Test_nodeDeviceCache_ConcurrentReserveOnPodAdd_NoDoubleCount asserts the key correctness
+// invariant: a Reserve racing the informer OnPodAdd for the same pod counts the allocation
+// exactly once — never double (reconcile is net-zero when the marker is set; the allocateSet
+// double-add guard prevents it otherwise) and never zero.
+func Test_nodeDeviceCache_ConcurrentReserveOnPodAdd_NoDoubleCount(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		cache := newNodeDeviceCache(nil)
+		pod := assumeTestPod(fmt.Sprintf("uid-%d", i), "node-1")
+		alloc := gpuAllocations(0, 100)
+		reserveInto(cache, "node-1", pod, alloc)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = cache.AssumePod(pod, "node-1") }()
+		go func() { defer wg.Done(); cache.OnPodAdd(eventPodFrom(pod, "node-1", alloc)) }()
+		wg.Wait()
+
+		nd := cache.getNodeDevice("node-1", false)
+		assert.ElementsMatch(t, []int{0}, gpuMinors(nd, pod.Namespace, pod.Name),
+			"allocation must be counted exactly once regardless of interleaving")
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
@@ -51,7 +51,7 @@ func Test_nodeDeviceCache_ConcurrentReserveAndEvents(t *testing.T) {
 		prebindPod.Spec.NodeName = ""
 		_ = apiext.SetDeviceAllocations(prebindPod, alloc)
 
-		wg.Add(4)
+		wg.Add(6)
 		go func() { defer wg.Done(); _ = cache.AssumePod(pod, node) }()
 		go func() { defer wg.Done(); cache.OnPodUpdate(pod, prebindPod) }()
 		go func() { defer wg.Done(); cache.OnPodAdd(eventPodFrom(pod, node, alloc)) }()
@@ -63,6 +63,10 @@ func Test_nodeDeviceCache_ConcurrentReserveAndEvents(t *testing.T) {
 				cache.OnPodDelete(eventPodFrom(pod, node, alloc))
 			}
 		}()
+		// The framework ForgetPod (arbitration failure) races the informer unassign event —
+		// the async pair that must stay idempotent and race-free.
+		go func() { defer wg.Done(); cache.forgetPod(pod) }()
+		go func() { defer wg.Done(); cache.OnPodUpdate(eventPodFrom(pod, node, alloc), prebindPod) }()
 	}
 
 	done := make(chan struct{})
@@ -76,8 +80,8 @@ func Test_nodeDeviceCache_ConcurrentReserveAndEvents(t *testing.T) {
 
 // Test_nodeDeviceCache_ConcurrentReserveOnPodAdd_NoDoubleCount asserts the key correctness
 // invariant: a Reserve racing the informer OnPodAdd for the same pod counts the allocation
-// exactly once — never double (reconcile is net-zero when the marker is set; the allocateSet
-// double-add guard prevents it otherwise) and never zero.
+// exactly once — never double (the positive event is suppressed once the marker is set; the
+// allocateSet double-add guard prevents it otherwise) and never zero.
 func Test_nodeDeviceCache_ConcurrentReserveOnPodAdd_NoDoubleCount(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		cache := newNodeDeviceCache(nil)

--- a/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_race_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 )
 
 // Test_nodeDeviceCache_ConcurrentReserveAndEvents stresses the assume/forget/reconcile paths
@@ -44,8 +46,14 @@ func Test_nodeDeviceCache_ConcurrentReserveAndEvents(t *testing.T) {
 		// Reserve writes the allocation to the per-node cache before AssumePod snapshots it.
 		reserveInto(cache, node, pod, alloc)
 
-		wg.Add(3)
+		// PreBind patch event: same pod, allocation annotation set, but NOT yet bound.
+		prebindPod := pod.DeepCopy()
+		prebindPod.Spec.NodeName = ""
+		_ = apiext.SetDeviceAllocations(prebindPod, alloc)
+
+		wg.Add(4)
 		go func() { defer wg.Done(); _ = cache.AssumePod(pod, node) }()
+		go func() { defer wg.Done(); cache.OnPodUpdate(pod, prebindPod) }()
 		go func() { defer wg.Done(); cache.OnPodAdd(eventPodFrom(pod, node, alloc)) }()
 		go func() {
 			defer wg.Done()

--- a/pkg/scheduler/plugins/deviceshare/device_cache_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_cache_test.go
@@ -83,7 +83,7 @@ func Test_nodeDevice_getUsed(t *testing.T) {
 }
 
 func Test_gcNodeDevices(t *testing.T) {
-	cache := newNodeDeviceCache()
+	cache := newNodeDeviceCache(nil)
 	fakeClient := kubefake.NewSimpleClientset()
 	expectedNodeNames := sets.NewString()
 	for i := 0; i < 10; i++ {

--- a/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
+++ b/pkg/scheduler/plugins/deviceshare/device_plugin_adapter_test.go
@@ -1213,6 +1213,7 @@ func TestPlugin_adaptForDevicePlugin(t *testing.T) {
 			pl, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 			assert.NoError(t, err)
 
+			suit.start(context.TODO())
 			suit.Framework.SharedInformerFactory().Start(nil)
 			suit.koordinatorSharedInformerFactory.Start(nil)
 			suit.Framework.SharedInformerFactory().WaitForCacheSync(nil)

--- a/pkg/scheduler/plugins/deviceshare/devicehandler_default_test.go
+++ b/pkg/scheduler/plugins/deviceshare/devicehandler_default_test.go
@@ -49,7 +49,7 @@ func TestDefaultDeviceHandler_CalcDesiredRequestsAndCount(t *testing.T) {
 		},
 	})
 
-	cache := newNodeDeviceCache()
+	cache := newNodeDeviceCache(nil)
 	cache.updateNodeDevice(fakeDeviceCRCopy.Name, fakeDeviceCRCopy)
 	nodeDeviceInfo := cache.getNodeDevice(fakeDeviceCRCopy.Name, false)
 	assert.Equal(t, map[schedulingv1alpha1.DeviceType]map[int32]int{

--- a/pkg/scheduler/plugins/deviceshare/eventhandler_device_test.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_device_test.go
@@ -205,7 +205,7 @@ func Test_nodeDeviceCache_onDeviceAdd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onDeviceAdd(tt.device)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)
@@ -462,7 +462,7 @@ func Test_nodeDeviceCache_onDeviceUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onDeviceUpdate(tt.oldDevice, tt.newDevice)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)
@@ -542,7 +542,7 @@ func Test_nodeDeviceCache_onDeviceDelete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onDeviceDelete(tt.device)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)

--- a/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -31,15 +30,16 @@ import (
 	reservationutil "github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
-func registerPodEventHandler(deviceCache *nodeDeviceCache, sharedInformerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
-	podInformer := sharedInformerFactory.Core().V1().Pods().Informer()
+// registerReservationEventHandler subscribes the deviceCache to Reservation CRD events,
+// which are converted to synthetic pod events by NewReservationToPodEventHandler. K8s Pod
+// events flow through the framework's unified SharedPluginCache dispatcher instead and
+// are handled by nodeDeviceCache.OnPodAdd/OnPodUpdate/OnPodDelete.
+func registerReservationEventHandler(deviceCache *nodeDeviceCache, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
 	eventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    deviceCache.onPodAdd,
 		UpdateFunc: deviceCache.onPodUpdate,
 		DeleteFunc: deviceCache.onPodDelete,
 	}
-	// make sure Pods are loaded before scheduler starts working
-	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), sharedInformerFactory, podInformer, eventHandler)
 	reservationInformer := koordSharedInformerFactory.Scheduling().V1alpha1().Reservations()
 	reservationEventHandler := reservationutil.NewReservationToPodEventHandler(eventHandler, reservationutil.IsObjValidActiveReservation)
 	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), koordSharedInformerFactory, reservationInformer.Informer(), reservationEventHandler)

--- a/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_pod.go
@@ -31,9 +31,10 @@ import (
 )
 
 // registerReservationEventHandler subscribes the deviceCache to Reservation CRD events,
-// which are converted to synthetic pod events by NewReservationToPodEventHandler. K8s Pod
-// events flow through the framework's unified SharedPluginCache dispatcher instead and
-// are handled by nodeDeviceCache.OnPodAdd/OnPodUpdate/OnPodDelete.
+// which NewReservationToPodEventHandler converts to synthetic reserve-pod events. Both these
+// synthetic events (via the onPod* adapters below) and real K8s Pod events (via the framework's
+// unified SharedPluginCache dispatcher) converge on nodeDeviceCache.OnPodAdd/OnPodUpdate/
+// OnPodDelete, so both consult the assumed ledger through one code path.
 func registerReservationEventHandler(deviceCache *nodeDeviceCache, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
 	eventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    deviceCache.onPodAdd,
@@ -45,13 +46,19 @@ func registerReservationEventHandler(deviceCache *nodeDeviceCache, koordSharedIn
 	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), koordSharedInformerFactory, reservationInformer.Informer(), reservationEventHandler)
 }
 
+// onPodAdd/onPodUpdate/onPodDelete are ResourceEventHandler adapters (interface{} args) that
+// route through the unified OnPodAdd/OnPodUpdate/OnPodDelete, so synthetic reservation events
+// consult the assumed ledger exactly like real pod events. A reservation's reserve pod goes
+// through Plugin.Reserve → AssumePod (marker keyed by the reserve pod's UID = reservation UID);
+// routing its delete/terminate through OnPod* is what lets releaseAssumed clear that marker,
+// instead of the legacy annotation path that leaked one ledger entry per device reservation.
 func (n *nodeDeviceCache) onPodAdd(obj interface{}) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		klog.Errorf("pod cache add failed to parse, obj %T", obj)
 		return
 	}
-	n.updatePod(nil, pod)
+	n.OnPodAdd(pod)
 }
 
 func (n *nodeDeviceCache) onPodUpdate(oldObj, newObj interface{}) {
@@ -64,8 +71,7 @@ func (n *nodeDeviceCache) onPodUpdate(oldObj, newObj interface{}) {
 	if !ok {
 		return
 	}
-	n.updatePod(oldPod, pod)
-	return
+	n.OnPodUpdate(oldPod, pod)
 }
 
 func (n *nodeDeviceCache) onPodDelete(obj interface{}) {
@@ -83,7 +89,7 @@ func (n *nodeDeviceCache) onPodDelete(obj interface{}) {
 	default:
 		return
 	}
-	n.deletePod(pod)
+	n.OnPodDelete(pod)
 }
 
 func (n *nodeDeviceCache) updatePod(oldPod *corev1.Pod, pod *corev1.Pod) {

--- a/pkg/scheduler/plugins/deviceshare/eventhandler_pod_test.go
+++ b/pkg/scheduler/plugins/deviceshare/eventhandler_pod_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deviceshare
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,11 +25,30 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	koordinatorinformers "github.com/koordinator-sh/koordinator/pkg/client/informers/externalversions"
+	frameworkexthelper "github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/helper"
 )
+
+// registerPodEventHandlerForTest wires the deviceCache's pod handlers directly onto the K8s
+// Pod informer. In production these events flow through the framework's unified
+// SharedPluginCache dispatcher (FrameworkExtenderFactory.StartSharedCaches), which is not
+// present in plugin-level unit tests. Tests that rely on pod-informer-driven cache population
+// register the handlers themselves, replicating the pre-migration registerPodEventHandler.
+func registerPodEventHandlerForTest(deviceCache *nodeDeviceCache, sharedInformerFactory informers.SharedInformerFactory, koordSharedInformerFactory koordinatorinformers.SharedInformerFactory) {
+	podInformer := sharedInformerFactory.Core().V1().Pods().Informer()
+	eventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    deviceCache.onPodAdd,
+		UpdateFunc: deviceCache.onPodUpdate,
+		DeleteFunc: deviceCache.onPodDelete,
+	}
+	frameworkexthelper.ForceSyncFromInformer(context.TODO().Done(), sharedInformerFactory, podInformer, eventHandler)
+	registerReservationEventHandler(deviceCache, koordSharedInformerFactory)
+}
 
 func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 	podNamespacedName := types.NamespacedName{
@@ -238,7 +258,7 @@ func Test_nodeDeviceCache_onPodAdd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onPodAdd(tt.pod)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)
@@ -499,7 +519,7 @@ func Test_nodeDeviceCache_onPodUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onPodUpdate(tt.oldPod, tt.pod)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)
@@ -721,7 +741,7 @@ func Test_nodeDeviceCache_onPodDelete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deviceCache := tt.deviceCache
 			if deviceCache == nil {
-				deviceCache = newNodeDeviceCache()
+				deviceCache = newNodeDeviceCache(nil)
 			}
 			deviceCache.onPodDelete(tt.pod)
 			assert.Equal(t, tt.wantCache, deviceCache.nodeDeviceInfos)

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -549,8 +549,11 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 	}
 	logAllocationContext(pod, nodeName, nodeDeviceInfo, state.designatedAllocation, state.allocationResult)
 	nodeDeviceInfo.lock.Lock()
-	defer nodeDeviceInfo.lock.Unlock()
 	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
+	nodeDeviceInfo.lock.Unlock()
+	if err := p.nodeDeviceCache.AssumePod(pod, nodeName); err != nil {
+		return fwktype.AsStatus(err)
+	}
 	return nil
 }
 
@@ -676,9 +679,9 @@ func (p *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, p
 	}
 
 	nodeDeviceInfo.lock.Lock()
-	defer nodeDeviceInfo.lock.Unlock()
-
 	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
+	nodeDeviceInfo.lock.Unlock()
+	_ = p.nodeDeviceCache.ForgetPod(pod)
 	state.allocationResult = nil
 }
 
@@ -844,10 +847,10 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 		return nil, fmt.Errorf("expect handle to be type frameworkext.ExtendedHandle, got %T", handle)
 	}
 
-	deviceCache := newNodeDeviceCache()
-	registerDeviceEventHandler(deviceCache, extendedHandle.KoordinatorSharedInformerFactory())
-	registerPodEventHandler(deviceCache, handle.SharedInformerFactory(), extendedHandle.KoordinatorSharedInformerFactory())
-	extendedHandle.RegisterForgetPodHandler(deviceCache.deletePod)
+	sharedCache := extendedHandle.GetOrRegisterSharedCache(Name, func(h frameworkext.ExtendedHandle) frameworkext.SharedPluginCache {
+		return newNodeDeviceCache(h)
+	})
+	deviceCache := sharedCache.(*nodeDeviceCache)
 	// Register the node informer synchronously during New so that the registration
 	// is visible to the framework's WaitForHandlersSync. If we registered it inside
 	// the gcNodeDevice goroutine, the framework might start scheduling before the
@@ -857,7 +860,6 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 	if _, err := frameworkexthelper.ForceSyncFromInformer(ctx.Done(), handle.SharedInformerFactory(), nodeInformer, nil); err != nil {
 		return nil, err
 	}
-	go deviceCache.gcNodeDevice(ctx, handle.SharedInformerFactory(), defaultGCPeriod)
 
 	gpuSharedResourceTemplatesCache := newGPUSharedResourceTemplatesCache()
 	registerGPUSharedResourceTemplatesConfigMapEventHandler(gpuSharedResourceTemplatesCache,

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -851,11 +851,12 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 		return newNodeDeviceCache(h)
 	})
 	deviceCache := sharedCache.(*nodeDeviceCache)
-	// Register the node informer synchronously during New so that the registration
-	// is visible to the framework's WaitForHandlersSync. If we registered it inside
-	// the gcNodeDevice goroutine, the framework might start scheduling before the
-	// handler registration is collected. Using a no-op handler because gcNodeDevice
-	// only reads from the node lister.
+	// Ensure the node informer is instantiated and its initial list is awaited during
+	// startup. Registering it here (per profile, during New) makes it visible to the
+	// framework's WaitForHandlersSync, so the scheduler waits for the node cache to finish
+	// its initial sync before accepting scheduling cycles. A no-op handler suffices:
+	// DeviceShare reads the node lister directly (in gcNodeDevice) rather than reacting to
+	// node events.
 	nodeInformer := handle.SharedInformerFactory().Core().V1().Nodes().Informer()
 	if _, err := frameworkexthelper.ForceSyncFromInformer(ctx.Done(), handle.SharedInformerFactory(), nodeInformer, nil); err != nil {
 		return nil, err

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -552,6 +552,13 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
 	nodeDeviceInfo.lock.Unlock()
 	if err := p.nodeDeviceCache.AssumePod(pod, nodeName); err != nil {
+		// The framework does not guarantee Unreserve for a Reserve plugin that returns an
+		// error at the Reserve extension point itself, so roll back the cache write here
+		// rather than relying on it. Safe if Unreserve does also run for this pod (vanilla
+		// and batch paths both do today): the isValid guard skips the second subtract.
+		nodeDeviceInfo.lock.Lock()
+		nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
+		nodeDeviceInfo.lock.Unlock()
 		return fwktype.AsStatus(err)
 	}
 	return nil

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -549,8 +549,18 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 	}
 	logAllocationContext(pod, nodeName, nodeDeviceInfo, state.designatedAllocation, state.allocationResult)
 	nodeDeviceInfo.lock.Lock()
-	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
+	applied := nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
 	nodeDeviceInfo.lock.Unlock()
+	if !applied {
+		// The add did not land: a pod with the same ns/name still holds the allocateSet slot
+		// (e.g. a StatefulSet replica recreated before the old pod's delete reached the cache).
+		// Publishing an assumed marker here would snapshot the OTHER pod's allocation (the marker
+		// is keyed by UID but the snapshot is read by name); once the old pod's delete frees the
+		// slot, this pod's positive events would be suppressed and its usage never re-added. Skip
+		// the marker and degrade to annotation semantics — the informer re-add credits this pod
+		// once the slot frees.
+		return nil
+	}
 	if err := p.nodeDeviceCache.AssumePod(pod, nodeName); err != nil {
 		// AssumePod only fails when the node's cache entry vanished (a benign GC race between
 		// the write above and here). Roll back the cache write — the framework does not
@@ -684,6 +694,12 @@ func (p *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, p
 		return
 	}
 
+	// Clear the assumed marker unconditionally, before the nil check. ForgetPod is idempotent,
+	// and if the node's cache entry has since vanished the subtract below is a no-op anyway — but
+	// the marker must still be cleared here, or it would dangle (with this pod's positive events
+	// suppressed) until the pod's terminal event.
+	_ = p.nodeDeviceCache.ForgetPod(pod)
+
 	nodeDeviceInfo := p.nodeDeviceCache.getNodeDevice(nodeName, false)
 	if nodeDeviceInfo == nil {
 		return
@@ -692,7 +708,6 @@ func (p *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, p
 	nodeDeviceInfo.lock.Lock()
 	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
 	nodeDeviceInfo.lock.Unlock()
-	_ = p.nodeDeviceCache.ForgetPod(pod)
 	state.allocationResult = nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -850,7 +850,10 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 	sharedCache := extendedHandle.GetOrRegisterSharedCache(Name, func(h frameworkext.ExtendedHandle) frameworkext.SharedPluginCache {
 		return newNodeDeviceCache(h)
 	})
-	deviceCache := sharedCache.(*nodeDeviceCache)
+	deviceCache, ok := sharedCache.(*nodeDeviceCache)
+	if !ok {
+		return nil, fmt.Errorf("unexpected shared cache type %T for key %q, want *nodeDeviceCache", sharedCache, Name)
+	}
 	// Ensure the node informer is instantiated and its initial list is awaited during
 	// startup. Registering it here (per profile, during New) makes it visible to the
 	// framework's WaitForHandlersSync, so the scheduler waits for the node cache to finish

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -552,14 +552,18 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
 	nodeDeviceInfo.lock.Unlock()
 	if err := p.nodeDeviceCache.AssumePod(pod, nodeName); err != nil {
-		// The framework does not guarantee Unreserve for a Reserve plugin that returns an
-		// error at the Reserve extension point itself, so roll back the cache write here
-		// rather than relying on it. Safe if Unreserve does also run for this pod (vanilla
-		// and batch paths both do today): the isValid guard skips the second subtract.
+		// AssumePod only fails when the node's cache entry vanished (a benign GC race between
+		// the write above and here). Roll back the cache write — the framework does not
+		// guarantee Unreserve for a Reserve plugin that returns an error at the Reserve
+		// extension point, so we clean up rather than rely on it (safe if Unreserve also runs:
+		// the isValid guard skips the second subtract) — then degrade to annotation semantics
+		// (no marker; informer events repopulate the cache) instead of failing the pod over a
+		// transient race.
 		nodeDeviceInfo.lock.Lock()
 		nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
 		nodeDeviceInfo.lock.Unlock()
-		return fwktype.AsStatus(err)
+		klog.InfoS("skip assuming pod in device cache, relying on informer events", "pod", klog.KObj(pod), "node", nodeName, "err", err)
+		return nil
 	}
 	return nil
 }
@@ -861,6 +865,12 @@ func New(ctx context.Context, obj runtime.Object, handle fwktype.Handle) (fwktyp
 	if !ok {
 		return nil, fmt.Errorf("unexpected shared cache type %T for key %q, want *nodeDeviceCache", sharedCache, Name)
 	}
+	// Register the ForgetPod handler per profile: forgetPodHandlers is per-extender state, so
+	// registering only on the profile that constructed the shared cache would miss ForgetPod
+	// invoked through any other profile's extender (e.g. multi-scheduler arbitration failure),
+	// leaving Reserve's write un-reverted and the assumed marker dangling. forgetPod is
+	// idempotent, so registering it on every profile's extender is safe.
+	extendedHandle.RegisterForgetPodHandler(deviceCache.forgetPod)
 	// Ensure the node informer is instantiated and its initial list is awaited during
 	// startup. Registering it here (per profile, during New) makes it visible to the
 	// framework's WaitForHandlersSync, so the scheduler waits for the node cache to finish

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -104,6 +104,12 @@ type preFilterState struct {
 	preemptibleDevices                map[string]map[schedulingv1alpha1.DeviceType]deviceResources
 	preemptibleInRRs                  map[string]map[types.UID]map[schedulingv1alpha1.DeviceType]deviceResources
 
+	// deviceCacheReserved records that Reserve wrote this pod's allocation into the shared device
+	// cache and published an assumed marker. Unreserve reverts the cache write only when this is
+	// set — a same-ns/name collision that skipped the add (and the marker) must not be subtracted,
+	// or it would evict the other pod's allocateSet entry (the set is keyed by ns/name, not UID).
+	deviceCacheReserved bool
+
 	isReservationRequired bool
 
 	// designatedAllocation is parsed from the Pod Annotation during the PreFilter phase. In this case, we should assume that the Node has already been selected. That is, all Score-related plug-ins will not be executed. Instead, we only need to call Filter to confirm whether the designatedAllocation is still valid and use it as the allocation result during actual allocation.
@@ -575,6 +581,7 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 		klog.InfoS("skip assuming pod in device cache, relying on informer events", "pod", klog.KObj(pod), "node", nodeName, "err", err)
 		return nil
 	}
+	state.deviceCacheReserved = true
 	return nil
 }
 
@@ -705,9 +712,14 @@ func (p *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, p
 		return
 	}
 
-	nodeDeviceInfo.lock.Lock()
-	nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
-	nodeDeviceInfo.lock.Unlock()
+	// Revert the cache write only if Reserve actually made one. When the add collided with a
+	// same-ns/name pod's slot Reserve skipped it (deviceCacheReserved stays false); subtracting
+	// here would evict that other pod's allocateSet entry, since the set is keyed by ns/name.
+	if state.deviceCacheReserved {
+		nodeDeviceInfo.lock.Lock()
+		nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, false)
+		nodeDeviceInfo.lock.Unlock()
+	}
 	state.allocationResult = nil
 }
 

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -555,10 +555,17 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 	}
 	logAllocationContext(pod, nodeName, nodeDeviceInfo, state.designatedAllocation, state.allocationResult)
 	nodeDeviceInfo.lock.Lock()
-	applied := nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
+	// canApplyAll gates the write instead of inspecting updateCacheUsed's return value:
+	// updateCacheUsed applies the non-colliding types before reporting false, which would leak an
+	// unrevertable partial write here (the marker is skipped and Unreserve is gated off). Gating
+	// keeps the add all-or-nothing on the Reserve path while leaving the informer path best-effort.
+	applied := nodeDeviceInfo.canApplyAll(state.allocationResult, pod, true)
+	if applied {
+		nodeDeviceInfo.updateCacheUsed(state.allocationResult, pod, true)
+	}
 	nodeDeviceInfo.lock.Unlock()
 	if !applied {
-		// The add did not land: a pod with the same ns/name still holds the allocateSet slot
+		// The add did not land: a pod with the same ns/name still holds an allocateSet slot
 		// (e.g. a StatefulSet replica recreated before the old pod's delete reached the cache).
 		// Publishing an assumed marker here would snapshot the OTHER pod's allocation (the marker
 		// is keyed by UID but the snapshot is read by name); once the old pod's delete frees the
@@ -572,7 +579,8 @@ func (p *Plugin) Reserve(ctx context.Context, cycleState fwktype.CycleState, pod
 		// the write above and here). Roll back the cache write — the framework does not
 		// guarantee Unreserve for a Reserve plugin that returns an error at the Reserve
 		// extension point, so we clean up rather than rely on it (safe if Unreserve also runs:
-		// the isValid guard skips the second subtract) — then degrade to annotation semantics
+		// deviceCacheReserved is left false on this path — it is set only after AssumePod
+		// succeeds — so Unreserve skips its subtract) — then degrade to annotation semantics
 		// (no marker; informer events repopulate the cache) instead of failing the pod over a
 		// transient race.
 		nodeDeviceInfo.lock.Lock()

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -168,7 +168,7 @@ type pluginTestSuit struct {
 // unit tests that rely on cache population must call it after proxyNew and before starting
 // the shared informer factory, matching the four-phase initialization order.
 func (s *pluginTestSuit) start(ctx context.Context) {
-	s.extenderFactory.StartSharedCaches(ctx, s.Framework.SharedInformerFactory())
+	_ = s.extenderFactory.StartSharedCaches(ctx, s.Framework.SharedInformerFactory())
 }
 
 func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -174,6 +174,9 @@ func (s *pluginTestSuit) start(ctx context.Context) {
 
 func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
 	frameworkexthelper.ResetRegistrations()
+	// suit.start() -> nodeDeviceCache.Start() registers an AfterAllInformersSynced hook in a
+	// package-global registry; reset it per suite so hooks don't accumulate across tests.
+	frameworkexthelper.ResetStartupHooks()
 	koordClientSet := koordfake.NewSimpleClientset()
 	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
 	extenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -158,6 +158,17 @@ type pluginTestSuit struct {
 	koordClientSet                   koordclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
 	proxyNew                         runtime.PluginFactory
+	extenderFactory                  *frameworkext.FrameworkExtenderFactory
+}
+
+// start drives the framework's shared-cache startup path (FrameworkExtenderFactory.
+// StartSharedCaches), which invokes Start(ctx) on each registered SharedPluginCache —
+// registering DeviceShare's Device/Reservation CRD handlers and the GC goroutine. In
+// production this is called by cmd/koord-scheduler after all plugins are built; plugin
+// unit tests that rely on cache population must call it after proxyNew and before starting
+// the shared informer factory, matching the four-phase initialization order.
+func (s *pluginTestSuit) start(ctx context.Context) {
+	s.extenderFactory.StartSharedCaches(ctx, s.Framework.SharedInformerFactory())
 }
 
 func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
@@ -209,6 +220,7 @@ func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
 		koordClientSet:                   koordClientSet,
 		koordinatorSharedInformerFactory: koordSharedInformerFactory,
 		proxyNew:                         proxyNew,
+		extenderFactory:                  extenderFactory,
 	}
 }
 
@@ -1200,7 +1212,7 @@ func Test_Plugin_Filter(t *testing.T) {
 		{
 			name:            "error missing nodecache",
 			state:           &preFilterState{skip: false},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			nodeInfo:        testNodeInfo,
 			want:            nil,
 		},
@@ -2662,7 +2674,7 @@ func Test_Plugin_Filter(t *testing.T) {
 					gpuShared: true,
 				},
 			},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			nodeInfo:        testNodeInfo,
 			want:            fwktype.NewStatus(fwktype.Error, "GPUIsolationProviderHAMICore not found on the node"),
 		},
@@ -2674,7 +2686,7 @@ func Test_Plugin_Filter(t *testing.T) {
 					gpuShared: true,
 				},
 			},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			nodeInfo:        testNodeInfoHami,
 			want:            nil,
 		},
@@ -2686,7 +2698,7 @@ func Test_Plugin_Filter(t *testing.T) {
 					gpuShared: true,
 				},
 			},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			nodeInfo:        testHuawei300IDuoNodeInfo,
 			want:            fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable, `model "Ascend-310P3-300I-DUO" of vendor "huawei" does not support GPU Share`),
 		},
@@ -3427,7 +3439,7 @@ func Test_Plugin_Reserve(t *testing.T) {
 		{
 			name: "error missing node cache",
 			args: args{
-				nodeDeviceCache: newNodeDeviceCache(),
+				nodeDeviceCache: newNodeDeviceCache(nil),
 				pod:             &corev1.Pod{},
 				node:            testNode,
 				state: &preFilterState{
@@ -5248,7 +5260,7 @@ func Test_Plugin_Unreserve(t *testing.T) {
 				state: &preFilterState{
 					skip: false,
 				},
-				nodeDeviceCache: newNodeDeviceCache(),
+				nodeDeviceCache: newNodeDeviceCache(nil),
 			},
 		},
 		{
@@ -5799,6 +5811,7 @@ func Test_Plugin_PreBind(t *testing.T) {
 			pl, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 			assert.NoError(t, err)
 
+			suit.start(context.TODO())
 			suit.Framework.SharedInformerFactory().Start(nil)
 			suit.koordinatorSharedInformerFactory.Start(nil)
 			suit.Framework.SharedInformerFactory().WaitForCacheSync(nil)
@@ -5877,6 +5890,7 @@ func Test_Plugin_PreBindReservation(t *testing.T) {
 	pl, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 	assert.NoError(t, err)
 
+	suit.start(context.TODO())
 	suit.Framework.SharedInformerFactory().Start(nil)
 	suit.koordinatorSharedInformerFactory.Start(nil)
 	suit.Framework.SharedInformerFactory().WaitForCacheSync(nil)

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -155,6 +155,7 @@ func (f *testSharedLister) Get(nodeName string) (fwktype.NodeInfo, error) {
 
 type pluginTestSuit struct {
 	framework.Framework
+	t                                testing.TB
 	koordClientSet                   koordclientset.Interface
 	koordinatorSharedInformerFactory koordinatorinformers.SharedInformerFactory
 	proxyNew                         runtime.PluginFactory
@@ -168,7 +169,7 @@ type pluginTestSuit struct {
 // unit tests that rely on cache population must call it after proxyNew and before starting
 // the shared informer factory, matching the four-phase initialization order.
 func (s *pluginTestSuit) start(ctx context.Context) {
-	_ = s.extenderFactory.StartSharedCaches(ctx, s.Framework.SharedInformerFactory())
+	assert.NoError(s.t, s.extenderFactory.StartSharedCaches(ctx, s.Framework.SharedInformerFactory()))
 }
 
 func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
@@ -217,6 +218,7 @@ func newPluginTestSuit(t testing.TB, nodes []*corev1.Node) *pluginTestSuit {
 	assert.Nil(t, err)
 	return &pluginTestSuit{
 		Framework:                        fh,
+		t:                                t,
 		koordClientSet:                   koordClientSet,
 		koordinatorSharedInformerFactory: koordSharedInformerFactory,
 		proxyNew:                         proxyNew,

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -269,6 +269,50 @@ func Test_New(t *testing.T) {
 	assert.Equal(t, Name, p.Name())
 }
 
+// Test_New_SharedCacheAcrossProfiles verifies the core P1 goal for DeviceShare: two scheduler
+// profiles that both load the plugin from the same FrameworkExtenderFactory share a single
+// nodeDeviceCache instance, rather than allocating one cache (and one handler set) per profile.
+func Test_New_SharedCacheAcrossProfiles(t *testing.T) {
+	frameworkexthelper.ResetRegistrations()
+	frameworkexthelper.ResetStartupHooks()
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+	extenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
+		frameworkext.WithKoordinatorClientSet(koordClientSet),
+		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	)
+	proxyNew := frameworkext.PluginFactoryProxy(extenderFactory, New)
+
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+
+	newProfile := func(schedulerName string) framework.Framework {
+		cs := kubefake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(cs, 0)
+		snapshot := newTestSharedLister(nil, nil)
+		fh, err := schedulertesting.NewFramework(
+			context.TODO(),
+			registeredPlugins,
+			schedulerName,
+			runtime.WithClientSet(cs),
+			runtime.WithInformerFactory(informerFactory),
+			runtime.WithSnapshotSharedLister(snapshot),
+		)
+		assert.NoError(t, err)
+		return fh
+	}
+
+	p1, err := proxyNew(context.TODO(), getDefaultArgs(), newProfile("koord-scheduler"))
+	assert.NoError(t, err)
+	p2, err := proxyNew(context.TODO(), getDefaultArgs(), newProfile("secondary-scheduler"))
+	assert.NoError(t, err)
+
+	assert.Same(t, p1.(*Plugin).nodeDeviceCache, p2.(*Plugin).nodeDeviceCache,
+		"DeviceShare must share a single nodeDeviceCache across scheduler profiles")
+}
+
 func Test_Plugin_PreFilterExtensions(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -451,6 +451,77 @@ func Test_Plugin_Reserve_SameNameRecreation_NoStaleMarker(t *testing.T) {
 		"UID2's allocation must become visible after the slot frees")
 }
 
+// Test_Plugin_Reserve_SameNameRecreation_PartialCollision_NoStaleMarker pins @ZiMengSheng review
+// item 1: updateCacheUsed must report all-or-nothing, not "any device type landed". A recreated
+// pod that requests a superset of device types ({gpu, rdma}) where only the gpu slot is still held
+// by the previous pod must NOT get a marker — the gpu add is skipped but the rdma add lands, and a
+// marker published here would snapshot the previous pod's gpu allocation (copyPodAllocations reads
+// by ns/name). Fails against the "any" return; passes once the return is all-or-nothing.
+func Test_Plugin_Reserve_SameNameRecreation_PartialCollision_NoStaleMarker(t *testing.T) {
+	suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}})
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	cache := pl.nodeDeviceCache
+	cache.getNodeDevice("node-1", true)
+
+	reserve := func(uid, name string, alloc apiext.DeviceAllocations) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Namespace: "default", Name: name}}
+		cs := framework.NewCycleState()
+		cs.Write(stateKey, &preFilterState{skip: false, allocationResult: alloc})
+		assert.True(t, pl.Reserve(context.TODO(), cs, pod, "node-1").IsSuccess())
+	}
+
+	// UID1 holds only the gpu slot for default/sts-0.
+	reserve("uid-1", "sts-0", gpuAllocations(0, 100))
+	_, ok := assumedEntry(cache, types.UID("uid-1"))
+	assert.True(t, ok, "UID1 must be assumed")
+
+	// UID2 recreated with the same ns/name requests {gpu, rdma}: gpu collides (skipped), rdma lands.
+	// The add is a partial collision, so no marker may be published for UID2.
+	reserve("uid-2", "sts-0", gpuRdmaAllocations(0, 100, 0))
+	_, ok = assumedEntry(cache, types.UID("uid-2"))
+	assert.False(t, ok, "Reserve must not publish a marker when only part of the add landed")
+}
+
+// Test_Plugin_Unreserve_SkipsSubtractOnCollision pins @ZiMengSheng review item 2: when Reserve
+// skipped the cache add because a same-ns/name pod still held the slot, Unreserve must not run the
+// subtract — doing so would evict the other pod's allocateSet entry (the set is keyed by ns/name,
+// not UID), after which that pod's own delete is skipped by isValid and its usage leaks forever.
+func Test_Plugin_Unreserve_SkipsSubtractOnCollision(t *testing.T) {
+	suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}})
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	cache := pl.nodeDeviceCache
+	cache.getNodeDevice("node-1", true)
+
+	reserve := func(uid, name string, alloc apiext.DeviceAllocations) *framework.CycleState {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Namespace: "default", Name: name}}
+		cs := framework.NewCycleState()
+		cs.Write(stateKey, &preFilterState{skip: false, allocationResult: alloc})
+		assert.True(t, pl.Reserve(context.TODO(), cs, pod, "node-1").IsSuccess())
+		return cs
+	}
+
+	// UID1 reserved on default/sts-0 holds the gpu slot; its allocateSet entry must survive.
+	reserve("uid-1", "sts-0", gpuAllocations(0, 100))
+
+	// UID2 recreated with the same ns/name: Reserve's add collides and is skipped (no marker).
+	cs2 := reserve("uid-2", "sts-0", gpuAllocations(0, 100))
+	if _, ok := assumedEntry(cache, types.UID("uid-2")); ok {
+		t.Fatal("precondition: UID2 must not be assumed (add collided)")
+	}
+
+	// UID2's Unreserve must be a no-op on the cache — UID1's slot must remain.
+	pod2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-2", Namespace: "default", Name: "sts-0"}}
+	pl.Unreserve(context.TODO(), cs2, pod2, "node-1")
+
+	nd := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, "default", "sts-0"),
+		"Unreserve of the colliding pod must not evict the other pod's allocateSet entry")
+}
+
 // Test_Plugin_Unreserve_ClearsMarkerWhenNodeGone pins @saintube review medium item: Unreserve must
 // clear the assumed marker even when the node's cache entry has vanished (GC), instead of returning
 // early on the nil check and leaving the marker dangling (with positive events suppressed) until
@@ -5494,7 +5565,8 @@ func Test_Plugin_Unreserve(t *testing.T) {
 					},
 				},
 				state: &preFilterState{
-					skip: false,
+					skip:                false,
+					deviceCacheReserved: true,
 					allocationResult: apiext.DeviceAllocations{
 						schedulingv1alpha1.GPU: {
 							{

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -404,6 +404,86 @@ func Test_SharedDispatcher_PopulatesCacheFromInitialList(t *testing.T) {
 	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, boundPod.Namespace, boundPod.Name))
 }
 
+// Test_Plugin_Reserve_SameNameRecreation_NoStaleMarker pins the same-name recreation regression
+// (@saintube review, high priority): allocateSet is keyed by ns/name but the marker by UID, and
+// copyPodAllocations reads by name. If a same-ns/name pod (e.g. a StatefulSet replica) is Reserved
+// before the previous pod's delete reaches the cache, its add is skipped by isValid (name slot
+// held), so Reserve must NOT publish a marker over the stale snapshot — otherwise, once the old
+// pod's delete frees the slot, the new pod's positive events are suppressed and its usage never
+// enters the cache (double allocation). With the fix, Reserve skips AssumePod when the add did not
+// land, and the informer re-add credits the new pod once the slot frees.
+func Test_Plugin_Reserve_SameNameRecreation_NoStaleMarker(t *testing.T) {
+	suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}})
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	cache := pl.nodeDeviceCache
+	cache.getNodeDevice("node-1", true) // seed an (empty) nodeDevice so Reserve's lookup is non-nil
+
+	reserve := func(uid, name string, alloc apiext.DeviceAllocations) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Namespace: "default", Name: name}}
+		cs := framework.NewCycleState()
+		cs.Write(stateKey, &preFilterState{skip: false, allocationResult: alloc})
+		assert.True(t, pl.Reserve(context.TODO(), cs, pod, "node-1").IsSuccess())
+	}
+
+	// UID1 reserved on node-1 (ns/name default/sts-0): cache credited, marker for UID1.
+	reserve("uid-1", "sts-0", gpuAllocations(0, 100))
+	_, ok := assumedEntry(cache, types.UID("uid-1"))
+	assert.True(t, ok, "UID1 must be assumed")
+
+	// UID2 recreated with the SAME ns/name before UID1's delete lands: the add collides with the
+	// held slot, so no marker may be published for UID2.
+	reserve("uid-2", "sts-0", gpuAllocations(1, 100))
+	_, ok = assumedEntry(cache, types.UID("uid-2"))
+	assert.False(t, ok, "Reserve must not publish a stale marker when the add did not land")
+
+	// UID1's delete arrives: releaseAssumed clears its marker and frees the ns/name slot.
+	cache.OnPodDelete(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Namespace: "default", Name: "sts-0"}})
+	_, ok = assumedEntry(cache, types.UID("uid-1"))
+	assert.False(t, ok)
+
+	// UID2's bound event: not assumed → updatePod credits alloc2 (self-heal), so its usage is visible.
+	pod2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-2", Namespace: "default", Name: "sts-0"}}
+	cache.OnPodAdd(eventPodFrom(pod2, "node-1", gpuAllocations(1, 100)))
+	nd := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{1}, gpuMinors(nd, "default", "sts-0"),
+		"UID2's allocation must become visible after the slot frees")
+}
+
+// Test_Plugin_Unreserve_ClearsMarkerWhenNodeGone pins @saintube review medium item: Unreserve must
+// clear the assumed marker even when the node's cache entry has vanished (GC), instead of returning
+// early on the nil check and leaving the marker dangling (with positive events suppressed) until
+// the pod's terminal event.
+func Test_Plugin_Unreserve_ClearsMarkerWhenNodeGone(t *testing.T) {
+	suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}})
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+	cache := pl.nodeDeviceCache
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Namespace: "default", Name: "pod-1"}}
+	alloc := gpuAllocations(0, 100)
+	nd := cache.getNodeDevice("node-1", true)
+	nd.lock.Lock()
+	nd.updateCacheUsed(alloc, pod, true)
+	nd.lock.Unlock()
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.True(t, ok, "pod must be assumed")
+
+	// The node's cache entry vanishes (GC) between Reserve and Unreserve.
+	cache.removeNodeDevice("node-1")
+	assert.Nil(t, cache.getNodeDevice("node-1", false))
+
+	cs := framework.NewCycleState()
+	cs.Write(stateKey, &preFilterState{skip: false, allocationResult: alloc})
+	pl.Unreserve(context.TODO(), cs, pod, "node-1")
+
+	_, ok = assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "Unreserve must clear the assumed marker even when the node's cache entry is gone")
+}
+
 func Test_Plugin_PreFilterExtensions(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -40,6 +40,7 @@ import (
 	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
@@ -311,6 +312,96 @@ func Test_New_SharedCacheAcrossProfiles(t *testing.T) {
 
 	assert.Same(t, p1.(*Plugin).nodeDeviceCache, p2.(*Plugin).nodeDeviceCache,
 		"DeviceShare must share a single nodeDeviceCache across scheduler profiles")
+}
+
+// Test_ForgetPodHandler_RegisteredPerProfile pins ZiMengSheng review item 1: the ForgetPod
+// handler must be registered per profile in New(), not once in Start() on the constructing
+// profile's handle. Invoking ForgetPod through a SECOND profile's extender must still reach the
+// shared cache and clear the assumed marker; if it were registered only on the first profile,
+// the marker would dangle and the reserved node keep a phantom allocation.
+func Test_ForgetPodHandler_RegisteredPerProfile(t *testing.T) {
+	frameworkexthelper.ResetRegistrations()
+	frameworkexthelper.ResetStartupHooks()
+	koordClientSet := koordfake.NewSimpleClientset()
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+	extenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
+		frameworkext.WithKoordinatorClientSet(koordClientSet),
+		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+	)
+	proxyNew := frameworkext.PluginFactoryProxy(extenderFactory, New)
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	newProfile := func(schedulerName string) framework.Framework {
+		cs := kubefake.NewSimpleClientset()
+		fh, err := schedulertesting.NewFramework(
+			context.TODO(), registeredPlugins, schedulerName,
+			runtime.WithClientSet(cs),
+			runtime.WithInformerFactory(informers.NewSharedInformerFactory(cs, 0)),
+			runtime.WithSnapshotSharedLister(newTestSharedLister(nil, nil)))
+		assert.NoError(t, err)
+		return fh
+	}
+
+	// p1 (constructed first) creates the shared cache; p2 is a second profile.
+	p1, err := proxyNew(context.TODO(), getDefaultArgs(), newProfile("koord-scheduler"))
+	assert.NoError(t, err)
+	p2, err := proxyNew(context.TODO(), getDefaultArgs(), newProfile("secondary-scheduler"))
+	assert.NoError(t, err)
+	cache := p1.(*Plugin).nodeDeviceCache
+
+	pod := assumeTestPod("1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	// Forget through the SECOND profile's extender (not the one that constructed the cache).
+	_ = p2.(*Plugin).handle.ForgetPod(klog.Background(), pod)
+
+	_, ok := assumedEntry(cache, pod.UID)
+	assert.False(t, ok, "ForgetPod via a second profile must clear the shared cache's assumed marker")
+	nd := cache.getNodeDevice("node-1", false)
+	assert.Empty(t, gpuMinors(nd, pod.Namespace, pod.Name), "ForgetPod via a second profile must roll back the assumed allocation")
+}
+
+// Test_SharedDispatcher_PopulatesCacheFromInitialList exercises the production wiring end to end
+// (ZiMengSheng review item 5, coverage): StartSharedCaches registers the unified pod dispatcher
+// on the shared informer factory, and a pre-existing bound pod carrying an allocation annotation
+// must flow dispatcher → OnPodAdd → updatePod into the shared cache via the informer initial-list
+// path — the path the legacy per-plugin test wiring never exercised.
+func Test_SharedDispatcher_PopulatesCacheFromInitialList(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}}
+	suit := newPluginTestSuit(t, []*corev1.Node{node})
+
+	_, err := suit.koordClientSet.SchedulingV1alpha1().Devices().Create(context.TODO(), fakeDeviceCRWithoutTopology, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	boundPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "existing-gpu-pod", UID: types.UID("existing-gpu-pod")},
+		Spec:       corev1.PodSpec{NodeName: "test-node-1"},
+	}
+	assert.NoError(t, apiext.SetDeviceAllocations(boundPod, gpuAllocations(0, 100)))
+	_, err = suit.ClientSet().CoreV1().Pods(boundPod.Namespace).Create(context.TODO(), boundPod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	pl, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+
+	// Four-phase startup: StartSharedCaches (registers the dispatcher) → informer Start → sync.
+	suit.start(context.TODO())
+	suit.Framework.SharedInformerFactory().Start(nil)
+	suit.koordinatorSharedInformerFactory.Start(nil)
+	suit.Framework.SharedInformerFactory().WaitForCacheSync(nil)
+	suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)
+
+	cache := pl.(*Plugin).nodeDeviceCache
+	assert.Eventually(t, func() bool {
+		nd := cache.getNodeDevice("test-node-1", false)
+		return nd != nil && len(gpuMinors(nd, boundPod.Namespace, boundPod.Name)) == 1
+	}, 10*time.Second, 20*time.Millisecond, "dispatcher must populate the shared cache from the informer initial list")
+
+	nd := cache.getNodeDevice("test-node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, boundPod.Namespace, boundPod.Name))
 }
 
 func Test_Plugin_PreFilterExtensions(t *testing.T) {

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -452,11 +452,13 @@ func Test_Plugin_Reserve_SameNameRecreation_NoStaleMarker(t *testing.T) {
 }
 
 // Test_Plugin_Reserve_SameNameRecreation_PartialCollision_NoStaleMarker pins @ZiMengSheng review
-// item 1: updateCacheUsed must report all-or-nothing, not "any device type landed". A recreated
-// pod that requests a superset of device types ({gpu, rdma}) where only the gpu slot is still held
-// by the previous pod must NOT get a marker — the gpu add is skipped but the rdma add lands, and a
-// marker published here would snapshot the previous pod's gpu allocation (copyPodAllocations reads
-// by ns/name). Fails against the "any" return; passes once the return is all-or-nothing.
+// item 1 (both rounds): a recreated pod that requests a superset of device types ({gpu, rdma})
+// where only the gpu slot is still held by the previous pod must (a) NOT get a marker, and (b)
+// leave the cache untouched. Reserve must be all-or-nothing: if any type collides it writes
+// nothing, so the non-colliding rdma add cannot leak into deviceUsed/allocateSet — otherwise it
+// stays accounted for a pod that never existed (Reserve skips the marker, Unreserve is gated off,
+// and gcNodeDevice never reaps orphaned allocateSet entries). Assertion (b) fails against the
+// partial-write code; passes once Reserve gates on canApplyAll.
 func Test_Plugin_Reserve_SameNameRecreation_PartialCollision_NoStaleMarker(t *testing.T) {
 	suit := newPluginTestSuit(t, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}})
 	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
@@ -477,11 +479,18 @@ func Test_Plugin_Reserve_SameNameRecreation_PartialCollision_NoStaleMarker(t *te
 	_, ok := assumedEntry(cache, types.UID("uid-1"))
 	assert.True(t, ok, "UID1 must be assumed")
 
-	// UID2 recreated with the same ns/name requests {gpu, rdma}: gpu collides (skipped), rdma lands.
+	// UID2 recreated with the same ns/name requests {gpu, rdma}: gpu collides, rdma would land.
 	// The add is a partial collision, so no marker may be published for UID2.
-	reserve("uid-2", "sts-0", gpuRdmaAllocations(0, 100, 0))
+	reserve("uid-2", "sts-0", gpuRdmaAllocations(0, 100, 3))
 	_, ok = assumedEntry(cache, types.UID("uid-2"))
 	assert.False(t, ok, "Reserve must not publish a marker when only part of the add landed")
+
+	// The skipped Reserve must have left the cache untouched: UID1's gpu slot stays, and UID2's
+	// rdma allocation must NOT have leaked in (nothing would ever subtract it back out).
+	nd := cache.getNodeDevice("node-1", false)
+	assert.ElementsMatch(t, []int{0}, gpuMinors(nd, "default", "sts-0"), "UID1's gpu slot must remain")
+	assert.Empty(t, rdmaMinors(nd, "default", "sts-0"),
+		"the non-colliding rdma add must not leak when the Reserve is skipped")
 }
 
 // Test_Plugin_Unreserve_SkipsSubtractOnCollision pins @ZiMengSheng review item 2: when Reserve

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -426,7 +426,7 @@ func Test_tryAllocateFromReservation(t *testing.T) {
 			Resources: resources,
 		})
 	}
-	deviceCache := newNodeDeviceCache()
+	deviceCache := newNodeDeviceCache(nil)
 	deviceCache.updateNodeDevice("test-node", device)
 
 	podRequestsHalfGPU := map[schedulingv1alpha1.DeviceType]corev1.ResourceList{

--- a/pkg/scheduler/plugins/deviceshare/scoring_test.go
+++ b/pkg/scheduler/plugins/deviceshare/scoring_test.go
@@ -82,14 +82,14 @@ func TestScore(t *testing.T) {
 		{
 			name:            "empty node info",
 			state:           &preFilterState{skip: false},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			wantScore:       0,
 			wantStatus:      nil,
 		},
 		{
 			name:            "error missing nodecache",
 			state:           &preFilterState{skip: false},
-			nodeDeviceCache: newNodeDeviceCache(),
+			nodeDeviceCache: newNodeDeviceCache(nil),
 			wantScore:       0,
 			wantStatus:      nil,
 		},
@@ -662,7 +662,7 @@ func TestScoreExtension(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Plugin{nodeDeviceCache: newNodeDeviceCache()}
+			p := &Plugin{nodeDeviceCache: newNodeDeviceCache(nil)}
 			status := p.ScoreExtensions().NormalizeScore(context.TODO(), framework.NewCycleState(), &corev1.Pod{}, tt.nodeScoreList)
 			assert.True(t, status.IsSuccess())
 			assert.Equal(t, tt.want, tt.nodeScoreList)

--- a/pkg/scheduler/plugins/deviceshare/service.go
+++ b/pkg/scheduler/plugins/deviceshare/service.go
@@ -40,4 +40,9 @@ func (p *Plugin) RegisterEndpoints(group *gin.RouterGroup) {
 		}
 		c.JSON(http.StatusOK, nodeDeviceSummary)
 	})
+	// Live view of the shared cache's assumed-allocation ledger (assumedPods), keyed by pod
+	// UID, for debugging assume/forget leaks alongside the shared_cache_assumed_pods metric.
+	group.GET("/assumedAllocations", func(c *gin.Context) {
+		c.JSON(http.StatusOK, p.nodeDeviceCache.getAssumedAllocationsSummary())
+	})
 }

--- a/pkg/scheduler/plugins/deviceshare/service_test.go
+++ b/pkg/scheduler/plugins/deviceshare/service_test.go
@@ -246,3 +246,26 @@ func TestEndpointsQueryNodeDeviceSummary(t *testing.T) {
 	}
 	assert.True(t, apiequality.Semantic.DeepEqual(nodeDeviceSummary["node1"].AllocateSet, nodeDeviceSummaryExpect["node1"].AllocateSet))
 }
+
+func TestEndpointsQueryAssumedAllocations(t *testing.T) {
+	cache := newNodeDeviceCache(nil)
+	pod := assumeTestPod("uid-1", "node-1")
+	reserveInto(cache, "node-1", pod, gpuAllocations(0, 100))
+	assert.NoError(t, cache.AssumePod(pod, "node-1"))
+
+	ds := &Plugin{nodeDeviceCache: cache}
+	engine := gin.Default()
+	ds.RegisterEndpoints(engine.Group("/"))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/assumedAllocations", nil)
+	engine.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	got := map[string]*AssumedAllocationSummary{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	if assert.Contains(t, got, string(pod.UID)) {
+		assert.Equal(t, "node-1", got[string(pod.UID)].NodeName)
+		assert.NotEmpty(t, got[string(pod.UID)].Allocations)
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/topology_hint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/topology_hint_test.go
@@ -223,6 +223,7 @@ func TestPlugin_GetPodTopologyHints(t *testing.T) {
 			p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 			assert.NoError(t, err)
 
+			suit.start(context.TODO())
 			suit.koordinatorSharedInformerFactory.Start(nil)
 			suit.SharedInformerFactory().Start(nil)
 			suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)
@@ -389,6 +390,7 @@ func TestPlugin_Allocate(t *testing.T) {
 			p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
 			assert.NoError(t, err)
 
+			suit.start(context.TODO())
 			suit.koordinatorSharedInformerFactory.Start(nil)
 			suit.SharedInformerFactory().Start(nil)
 			suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Koordinator's out-of-tree plugins build their cache once per scheduling profile, so with N profiles DeviceShare's `nodeDeviceCache` is instantiated N times — N handler sets, N GC goroutines, N assume-window views — all tracking the same cluster-wide state. This PR introduces an opt-in `SharedPluginCache` mechanism in `frameworkext` and migrates DeviceShare onto it, so the cache is created exactly once per scheduler instance and shared across all profiles.

The framework extender owns the lifecycle: plugins register a cache from `New()` via `ExtendedHandle.GetOrRegisterSharedCache(key, create)` (exactly-once by key); after all profiles are built, `FrameworkExtenderFactory.StartSharedCaches` invokes `Start(ctx)` on each cache once and wires a single unified pod/node event dispatcher that fans out to every registered cache in registration order. Plugin-specific CRD handlers (DeviceShare's `Device` handler) and the GC goroutine move into `Start()`; per-profile hooks (the `ForgetPod` handler, the node informer) are registered in `New()`, since they are per-extender state.

A `CacheReserver` optional interface adds the `AssumePod`/`ForgetPod` assume/forget contract. `AssumePod` records what `Reserve` wrote as a **rollback marker**. The marker is a pure rollback record: it is consumed only by a **negative** event — `ForgetPod`, or a delete / bound→unassigned / terminate through `OnPodDelete`/`OnPodUpdate` — which rolls back the recorded snapshot. A **positive** (assigned) event for an assumed pod is **not** re-added or reconciled: `spec.nodeName` is not a trustworthy bind signal (multi-scheduler arbitration fakes it via a client-go transform and clears it back to `""`), and the marker must survive for a racing `ForgetPod`. The pre-existing `nodeDevice.isValid` guard keeps the informer-add idempotent with the `Reserve` write. The mechanism is opt-in — plugins that do not implement `SharedPluginCache` are unaffected.

### Ⅱ. Does this pull request fix one issue?

Part of #3095 #2749 — this is the first implementation PR (DeviceShare portion of Phase 1) following the approved design proposal. NodeNUMAResource and Reservation cache migrations follow in subsequent PRs.

### Ⅲ. Describe how to verify it

Scoped to the changed packages:

```bash
go build ./pkg/scheduler/frameworkext/... ./pkg/scheduler/plugins/deviceshare/... ./cmd/koord-scheduler/...
go vet   ./pkg/scheduler/frameworkext/... ./pkg/scheduler/plugins/deviceshare/... ./cmd/koord-scheduler/...
go test  ./pkg/scheduler/frameworkext/... ./pkg/scheduler/plugins/deviceshare/... -count=1
go test  ./pkg/scheduler/frameworkext/... ./pkg/scheduler/plugins/deviceshare/... -race -count=1
./bin/golangci-lint run ./pkg/scheduler/frameworkext/... ./pkg/scheduler/plugins/deviceshare/...
```

All green locally, including `-race` and golangci-lint (0 issues). Coverage:

- **Multi-profile sharing:** two profiles built from one factory share a single `nodeDeviceCache` instance, created exactly once; and the `ForgetPod` handler reaches the shared cache when invoked through a *second* profile's extender (not only the one that constructed the cache).
- **Registry + dispatcher:** same-key/distinct-key semantics; `StartSharedCaches` starts each cache once and is idempotent; dispatcher fans out to all caches in registration order across all six pod/node event types; tombstone unwrapping; registering a new cache after start panics.
- **Assume/forget marker model** (`device_cache_assume_test.go`): AssumePod snapshot atomicity + empty-marker skip + missing-node error; ForgetPod idempotency; positive events do not re-add or clear the marker; negative events (delete / unassign / terminate / framework ForgetPod) roll back the snapshot and clear the marker, idempotent across the async ForgetPod↔unassign pair; delete-before-bind rolls back via the snapshot without relying on annotations; reservation synthetic delete/terminate release the marker.
- **Production dispatch path:** a pre-existing bound pod carrying an allocation annotation is populated into the shared cache through the informer initial-list → dispatcher → `OnPodAdd` path.
- **Startup ordering:** no pod/node event is observed by a cache before its `Start()` returns.
- **Race:** concurrent Reserve/AssumePod + informer events (incl. the framework ForgetPod vs unassign pair) under `-race`, with a no-double-count invariant.

Existing DeviceShare and frameworkext unit tests pass unchanged.

### Ⅳ. Special notes for reviews

This PR was opened as 7 bisectable commits and has grown to 19 across review rounds 1–8; each commit still builds and passes independently. High-level structure:

- **New mechanism (frameworkext):** the `SharedPluginCache` / `CacheReserver` interfaces; the registry + `StartSharedCaches` + unified pod/node dispatcher on `FrameworkExtenderFactory` (lock-free `atomic.Pointer` snapshot on the per-event path); the `ExtendedHandle` accessor; the startup wiring in `cmd/koord-scheduler` (in `Run()`, after all plugins are built and before the shared informer factory starts, with an ordering guard).
- **DeviceShare migration:** `nodeDeviceCache` implements both interfaces; `New()` becomes profile-independent and registers the per-profile hooks; the Device/Reservation CRD handlers and GC (behind an `AfterAllInformersSynced` hook) move into `Start()`; `Reserve`/`Unreserve` use `AssumePod`/`ForgetPod`. Existing DeviceShare tests were adapted in the same commits as the signature/handler changes so no intermediate commit fails to build.
- **Assumed-ledger semantics** were refined across rounds into the rollback-marker model described in §Ⅰ; `AssumePod` snapshots and publishes the marker under a single cache-lock hold; reservation synthetic events and real pod events share one `OnPod*` code path.

Other notes:
- The no-double-count property leans on the pre-existing `nodeDevice.isValid` guard (skips an add when the pod is already in `allocateSet` after Reserve, and skips a subtract when it is already gone), unchanged by this PR.
- Per-node `nodeDevice.lock` is preserved. The per-event handler path takes no cache-wide write lock; the per-Reserve/Unreserve `AssumePod`/`ForgetPod` calls do hold `nodeDeviceCache.lock` briefly.
- Out of scope here (follow-ups): `gpuSharedResourceTemplatesCache` (also per-profile), NodeNUMAResource + Reservation migrations, the dispatcher's configurable parallel mode + per-handler metrics, and re-scoping the assumed-pods observability now that the marker is lifetime-scoped.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
