### PR TITLE
fix(runtimeproxy): retain checkpoints when CRI stops fail

### DIFF
--- a/pkg/runtimeproxy/server/cri/criserver.go
+++ b/pkg/runtimeproxy/server/cri/criserver.go
@@ -132,8 +132,6 @@ func (c *RuntimeManagerCriServer) InterceptRuntimeRequest(serviceType RuntimeSer
 	if err != nil {
 		klog.Errorf("fail to parse request %v %v", request, err)
 	}
-	defer resourceExecutor.DeleteCheckpointIfNeed(request)
-
 	switch callHookOperation {
 	case utils.ShouldCallHookPlugin:
 		// TODO deal with the Dispatch response
@@ -170,6 +168,9 @@ func (c *RuntimeManagerCriServer) InterceptRuntimeRequest(serviceType RuntimeSer
 		// store checkpoint info basing request only when response success
 		if err := resourceExecutor.ResourceCheckPoint(res); err != nil {
 			klog.Errorf("fail to checkpoint %v %v", resourceExecutor.GetMetaInfo(), err)
+		}
+		if err := resourceExecutor.DeleteCheckpointIfNeed(request); err != nil {
+			klog.Errorf("fail to delete checkpoint %v %v", resourceExecutor.GetMetaInfo(), err)
 		}
 	} else {
 		klog.Errorf("%v call containerd %v fail %v", resourceExecutor.GetMetaInfo(), string(runtimeHookPath), err)

--- a/pkg/runtimeproxy/server/cri/criserver_test.go
+++ b/pkg/runtimeproxy/server/cri/criserver_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/koordinator-sh/koordinator/apis/runtime/v1alpha1"
+	"github.com/koordinator-sh/koordinator/cmd/koord-runtime-proxy/options"
+	"github.com/koordinator-sh/koordinator/pkg/runtimeproxy/store"
+)
+
+func TestInterceptRuntimeRequestHandlesCheckpointAfterStop(t *testing.T) {
+	const (
+		skipHookKey = "test.koordinator.sh/skip-hook"
+		skipHookVal = "true"
+	)
+
+	previousKey, previousVal := options.RuntimeHookServerKey, options.RuntimeHookServerVal
+	options.RuntimeHookServerKey, options.RuntimeHookServerVal = skipHookKey, skipHookVal
+	t.Cleanup(func() {
+		options.RuntimeHookServerKey, options.RuntimeHookServerVal = previousKey, previousVal
+	})
+
+	tests := []struct {
+		name                  string
+		serviceType           RuntimeServiceType
+		request               interface{}
+		writeCheckpoint       func() error
+		getCheckpoint         func() interface{}
+		deleteCheckpoint      func()
+		backendResponse       interface{}
+		backendErr            error
+		checkpointShouldExist bool
+	}{
+		{
+			name:        "container checkpoint is deleted after successful stop",
+			serviceType: StopContainer,
+			request: &runtimeapi.StopContainerRequest{
+				ContainerId: "container-stop-success",
+			},
+			writeCheckpoint: func() error {
+				return store.WriteContainerInfo("container-stop-success", &store.ContainerInfo{
+					ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+						PodLabels: map[string]string{skipHookKey: skipHookVal},
+					},
+				})
+			},
+			getCheckpoint: func() interface{} {
+				return store.GetContainerInfo("container-stop-success")
+			},
+			deleteCheckpoint: func() {
+				store.DeleteContainerInfo("container-stop-success")
+			},
+			backendResponse:       &runtimeapi.StopContainerResponse{},
+			checkpointShouldExist: false,
+		},
+		{
+			name:        "container checkpoint is retained after failed stop",
+			serviceType: StopContainer,
+			request: &runtimeapi.StopContainerRequest{
+				ContainerId: "container-stop-failure",
+			},
+			writeCheckpoint: func() error {
+				return store.WriteContainerInfo("container-stop-failure", &store.ContainerInfo{
+					ContainerResourceHookRequest: &v1alpha1.ContainerResourceHookRequest{
+						PodLabels: map[string]string{skipHookKey: skipHookVal},
+					},
+				})
+			},
+			getCheckpoint: func() interface{} {
+				return store.GetContainerInfo("container-stop-failure")
+			},
+			deleteCheckpoint: func() {
+				store.DeleteContainerInfo("container-stop-failure")
+			},
+			backendErr:            errors.New("backend stop failed"),
+			checkpointShouldExist: true,
+		},
+		{
+			name:        "pod sandbox checkpoint is deleted after successful stop",
+			serviceType: StopPodSandbox,
+			request: &runtimeapi.StopPodSandboxRequest{
+				PodSandboxId: "pod-stop-success",
+			},
+			writeCheckpoint: func() error {
+				return store.WritePodSandboxInfo("pod-stop-success", &store.PodSandboxInfo{
+					PodSandboxHookRequest: &v1alpha1.PodSandboxHookRequest{
+						Labels: map[string]string{skipHookKey: skipHookVal},
+					},
+				})
+			},
+			getCheckpoint: func() interface{} {
+				return store.GetPodSandboxInfo("pod-stop-success")
+			},
+			deleteCheckpoint: func() {
+				store.DeletePodSandboxInfo("pod-stop-success")
+			},
+			backendResponse:       &runtimeapi.StopPodSandboxResponse{},
+			checkpointShouldExist: false,
+		},
+		{
+			name:        "pod sandbox checkpoint is retained after failed stop",
+			serviceType: StopPodSandbox,
+			request: &runtimeapi.StopPodSandboxRequest{
+				PodSandboxId: "pod-stop-failure",
+			},
+			writeCheckpoint: func() error {
+				return store.WritePodSandboxInfo("pod-stop-failure", &store.PodSandboxInfo{
+					PodSandboxHookRequest: &v1alpha1.PodSandboxHookRequest{
+						Labels: map[string]string{skipHookKey: skipHookVal},
+					},
+				})
+			},
+			getCheckpoint: func() interface{} {
+				return store.GetPodSandboxInfo("pod-stop-failure")
+			},
+			deleteCheckpoint: func() {
+				store.DeletePodSandboxInfo("pod-stop-failure")
+			},
+			backendErr:            errors.New("backend stop failed"),
+			checkpointShouldExist: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.writeCheckpoint())
+			t.Cleanup(tt.deleteCheckpoint)
+
+			_, err := (&RuntimeManagerCriServer{}).InterceptRuntimeRequest(
+				tt.serviceType,
+				context.Background(),
+				tt.request,
+				func(context.Context, interface{}) (interface{}, error) {
+					return tt.backendResponse, tt.backendErr
+				},
+				false,
+			)
+
+			if tt.backendErr != nil {
+				require.ErrorIs(t, err, tt.backendErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.checkpointShouldExist {
+				require.NotNil(t, tt.getCheckpoint())
+			} else {
+				require.Nil(t, tt.getCheckpoint())
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a runtime-proxy checkpoint cleanup issue in the CRI request path.

Previously, the runtime proxy scheduled checkpoint deletion before calling the backend container runtime. As a result, a failed `StopContainer` or `StopPodSandbox` request still deleted its saved checkpoint.

This change deletes the checkpoint only after the backend stop request succeeds.

It also adds regression tests for both container and pod sandbox stop requests:

- Successful stop requests delete their checkpoints.
- Failed stop requests retain their checkpoints.

### Ⅱ. Does this pull request fix one issue?

Fixes #3141 

### Ⅲ. Describe how to verify it

Run:

```bash
go test ./pkg/runtimeproxy/...
```

Expected result: all runtime-proxy tests pass.

The new test verifies that checkpoints remain available after failed CRI `StopContainer` and `StopPodSandbox` requests.

### Ⅳ. Special notes for reviews

The change is intentionally limited to the CRI runtime-proxy interception path.

The Docker runtime-proxy stop path has separate logic and is outside this PR’s scope.

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`