### PR TITLE
koordlet: support pod-level oom_score_adj hot update

### DIFF
--- a/apis/extension/constants.go
+++ b/apis/extension/constants.go
@@ -65,6 +65,19 @@ const (
 	// AnnotationPodPreAllocatablePriority is the annotation key used to prioritize pre-allocatable pods in cluster mode.
 	// The value should be a numeric string. Higher values indicate higher priority for pre-allocation.
 	AnnotationPodPreAllocatablePriority = PodDomainPrefix + "/pre-allocatable-priority"
+
+	// AnnotationOOMScoreAdj is the pod-level default oom_score_adj value (int64 string, range [-1000, 1000]).
+	// The koordlet periodically reconciles the value to /proc/<pid>/oom_score_adj of all processes of the
+	// pod's containers (including init/sidecar containers), so it supports hot-updating without restarting
+	// the containers, with a latency up to the reconcile interval. Note that:
+	// 1. The sandbox (pause) container is not affected since its oom_score_adj is managed by the runtime.
+	// 2. Removing the annotation does NOT revert the processes to the runtime default values.
+	AnnotationOOMScoreAdj = DomainPrefix + "oom-score-adj"
+
+	// AnnotationOOMScoreAdjSpec is the container-level oom_score_adj spec in JSON format.
+	// Example: {"container-a": -500, "container-b": 200}
+	// Containers not listed here fall back to AnnotationOOMScoreAdj; if neither is set, no intervention is made.
+	AnnotationOOMScoreAdjSpec = DomainPrefix + "oom-score-adj-spec"
 )
 
 type AggregationType string

--- a/pkg/koordlet/metrics/internal_metrics.go
+++ b/pkg/koordlet/metrics/internal_metrics.go
@@ -42,6 +42,7 @@ func init() {
 	internalMustRegister(CPUSetCollector...)
 	internalMustRegister(PredictionCollectors...)
 	internalMustRegister(CoreSchedCollector...)
+	internalMustRegister(OOMScoreAdjCollector...)
 	internalMustRegister(ResourceExecutorCollector...)
 	internalMustRegister(KubeletStubCollector...)
 	internalMustRegister(RuntimeHookCollectors...)

--- a/pkg/koordlet/metrics/oom_score_adj.go
+++ b/pkg/koordlet/metrics/oom_score_adj.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/koordinator-sh/koordinator/pkg/util/metrics"
+)
+
+var (
+	ContainerOOMScoreAdj = metrics.NewGCGaugeVec("container_oom_score_adj", prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "container_oom_score_adj",
+		Help:      "the oom_score_adj value set for the container",
+	}, []string{NodeKey, PodName, PodNamespace, PodUID, ContainerName}))
+
+	OOMScoreAdjCollector = []prometheus.Collector{
+		ContainerOOMScoreAdj.GetGaugeVec(),
+	}
+)
+
+// RecordContainerOOMScoreAdj records the oom_score_adj value for a container.
+func RecordContainerOOMScoreAdj(namespace, podName, podUID, containerName string, val int64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[PodNamespace] = namespace
+	labels[PodName] = podName
+	labels[PodUID] = podUID
+	labels[ContainerName] = containerName
+	ContainerOOMScoreAdj.WithSet(labels, float64(val))
+}

--- a/pkg/koordlet/runtimehooks/config.go
+++ b/pkg/koordlet/runtimehooks/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/cpuset"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/gpu"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/groupidentity"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/oomscoreadj"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/rdma"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/resctrl"
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks/tc"
@@ -101,6 +102,12 @@ const (
 	// owner: @kangclzjc @saintube @zwzhang0107
 	// alpha: v1.5
 	Resctrl featuregate.Feature = "Resctrl"
+
+	// OOMScoreAdj manages per-container /proc/<pid>/oom_score_adj via pod annotations.
+	//
+	// owner: @saintube
+	// alpha: v1.8
+	OOMScoreAdj featuregate.Feature = "OOMScoreAdj"
 )
 
 var (
@@ -115,6 +122,7 @@ var (
 		TerwayQoS:        {Default: false, PreRelease: featuregate.Alpha},
 		TCNetworkQoS:     {Default: false, PreRelease: featuregate.Alpha},
 		Resctrl:          {Default: false, PreRelease: featuregate.Alpha},
+		OOMScoreAdj:      {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	runtimeHookPlugins = map[featuregate.Feature]HookPlugin{
@@ -128,6 +136,7 @@ var (
 		TerwayQoS:        terwayqos.Object(),
 		TCNetworkQoS:     tc.Object(),
 		Resctrl:          resctrl.Object(),
+		OOMScoreAdj:      oomscoreadj.Object(),
 	}
 )
 

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
@@ -72,8 +72,9 @@ func getContainerPIDs(reader resourceexecutor.CgroupReader, cgroupParent string)
 	return pids, nil
 }
 
-// setOOMScoreAdjForPIDs writes the target oom_score_adj to each PID via the given interface,
-// skipping PIDs that already match. Returns (updated, skipped).
+// setOOMScoreAdjForPIDs writes the target oom_score_adj to each PID via the given interface.
+// It returns the count of updated PIDs and the count of PIDs skipped due to read/write errors;
+// PIDs already matching the target are neither updated nor counted as skipped.
 func setOOMScoreAdjForPIDs(ome sysutil.OOMScoreAdjInterface, pids []uint32, target int64) (int, int) {
 	var updated, skipped int
 	for _, pid := range pids {

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
@@ -75,10 +75,10 @@ func getContainerPIDs(reader resourceexecutor.CgroupReader, cgroupParent string)
 // setOOMScoreAdjForPIDs writes the target oom_score_adj to each PID via the given interface.
 // It returns the count of updated PIDs and the count of PIDs skipped due to read/write errors;
 // PIDs already matching the target are neither updated nor counted as skipped.
-func setOOMScoreAdjForPIDs(ome sysutil.OOMScoreAdjInterface, pids []uint32, target int64) (int, int) {
+func setOOMScoreAdjForPIDs(operator sysutil.OOMScoreAdjInterface, pids []uint32, target int64) (int, int) {
 	var updated, skipped int
 	for _, pid := range pids {
-		current, err := ome.Get(pid)
+		current, err := operator.Get(pid)
 		if err != nil {
 			klog.V(5).Infof("failed to read oom_score_adj for pid %d, skipping: %s", pid, err)
 			skipped++
@@ -87,7 +87,7 @@ func setOOMScoreAdjForPIDs(ome sysutil.OOMScoreAdjInterface, pids []uint32, targ
 		if current == target {
 			continue
 		}
-		if err := ome.Set(pid, target); err != nil {
+		if err := operator.Set(pid, target); err != nil {
 			klog.V(4).Infof("failed to write oom_score_adj=%d for pid %d: %s", target, pid, err)
 			skipped++
 			continue

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+// getOOMScoreAdjForContainer returns the target oom_score_adj for the given container.
+// It first checks AnnotationOOMScoreAdjSpec (per-container JSON map), then falls back to
+// AnnotationOOMScoreAdj (pod-level default). Returns (nil, nil) if neither is set.
+func getOOMScoreAdjForContainer(podAnnotations map[string]string, containerName string) (*int64, error) {
+	if podAnnotations == nil {
+		return nil, nil
+	}
+
+	// Try per-container spec first.
+	if spec, ok := podAnnotations[extension.AnnotationOOMScoreAdjSpec]; ok && spec != "" {
+		containerSpec := map[string]int64{}
+		if err := json.Unmarshal([]byte(spec), &containerSpec); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s as JSON: %w", extension.AnnotationOOMScoreAdjSpec, err)
+		}
+		if val, exists := containerSpec[containerName]; exists {
+			return &val, nil
+		}
+	}
+
+	// Fall back to pod-level default.
+	if defaultVal, ok := podAnnotations[extension.AnnotationOOMScoreAdj]; ok && defaultVal != "" {
+		val, err := strconv.ParseInt(defaultVal, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s as int64: %w", extension.AnnotationOOMScoreAdj, err)
+		}
+		return &val, nil
+	}
+
+	return nil, nil
+}
+
+// getContainerPIDs reads the PIDs from the container's cgroup directory.
+func getContainerPIDs(reader resourceexecutor.CgroupReader, cgroupParent string) ([]uint32, error) {
+	pids, err := reader.ReadCPUProcs(cgroupParent)
+	if err != nil && resourceexecutor.IsCgroupDirErr(err) {
+		klog.V(5).Infof("aborted to get PIDs for container dir %s, err: %s", cgroupParent, err)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get container PIDs failed, err: %w", err)
+	}
+	return pids, nil
+}
+
+// setOOMScoreAdjForPIDs writes the target oom_score_adj to each PID via the given interface,
+// skipping PIDs that already match. Returns (updated, skipped).
+func setOOMScoreAdjForPIDs(ome sysutil.OOMScoreAdjInterface, pids []uint32, target int64) (int, int) {
+	var updated, skipped int
+	for _, pid := range pids {
+		current, err := ome.Get(pid)
+		if err != nil {
+			klog.V(5).Infof("failed to read oom_score_adj for pid %d, skipping: %s", pid, err)
+			skipped++
+			continue
+		}
+		if current == target {
+			continue
+		}
+		if err := ome.Set(pid, target); err != nil {
+			klog.V(4).Infof("failed to write oom_score_adj=%d for pid %d: %s", target, pid, err)
+			skipped++
+			continue
+		}
+		updated++
+	}
+	return updated, skipped
+}

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/helper_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func Test_getOOMScoreAdjForContainer(t *testing.T) {
+	tests := []struct {
+		name           string
+		podAnnotations map[string]string
+		containerName  string
+		want           *int64
+		wantErr        bool
+	}{
+		{
+			name:           "nil annotations",
+			podAnnotations: nil,
+			containerName:  "c1",
+			want:           nil,
+			wantErr:        false,
+		},
+		{
+			name:           "no oom score adj annotations",
+			podAnnotations: map[string]string{"foo": "bar"},
+			containerName:  "c1",
+			want:           nil,
+			wantErr:        false,
+		},
+		{
+			name: "pod-level default applied",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdj: "-500",
+			},
+			containerName: "c1",
+			want:          ptr.To[int64](-500),
+			wantErr:       false,
+		},
+		{
+			name: "container spec overrides pod-level default",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdj:     "-500",
+				extension.AnnotationOOMScoreAdjSpec: `{"c1": 100}`,
+			},
+			containerName: "c1",
+			want:          ptr.To[int64](100),
+			wantErr:       false,
+		},
+		{
+			name: "container not in spec falls back to pod-level default",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdj:     "-500",
+				extension.AnnotationOOMScoreAdjSpec: `{"c2": 100}`,
+			},
+			containerName: "c1",
+			want:          ptr.To[int64](-500),
+			wantErr:       false,
+		},
+		{
+			name: "container not in spec and no pod-level default",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdjSpec: `{"c2": 100}`,
+			},
+			containerName: "c1",
+			want:          nil,
+			wantErr:       false,
+		},
+		{
+			name: "invalid spec JSON",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdjSpec: `{invalid}`,
+			},
+			containerName: "c1",
+			want:          nil,
+			wantErr:       true,
+		},
+		{
+			name: "invalid pod-level default value",
+			podAnnotations: map[string]string{
+				extension.AnnotationOOMScoreAdj: "not-a-number",
+			},
+			containerName: "c1",
+			want:          nil,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := getOOMScoreAdjForContainer(tt.podAnnotations, tt.containerName)
+			assert.Equal(t, tt.wantErr, gotErr != nil, "unexpected error status, err: %v", gotErr)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func Test_setOOMScoreAdjForPIDs(t *testing.T) {
+	tests := []struct {
+		name        string
+		pidToVal    map[uint32]int64
+		pidToErr    map[uint32]bool
+		pids        []uint32
+		target      int64
+		wantUpdated int
+		wantSkipped int
+		wantVals    map[uint32]int64
+	}{
+		{
+			name:        "no pid",
+			pids:        nil,
+			target:      -500,
+			wantUpdated: 0,
+			wantSkipped: 0,
+		},
+		{
+			name:        "all pids updated",
+			pidToVal:    map[uint32]int64{12: 0, 13: 100},
+			pids:        []uint32{12, 13},
+			target:      -500,
+			wantUpdated: 2,
+			wantSkipped: 0,
+			wantVals:    map[uint32]int64{12: -500, 13: -500},
+		},
+		{
+			name:        "diff-aware skips matched pid",
+			pidToVal:    map[uint32]int64{12: 0, 13: -500},
+			pids:        []uint32{12, 13},
+			target:      -500,
+			wantUpdated: 1,
+			wantSkipped: 0,
+			wantVals:    map[uint32]int64{12: -500, 13: -500},
+		},
+		{
+			name:        "error pid skipped without blocking others",
+			pidToVal:    map[uint32]int64{12: 0, 13: 0},
+			pidToErr:    map[uint32]bool{12: true},
+			pids:        []uint32{12, 13},
+			target:      -500,
+			wantUpdated: 1,
+			wantSkipped: 1,
+			wantVals:    map[uint32]int64{12: 0, 13: -500},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := sysutil.NewFakeOOMScoreAdj(tt.pidToVal, tt.pidToErr)
+			gotUpdated, gotSkipped := setOOMScoreAdjForPIDs(fake, tt.pids, tt.target)
+			assert.Equal(t, tt.wantUpdated, gotUpdated, "updated count")
+			assert.Equal(t, tt.wantSkipped, gotSkipped, "skipped count")
+			for pid, wantVal := range tt.wantVals {
+				gotVal, err := fake.Get(pid)
+				if tt.pidToErr[pid] {
+					assert.Error(t, err)
+					continue
+				}
+				assert.NoError(t, err)
+				assert.Equal(t, wantVal, gotVal, "pid %d value", pid)
+			}
+		})
+	}
+}

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/metrics"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/reconciler"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/rule"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+const (
+	name        = "OOMScoreAdj"
+	description = "manage oom_score_adj for pod containers via annotation"
+
+	ruleNameForAllPods = name + " (allPods)"
+)
+
+// Plugin manages oom_score_adj for containers based on pod annotations.
+type Plugin struct {
+	rule *Rule
+
+	reader   resourceexecutor.CgroupReader
+	executor resourceexecutor.ResourceUpdateExecutor
+	ome      sysutil.OOMScoreAdjInterface
+}
+
+var singleton *Plugin
+
+// Object returns the singleton Plugin instance.
+func Object() *Plugin {
+	if singleton == nil {
+		singleton = newPlugin()
+	}
+	return singleton
+}
+
+func newPlugin() *Plugin {
+	return &Plugin{
+		rule: newRule(),
+	}
+}
+
+// Register registers the OOMScoreAdj reconcilers and rule callbacks.
+func (p *Plugin) Register(op hooks.Options) {
+	klog.V(5).Infof("register hook %v", name)
+
+	rule.Register(ruleNameForAllPods, description,
+		rule.WithParseFunc(statesinformer.RegisterTypeAllPods, p.parseForAllPods),
+		rule.WithUpdateCallback(p.ruleUpdateCb))
+
+	// Use NoneFilter so that all pods (including SYSTEM QoS) are reconciled.
+	// NOTE: the sandbox (pause) container is deliberately NOT reconciled, since its oom_score_adj is
+	// managed by the runtime (e.g. -998) and overriding it may cause the sandbox to be OOM killed.
+	reconciler.RegisterCgroupReconciler(reconciler.ContainerLevel, sysutil.VirtualOOMScoreAdj,
+		"set oom_score_adj to processes of container specified",
+		p.SetContainerOOMScoreAdj, reconciler.NoneFilter())
+
+	p.Setup(op)
+}
+
+// Setup initializes the reader, executor and oom_score_adj operator from hook options.
+func (p *Plugin) Setup(op hooks.Options) {
+	p.reader = op.Reader
+	p.executor = op.Executor
+	p.ome = sysutil.NewOOMScoreAdj()
+}
+
+// SetContainerOOMScoreAdj reconciles oom_score_adj for a single container.
+func (p *Plugin) SetContainerOOMScoreAdj(proto protocol.HooksProtocol) error {
+	containerCtx := proto.(*protocol.ContainerContext)
+	if containerCtx == nil {
+		return fmt.Errorf("container protocol is nil for plugin %s", name)
+	}
+	if !util.IsValidContainerCgroupDir(containerCtx.Request.CgroupParent) {
+		return fmt.Errorf("invalid container cgroup parent %s for plugin %s", containerCtx.Request.CgroupParent, name)
+	}
+
+	podUID := containerCtx.Request.PodMeta.UID
+	if len(podUID) == 0 || len(containerCtx.Request.ContainerMeta.ID) == 0 {
+		klog.V(5).Infof("aborted to set oom_score_adj for container %s/%s, empty pod UID %s or container ID %s",
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name,
+			podUID, containerCtx.Request.ContainerMeta.ID)
+		return nil
+	}
+	// Skip the sandbox (pause) container whose oom_score_adj is managed by the runtime.
+	if containerCtx.Request.ContainerMeta.Sandbox {
+		return nil
+	}
+
+	targetVal, err := getOOMScoreAdjForContainer(containerCtx.Request.PodAnnotations, containerCtx.Request.ContainerMeta.Name)
+	if err != nil {
+		klog.V(4).Infof("failed to parse oom_score_adj for container %s/%s: %s",
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name, err)
+		return nil
+	}
+	if targetVal == nil {
+		// No annotation set for this container; nothing to do.
+		return nil
+	}
+
+	// Validate range before proceeding.
+	if *targetVal < sysutil.OOMScoreAdjMin || *targetVal > sysutil.OOMScoreAdjMax {
+		klog.Warningf("oom_score_adj value %d out of range [%d, %d] for container %s/%s, skipping",
+			*targetVal, sysutil.OOMScoreAdjMin, sysutil.OOMScoreAdjMax,
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name)
+		return nil
+	}
+
+	pids, err := getContainerPIDs(p.reader, containerCtx.Request.CgroupParent)
+	if err != nil {
+		klog.V(5).Infof("failed to get PIDs for container %s/%s: %s",
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name, err)
+		return nil
+	}
+	if len(pids) == 0 {
+		klog.V(5).Infof("no PID found for container %s/%s",
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name)
+		return nil
+	}
+
+	updated, skipped := setOOMScoreAdjForPIDs(p.ome, pids, *targetVal)
+	if updated > 0 {
+		klog.V(4).Infof("set oom_score_adj=%d for container %s/%s, updated %d PIDs, skipped %d",
+			*targetVal, containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name, updated, skipped)
+	} else {
+		klog.V(6).Infof("no PID updated for container %s/%s oom_score_adj=%d (all already match or skipped %d)",
+			containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name, *targetVal, skipped)
+	}
+	// Record the metric on every reconciliation (including the already-matched case) to keep the
+	// GC gauge alive, since the GCGaugeVec expires series which are not refreshed periodically.
+	if skipped < len(pids) { // at least one PID holds the target value
+		metrics.RecordContainerOOMScoreAdj(
+			containerCtx.Request.PodMeta.Namespace,
+			containerCtx.Request.PodMeta.Name,
+			podUID,
+			containerCtx.Request.ContainerMeta.Name,
+			*targetVal)
+	}
+
+	return nil
+}

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj.go
@@ -43,9 +43,9 @@ const (
 type Plugin struct {
 	rule *Rule
 
-	reader   resourceexecutor.CgroupReader
-	executor resourceexecutor.ResourceUpdateExecutor
-	ome      sysutil.OOMScoreAdjInterface
+	reader              resourceexecutor.CgroupReader
+	executor            resourceexecutor.ResourceUpdateExecutor
+	oomScoreAdjOperator sysutil.OOMScoreAdjInterface
 }
 
 var singleton *Plugin
@@ -86,7 +86,7 @@ func (p *Plugin) Register(op hooks.Options) {
 func (p *Plugin) Setup(op hooks.Options) {
 	p.reader = op.Reader
 	p.executor = op.Executor
-	p.ome = sysutil.NewOOMScoreAdj()
+	p.oomScoreAdjOperator = sysutil.NewOOMScoreAdj()
 }
 
 // SetContainerOOMScoreAdj reconciles oom_score_adj for a single container.
@@ -142,7 +142,7 @@ func (p *Plugin) SetContainerOOMScoreAdj(proto protocol.HooksProtocol) error {
 		return nil
 	}
 
-	updated, skipped := setOOMScoreAdjForPIDs(p.ome, pids, *targetVal)
+	updated, skipped := setOOMScoreAdjForPIDs(p.oomScoreAdjOperator, pids, *targetVal)
 	if updated > 0 {
 		klog.V(4).Infof("set oom_score_adj=%d for container %s/%s, updated %d PIDs, skipped %d",
 			*targetVal, containerCtx.Request.PodMeta.String(), containerCtx.Request.ContainerMeta.Name, updated, skipped)
@@ -152,7 +152,10 @@ func (p *Plugin) SetContainerOOMScoreAdj(proto protocol.HooksProtocol) error {
 	}
 	// Record the metric on every reconciliation (including the already-matched case) to keep the
 	// GC gauge alive, since the GCGaugeVec expires series which are not refreshed periodically.
-	if skipped < len(pids) { // at least one PID holds the target value
+	// A non-skipped PID was either updated to the target value or already matched it, so the
+	// condition holds iff at least one PID currently holds the target value; when all PIDs fail
+	// to read/write (e.g. the container exited), the series is left to expire.
+	if skipped < len(pids) {
 		metrics.RecordContainerOOMScoreAdj(
 			containerCtx.Request.PodMeta.Namespace,
 			containerCtx.Request.PodMeta.Name,

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj_test.go
@@ -36,7 +36,7 @@ func newTestPlugin(fake sysutil.OOMScoreAdjInterface) *Plugin {
 		Reader:   resourceexecutor.NewCgroupReader(),
 		Executor: resourceexecutor.NewTestResourceExecutor(),
 	})
-	p.ome = fake
+	p.oomScoreAdjOperator = fake
 	return p
 }
 

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/oom_score_adj_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/resourceexecutor"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/hooks"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+const testContainerCgroupParent = "kubepods.slice/kubepods-podxxxxxx.slice/cri-containerd-yyyyyy.scope"
+
+func newTestPlugin(fake sysutil.OOMScoreAdjInterface) *Plugin {
+	p := newPlugin()
+	p.Setup(hooks.Options{
+		Reader:   resourceexecutor.NewCgroupReader(),
+		Executor: resourceexecutor.NewTestResourceExecutor(),
+	})
+	p.ome = fake
+	return p
+}
+
+func newTestContainerCtx(annotations map[string]string, sandbox bool) *protocol.ContainerContext {
+	containerCtx := &protocol.ContainerContext{}
+	containerCtx.Request.PodMeta = protocol.PodMeta{
+		Namespace: "test-ns",
+		Name:      "test-pod",
+		UID:       "xxxxxx",
+	}
+	containerCtx.Request.ContainerMeta = protocol.ContainerMeta{
+		Name:    "c1",
+		ID:      "containerd://yyyyyy",
+		Sandbox: sandbox,
+	}
+	containerCtx.Request.PodAnnotations = annotations
+	containerCtx.Request.CgroupParent = testContainerCgroupParent
+	return containerCtx
+}
+
+func TestObject(t *testing.T) {
+	assert.NotNil(t, Object())
+}
+
+func TestPlugin_SetContainerOOMScoreAdj(t *testing.T) {
+	type fields struct {
+		pidToVal map[uint32]int64
+		pidToErr map[uint32]bool
+		procs    string
+	}
+	type args struct {
+		annotations map[string]string
+		sandbox     bool
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		wantVals map[uint32]int64
+	}{
+		{
+			name: "no annotation is a no-op",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0, 13: 0},
+				procs:    "12\n13\n",
+			},
+			args: args{
+				annotations: nil,
+			},
+			wantVals: map[uint32]int64{12: 0, 13: 0},
+		},
+		{
+			name: "pod-level default applied to all pids",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0, 13: -500},
+				procs:    "12\n13\n",
+			},
+			args: args{
+				annotations: map[string]string{
+					extension.AnnotationOOMScoreAdj: "-500",
+				},
+			},
+			wantVals: map[uint32]int64{12: -500, 13: -500},
+		},
+		{
+			name: "container spec overrides pod-level default",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0},
+				procs:    "12\n",
+			},
+			args: args{
+				annotations: map[string]string{
+					extension.AnnotationOOMScoreAdj:     "-500",
+					extension.AnnotationOOMScoreAdjSpec: `{"c1": 200}`,
+				},
+			},
+			wantVals: map[uint32]int64{12: 200},
+		},
+		{
+			name: "out-of-range value is rejected",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0},
+				procs:    "12\n",
+			},
+			args: args{
+				annotations: map[string]string{
+					extension.AnnotationOOMScoreAdj: "-2000",
+				},
+			},
+			wantVals: map[uint32]int64{12: 0},
+		},
+		{
+			name: "invalid annotation is a no-op",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0},
+				procs:    "12\n",
+			},
+			args: args{
+				annotations: map[string]string{
+					extension.AnnotationOOMScoreAdjSpec: `{invalid}`,
+				},
+			},
+			wantVals: map[uint32]int64{12: 0},
+		},
+		{
+			name: "sandbox container is skipped",
+			fields: fields{
+				pidToVal: map[uint32]int64{12: 0},
+				procs:    "12\n",
+			},
+			args: args{
+				annotations: map[string]string{
+					extension.AnnotationOOMScoreAdj: "-500",
+				},
+				sandbox: true,
+			},
+			wantVals: map[uint32]int64{12: 0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := sysutil.NewFileTestUtil(t)
+			defer helper.Cleanup()
+			helper.WriteCgroupFileContents(testContainerCgroupParent, sysutil.CPUProcs, tt.fields.procs)
+			helper.WriteCgroupFileContents(testContainerCgroupParent, sysutil.CPUProcsV2, tt.fields.procs)
+
+			fake := sysutil.NewFakeOOMScoreAdj(tt.fields.pidToVal, tt.fields.pidToErr)
+			p := newTestPlugin(fake)
+
+			containerCtx := newTestContainerCtx(tt.args.annotations, tt.args.sandbox)
+			err := p.SetContainerOOMScoreAdj(containerCtx)
+			assert.NoError(t, err)
+
+			for pid, wantVal := range tt.wantVals {
+				gotVal, err := fake.Get(pid)
+				assert.NoError(t, err)
+				assert.Equal(t, wantVal, gotVal, "pid %d value", pid)
+			}
+		})
+	}
+}
+
+func TestPlugin_SetContainerOOMScoreAdj_invalidRequest(t *testing.T) {
+	fake := sysutil.NewFakeOOMScoreAdj(nil, nil)
+	p := newTestPlugin(fake)
+
+	t.Run("invalid cgroup parent", func(t *testing.T) {
+		containerCtx := newTestContainerCtx(nil, false)
+		containerCtx.Request.CgroupParent = ""
+		err := p.SetContainerOOMScoreAdj(containerCtx)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty container ID", func(t *testing.T) {
+		containerCtx := newTestContainerCtx(map[string]string{
+			extension.AnnotationOOMScoreAdj: "-500",
+		}, false)
+		containerCtx.Request.ContainerMeta.ID = ""
+		err := p.SetContainerOOMScoreAdj(containerCtx)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
@@ -46,7 +46,7 @@ func (p *Plugin) parseForAllPods(e interface{}) (bool, error) {
 	needSync := false
 	p.rule.allPodsSyncOnce.Do(func() {
 		needSync = true
-		klog.V(5).Infof("plugin %s callback the first all pods update", name)
+		klog.V(5).Infof("plugin %s received the first all-pods update callback", name)
 	})
 	return needSync, nil
 }

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
@@ -75,9 +76,14 @@ func (p *Plugin) refreshForAllPods(podMetas []*statesinformer.PodMeta) error {
 			continue
 		}
 
-		// regular containers; the sandbox (pause) container is deliberately skipped since its
-		// oom_score_adj is managed by the runtime
-		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+		// init containers (e.g. running sidecars during Pending) and regular containers;
+		// the sandbox (pause) container is deliberately skipped since its oom_score_adj is
+		// managed by the runtime
+		containerStatuses := make([]corev1.ContainerStatus, 0,
+			len(podMeta.Pod.Status.InitContainerStatuses)+len(podMeta.Pod.Status.ContainerStatuses))
+		containerStatuses = append(containerStatuses, podMeta.Pod.Status.InitContainerStatuses...)
+		containerStatuses = append(containerStatuses, podMeta.Pod.Status.ContainerStatuses...)
+		for _, containerStat := range containerStatuses {
 			containerCtx := &protocol.ContainerContext{}
 			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
 			if err := p.SetContainerOOMScoreAdj(containerCtx); err != nil {

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/runtimehooks/protocol"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+)
+
+// Rule is stateless for OOMScoreAdj: the target value is driven purely by pod annotations.
+// It tracks whether the initial AllPods sync has occurred so the reconciler can begin operating.
+type Rule struct {
+	allPodsSyncOnce sync.Once
+}
+
+func newRule() *Rule {
+	return &Rule{}
+}
+
+func (p *Plugin) parseForAllPods(e interface{}) (bool, error) {
+	_, ok := e.(*struct{})
+	if !ok {
+		return false, fmt.Errorf("invalid rule type %T", e)
+	}
+
+	needSync := false
+	p.rule.allPodsSyncOnce.Do(func() {
+		needSync = true
+		klog.V(5).Infof("plugin %s callback the first all pods update", name)
+	})
+	return needSync, nil
+}
+
+func (p *Plugin) ruleUpdateCb(target *statesinformer.CallbackTarget) error {
+	if target == nil {
+		return fmt.Errorf("callback target is nil")
+	}
+
+	podMetas := target.Pods
+	if len(podMetas) <= 0 {
+		klog.V(5).Infof("plugin %s skipped for rule update, no pod passed from callback", name)
+		return nil
+	}
+
+	return p.refreshForAllPods(podMetas)
+}
+
+func (p *Plugin) refreshForAllPods(podMetas []*statesinformer.PodMeta) error {
+	for _, podMeta := range podMetas {
+		if podMeta.Pod == nil {
+			continue
+		}
+		if !podMeta.IsRunningOrPending() {
+			klog.V(6).Infof("skip oom_score_adj for pod %s, pod is non-running, phase %s",
+				podMeta.Key(), podMeta.Pod.Status.Phase)
+			continue
+		}
+
+		// regular containers; the sandbox (pause) container is deliberately skipped since its
+		// oom_score_adj is managed by the runtime
+		for _, containerStat := range podMeta.Pod.Status.ContainerStatuses {
+			containerCtx := &protocol.ContainerContext{}
+			containerCtx.FromReconciler(podMeta, containerStat.Name, false)
+			if err := p.SetContainerOOMScoreAdj(containerCtx); err != nil {
+				klog.V(4).Infof("failed to set oom_score_adj for container %s/%s: %s",
+					podMeta.Key(), containerStat.Name, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule_test.go
+++ b/pkg/koordlet/runtimehooks/hooks/oomscoreadj/rule_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oomscoreadj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/statesinformer"
+	koordletutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util"
+	sysutil "github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func TestPlugin_refreshForAllPods(t *testing.T) {
+	helper := sysutil.NewFileTestUtil(t)
+	defer helper.Cleanup()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-pod",
+			UID:       "xxxxxx",
+			Annotations: map[string]string{
+				extension.AnnotationOOMScoreAdj: "-500",
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init-c"},
+			},
+			Containers: []corev1.Container{
+				{Name: "c1"},
+			},
+		},
+		Status: corev1.PodStatus{
+			// the pod is Pending while its init container is running
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "init-c", ContainerID: "containerd://init111"},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", ContainerID: "containerd://main222"},
+			},
+		},
+	}
+	podMeta := &statesinformer.PodMeta{
+		Pod:       pod,
+		CgroupDir: "kubepods.slice/kubepods-podxxxxxx.slice",
+	}
+	// write the procs of both containers under the same cgroup parents the reconciler resolves
+	initCgroupParent, err := koordletutil.GetContainerCgroupParentDirByID(podMeta.CgroupDir, "containerd://init111")
+	assert.NoError(t, err)
+	helper.WriteCgroupFileContents(initCgroupParent, sysutil.CPUProcs, "21\n")
+	helper.WriteCgroupFileContents(initCgroupParent, sysutil.CPUProcsV2, "21\n")
+	mainCgroupParent, err := koordletutil.GetContainerCgroupParentDirByID(podMeta.CgroupDir, "containerd://main222")
+	assert.NoError(t, err)
+	helper.WriteCgroupFileContents(mainCgroupParent, sysutil.CPUProcs, "22\n")
+	helper.WriteCgroupFileContents(mainCgroupParent, sysutil.CPUProcsV2, "22\n")
+
+	fake := sysutil.NewFakeOOMScoreAdj(map[uint32]int64{21: 0, 22: 0}, nil)
+	p := newTestPlugin(fake)
+
+	assert.NoError(t, p.refreshForAllPods([]*statesinformer.PodMeta{podMeta}))
+
+	// both the init container and the regular container are reconciled
+	gotVal, err := fake.Get(21)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(-500), gotVal, "init container pid")
+	gotVal, err = fake.Get(22)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(-500), gotVal, "regular container pid")
+}

--- a/pkg/koordlet/util/system/oom_score_adj.go
+++ b/pkg/koordlet/util/system/oom_score_adj.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"sync"
+)
+
+const (
+	// VirtualOOMScoreAdjName is the name of a virtual system resource for oom_score_adj.
+	VirtualOOMScoreAdjName = "oom_score_adj"
+)
+
+var (
+	// VirtualOOMScoreAdj represents a virtual system resource for oom_score_adj.
+	// It is virtual for denoting the operation on processes' oom_score_adj, and it is not allowed to do
+	// any real read or write on the provided filepath.
+	VirtualOOMScoreAdj = NewCommonSystemResource("", VirtualOOMScoreAdjName, GetProcRootDir)
+)
+
+// OOMScoreAdjInterface defines the operations on per-process /proc/<pid>/oom_score_adj.
+type OOMScoreAdjInterface interface {
+	// Get reads the current oom_score_adj value for the given PID.
+	Get(pid uint32) (int64, error)
+	// Set writes the target oom_score_adj value for the given PID.
+	// It should validate that the value is within [OOMScoreAdjMin, OOMScoreAdjMax].
+	Set(pid uint32, val int64) error
+}
+
+// FakeOOMScoreAdj implements OOMScoreAdjInterface for testing.
+type FakeOOMScoreAdj struct {
+	mu       sync.RWMutex
+	PIDToVal map[uint32]int64
+	PIDToErr map[uint32]bool
+}
+
+// NewFakeOOMScoreAdj creates a FakeOOMScoreAdj for testing.
+func NewFakeOOMScoreAdj(pidToVal map[uint32]int64, pidToErr map[uint32]bool) OOMScoreAdjInterface {
+	f := &FakeOOMScoreAdj{
+		PIDToVal: pidToVal,
+		PIDToErr: pidToErr,
+	}
+	if f.PIDToVal == nil {
+		f.PIDToVal = map[uint32]int64{}
+	}
+	if f.PIDToErr == nil {
+		f.PIDToErr = map[uint32]bool{}
+	}
+	return f
+}
+
+func (f *FakeOOMScoreAdj) Get(pid uint32) (int64, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if _, ok := f.PIDToErr[pid]; ok {
+		return 0, fmt.Errorf("get oom_score_adj error for pid %d", pid)
+	}
+	if val, ok := f.PIDToVal[pid]; ok {
+		return val, nil
+	}
+	return 0, nil
+}
+
+func (f *FakeOOMScoreAdj) Set(pid uint32, val int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.PIDToErr[pid]; ok {
+		return fmt.Errorf("set oom_score_adj error for pid %d", pid)
+	}
+	if val < OOMScoreAdjMin || val > OOMScoreAdjMax {
+		return fmt.Errorf("oom_score_adj value %d out of range [%d, %d] for pid %d", val, OOMScoreAdjMin, OOMScoreAdjMax, pid)
+	}
+	f.PIDToVal[pid] = val
+	return nil
+}

--- a/pkg/koordlet/util/system/oom_score_adj_linux.go
+++ b/pkg/koordlet/util/system/oom_score_adj_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// OOMScoreAdj operates on /proc/<pid>/oom_score_adj.
+type OOMScoreAdj struct{}
+
+// NewOOMScoreAdj creates a new OOMScoreAdj that reads/writes the real proc file.
+func NewOOMScoreAdj() OOMScoreAdjInterface {
+	return &OOMScoreAdj{}
+}
+
+func (o *OOMScoreAdj) Get(pid uint32) (int64, error) {
+	content, err := os.ReadFile(GetProcPIDOOMScoreAdjPath(pid))
+	if err != nil {
+		return 0, err
+	}
+	val, err := strconv.ParseInt(strings.TrimSpace(string(content)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse oom_score_adj for pid %d: %w", pid, err)
+	}
+	return val, nil
+}
+
+func (o *OOMScoreAdj) Set(pid uint32, val int64) error {
+	if val < OOMScoreAdjMin || val > OOMScoreAdjMax {
+		return fmt.Errorf("oom_score_adj value %d out of range [%d, %d] for pid %d", val, OOMScoreAdjMin, OOMScoreAdjMax, pid)
+	}
+	return os.WriteFile(GetProcPIDOOMScoreAdjPath(pid), []byte(strconv.FormatInt(val, 10)), 0640)
+}

--- a/pkg/koordlet/util/system/oom_score_adj_unsupported.go
+++ b/pkg/koordlet/util/system/oom_score_adj_unsupported.go
@@ -1,0 +1,38 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import "fmt"
+
+// OOMScoreAdj is a stub for unsupported platforms.
+type OOMScoreAdj struct{}
+
+// NewOOMScoreAdj returns a stub that always returns an error on unsupported platforms.
+func NewOOMScoreAdj() OOMScoreAdjInterface {
+	return &OOMScoreAdj{}
+}
+
+func (o *OOMScoreAdj) Get(pid uint32) (int64, error) {
+	return 0, fmt.Errorf("unsupported platform")
+}
+
+func (o *OOMScoreAdj) Set(pid uint32, val int64) error {
+	return fmt.Errorf("unsupported platform")
+}

--- a/pkg/koordlet/util/system/proc.go
+++ b/pkg/koordlet/util/system/proc.go
@@ -31,6 +31,14 @@ const (
 	ProcStatName    = "stat"
 	ProcMemInfoName = "meminfo"
 	ProcCPUInfoName = "cpuinfo"
+
+	// ProcOOMScoreAdjName is the filename for per-process oom_score_adj.
+	ProcOOMScoreAdjName = "oom_score_adj"
+
+	// OOMScoreAdjMin is the minimum allowed value for oom_score_adj.
+	OOMScoreAdjMin int64 = -1000
+	// OOMScoreAdjMax is the maximum allowed value for oom_score_adj.
+	OOMScoreAdjMax int64 = 1000
 )
 
 func GetProcFilePath(procRelativePath string) string {
@@ -178,4 +186,9 @@ func GetContainerPGIDs(containerParentDir string) ([]uint32, error) {
 	}
 
 	return GetPGIDsForPIDs(pids)
+}
+
+// GetProcPIDOOMScoreAdjPath returns the absolute path of /proc/<pid>/oom_score_adj.
+func GetProcPIDOOMScoreAdjPath(pid uint32) string {
+	return filepath.Join(Conf.ProcRootDir, strconv.FormatUint(uint64(pid), 10), ProcOOMScoreAdjName)
 }


### PR DESCRIPTION
Add the oomscoreadj runtime hook that reconciles /proc/<pid>/oom_score_adj for all processes of the pod's containers according to the pod annotations koordinator.sh/oom-score-adj (pod-level default) and koordinator.sh/oom-score-adj-spec (per-container), so the value can be hot-updated without restarting containers. The sandbox container is not touched since its oom_score_adj is managed by the runtime. Gated by the OOMScoreAdj feature (default off).

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

koordlet: support runtime hook OOMScoreAdj for setting oom_score_adj at the pod-level.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
