### PR TITLE
koordlet: count still-present evicted pods as pending release

### DIFF
--- a/apis/extension/constants.go
+++ b/apis/extension/constants.go
@@ -55,6 +55,12 @@ const (
 	// When this annotation is missing, there are no policy restrictions
 	AnnotationPodEvictPolicy = DomainPrefix + "eviction-policy"
 
+	// AnnotationPodEvictionPriority is the pod-level eviction priority (int32 string, negative allowed).
+	// In the koordlet resource eviction (e.g. MemoryEvict, CPUEvict), pods with lower values are evicted
+	// before pods with higher values, taking precedence over spec.priority and the koordinator.sh/priority
+	// label. Pods without the annotation take the implicit priority 0.
+	AnnotationPodEvictionPriority = DomainPrefix + "eviction-priority"
+
 	// LabelPodSkipEnhancedValidation is the pod label key used to opt out a pod from enhanced validation.
 	LabelPodSkipEnhancedValidation = PodDomainPrefix + "/skip-enhanced-validation"
 

--- a/apis/extension/evict.go
+++ b/apis/extension/evict.go
@@ -37,7 +37,8 @@ func PodEvictEnabled(pod *corev1.Pod) bool {
 }
 
 // GetPodEvictionPriority parses the eviction priority from the pod annotations.
-// It returns the implicit priority 0 when the annotation is missing or invalid.
+// It returns the implicit priority 0 when the annotation is missing; when the value is invalid,
+// it returns 0 along with a non-nil error.
 func GetPodEvictionPriority(pod *corev1.Pod) (int32, error) {
 	if pod == nil || pod.Annotations == nil {
 		return 0, nil

--- a/apis/extension/evict.go
+++ b/apis/extension/evict.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package extension
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func PodEvictEnabled(pod *corev1.Pod) bool {
 	if pod == nil {
@@ -29,4 +34,22 @@ func PodEvictEnabled(pod *corev1.Pod) bool {
 		return false
 	}
 	return true
+}
+
+// GetPodEvictionPriority parses the eviction priority from the pod annotations.
+// It returns the implicit priority 0 when the annotation is missing or invalid.
+func GetPodEvictionPriority(pod *corev1.Pod) (int32, error) {
+	if pod == nil || pod.Annotations == nil {
+		return 0, nil
+	}
+	value, exist := pod.Annotations[AnnotationPodEvictionPriority]
+	if !exist {
+		return 0, nil
+	}
+	i, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		// make sure we default to 0 on error
+		return 0, fmt.Errorf("invalid value %q, err: %w", value, err)
+	}
+	return int32(i), nil
 }

--- a/apis/extension/evict_test.go
+++ b/apis/extension/evict_test.go
@@ -96,3 +96,70 @@ func Test_PodEvictDisabled(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetPodEvictionPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected int32
+		wantErr  bool
+	}{
+		{
+			name:     "nil pod",
+			pod:      nil,
+			expected: 0,
+		},
+		{
+			name: "no annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"xxx": "xxx",
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "invalid value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationPodEvictionPriority: "xxx",
+					},
+				},
+			},
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name: "positive value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationPodEvictionPriority: "100",
+					},
+				},
+			},
+			expected: 100,
+		},
+		{
+			name: "negative value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationPodEvictionPriority: "-10",
+					},
+				},
+			},
+			expected: -10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := GetPodEvictionPriority(tt.pod)
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.wantErr, gotErr != nil)
+		})
+	}
+}

--- a/pkg/koordlet/qosmanager/plugins/cpuevict/cpu_evict.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuevict/cpu_evict.go
@@ -529,7 +529,12 @@ func (c *cpuEvictor) getPodEvictInfoAndSortByPriority(evictionPolicy string, pri
 		if !apiext.PodEvictEnabled(pod) {
 			continue
 		}
-		// 3. sort :  koordinator.sh/priority
+		// 3. sort :  koordinator.sh/eviction-priority > spec.priority > koordinator.sh/priority
+		evictionPriority, err := apiext.GetPodEvictionPriority(pod)
+		if err != nil {
+			klog.Warningf("failed to parse eviction priority of pod %s/%s, use the default 0, err: %v", pod.Namespace, pod.Name, err)
+		}
+		podInfo.EvictionPriority = evictionPriority
 		podPriority := qosmanagerUtil.GetPodPriorityLabel(pod, int64(podInfo.Priority))
 		podInfo.LabelPriority = podPriority
 		// 4. filter no metrics
@@ -550,6 +555,9 @@ func (c *cpuEvictor) getPodEvictInfoAndSortByPriority(evictionPolicy string, pri
 	}
 
 	sort.Slice(podsInfos, func(i, j int) bool {
+		if podsInfos[i].EvictionPriority != podsInfos[j].EvictionPriority {
+			return podsInfos[i].EvictionPriority < podsInfos[j].EvictionPriority
+		}
 		if podsInfos[i].Priority != podsInfos[j].Priority {
 			return podsInfos[i].Priority < podsInfos[j].Priority
 		}

--- a/pkg/koordlet/qosmanager/plugins/cpuevict/cpu_evict_test.go
+++ b/pkg/koordlet/qosmanager/plugins/cpuevict/cpu_evict_test.go
@@ -1320,6 +1320,58 @@ type podCPUSample struct {
 	}
 }
 
+func Test_getPodEvictInfoAndSortByPriority(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	podEvictPriority100 := createCPUEvictTestPodWithLabels("test_evictPriority_100", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true", apiext.LabelPodPriority: "3000"}, corev1.PodRunning)
+	podEvictPriority100.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "100"}
+	podEvictPriorityNegative := createCPUEvictTestPodWithLabels("test_evictPriority_negative", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true", apiext.LabelPodPriority: "4000"}, corev1.PodRunning)
+	podEvictPriorityNegative.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "-1"}
+	podEvictPriorityUnset := createCPUEvictTestPodWithLabels("test_evictPriority_unset", apiext.QoSBE, 100, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
+	podEvictPriorityInvalid := createCPUEvictTestPodWithLabels("test_evictPriority_invalid", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
+	podEvictPriorityInvalid.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "invalid"}
+	pods := []*corev1.Pod{podEvictPriority100, podEvictPriorityNegative, podEvictPriorityUnset, podEvictPriorityInvalid}
+	podMetrics := []podCPUSample{
+		{UID: "test_evictPriority_100", CpuUsed: resource.MustParse("4")},
+		{UID: "test_evictPriority_negative", CpuUsed: resource.MustParse("1")},
+		{UID: "test_evictPriority_unset", CpuUsed: resource.MustParse("2")},
+		{UID: "test_evictPriority_invalid", CpuUsed: resource.MustParse("3")},
+	}
+
+	mockMetricCache := mock_metriccache.NewMockMetricCache(ctl)
+	mockResultFactory := mock_metriccache.NewMockAggregateResultFactory(ctl)
+	originalFactory := metriccache.DefaultAggregateResultFactory
+	metriccache.DefaultAggregateResultFactory = mockResultFactory
+	defer func() { metriccache.DefaultAggregateResultFactory = originalFactory }()
+	mockQuerier := mock_metriccache.NewMockQuerier(ctl)
+	mockMetricCache.EXPECT().Querier(gomock.Any(), gomock.Any()).Return(mockQuerier, nil).AnyTimes()
+	for _, podMetric := range podMetrics {
+		result := mock_metriccache.NewMockAggregateResult(ctl)
+		result.EXPECT().Value(gomock.Any()).Return(float64(podMetric.CpuUsed.Value()), nil).AnyTimes()
+		result.EXPECT().Count().Return(1).AnyTimes()
+		podQueryMeta, err := metriccache.PodCPUUsageMetric.BuildQueryMeta(metriccache.MetricPropertiesFunc.Pod(podMetric.UID))
+		assert.NoError(t, err)
+		mockResultFactory.EXPECT().New(podQueryMeta).Return(result).AnyTimes()
+		mockQuerier.EXPECT().QueryAndClose(podQueryMeta, gomock.Any(), gomock.Any()).SetArg(2, *result).Return(nil).AnyTimes()
+	}
+
+	c := &cpuEvictor{
+		metricCache:           mockMetricCache,
+		metricCollectInterval: time.Second,
+	}
+	res := c.getPodEvictInfoAndSortByPriority(string(features.CPUEvict), 3000, testutil.GetPodMetas(pods), func(a, b *qosmanagerUtil.PodEvictInfo) bool {
+		return a.MilliCPUUsed > b.MilliCPUUsed
+	})
+	// eviction-priority takes precedence over spec.priority and the priority label:
+	// -1 < 0 (unset, spec.priority 100) < 0 (invalid, spec.priority 120) < 100
+	expectPodEvictNames := []string{"test_evictPriority_negative", "test_evictPriority_unset", "test_evictPriority_invalid", "test_evictPriority_100"}
+	assert.Equal(t, len(expectPodEvictNames), len(res))
+	for k, podEvictInfo := range res {
+		assert.Equal(t, expectPodEvictNames[k], podEvictInfo.Pod.Name)
+	}
+}
+
 func Test_cpuEvict(t *testing.T) {
 	klog.InitFlags(nil)
 	flag.Set("v", "5")

--- a/pkg/koordlet/qosmanager/plugins/memoryevict/memory_evict.go
+++ b/pkg/koordlet/qosmanager/plugins/memoryevict/memory_evict.go
@@ -428,7 +428,12 @@ func (m *memoryEvictor) getPodEvictInfoAndSortByPriority(evictionPolicy string, 
 		if !apiext.PodEvictEnabled(pod) {
 			continue
 		}
-		// 3. sort :  koordinator.sh/priority
+		// 3. sort :  koordinator.sh/eviction-priority > spec.priority > koordinator.sh/priority
+		evictionPriority, err := apiext.GetPodEvictionPriority(pod)
+		if err != nil {
+			klog.Warningf("failed to parse eviction priority of pod %s/%s, use the default 0, err: %v", pod.Namespace, pod.Name, err)
+		}
+		podInfo.EvictionPriority = evictionPriority
 		podPriority := qosmanagerUtil.GetPodPriorityLabel(pod, int64(podInfo.Priority))
 		podInfo.LabelPriority = podPriority
 		// 4. filter no metrics
@@ -449,6 +454,9 @@ func (m *memoryEvictor) getPodEvictInfoAndSortByPriority(evictionPolicy string, 
 	}
 
 	sort.Slice(podsInfos, func(i, j int) bool {
+		if podsInfos[i].EvictionPriority != podsInfos[j].EvictionPriority {
+			return podsInfos[i].EvictionPriority < podsInfos[j].EvictionPriority
+		}
 		if podsInfos[i].Priority != podsInfos[j].Priority {
 			return podsInfos[i].Priority < podsInfos[j].Priority
 		}

--- a/pkg/koordlet/qosmanager/plugins/memoryevict/memory_evict_test.go
+++ b/pkg/koordlet/qosmanager/plugins/memoryevict/memory_evict_test.go
@@ -991,6 +991,13 @@ func Test_getPodEvictInfoAndSortByPriority(t *testing.T) {
 	pod5 := createMemoryEvictTestPodWithLabels("test_podPriority_120_4000", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true", apiext.LabelPodPriority: "4000"}, corev1.PodRunning)
 	pod6 := createMemoryEvictTestPodWithLabels("test_podPriority_100_9999", apiext.QoSBE, 100, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
 	pod7 := createMemoryEvictTestPodWithLabels("test_podPriority_100_9999_1", apiext.QoSBE, 100, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
+	podEvictPriority100 := createMemoryEvictTestPodWithLabels("test_evictPriority_100", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true", apiext.LabelPodPriority: "3000"}, corev1.PodRunning)
+	podEvictPriority100.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "100"}
+	podEvictPriorityNegative := createMemoryEvictTestPodWithLabels("test_evictPriority_negative", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true", apiext.LabelPodPriority: "4000"}, corev1.PodRunning)
+	podEvictPriorityNegative.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "-1"}
+	podEvictPriorityUnset := createMemoryEvictTestPodWithLabels("test_evictPriority_unset", apiext.QoSBE, 100, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
+	podEvictPriorityInvalid := createMemoryEvictTestPodWithLabels("test_evictPriority_invalid", apiext.QoSBE, 120, map[string]string{apiext.LabelPodEvictEnabled: "true"}, corev1.PodRunning)
+	podEvictPriorityInvalid.Annotations = map[string]string{apiext.AnnotationPodEvictionPriority: "invalid"}
 	tests := []struct {
 		name                string
 		pods                []*corev1.Pod
@@ -1022,6 +1029,28 @@ func Test_getPodEvictInfoAndSortByPriority(t *testing.T) {
 				EvictEnabledPriorityThreshold: ptr.To[int32](3000),
 			}, // >91.2G
 			expectPodEvictNames: []string{"test_podPriority_100_9999_1", "test_podPriority_100_9999", "test_podPriority_120_2000", "test_podPriority_120_3000", "test_podPriority_120_4000"},
+		},
+		{
+			name: "test_memoryevict_sort_by_eviction_priority_annotation",
+			node: testutil.MockTestNode("80", "120G"),
+			pods: []*corev1.Pod{
+				podEvictPriority100, podEvictPriorityNegative, podEvictPriorityUnset, podEvictPriorityInvalid,
+			},
+			nodeMemUsed: resource.MustParse("115G"),
+			podMetrics: []podMemSample{
+				{UID: "test_evictPriority_100", MemUsed: resource.MustParse("40G")},
+				{UID: "test_evictPriority_negative", MemUsed: resource.MustParse("5G")},
+				{UID: "test_evictPriority_unset", MemUsed: resource.MustParse("10G")},
+				{UID: "test_evictPriority_invalid", MemUsed: resource.MustParse("20G")},
+			},
+			thresholdConfig: &slov1alpha1.ResourceThresholdStrategy{
+				Enable:                        ptr.To[bool](true),
+				MemoryEvictThresholdPercent:   ptr.To[int64](80),
+				EvictEnabledPriorityThreshold: ptr.To[int32](3000),
+			},
+			// eviction-priority takes precedence over spec.priority and the priority label:
+			// -1 < 0 (unset, spec.priority 100) < 0 (invalid, spec.priority 120) < 100
+			expectPodEvictNames: []string{"test_evictPriority_negative", "test_evictPriority_unset", "test_evictPriority_invalid", "test_evictPriority_100"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/koordlet/qosmanager/plugins/util/evict.go
+++ b/pkg/koordlet/qosmanager/plugins/util/evict.go
@@ -57,6 +57,9 @@ type PodEvictInfo struct {
 	// sort helper
 	Priority      int32
 	LabelPriority int64
+	// EvictionPriority is from the annotation koordinator.sh/eviction-priority (implicit 0 when unset).
+	// Pods with lower values are evicted first, taking precedence over Priority and LabelPriority.
+	EvictionPriority int32
 }
 
 type EvictTaskInfo struct {

--- a/pkg/koordlet/qosmanager/plugins/util/evict.go
+++ b/pkg/koordlet/qosmanager/plugins/util/evict.go
@@ -160,8 +160,9 @@ func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, task
 		releaseTarget := task.ReleaseTarget
 		podInfos := task.SortedEvictPods
 		releaseReason := task.Reason
-		needToRelease := subReleaseListNoNegative(task.ToReleaseResource, releasedAll[releaseTarget])
-		if len(needToRelease) == 0 || isZeroResourceList(needToRelease) {
+		// releasedAll accumulates across tasks, so the completion check compares the task's
+		// original target against the accumulated release to avoid double subtraction
+		if len(subReleaseListNoNegative(task.ToReleaseResource, releasedAll[releaseTarget])) == 0 {
 			continue
 		}
 		for _, info := range podInfos {
@@ -176,7 +177,7 @@ func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, task
 				evictedPodsMp[podKey] = true
 				addResource(releasedAll, aggregateReleaseFunc(info))
 				klog.V(4).Infof("pod %s was evicted but still present, count as pending release, release reason: %v", podKey, releaseReason)
-				if len(subReleaseListNoNegative(needToRelease, releasedAll[releaseTarget])) == 0 {
+				if len(subReleaseListNoNegative(task.ToReleaseResource, releasedAll[releaseTarget])) == 0 {
 					break
 				}
 				continue
@@ -188,7 +189,7 @@ func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, task
 				newlyEvicted = true
 				resource := aggregateReleaseFunc(info)
 				addResource(releasedAll, resource)
-				if len(subReleaseListNoNegative(needToRelease, releasedAll[releaseTarget])) == 0 {
+				if len(subReleaseListNoNegative(task.ToReleaseResource, releasedAll[releaseTarget])) == 0 {
 					break
 				}
 			} else {

--- a/pkg/koordlet/qosmanager/plugins/util/evict.go
+++ b/pkg/koordlet/qosmanager/plugins/util/evict.go
@@ -116,6 +116,7 @@ func InitializeEvictionExecutor(evictor *Evictor, onlyEvictByAPI bool) EvictionE
 func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, tasks []*EvictTaskInfo) (ReleaseList, bool) {
 	releasedAll := make(ReleaseList)
 	evictedPodsMp := make(map[string]bool)
+	newlyEvicted := false
 	releaseTypes := make(map[ReleaseTargetType][]corev1.ResourceName)
 	var getPodResourceFuncs []func(*PodEvictInfo) ReleaseList
 	for _, task := range tasks {
@@ -164,17 +165,27 @@ func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, task
 			continue
 		}
 		for _, info := range podInfos {
-			if evictionExecutor.IsPodEvicted(info.Pod) {
-				continue
-			}
 			podKey := util.GetPodKey(info.Pod)
 			if evictedPodsMp[podKey] {
+				continue
+			}
+			if evictionExecutor.IsPodEvicted(info.Pod) {
+				// The pod was evicted in a previous round but is still present, e.g. terminating
+				// or waiting for an external evictor. Count its resource as pending release so
+				// that extra victims are not picked for the same pressure.
+				evictedPodsMp[podKey] = true
+				addResource(releasedAll, aggregateReleaseFunc(info))
+				klog.V(4).Infof("pod %s was evicted but still present, count as pending release, release reason: %v", podKey, releaseReason)
+				if len(subReleaseListNoNegative(needToRelease, releasedAll[releaseTarget])) == 0 {
+					break
+				}
 				continue
 			}
 			successEvict := evictionExecutor.Evict(info.Pod, node, EvictedStr, fmt.Sprintf("%v, kill pod: %v", releaseReason, info.Pod.Name))
 			if successEvict {
 				klog.V(4).Infof("successfully picked pod %s to evict, release reason: %v", podKey, releaseReason)
 				evictedPodsMp[podKey] = true
+				newlyEvicted = true
 				resource := aggregateReleaseFunc(info)
 				addResource(releasedAll, resource)
 				if len(subReleaseListNoNegative(needToRelease, releasedAll[releaseTarget])) == 0 {
@@ -185,7 +196,7 @@ func KillAndEvictPods(evictionExecutor EvictionExecutor, node *corev1.Node, task
 			}
 		}
 	}
-	return releasedAll, len(evictedPodsMp) > 0
+	return releasedAll, newlyEvicted
 }
 
 func IsEvictionPolicyAllowed(policy string, pod *corev1.Pod) bool {

--- a/pkg/koordlet/qosmanager/plugins/util/evict_test.go
+++ b/pkg/koordlet/qosmanager/plugins/util/evict_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
@@ -1130,6 +1131,78 @@ func Test_KillAndEvictPods(t *testing.T) {
 		assert.True(t, cpuReleased.Value() >= 1500, "BatchCPU should be released at least 1200m")
 		assert.True(t, cpuReleased.Value() == 2000)
 	}
+}
+
+func Test_KillAndEvictPods_PendingRelease(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-3",
+		},
+	}
+	newBEPodInfo := func(name string, memUsed int64) *PodEvictInfo {
+		return &PodEvictInfo{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					UID:       types.UID(name + "-uid"),
+					Labels: map[string]string{
+						apiext.LabelPodQoS: string(apiext.QoSBE),
+					},
+				},
+			},
+			MemoryUsed: memUsed,
+		}
+	}
+	newTasks := func(toRelease int64, pods ...*PodEvictInfo) []*EvictTaskInfo {
+		return []*EvictTaskInfo{
+			{
+				Reason:        "evict-by-memory-usage",
+				ReleaseTarget: ReleaseTargetTypeResourceUsed,
+				ToReleaseResource: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(toRelease, resource.BinarySI),
+				},
+				SortedEvictPods: pods,
+				GetPodResourceFunc: func(podInfo *PodEvictInfo) corev1.ResourceList {
+					return corev1.ResourceList{
+						corev1.ResourceMemory: *resource.NewQuantity(podInfo.MemoryUsed, resource.BinarySI),
+					}
+				},
+			},
+		}
+	}
+
+	t.Run("pending release satisfies the target, no new victim picked", func(t *testing.T) {
+		ctl := gomock.NewController(t)
+		defer ctl.Finish()
+		markedPod := newBEPodInfo("marked-pod", 2*1024*1024*1024)
+		otherPod := newBEPodInfo("other-pod", 1024*1024*1024)
+		executor := NewMockEvictionExecutor(ctl)
+		executor.EXPECT().IsPodEvicted(markedPod.Pod).Return(true).AnyTimes()
+		executor.EXPECT().IsPodEvicted(otherPod.Pod).Return(false).AnyTimes()
+		// no Evict expectation: any eviction fails the test
+
+		released, hasReleased := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
+		assert.False(t, hasReleased, "pending release should not count as a new eviction")
+		memoryReleased := released[ReleaseTargetTypeResourceUsed][corev1.ResourceMemory]
+		assert.Equal(t, int64(2*1024*1024*1024), memoryReleased.Value())
+	})
+
+	t.Run("pending release insufficient, evict the next victim", func(t *testing.T) {
+		ctl := gomock.NewController(t)
+		defer ctl.Finish()
+		markedPod := newBEPodInfo("marked-pod", 1024*1024*1024)
+		otherPod := newBEPodInfo("other-pod", 2*1024*1024*1024)
+		executor := NewMockEvictionExecutor(ctl)
+		executor.EXPECT().IsPodEvicted(markedPod.Pod).Return(true).AnyTimes()
+		executor.EXPECT().IsPodEvicted(otherPod.Pod).Return(false).AnyTimes()
+		executor.EXPECT().Evict(otherPod.Pod, node, gomock.Any(), gomock.Any()).Return(true).Times(1)
+
+		released, hasReleased := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
+		assert.True(t, hasReleased)
+		memoryReleased := released[ReleaseTargetTypeResourceUsed][corev1.ResourceMemory]
+		assert.Equal(t, int64(3*1024*1024*1024), memoryReleased.Value())
+	})
 }
 
 func Test_mergeResourceListByMax(t *testing.T) {

--- a/pkg/koordlet/qosmanager/plugins/util/evict_test.go
+++ b/pkg/koordlet/qosmanager/plugins/util/evict_test.go
@@ -1182,8 +1182,8 @@ func Test_KillAndEvictPods_PendingRelease(t *testing.T) {
 		executor.EXPECT().IsPodEvicted(otherPod.Pod).Return(false).AnyTimes()
 		// no Evict expectation: any eviction fails the test
 
-		released, hasReleased := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
-		assert.False(t, hasReleased, "pending release should not count as a new eviction")
+		released, hasNewlyEvicted := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
+		assert.False(t, hasNewlyEvicted, "pending release should not count as a new eviction")
 		memoryReleased := released[ReleaseTargetTypeResourceUsed][corev1.ResourceMemory]
 		assert.Equal(t, int64(2*1024*1024*1024), memoryReleased.Value())
 	})
@@ -1198,8 +1198,8 @@ func Test_KillAndEvictPods_PendingRelease(t *testing.T) {
 		executor.EXPECT().IsPodEvicted(otherPod.Pod).Return(false).AnyTimes()
 		executor.EXPECT().Evict(otherPod.Pod, node, gomock.Any(), gomock.Any()).Return(true).Times(1)
 
-		released, hasReleased := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
-		assert.True(t, hasReleased)
+		released, hasNewlyEvicted := KillAndEvictPods(executor, node, newTasks(2*1024*1024*1024, markedPod, otherPod))
+		assert.True(t, hasNewlyEvicted)
 		memoryReleased := released[ReleaseTargetTypeResourceUsed][corev1.ResourceMemory]
 		assert.Equal(t, int64(3*1024*1024*1024), memoryReleased.Value())
 	})


### PR DESCRIPTION
When a victim pod evicted in a previous round is still present (e.g. terminating), its resource is credited as pending release so that extra victims are not picked for the same memory/cpu pressure. Rounds that only credit pending release do not refresh the eviction cooling time.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: refine MemoryEvict when the pod eviction is stuck.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
