### PR TITLE
scheduler: fix elasticquota queueing hint unstructured conversion

### DIFF
--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
@@ -356,34 +357,78 @@ func (g *Plugin) getPodAssociateQuotaNameAndTreeIDFromSnapshot(pod *corev1.Pod) 
 	}
 	return extension.DefaultQuotaName, ""
 }
+func toElasticQuota(obj interface{}) *apiv1alpha1.ElasticQuota {
+	if obj == nil {
+		return nil
+	}
+
+	var unstructuredObj *unstructured.Unstructured
+	switch t := obj.(type) {
+	case *apiv1alpha1.ElasticQuota:
+		return t
+	case *unstructured.Unstructured:
+		unstructuredObj = t
+	case cache.DeletedFinalStateUnknown:
+		switch inner := t.Obj.(type) {
+		case *apiv1alpha1.ElasticQuota:
+			return inner
+		case *unstructured.Unstructured:
+			unstructuredObj = inner
+		default:
+			klog.Errorf("Unable to handle quota object wrapped in DeletedFinalStateUnknown, type %T", t.Obj)
+			return nil
+		}
+	default:
+		klog.Errorf("Unable to handle quota object in %T", obj)
+		return nil
+	}
+
+	if unstructuredObj == nil || unstructuredObj.Object == nil {
+		klog.Errorf("Fail to convert quota object, unstructured object or its content is nil")
+		return nil
+	}
+
+	quota := &apiv1alpha1.ElasticQuota{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, quota); err != nil {
+		klog.Errorf("Fail to convert unstructured object %v to ElasticQuota: %v", obj, err)
+		return nil
+	}
+	return quota
+}
 
 // isSchedulableAfterQuotaChanged determines if a pod becomes schedulable after quota is updated.
 // QueueAfterBackoff is default queueingHintFn behavior.
 func (g *Plugin) isSchedulableAfterQuotaChanged(logger klog.Logger, pod *corev1.Pod, oldObj, newObj interface{}) (fwktype.QueueingHint, error) {
-	originalQuota, modifiedQuota, err := schedutil.As[*apiv1alpha1.ElasticQuota](oldObj, newObj)
-	if err != nil {
-		logger.Error(err, "Failed to convert oldObj or newObj to ElasticQuota", "oldObj", oldObj, "newObj", newObj)
-		return fwktype.Queue, nil
-	}
+	originalQuota := toElasticQuota(oldObj)
+	modifiedQuota := toElasticQuota(newObj)
 
 	if originalQuota == nil || modifiedQuota == nil {
+		logger.V(5).Info("ElasticQuota QueueHint: Queue, originalQuota or modifiedQuota is nil",
+			"pod", klog.KObj(pod))
 		return fwktype.Queue, nil
 	}
 
 	// Use snapshot to get pod quota name and tree ID without locking
 	podQuotaName, podTreeID := g.getPodAssociateQuotaNameAndTreeIDFromSnapshot(pod)
 	if podQuotaName == "" {
+		logger.V(5).Info("ElasticQuota QueueHint: QueueSkip, pod has no associated quota",
+			"pod", klog.KObj(pod), "modifiedQuota", modifiedQuota.Name)
 		return fwktype.QueueSkip, nil
 	}
 
 	// Check if modified quota is in the same tree as the pod
 	modifiedQuotaTreeID := extension.GetQuotaTreeID(modifiedQuota)
 	if modifiedQuotaTreeID != podTreeID {
+		logger.V(5).Info("ElasticQuota QueueHint: QueueSkip, modified quota is in a different tree",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName, "podTreeID", podTreeID,
+			"modifiedQuota", modifiedQuota.Name, "modifiedQuotaTreeID", modifiedQuotaTreeID)
 		return fwktype.QueueSkip, nil
 	}
 
 	mgr := g.GetGroupQuotaManagerForTree(podTreeID)
 	if mgr == nil {
+		logger.V(5).Info("ElasticQuota QueueHint: QueueSkip, no GroupQuotaManager for tree",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName, "podTreeID", podTreeID)
 		return fwktype.QueueSkip, nil
 	}
 
@@ -393,12 +438,16 @@ func (g *Plugin) isSchedulableAfterQuotaChanged(logger klog.Logger, pod *corev1.
 
 	hasChanged := oldQuotaInfo.IsQuotaChange(newQuotaInfo) || mgr.IsQuotaUpdated(oldQuotaInfo, newQuotaInfo, modifiedQuota)
 	if !hasChanged {
+		logger.V(5).Info("ElasticQuota QueueHint: QueueSkip, modified quota has no meaningful change",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName, "modifiedQuota", modifiedQuota.Name)
 		return fwktype.QueueSkip, nil
 	}
 
 	// Quota has changed, check if modified quota is in the pod's path to root
 	if modifiedQuota.Name == podQuotaName {
 		// Modified quota is the pod's quota, allow queueing
+		logger.V(5).Info("ElasticQuota QueueHint: Queue, modified quota is the pod's quota",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName)
 		return fwktype.Queue, nil
 	}
 
@@ -407,6 +456,9 @@ func (g *Plugin) isSchedulableAfterQuotaChanged(logger klog.Logger, pod *corev1.
 		snapshot, exists := g.getQuotaSnapshot(podTreeID)
 
 		if !exists || snapshot == nil {
+			logger.V(5).Info("ElasticQuota QueueHint: Queue, quota snapshot not found for tree",
+				"pod", klog.KObj(pod), "podQuota", podQuotaName, "podTreeID", podTreeID,
+				"modifiedQuota", modifiedQuota.Name)
 			return fwktype.Queue, nil
 		}
 
@@ -414,12 +466,18 @@ func (g *Plugin) isSchedulableAfterQuotaChanged(logger klog.Logger, pod *corev1.
 		parentPath := snapshot.GetQuotaPathToRoot(podQuotaName)
 		for _, quotaNameInPath := range parentPath {
 			if quotaNameInPath == modifiedQuota.Name {
+				logger.V(5).Info("ElasticQuota QueueHint: Queue, modified quota is on the pod's path to root",
+					"pod", klog.KObj(pod), "podQuota", podQuotaName, "modifiedQuota", modifiedQuota.Name,
+					"parentPath", parentPath)
 				return fwktype.Queue, nil
 			}
 		}
 	}
 
 	// Modified quota is not in the pod's path to root, skip
+	logger.V(5).Info("ElasticQuota QueueHint: QueueSkip, modified quota is not on the pod's path to root",
+		"pod", klog.KObj(pod), "podQuota", podQuotaName, "modifiedQuota", modifiedQuota.Name,
+		"enableCheckParentQuota", g.pluginArgs.EnableCheckParentQuota)
 	return fwktype.QueueSkip, nil
 }
 
@@ -433,38 +491,52 @@ func (g *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 	}
 
 	if deletedPod == nil {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: Queue, deletedPod is nil", "pod", klog.KObj(pod))
 		return fwktype.Queue, nil
 	}
 
 	// Use snapshot to get quota names and tree IDs without locking
 	deletedPodQuotaName, deletedPodTreeID := g.getPodAssociateQuotaNameAndTreeIDFromSnapshot(deletedPod)
 	if deletedPodQuotaName == "" {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: QueueSkip, deleted pod has no associated quota",
+			"pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 		return fwktype.QueueSkip, nil
 	}
 
 	podQuotaName, podTreeID := g.getPodAssociateQuotaNameAndTreeIDFromSnapshot(pod)
 	if podQuotaName == "" {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: QueueSkip, unschedulable pod has no associated quota",
+			"pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 		return fwktype.QueueSkip, nil
 	}
 
 	// Check if deleted pod and unschedulable pod are in the same tree
 	if deletedPodTreeID != podTreeID {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: QueueSkip, deleted pod is in a different tree",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName, "podTreeID", podTreeID,
+			"deletedPod", klog.KObj(deletedPod), "deletedPodQuota", deletedPodQuotaName, "deletedPodTreeID", deletedPodTreeID)
 		return fwktype.QueueSkip, nil
 	}
 
 	snapshot, exists := g.getQuotaSnapshot(podTreeID)
 	if !exists || snapshot == nil {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: Queue, quota snapshot not found for tree",
+			"pod", klog.KObj(pod), "podTreeID", podTreeID)
 		return fwktype.Queue, nil
 	}
 
 	// Get quota info from snapshot and check if pod is assigned
 	quotaInfo := snapshot.GetQuotaInfoByName(deletedPodQuotaName)
 	if quotaInfo != nil && !quotaInfo.CheckPodIsAssigned(deletedPod) {
+		logger.V(5).Info("isSchedulableAfterPodDeletion: QueueSkip, deleted pod was not assigned to quota (no resource released)",
+			"pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod), "deletedPodQuota", deletedPodQuotaName)
 		return fwktype.QueueSkip, nil
 	}
 
 	if deletedPodQuotaName == podQuotaName {
 		// Deleted pod is in the same quota as the unschedulable pod, allow queueing
+		logger.V(5).Info("isSchedulableAfterPodDeletion: Queue, deleted pod shares the same quota",
+			"pod", klog.KObj(pod), "podQuota", podQuotaName, "deletedPod", klog.KObj(deletedPod))
 		return fwktype.Queue, nil
 	}
 
@@ -475,12 +547,18 @@ func (g *Plugin) isSchedulableAfterPodDeletion(logger klog.Logger, pod *corev1.P
 		for _, quotaNameInPath := range parentPath {
 			if quotaNameInPath == deletedPodQuotaName {
 				// Deleted pod's quota is in the path to root, allow queueing
+				logger.V(5).Info("isSchedulableAfterPodDeletion: Queue, deleted pod's quota is on the pod's path to root",
+					"pod", klog.KObj(pod), "podQuota", podQuotaName, "deletedPod", klog.KObj(deletedPod),
+					"deletedPodQuota", deletedPodQuotaName, "parentPath", parentPath)
 				return fwktype.Queue, nil
 			}
 		}
 	}
 
 	// Deleted pod's quota is not in the unschedulable pod's path to root, skip
+	logger.V(5).Info("isSchedulableAfterPodDeletion: QueueSkip, deleted pod's quota is not on the pod's path to root",
+		"pod", klog.KObj(pod), "podQuota", podQuotaName, "deletedPod", klog.KObj(deletedPod),
+		"deletedPodQuota", deletedPodQuotaName, "enableCheckParentQuota", g.pluginArgs.EnableCheckParentQuota)
 	return fwktype.QueueSkip, nil
 }
 

--- a/pkg/scheduler/plugins/elasticquota/plugin.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin.go
@@ -384,13 +384,13 @@ func toElasticQuota(obj interface{}) *apiv1alpha1.ElasticQuota {
 	}
 
 	if unstructuredObj == nil || unstructuredObj.Object == nil {
-		klog.Errorf("Fail to convert quota object, unstructured object or its content is nil")
+		klog.Errorf("Failed to convert quota object, unstructured object or its content is nil")
 		return nil
 	}
 
 	quota := &apiv1alpha1.ElasticQuota{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, quota); err != nil {
-		klog.Errorf("Fail to convert unstructured object %v to ElasticQuota: %v", obj, err)
+		klog.Errorf("Failed to convert unstructured object %v to ElasticQuota: %v", obj, err)
 		return nil
 	}
 	return quota

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
@@ -43,6 +44,7 @@ import (
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -2497,6 +2499,90 @@ func TestPlugin_updateQuotaSnapshot(t *testing.T) {
 			if gp.groupQuotaManager != nil {
 				assert.True(t, exists, "default quota manager snapshot should exist")
 			}
+		})
+	}
+}
+
+func TestToElasticQuota(t *testing.T) {
+	eq := &v1alpha1.ElasticQuota{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ElasticQuota",
+			APIVersion: "scheduling.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-quota",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				extension.LabelQuotaTreeID: "tree1",
+			},
+		},
+		Spec: v1alpha1.ElasticQuotaSpec{
+			Max: MakeResourceList().CPU(10).Mem(30).Obj(),
+			Min: MakeResourceList().CPU(1).Mem(2).Obj(),
+		},
+	}
+
+	// Build an *unstructured.Unstructured from the typed ElasticQuota.
+	rawMap, err := apiruntime.DefaultUnstructuredConverter.ToUnstructured(eq)
+	assert.NoError(t, err)
+	unstructuredObj := &unstructured.Unstructured{Object: rawMap}
+
+	tests := []struct {
+		name    string
+		obj     interface{}
+		wantNil bool
+	}{
+		{
+			name:    "nil object",
+			obj:     nil,
+			wantNil: true,
+		},
+		{
+			name:    "typed ElasticQuota",
+			obj:     eq,
+			wantNil: false,
+		},
+		{
+			name:    "unstructured ElasticQuota",
+			obj:     unstructuredObj,
+			wantNil: false,
+		},
+		{
+			name: "DeletedFinalStateUnknown wrapping unstructured",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test-ns/test-quota",
+				Obj: unstructuredObj,
+			},
+			wantNil: false,
+		},
+		{
+			name: "DeletedFinalStateUnknown wrapping typed ElasticQuota",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test-ns/test-quota",
+				Obj: eq,
+			},
+			wantNil: false,
+		},
+		{
+			name:    "unhandled type",
+			obj:     &corev1.Pod{},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toElasticQuota(tt.obj)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+			assert.Equal(t, eq.Name, got.Name)
+			assert.Equal(t, eq.Namespace, got.Namespace)
+			assert.Equal(t, "tree1", got.Labels[extension.LabelQuotaTreeID])
+			assert.True(t, quotav1.Equals(eq.Spec.Max, got.Spec.Max))
+			assert.True(t, quotav1.Equals(eq.Spec.Min, got.Spec.Min))
 		})
 	}
 }

--- a/pkg/scheduler/plugins/elasticquota/plugin_test.go
+++ b/pkg/scheduler/plugins/elasticquota/plugin_test.go
@@ -2018,6 +2018,48 @@ func TestPlugin_QueueingHint_IsSchedulableAfterQuotaChanged(t *testing.T) {
 	}
 }
 
+// The ElasticQuota update event is registered by GVK, so the scheduler informer delivers
+// oldObj/newObj as *unstructured.Unstructured instead of typed *ElasticQuota. The hint must
+// still reach the QueueSkip branch rather than falling back to Queue on a failed conversion.
+func TestPlugin_QueueingHint_IsSchedulableAfterQuotaChanged_UnstructuredPayload(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, k8sfeature.DefaultMutableFeatureGate, features.MultiQuotaTree, true)()
+
+	quota := &v1alpha1.ElasticQuota{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ElasticQuota",
+			APIVersion: "scheduling.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test1",
+			Labels: map[string]string{extension.LabelQuotaTreeID: "tree1"},
+			Annotations: map[string]string{
+				extension.AnnotationSharedWeight: `{"cpu":"10","memory":"30"}`,
+			},
+		},
+		Spec: v1alpha1.ElasticQuotaSpec{
+			Max: MakeResourceList().CPU(10).Mem(30).Obj(),
+			Min: MakeResourceList().CPU(0).Mem(0).Obj(),
+		},
+	}
+
+	suit := newPluginTestSuit(t, nil)
+	gp := suit.createPlugin(t).(*Plugin)
+	gp.OnQuotaAdd(quota)
+	gp.updateQuotaSnapshot()
+
+	rawMap, err := apiruntime.DefaultUnstructuredConverter.ToUnstructured(quota)
+	assert.NoError(t, err)
+	unstructuredQuota := &unstructured.Unstructured{Object: rawMap}
+
+	pod := MakePod("t1-ns1", "pod1").Label(extension.LabelQuotaName, "test1").
+		Label(extension.LabelQuotaTreeID, "tree1").Obj()
+
+	result, err := gp.isSchedulableAfterQuotaChanged(klog.Background(), pod,
+		unstructuredQuota, unstructuredQuota.DeepCopy())
+	assert.NoError(t, err)
+	assert.Equal(t, fwktype.QueueSkip, result)
+}
+
 func TestPlugin_EventsToRegister(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

schedutil.As[*apiv1alpha1.ElasticQuota](oldObj, newObj)
The assertion always failed → error branch → unconditionally returned fwktype.Queue for every quota update, because oldObj/newObj are *unstructured.Unstructured, not he typed struct.

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
