### PR TITLE
webhook: evaluate quota when pod resources change on update

### DIFF
--- a/pkg/webhook/pod/validating/evaluate_quota.go
+++ b/pkg/webhook/pod/validating/evaluate_quota.go
@@ -22,6 +22,8 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
+	apiresource "k8s.io/component-helpers/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -54,7 +56,11 @@ func (h *PodValidatingHandler) evaluateQuota(ctx context.Context, req admission.
 		oldQuotaName := elasticquota.GetQuotaName(oldPod, h.Client)
 		quotaName = elasticquota.GetQuotaName(newPod, h.Client)
 		if oldQuotaName == quotaName {
-			return true, "", nil
+			oldRequests := apiresource.PodRequests(oldPod, apiresource.PodResourcesOptions{})
+			newRequests := apiresource.PodRequests(newPod, apiresource.PodResourcesOptions{})
+			if quotav1.Equals(oldRequests, newRequests) {
+				return true, "", nil
+			}
 		}
 	default:
 		return true, "", nil

--- a/pkg/webhook/pod/validating/evaluate_quota_test.go
+++ b/pkg/webhook/pod/validating/evaluate_quota_test.go
@@ -376,6 +376,67 @@ func TestEvaluateQuota(t *testing.T) {
 			wantUsed:    corev1.ResourceList{},
 		},
 		{
+			name:      "update with same quota label but increased resources on full quota, denied",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota1").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).ChildRequest(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}).Obj(),
+			prepareFn: func() func() {
+				return utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate,
+					features.EnableQuotaAdmissionOnUpdate, true)
+			},
+			wantAllowed: false,
+			wantReason:  "exceeded quota: kube-system/quota1, requested: cpu=4,memory=8Gi, used: cpu=4,memory=8Gi, limited: cpu=4,memory=8Gi",
+			wantErr:     true,
+			wantUsed:    corev1.ResourceList{},
+		},
+		{
+			name:      "update with same quota label but increased resources, allowed when quota has capacity",
+			operation: admissionv1.Update,
+			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				}).Obj(),
+			newPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").
+				Container(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				}).Obj(),
+			quota: elasticquota.MakeQuota("quota1").Namespace("kube-system").Max(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}).ChildRequest(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			}).Obj(),
+			prepareFn: func() func() {
+				return utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate,
+					features.EnableQuotaAdmissionOnUpdate, true)
+			},
+			wantAllowed: true,
+			wantReason:  "",
+			wantErr:     false,
+			wantUsed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("6"),
+				corev1.ResourceMemory: resource.MustParse("12Gi"),
+			},
+		},
+		{
 			name:      "update quota label to a quota with capacity, allowed",
 			operation: admissionv1.Update,
 			oldPod: elasticquota.MakePod("ns1", "pod1").Label("quota.scheduling.koordinator.sh/name", "quota1").


### PR DESCRIPTION
Re-run quota admission on pod UPDATE when the quota label is unchanged but resource requests differ, so resource edits cannot bypass quota limits.

### Ⅰ. Describe what this PR does

When `EnableQuotaAdmissionOnUpdate` is enabled, the webhook skipped quota evaluation on UPDATE if the quota label did not change, even when CPU or memory requests increased. This change compares old and new pod requests and only skips evaluation when they are the same.

### Ⅱ. Does this pull request fix one issue?

fixes #3143

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/webhook/pod/validating/ -run TestEvaluateQuota -v
```

The new case `update with same quota label but increased resources on full quota, denied` should pass.

### Ⅳ. Special notes for reviews

Small change in `evaluate_quota.go` only. Uses `PodRequests` and `quotav1.Equals`, same as the quota evaluator.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
