### PR TITLE
scheduler: add sandbox score-free profile

### DIFF
--- a/apis/extension/multi_scheduler.go
+++ b/apis/extension/multi_scheduler.go
@@ -26,6 +26,9 @@ const (
 	// LabelSchedulerName is used to specify the internal scheduler name for a pod, overriding the spec.schedulerName.
 	LabelSchedulerName = SchedulingDomainPrefix + "/scheduler-name"
 
+	// SandboxSchedulerName is the scheduler profile used for sandbox workloads.
+	SandboxSchedulerName = "koord-scheduler-sandbox"
+
 	// AnnotationOriginalSchedulerName stores the original pod.Spec.SchedulerName before
 	// TransformSchedulerName overwrites it, allowing later restoration.
 	AnnotationOriginalSchedulerName = InternalSchedulingDomainPrefix + "/original-scheduler-name"

--- a/apis/extension/multi_scheduler_test.go
+++ b/apis/extension/multi_scheduler_test.go
@@ -26,35 +26,44 @@ import (
 )
 
 func TestGetSchedulerName(t *testing.T) {
-	// Test case 1: Pod with LabelSchedulerName label
-	podWithLabel := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		specName       string
+		expectedResult string
+	}{
+		{
+			name: "scheduler name label takes precedence",
+			labels: map[string]string{
 				LabelSchedulerName: "custom-scheduler",
 			},
+			specName:       "default-scheduler",
+			expectedResult: "custom-scheduler",
 		},
-		Spec: corev1.PodSpec{
-			SchedulerName: "default-scheduler",
+		{
+			name:           "sandbox scheduler name is used directly",
+			specName:       SandboxSchedulerName,
+			expectedResult: SandboxSchedulerName,
 		},
-	}
-
-	result := GetSchedulerName(podWithLabel)
-	assert.Equal(t, "custom-scheduler", result, "Should return scheduler name from label when present")
-
-	// Test case 2: Pod without LabelSchedulerName label
-	podWithoutLabel := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
+		{
+			name: "non-sandbox pod keeps spec scheduler",
+			labels: map[string]string{
 				"other-label": "value",
 			},
-		},
-		Spec: corev1.PodSpec{
-			SchedulerName: "default-scheduler",
+			specName:       "default-scheduler",
+			expectedResult: "default-scheduler",
 		},
 	}
 
-	result = GetSchedulerName(podWithoutLabel)
-	assert.Equal(t, "default-scheduler", result, "Should return spec.SchedulerName when label is not present")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: tt.labels},
+				Spec:       corev1.PodSpec{SchedulerName: tt.specName},
+			}
+			assert.Equal(t, tt.expectedResult, GetSchedulerName(pod))
+		})
+	}
 }
 
 func TestGetSchedulingHint(t *testing.T) {

--- a/cmd/koord-scheduler/app/server.go
+++ b/cmd/koord-scheduler/app/server.go
@@ -461,6 +461,9 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	cc := c.Complete()
 
 	defaultprofile.AppendDefaultPlugins(cc.ComponentConfig.Profiles)
+	if utilfeature.DefaultFeatureGate.Enabled(koordfeatures.SandboxScheduling) {
+		cc.ComponentConfig.Profiles = defaultprofile.AppendSandboxProfile(cc.ComponentConfig.Profiles)
+	}
 
 	informer.SetupCustomInformers(cc.InformerFactory)
 	transformer.SetupTransformers(cc.InformerFactory, cc.KoordinatorSharedInformerFactory, cc.NodeResourceTopologyInformerFactory)

--- a/pkg/features/scheduler_features.go
+++ b/pkg/features/scheduler_features.go
@@ -153,6 +153,12 @@ const (
 	// reservation restore. It is enabled by default; when disabled, the flow performs no snapshot
 	// writes and the framework's default shared snapshot lister is used instead.
 	EnableBatchScheduleNodeSnapshot featuregate.Feature = "EnableBatchScheduleNodeSnapshot"
+
+	// owner: @tan90github
+	// alpha: v1.9
+	//
+	// SandboxScheduling enables the sandbox scheduler profile for sandbox workloads.
+	SandboxScheduling featuregate.Feature = "SandboxScheduling"
 )
 
 var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -184,6 +190,7 @@ var defaultSchedulerFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	GangPendingPodsConditionPatch:             {Default: true, PreRelease: featuregate.Beta},
 	EnableInlineBatchSchedule:                 {Default: false, PreRelease: featuregate.Alpha},
 	EnableBatchScheduleNodeSnapshot:           {Default: true, PreRelease: featuregate.Beta},
+	SandboxScheduling:                         {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/features/scheduler_features_test.go
+++ b/pkg/features/scheduler_features_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sfeature "k8s.io/apiserver/pkg/util/feature"
+)
+
+func TestSandboxSchedulingFeatureGateDefault(t *testing.T) {
+	assert.False(t, k8sfeature.DefaultFeatureGate.Enabled(SandboxScheduling))
+}

--- a/pkg/scheduler/frameworkext/defaultprofile/profile.go
+++ b/pkg/scheduler/frameworkext/defaultprofile/profile.go
@@ -19,6 +19,7 @@ package defaultprofile
 import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
 )
 
@@ -51,5 +52,34 @@ func AppendDefaultPlugins(profiles []kubeschedulerconfig.KubeSchedulerProfile) {
 				Name: defaultprebind.Name,
 			})
 		}
+	}
+}
+
+// AppendSandboxProfile adds a score-free profile derived from the first configured profile.
+// A user-defined profile with the sandbox scheduler name takes precedence.
+func AppendSandboxProfile(profiles []kubeschedulerconfig.KubeSchedulerProfile) []kubeschedulerconfig.KubeSchedulerProfile {
+	for _, profile := range profiles {
+		if profile.SchedulerName == apiext.SandboxSchedulerName {
+			return profiles
+		}
+	}
+	if len(profiles) == 0 {
+		return profiles
+	}
+
+	sandboxProfile := profiles[0].DeepCopy()
+	if sandboxProfile.Plugins == nil {
+		sandboxProfile.Plugins = &kubeschedulerconfig.Plugins{}
+	}
+	sandboxProfile.SchedulerName = apiext.SandboxSchedulerName
+	sandboxProfile.Plugins.PreScore = disabledAllPlugin()
+	sandboxProfile.Plugins.Score = disabledAllPlugin()
+
+	return append(profiles, *sandboxProfile)
+}
+
+func disabledAllPlugin() kubeschedulerconfig.PluginSet {
+	return kubeschedulerconfig.PluginSet{
+		Disabled: []kubeschedulerconfig.Plugin{{Name: "*"}},
 	}
 }

--- a/pkg/scheduler/frameworkext/defaultprofile/profile.go
+++ b/pkg/scheduler/frameworkext/defaultprofile/profile.go
@@ -17,11 +17,16 @@ limitations under the License.
 package defaultprofile
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	pluginNames "k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/utils/ptr"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
 )
+
+const defaultSandboxPercentageOfNodesToScore int32 = 5
 
 func AppendDefaultPlugins(profiles []kubeschedulerconfig.KubeSchedulerProfile) {
 	for i := range profiles {
@@ -55,7 +60,7 @@ func AppendDefaultPlugins(profiles []kubeschedulerconfig.KubeSchedulerProfile) {
 	}
 }
 
-// AppendSandboxProfile adds a score-free profile derived from the first configured profile.
+// AppendSandboxProfile adds a lightweight scoring profile derived from the first configured profile.
 // A user-defined profile with the sandbox scheduler name takes precedence.
 func AppendSandboxProfile(profiles []kubeschedulerconfig.KubeSchedulerProfile) []kubeschedulerconfig.KubeSchedulerProfile {
 	for _, profile := range profiles {
@@ -72,14 +77,51 @@ func AppendSandboxProfile(profiles []kubeschedulerconfig.KubeSchedulerProfile) [
 		sandboxProfile.Plugins = &kubeschedulerconfig.Plugins{}
 	}
 	sandboxProfile.SchedulerName = apiext.SandboxSchedulerName
-	sandboxProfile.Plugins.PreScore = disabledAllPlugin()
-	sandboxProfile.Plugins.Score = disabledAllPlugin()
+	sandboxProfile.PercentageOfNodesToScore = ptr.To(defaultSandboxPercentageOfNodesToScore)
+	sandboxProfile.Plugins.PreScore = kubeschedulerconfig.PluginSet{
+		Enabled:  []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit}},
+		Disabled: []kubeschedulerconfig.Plugin{{Name: "*"}},
+	}
+	sandboxProfile.Plugins.Score = kubeschedulerconfig.PluginSet{
+		Enabled:  []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit, Weight: 1}},
+		Disabled: []kubeschedulerconfig.Plugin{{Name: "*"}},
+	}
+	sandboxProfile.PluginConfig = withSandboxNodeResourcesFitConfig(sandboxProfile.PluginConfig)
 
 	return append(profiles, *sandboxProfile)
 }
 
-func disabledAllPlugin() kubeschedulerconfig.PluginSet {
-	return kubeschedulerconfig.PluginSet{
-		Disabled: []kubeschedulerconfig.Plugin{{Name: "*"}},
+func withSandboxNodeResourcesFitConfig(pluginConfigs []kubeschedulerconfig.PluginConfig) []kubeschedulerconfig.PluginConfig {
+	sandboxPluginConfig := kubeschedulerconfig.PluginConfig{
+		Name: pluginNames.NodeResourcesFit,
+		Args: &kubeschedulerconfig.NodeResourcesFitArgs{
+			ScoringStrategy: &kubeschedulerconfig.ScoringStrategy{
+				Type: kubeschedulerconfig.LeastAllocated,
+				Resources: []kubeschedulerconfig.ResourceSpec{
+					{Name: string(corev1.ResourceCPU), Weight: 1},
+					{Name: string(corev1.ResourceMemory), Weight: 1},
+					{Name: string(apiext.BatchCPU), Weight: 1},
+					{Name: string(apiext.BatchMemory), Weight: 1},
+					{Name: string(apiext.MidCPU), Weight: 1},
+					{Name: string(apiext.MidMemory), Weight: 1},
+				},
+			},
+		},
 	}
+	result := make([]kubeschedulerconfig.PluginConfig, 0, len(pluginConfigs)+1)
+	replaced := false
+	for _, pluginConfig := range pluginConfigs {
+		if pluginConfig.Name != pluginNames.NodeResourcesFit {
+			result = append(result, pluginConfig)
+			continue
+		}
+		if !replaced {
+			result = append(result, sandboxPluginConfig)
+			replaced = true
+		}
+	}
+	if !replaced {
+		result = append(result, sandboxPluginConfig)
+	}
+	return result
 }

--- a/pkg/scheduler/frameworkext/defaultprofile/profile_test.go
+++ b/pkg/scheduler/frameworkext/defaultprofile/profile_test.go
@@ -17,13 +17,25 @@ limitations under the License.
 package defaultprofile
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fwktype "k8s.io/kube-scheduler/framework"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	pluginNames "k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	kubeschedmetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
 
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
 )
+
+func init() {
+	kubeschedmetrics.Register()
+}
 
 func TestAppendDefaultPlugins(t *testing.T) {
 	tests := []struct {
@@ -126,4 +138,232 @@ func TestAppendDefaultPlugins(t *testing.T) {
 			assert.Equal(t, tt.wantProfiles, tt.profiles)
 		})
 	}
+}
+
+func TestAppendSandboxProfile(t *testing.T) {
+	base := kubeschedulerconfig.KubeSchedulerProfile{
+		SchedulerName: "koord-scheduler",
+		Plugins: &kubeschedulerconfig.Plugins{
+			MultiPoint: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{
+					{Name: "NodeResourcesFit"},
+					{Name: pluginNames.PodTopologySpread},
+					{Name: pluginNames.InterPodAffinity},
+				},
+			},
+			PreFilter: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{
+					{Name: "NodeResourcesFit"},
+					{Name: pluginNames.PodTopologySpread},
+				},
+				Disabled: []kubeschedulerconfig.Plugin{
+					{Name: "ExistingPreFilterPlugin"},
+				},
+			},
+			Filter: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{
+					{Name: "NodeResourcesFit"},
+					{Name: pluginNames.InterPodAffinity},
+				},
+			},
+			PreScore: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{{Name: "Reservation"}},
+			},
+			Score: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{{Name: "NodeResourcesFit", Weight: 1}},
+			},
+			Reserve: kubeschedulerconfig.PluginSet{
+				Enabled: []kubeschedulerconfig.Plugin{{Name: "Reservation"}},
+			},
+		},
+		PluginConfig: []kubeschedulerconfig.PluginConfig{
+			{Name: "NodeResourcesFit"},
+			{Name: "Reservation"},
+		},
+	}
+	original := base.DeepCopy()
+
+	profiles := AppendSandboxProfile([]kubeschedulerconfig.KubeSchedulerProfile{base})
+
+	assert.Len(t, profiles, 2)
+	assert.Equal(t, original, &profiles[0])
+
+	sandbox := profiles[1]
+	assert.Equal(t, apiext.SandboxSchedulerName, sandbox.SchedulerName)
+	assert.Equal(t, original.Plugins.MultiPoint, sandbox.Plugins.MultiPoint)
+	assert.Equal(t, original.Plugins.PreFilter, sandbox.Plugins.PreFilter)
+	assert.Equal(t, original.Plugins.Filter, sandbox.Plugins.Filter)
+	assert.Equal(t, original.Plugins.Reserve, sandbox.Plugins.Reserve)
+	assert.Empty(t, sandbox.Plugins.PreScore.Enabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, sandbox.Plugins.PreScore.Disabled)
+	assert.Empty(t, sandbox.Plugins.Score.Enabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, sandbox.Plugins.Score.Disabled)
+	assert.Equal(t, original.PluginConfig, sandbox.PluginConfig)
+}
+
+func TestAppendSandboxProfileWithoutExplicitPlugins(t *testing.T) {
+	profiles := AppendSandboxProfile([]kubeschedulerconfig.KubeSchedulerProfile{
+		{SchedulerName: "koord-scheduler"},
+	})
+
+	assert.Len(t, profiles, 2)
+	assert.Equal(t, apiext.SandboxSchedulerName, profiles[1].SchedulerName)
+	assert.NotNil(t, profiles[1].Plugins)
+	assert.Empty(t, profiles[1].Plugins.MultiPoint.Enabled)
+	assert.Empty(t, profiles[1].Plugins.PreFilter.Enabled)
+	assert.Empty(t, profiles[1].Plugins.PreFilter.Disabled)
+	assert.Empty(t, profiles[1].Plugins.Filter.Enabled)
+	assert.Empty(t, profiles[1].Plugins.Filter.Disabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, profiles[1].Plugins.PreScore.Disabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, profiles[1].Plugins.Score.Disabled)
+}
+
+func TestAppendSandboxProfileDoesNotDuplicateExplicitProfile(t *testing.T) {
+	profiles := []kubeschedulerconfig.KubeSchedulerProfile{
+		{
+			SchedulerName: "koord-scheduler",
+			Plugins:       &kubeschedulerconfig.Plugins{},
+		},
+		{
+			SchedulerName: apiext.SandboxSchedulerName,
+			Plugins:       &kubeschedulerconfig.Plugins{},
+		},
+	}
+
+	got := AppendSandboxProfile(profiles)
+
+	assert.Len(t, got, 2)
+	assert.Same(t, &profiles[0], &got[0])
+	assert.Same(t, &profiles[1], &got[1])
+}
+
+type testSandboxProfilePlugin struct{}
+
+func (p *testSandboxProfilePlugin) Name() string {
+	return "test-sandbox-profile-plugin"
+}
+
+func (p *testSandboxProfilePlugin) Less(_, _ fwktype.QueuedPodInfo) bool {
+	return false
+}
+
+func (p *testSandboxProfilePlugin) PreScore(context.Context, fwktype.CycleState, *corev1.Pod, []fwktype.NodeInfo) *fwktype.Status {
+	return nil
+}
+
+func (p *testSandboxProfilePlugin) Score(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.NodeInfo) (int64, *fwktype.Status) {
+	return 0, nil
+}
+
+func (p *testSandboxProfilePlugin) ScoreExtensions() fwktype.ScoreExtensions {
+	return nil
+}
+
+func (p *testSandboxProfilePlugin) PreFilter(context.Context, fwktype.CycleState, *corev1.Pod, []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
+	return nil, nil
+}
+
+func (p *testSandboxProfilePlugin) PreFilterExtensions() fwktype.PreFilterExtensions {
+	return nil
+}
+
+func (p *testSandboxProfilePlugin) Filter(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.NodeInfo) *fwktype.Status {
+	return nil
+}
+
+func (p *testSandboxProfilePlugin) Bind(context.Context, fwktype.CycleState, *corev1.Pod, string) *fwktype.Status {
+	return nil
+}
+
+type testSandboxFilterPlugin struct {
+	name string
+}
+
+func (p *testSandboxFilterPlugin) Name() string {
+	return p.name
+}
+
+func (p *testSandboxFilterPlugin) PreFilter(context.Context, fwktype.CycleState, *corev1.Pod, []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
+	return nil, nil
+}
+
+func (p *testSandboxFilterPlugin) PreFilterExtensions() fwktype.PreFilterExtensions {
+	return nil
+}
+
+func (p *testSandboxFilterPlugin) Filter(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.NodeInfo) *fwktype.Status {
+	return nil
+}
+
+func (p *testSandboxFilterPlugin) PreScore(context.Context, fwktype.CycleState, *corev1.Pod, []fwktype.NodeInfo) *fwktype.Status {
+	return nil
+}
+
+func (p *testSandboxFilterPlugin) Score(context.Context, fwktype.CycleState, *corev1.Pod, fwktype.NodeInfo) (int64, *fwktype.Status) {
+	return 0, nil
+}
+
+func (p *testSandboxFilterPlugin) ScoreExtensions() fwktype.ScoreExtensions {
+	return nil
+}
+
+func TestAppendSandboxProfilePreservesFilterPluginsInFramework(t *testing.T) {
+	factoryCalls := make(map[string]int)
+	profiles := AppendSandboxProfile([]kubeschedulerconfig.KubeSchedulerProfile{
+		{
+			SchedulerName: "koord-scheduler",
+			Plugins: &kubeschedulerconfig.Plugins{
+				MultiPoint: kubeschedulerconfig.PluginSet{
+					Enabled: []kubeschedulerconfig.Plugin{
+						{Name: "test-sandbox-filter-plugin"},
+						{Name: pluginNames.PodTopologySpread},
+						{Name: pluginNames.InterPodAffinity},
+					},
+				},
+				QueueSort: kubeschedulerconfig.PluginSet{
+					Enabled: []kubeschedulerconfig.Plugin{{Name: "test-sandbox-profile-plugin"}},
+				},
+				Bind: kubeschedulerconfig.PluginSet{
+					Enabled: []kubeschedulerconfig.Plugin{{Name: "test-sandbox-profile-plugin"}},
+				},
+			},
+		},
+	})
+	registry := frameworkruntime.Registry{
+		"test-sandbox-profile-plugin": func(context.Context, runtime.Object, fwktype.Handle) (fwktype.Plugin, error) {
+			return &testSandboxProfilePlugin{}, nil
+		},
+		"test-sandbox-filter-plugin": func(context.Context, runtime.Object, fwktype.Handle) (fwktype.Plugin, error) {
+			return &testSandboxFilterPlugin{name: "test-sandbox-filter-plugin"}, nil
+		},
+	}
+	for _, name := range []string{pluginNames.PodTopologySpread, pluginNames.InterPodAffinity} {
+		name := name
+		registry[name] = func(context.Context, runtime.Object, fwktype.Handle) (fwktype.Plugin, error) {
+			factoryCalls[name]++
+			return &testSandboxFilterPlugin{name: name}, nil
+		}
+	}
+
+	baseFramework, err := frameworkruntime.NewFramework(context.Background(), registry, &profiles[0])
+	assert.NoError(t, err)
+	assert.Contains(t, baseFramework.ListPlugins().PreFilter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.PodTopologySpread})
+	assert.Contains(t, baseFramework.ListPlugins().Filter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.InterPodAffinity})
+	factoryCalls = make(map[string]int)
+
+	sandboxFramework, err := frameworkruntime.NewFramework(context.Background(), registry, &profiles[1])
+	assert.NoError(t, err)
+
+	assert.True(t, baseFramework.HasScorePlugins())
+	assert.False(t, sandboxFramework.HasScorePlugins())
+	assert.Contains(t, sandboxFramework.ListPlugins().PreFilter.Enabled, kubeschedulerconfig.Plugin{Name: "test-sandbox-filter-plugin"})
+	assert.Contains(t, sandboxFramework.ListPlugins().Filter.Enabled, kubeschedulerconfig.Plugin{Name: "test-sandbox-filter-plugin"})
+	assert.Contains(t, sandboxFramework.ListPlugins().PreFilter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.PodTopologySpread})
+	assert.Contains(t, sandboxFramework.ListPlugins().Filter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.InterPodAffinity})
+	assert.Empty(t, sandboxFramework.ListPlugins().PreScore.Enabled)
+	assert.Empty(t, sandboxFramework.ListPlugins().Score.Enabled)
+	assert.Equal(t, map[string]int{
+		pluginNames.PodTopologySpread: 1,
+		pluginNames.InterPodAffinity:  1,
+	}, factoryCalls)
 }

--- a/pkg/scheduler/frameworkext/defaultprofile/profile_test.go
+++ b/pkg/scheduler/frameworkext/defaultprofile/profile_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fwktype "k8s.io/kube-scheduler/framework"
@@ -28,6 +29,7 @@ import (
 	pluginNames "k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	kubeschedmetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/utils/ptr"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/defaultprebind"
@@ -142,7 +144,8 @@ func TestAppendDefaultPlugins(t *testing.T) {
 
 func TestAppendSandboxProfile(t *testing.T) {
 	base := kubeschedulerconfig.KubeSchedulerProfile{
-		SchedulerName: "koord-scheduler",
+		SchedulerName:            "koord-scheduler",
+		PercentageOfNodesToScore: ptr.To[int32](20),
 		Plugins: &kubeschedulerconfig.Plugins{
 			MultiPoint: kubeschedulerconfig.PluginSet{
 				Enabled: []kubeschedulerconfig.Plugin{
@@ -177,7 +180,17 @@ func TestAppendSandboxProfile(t *testing.T) {
 			},
 		},
 		PluginConfig: []kubeschedulerconfig.PluginConfig{
-			{Name: "NodeResourcesFit"},
+			{
+				Name: pluginNames.NodeResourcesFit,
+				Args: &kubeschedulerconfig.NodeResourcesFitArgs{
+					ScoringStrategy: &kubeschedulerconfig.ScoringStrategy{
+						Type: kubeschedulerconfig.MostAllocated,
+						Resources: []kubeschedulerconfig.ResourceSpec{
+							{Name: string(corev1.ResourceCPU), Weight: 10},
+						},
+					},
+				},
+			},
 			{Name: "Reservation"},
 		},
 	}
@@ -190,15 +203,17 @@ func TestAppendSandboxProfile(t *testing.T) {
 
 	sandbox := profiles[1]
 	assert.Equal(t, apiext.SandboxSchedulerName, sandbox.SchedulerName)
+	assert.Equal(t, ptr.To(defaultSandboxPercentageOfNodesToScore), sandbox.PercentageOfNodesToScore)
 	assert.Equal(t, original.Plugins.MultiPoint, sandbox.Plugins.MultiPoint)
 	assert.Equal(t, original.Plugins.PreFilter, sandbox.Plugins.PreFilter)
 	assert.Equal(t, original.Plugins.Filter, sandbox.Plugins.Filter)
 	assert.Equal(t, original.Plugins.Reserve, sandbox.Plugins.Reserve)
-	assert.Empty(t, sandbox.Plugins.PreScore.Enabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit}}, sandbox.Plugins.PreScore.Enabled)
 	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, sandbox.Plugins.PreScore.Disabled)
-	assert.Empty(t, sandbox.Plugins.Score.Enabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit, Weight: 1}}, sandbox.Plugins.Score.Enabled)
 	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, sandbox.Plugins.Score.Disabled)
-	assert.Equal(t, original.PluginConfig, sandbox.PluginConfig)
+	assert.Equal(t, original.PluginConfig[1], sandbox.PluginConfig[1])
+	assertSandboxNodeResourcesFitConfig(t, sandbox.PluginConfig)
 }
 
 func TestAppendSandboxProfileWithoutExplicitPlugins(t *testing.T) {
@@ -208,33 +223,83 @@ func TestAppendSandboxProfileWithoutExplicitPlugins(t *testing.T) {
 
 	assert.Len(t, profiles, 2)
 	assert.Equal(t, apiext.SandboxSchedulerName, profiles[1].SchedulerName)
+	assert.Equal(t, ptr.To(defaultSandboxPercentageOfNodesToScore), profiles[1].PercentageOfNodesToScore)
 	assert.NotNil(t, profiles[1].Plugins)
 	assert.Empty(t, profiles[1].Plugins.MultiPoint.Enabled)
 	assert.Empty(t, profiles[1].Plugins.PreFilter.Enabled)
 	assert.Empty(t, profiles[1].Plugins.PreFilter.Disabled)
 	assert.Empty(t, profiles[1].Plugins.Filter.Enabled)
 	assert.Empty(t, profiles[1].Plugins.Filter.Disabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit}}, profiles[1].Plugins.PreScore.Enabled)
 	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, profiles[1].Plugins.PreScore.Disabled)
+	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: pluginNames.NodeResourcesFit, Weight: 1}}, profiles[1].Plugins.Score.Enabled)
 	assert.Equal(t, []kubeschedulerconfig.Plugin{{Name: "*"}}, profiles[1].Plugins.Score.Disabled)
+	assertSandboxNodeResourcesFitConfig(t, profiles[1].PluginConfig)
 }
 
 func TestAppendSandboxProfileDoesNotDuplicateExplicitProfile(t *testing.T) {
+	customNodeResourcesFitArgs := &kubeschedulerconfig.NodeResourcesFitArgs{
+		ScoringStrategy: &kubeschedulerconfig.ScoringStrategy{
+			Type: kubeschedulerconfig.MostAllocated,
+			Resources: []kubeschedulerconfig.ResourceSpec{
+				{Name: string(corev1.ResourceCPU), Weight: 5},
+			},
+		},
+	}
 	profiles := []kubeschedulerconfig.KubeSchedulerProfile{
 		{
 			SchedulerName: "koord-scheduler",
 			Plugins:       &kubeschedulerconfig.Plugins{},
 		},
 		{
-			SchedulerName: apiext.SandboxSchedulerName,
-			Plugins:       &kubeschedulerconfig.Plugins{},
+			SchedulerName:            apiext.SandboxSchedulerName,
+			PercentageOfNodesToScore: ptr.To[int32](30),
+			Plugins:                  &kubeschedulerconfig.Plugins{},
+			PluginConfig: []kubeschedulerconfig.PluginConfig{
+				{Name: pluginNames.NodeResourcesFit, Args: customNodeResourcesFitArgs},
+			},
 		},
 	}
+	originalSandboxProfile := profiles[1].DeepCopy()
 
 	got := AppendSandboxProfile(profiles)
 
 	assert.Len(t, got, 2)
 	assert.Same(t, &profiles[0], &got[0])
 	assert.Same(t, &profiles[1], &got[1])
+	assert.Equal(t, ptr.To[int32](30), got[1].PercentageOfNodesToScore)
+	assert.Equal(t, originalSandboxProfile, &got[1])
+}
+
+func assertSandboxNodeResourcesFitConfig(t *testing.T, pluginConfigs []kubeschedulerconfig.PluginConfig) {
+	t.Helper()
+
+	var got *kubeschedulerconfig.NodeResourcesFitArgs
+	count := 0
+	for _, pluginConfig := range pluginConfigs {
+		if pluginConfig.Name != pluginNames.NodeResourcesFit {
+			continue
+		}
+		count++
+		var ok bool
+		got, ok = pluginConfig.Args.(*kubeschedulerconfig.NodeResourcesFitArgs)
+		require.True(t, ok)
+	}
+
+	require.Equal(t, 1, count)
+	assert.Equal(t, &kubeschedulerconfig.NodeResourcesFitArgs{
+		ScoringStrategy: &kubeschedulerconfig.ScoringStrategy{
+			Type: kubeschedulerconfig.LeastAllocated,
+			Resources: []kubeschedulerconfig.ResourceSpec{
+				{Name: string(corev1.ResourceCPU), Weight: 1},
+				{Name: string(corev1.ResourceMemory), Weight: 1},
+				{Name: string(apiext.BatchCPU), Weight: 1},
+				{Name: string(apiext.BatchMemory), Weight: 1},
+				{Name: string(apiext.MidCPU), Weight: 1},
+				{Name: string(apiext.MidMemory), Weight: 1},
+			},
+		},
+	}, got)
 }
 
 type testSandboxProfilePlugin struct{}
@@ -336,6 +401,10 @@ func TestAppendSandboxProfilePreservesFilterPluginsInFramework(t *testing.T) {
 		"test-sandbox-filter-plugin": func(context.Context, runtime.Object, fwktype.Handle) (fwktype.Plugin, error) {
 			return &testSandboxFilterPlugin{name: "test-sandbox-filter-plugin"}, nil
 		},
+		pluginNames.NodeResourcesFit: func(context.Context, runtime.Object, fwktype.Handle) (fwktype.Plugin, error) {
+			factoryCalls[pluginNames.NodeResourcesFit]++
+			return &testSandboxFilterPlugin{name: pluginNames.NodeResourcesFit}, nil
+		},
 	}
 	for _, name := range []string{pluginNames.PodTopologySpread, pluginNames.InterPodAffinity} {
 		name := name
@@ -355,15 +424,16 @@ func TestAppendSandboxProfilePreservesFilterPluginsInFramework(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, baseFramework.HasScorePlugins())
-	assert.False(t, sandboxFramework.HasScorePlugins())
+	assert.True(t, sandboxFramework.HasScorePlugins())
 	assert.Contains(t, sandboxFramework.ListPlugins().PreFilter.Enabled, kubeschedulerconfig.Plugin{Name: "test-sandbox-filter-plugin"})
 	assert.Contains(t, sandboxFramework.ListPlugins().Filter.Enabled, kubeschedulerconfig.Plugin{Name: "test-sandbox-filter-plugin"})
 	assert.Contains(t, sandboxFramework.ListPlugins().PreFilter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.PodTopologySpread})
 	assert.Contains(t, sandboxFramework.ListPlugins().Filter.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.InterPodAffinity})
-	assert.Empty(t, sandboxFramework.ListPlugins().PreScore.Enabled)
-	assert.Empty(t, sandboxFramework.ListPlugins().Score.Enabled)
+	assert.Contains(t, sandboxFramework.ListPlugins().PreScore.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.NodeResourcesFit})
+	assert.Contains(t, sandboxFramework.ListPlugins().Score.Enabled, kubeschedulerconfig.Plugin{Name: pluginNames.NodeResourcesFit, Weight: 1})
 	assert.Equal(t, map[string]int{
 		pluginNames.PodTopologySpread: 1,
 		pluginNames.InterPodAffinity:  1,
+		pluginNames.NodeResourcesFit:  1,
 	}, factoryCalls)
 }

--- a/pkg/util/reservation/reservation_test.go
+++ b/pkg/util/reservation/reservation_test.go
@@ -246,6 +246,19 @@ func TestGetReservationSchedulerName(t *testing.T) {
 			},
 			want: "test-scheduler",
 		},
+		{
+			name: "sandbox scheduler name is read from template",
+			arg: &schedulingv1alpha1.Reservation{
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							SchedulerName: apiext.SandboxSchedulerName,
+						},
+					},
+				},
+			},
+			want: apiext.SandboxSchedulerName,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds a dedicated score-free scheduler profile for sandbox workloads.

Main changes:

- Add a new scheduler feature gate: `SandboxScheduling`, disabled by default.
- Add the sandbox scheduler profile name: `koord-scheduler-sandbox`.
- When `SandboxScheduling=true`, koord-scheduler automatically appends a sandbox profile derived from the first configured scheduler profile.
- The sandbox profile keeps the existing queue, filter, reserve, pre-bind, and bind behavior, but disables all `PreScore` and `Score` plugins.
- If users already define a profile named `koord-scheduler-sandbox`, the auto-append logic does not create a duplicate profile.



Why this change is needed:

Sandbox workloads need a high-throughput scheduling path. In large-scale pod/node benchmarks, the scoring stage becomes visible in the scheduler hot path. For sandbox pods, we can keep hard scheduling constraints in filter-related stages while skipping score/pre-score plugins to reduce per-pod scheduling overhead.

Current benchmark result:

- Stable scheduling throughput: about `2k scheduled pods/s`.
- Benchmark pod creation throughput: about `3k pods/s`.
- Final benchmark workload size: about `200k` pods.
- Node scale: about `1.2k` simulated nodes in the target cluster. 
Scheduling QPS:

<img width="1398" height="463" alt="image" src="https://github.com/user-attachments/assets/b245c2d9-d081-4489-a381-c70878d4d6e1" />

Pod creation QPS:
<img width="1388" height="465" alt="image" src="https://github.com/user-attachments/assets/5d1e8aa2-4245-46c7-970a-1056831aae99" />

Benchmark environment:

- Kubernetes / scheduler dependency version: `1.35.x`
  - Exact revision from this branch: `k8s.io/kubernetes v1.35.6`
  - Scheduler module: `k8s.io/kube-scheduler v0.35.6`
- Load generator: ClusterLoader2 CronJob running in the target cluster.
- Workload size: about `200k` pods.
- Node scale: about `1.2k` simulated nodes.
- koord-scheduler:
  - replicas: `2`
  - feature gates include `SandboxScheduling=true`
  - `percentageOfNodesToScore: 1`
  - clientConnection: `qps: 100000`, `burst: 200000`
- koord-manager:
  - replicas: `2`
  - client config args: `--rest-config-qps=100000`, `--rest-config-burst=200000`
- apiserver benchmark tuning:
  - `--max-requests-inflight=1500`
  - `--max-mutating-requests-inflight=1000`
  - `--http2-max-streams-per-connection=3000`

Why apiserver parameters were adjusted:

The benchmark target is to measure the scheduler path under high pod throughput. With about `3k` pod create requests per second and about `2k` scheduled pods per second, apiserver receives a large amount of concurrent mutating traffic, including pod create, pod binding, status updates, and event-related writes. If apiserver keeps the default low concurrency settings, the test can become limited by apiserver request admission before the scheduler path is fully exercised.

In Kubernetes `1.35.6`, the default values are `400` for `max-requests-inflight`, `200` for `max-mutating-requests-inflight`, and `1000` for `http2-max-streams-per-connection`. For this benchmark, these values were raised to `1500`, `1000`, and `3000` so that apiserver has enough request concurrency and HTTP/2 stream capacity for the load generator, scheduler, controllers, and webhooks.

Parameter meanings:

- `--max-requests-inflight`: controls the non-mutating request concurrency budget. When APF is enabled, it is also part of the total server concurrency budget.
- `--max-mutating-requests-inflight`: controls the mutating request concurrency budget. Pod create and bind traffic are mutating requests, so this value is directly relevant to scheduler benchmark pressure. When APF is enabled, this is also added into the total server concurrency budget.
- `--http2-max-streams-per-connection`: controls the maximum concurrent HTTP/2 streams allowed on one client connection. High-QPS clients may otherwise queue behind the per-connection stream limit even if apiserver still has CPU and request concurrency available.

These values are benchmark-environment tuning, not a semantic dependency of this PR. Larger apiserver limits reduce apiserver-side queueing but may push pressure downstream to etcd or admission webhooks. During benchmark runs, apiserver 429/5xx, webhook timeout, and etcd write latency should be observed together.

Other webhook tuning requirement:

Pod creation goes through all enabled admission webhooks. Unrelated mutating/validating webhooks can dominate pod creation latency or reduce create QPS if their own client QPS/burst, replicas, timeout, or failure policy is not suitable for high-QPS tests. For scheduler-only benchmarks, unrelated webhook impact should be reduced or separately tuned, otherwise the measured pod create rate may reflect webhook throughput rather than scheduler throughput.

Current limitation:

This PR only introduces a score-free scheduler profile. It does not introduce a custom scheduling workflow, concurrent `ScheduleOne`, batch binding, or apiserver/webhook tuning as product code. The benchmark numbers depend on the test environment and should not be treated as a general production SLO.

### Ⅱ. Does this pull request fix one issue?
https://github.com/koordinator-sh/koordinator/pull/3112

### Ⅲ. Describe how to verify it



Minimal sanitized ClusterLoader2 benchmark YAML:

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: benchmark-system
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: sandbox-scheduler-loadtest
  namespace: benchmark-system
spec:
  schedule: "*/20 * * * *"
  suspend: true
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 1
  successfulJobsHistoryLimit: 3
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: Never
          schedulerName: default-scheduler
          nodeSelector:
            benchmark-role: driver
          containers:
            - name: clusterloader
              image: <clusterloader2-image>
              imagePullPolicy: IfNotPresent
              env:
                - name: CONFIG_DIR
                  value: /config
                - name: TEST_CONFIG
                  value: loadtest-config.yaml
                - name: K8S_CLIENTS_NUMBER
                  value: "10000"
                - name: DELETE_AUTOMANAGED_NAMESPACES
                  value: "true"
                - name: CL2_POD_NUM
                  value: "200000"
                - name: CL2_NAMESPACE_NUM
                  value: "20"
                - name: CL2_DEFAULT_QPS
                  value: "5000"
              volumeMounts:
                - name: loadtest-config
                  mountPath: /config
                  readOnly: true
          volumes:
            - name: loadtest-config
              projected:
                sources:
                  - configMap:
                      name: loadtest-main-config
                  - configMap:
                      name: loadtest-pod-template
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: loadtest-main-config
  namespace: benchmark-system
data:
  loadtest-config.yaml: |
    {{$defaultQps := DefaultParam .CL2_DEFAULT_QPS 5000}}
    {{$namespaceNum := DefaultParam .CL2_NAMESPACE_NUM 20}}
    {{$podNum := DefaultParam .CL2_POD_NUM 200000}}
    {{$sleepAfterExecDuration := DefaultParam .CL2_SLEEP_AFTER_EXEC_DURATION "2m"}}

    name: sandbox-scheduler-loadtest

    namespace:
      number: {{$namespaceNum}}

    tuningSets:
      - name: UniformQps
        qpsLoad:
          qps: {{$defaultQps}}

    steps:
      - name: Create benchmark pods
        phases:
          - namespaceRange:
              min: 1
              max: {{$namespaceNum}}
            replicasPerNamespace: {{DivideInt $podNum $namespaceNum}}
            tuningSet: UniformQps
            operationTimeout: 60m
            objectBundle:
              - basename: benchmark-pod
                objectTemplatePath: pod-template.yaml
                templateFillMap:
                  SchedulerName: koord-scheduler-sandbox
      - name: Sleep
        measurements:
          - Identifier: WaitAfterExec
            Method: Sleep
            Params:
              duration: {{$sleepAfterExecDuration}}
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: loadtest-pod-template
  namespace: benchmark-system
data:
  pod-template.yaml: |
    apiVersion: v1
    kind: Pod
    metadata:
      name: {{.Name}}
      labels:
        app: benchmark-pod
    spec:
      schedulerName: {{.SchedulerName}}
      restartPolicy: Always
      terminationGracePeriodSeconds: 30
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: benchmark-role
                    operator: In
                    values:
                      - workload
      tolerations:
        - key: benchmark-role
          operator: Equal
          value: workload
          effect: NoSchedule
        - key: node.kubernetes.io/not-ready
          operator: Exists
          effect: NoExecute
          tolerationSeconds: 300
        - key: node.kubernetes.io/unreachable
          operator: Exists
          effect: NoExecute
          tolerationSeconds: 300
      containers:
        - name: pause
          image: <small-test-image>
          imagePullPolicy: IfNotPresent
          resources:
            requests:
              cpu: "1"
              memory: 10Mi
            limits:
              cpu: "1"
              memory: 10Mi
```

Run the benchmark manually:

```bash
kubectl -n benchmark-system create job sandbox-scheduler-loadtest-manual-$(date +%Y%m%d%H%M%S) --from=cronjob/sandbox-scheduler-loadtest
kubectl -n benchmark-system logs -f job/<created-job-name>
```

Minimal sanitized simulated-node setup:

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: node-simulator
---
apiVersion: v1
kind: Secret
metadata:
  name: simulator-target-kubeconfig
  namespace: node-simulator
type: Opaque
stringData:
  kubelet.kubeconfig: |
    apiVersion: v1
    kind: Config
    clusters:
      - name: benchmark-target
        cluster:
          server: https://<target-apiserver>:6443
          certificate-authority-data: <base64-ca>
    contexts:
      - name: benchmark-target
        context:
          cluster: benchmark-target
          user: simulated-kubelet
    current-context: benchmark-target
    users:
      - name: simulated-kubelet
        user:
          client-certificate-data: <base64-client-cert>
          client-key-data: <base64-client-key>
---
apiVersion: v1
kind: ReplicationController
metadata:
  name: simulated-node
  namespace: node-simulator
  labels:
    app: simulated-node
spec:
  replicas: 1000
  selector:
    app: simulated-node
  template:
    metadata:
      labels:
        app: simulated-node
    spec:
      automountServiceAccountToken: false
      restartPolicy: Always
      tolerations:
        - operator: Exists
      initContainers:
        - name: init-inotify-limit
          image: busybox:1.36
          command:
            - sysctl
            - -w
            - fs.inotify.max_user_instances=1000
          securityContext:
            privileged: true
      containers:
        - name: simulated-kubelet
          image: <kubemark-image-compatible-with-k8s-1.35>
          imagePullPolicy: IfNotPresent
          securityContext:
            privileged: true
          command:
            - /kubemark
            - --morph=kubelet
            - --name=$(NODE_NAME)
            - --kubeconfig=/kubeconfig/kubelet.kubeconfig
            - --logtostderr=true
            - --max-pods=256
            - --v=2
            - --extended-resources=example.com/fake-resource=1000
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
          resources:
            requests:
              cpu: 50m
              memory: 100M
          volumeMounts:
            - name: target-kubeconfig
              mountPath: /kubeconfig
              readOnly: true
        - name: simulated-proxy
          image: <kubemark-image-compatible-with-k8s-1.35>
          imagePullPolicy: IfNotPresent
          command:
            - /kubemark
            - --morph=proxy
            - --name=$(NODE_NAME)
            - --kubeconfig=/kubeconfig/kubelet.kubeconfig
            - --logtostderr=true
            - --v=2
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
          resources:
            requests:
              cpu: 50m
              memory: 100M
          volumeMounts:
            - name: target-kubeconfig
              mountPath: /kubeconfig
              readOnly: true
      volumes:
        - name: target-kubeconfig
          secret:
            secretName: simulator-target-kubeconfig
```

Simulated node creation flow:

```bash
kubectl apply -f simulated-node.yaml
kubectl -n node-simulator scale rc simulated-node --replicas=1000
kubectl get nodes | grep simulated-node
kubectl label node -l '<simulated-node-selector>' benchmark-role=workload
kubectl taint node -l '<simulated-node-selector>' benchmark-role=workload:NoSchedule
```

Important notes for the benchmark YAML:

- The benchmark driver should run on a real node labeled `benchmark-role=driver`.
- Benchmark pods are scheduled onto nodes labeled `benchmark-role=workload`.
- The simulated-node setup still needs a kubeconfig secret because the simulated kubelet must know which target apiserver to register nodes into. This is different from local `kubectl --kubeconfig ...` usage and should be replaced with the target cluster’s own test credential before running.
- For this PR, the expected scheduler profile name is `koord-scheduler-sandbox`.

### Ⅳ. Special notes for reviews

- `SandboxScheduling` is disabled by default, so existing scheduler behavior is unchanged unless the feature gate is explicitly enabled.
- The auto-generated sandbox profile is derived from the first configured profile. This keeps the same hard constraints and bind path as the normal profile, but intentionally removes score/pre-score work.
- If users need a fully customized sandbox profile, they can define `schedulerName: koord-scheduler-sandbox` explicitly; this PR will not overwrite it.
- The reported QPS numbers require apiserver and webhook tuning in the benchmark environment. Without those changes, pod creation or admission may become the bottleneck before scheduler profiling is meaningful.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`