### PR TITLE
scheduler: fix flaky TestSyncStatus by keeping the controller's background loops out of the metric assertions

### DIFF
--- a/pkg/scheduler/plugins/reservation/controller/controller_test.go
+++ b/pkg/scheduler/plugins/reservation/controller/controller_test.go
@@ -250,6 +250,11 @@ func TestSyncStatus(t *testing.T) {
 	metricsResourceRegistry := basemetrics.NewKubeRegistry()
 	metrics.ReservationResource.Reset()
 	metricsResourceRegistry.Registerer().MustRegister(metrics.ReservationResource)
+	// ReservationResource is a package-level collector and Start() below appends
+	// to the package-level handler registrations, so leave neither behind for
+	// whichever test runs next.
+	t.Cleanup(metrics.ReservationResource.Reset)
+	t.Cleanup(frameworkexthelper.ResetRegistrations)
 
 	reservation := &schedulingv1alpha1.Reservation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -319,9 +324,32 @@ func TestSyncStatus(t *testing.T) {
 	}
 
 	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{ControllerWorkers: 2, GCDurationSeconds: 3600, GCIntervalSeconds: 60})
+	// This test drives sync() itself and then asserts on ReservationResource,
+	// which is a process-wide gauge. resyncReservations() would write that same
+	// gauge from a background loop: it resets the gauge and re-records every
+	// reservation from a lister snapshot that can lag the status update sync()
+	// performs below, which reports allocated=0 for a reservation just recorded
+	// as allocated=8. The workers are disabled as well so that the test has
+	// exactly one sync writer. Start() already guards all three loops, and
+	// Start() itself is covered by TestControllerStart.
+	controller.numWorker = 0
+	controller.isGCDisabled = true
+	controller.resyncInterval = 0
 	controller.Start()
 
-	time.Sleep(100 * time.Millisecond)
+	// Start() registers the pod handlers but does not wait for them:
+	// ForceSyncFromInformer only adds the handler, and the WaitForCacheSync
+	// inside Start() covers the listers rather than handler delivery. sync()
+	// derives the allocation from the index those handlers maintain, so wait
+	// for the owner pods to actually land in it instead of sleeping for a
+	// fixed interval and hoping. This is a precondition, not an assertion:
+	// continuing without it only produces confusing secondary failures.
+	if err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Millisecond, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			return len(controller.getPodsOnReservation(reservation.UID)) == len(owners), nil
+		}); err != nil {
+		t.Fatalf("timed out waiting for the reservation's owner pods to be indexed: %v", err)
+	}
 
 	r, err := controller.sync(getReservationKey(reservation))
 	assert.NoError(t, err)
@@ -1127,9 +1155,19 @@ func TestControllerStart(t *testing.T) {
 	_, err = fakeClientSet.CoreV1().Pods(testPod.Namespace).Create(context.TODO(), testPod, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	// Create controller with GC and resync disabled to keep the test focused.
+	// Create controller with GC, resync and workers disabled to keep the test
+	// focused: it only checks handler registration and the resulting pod index.
+	// Neither args field disables the loops on its own. New() falls back to
+	// defaultResyncInterval for any ResyncIntervalSeconds that is not positive,
+	// and to a single worker when ControllerWorkers is not positive, so both are
+	// set on the controller directly. That matters beyond this test: Start()
+	// passes a nil stop channel to wait.Until and the queue is never shut down,
+	// so a loop or worker started here outlives the test and keeps writing the
+	// process-wide reservation metrics while other tests assert on them.
 	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet,
 		&config.ReservationArgs{DisableGarbageCollection: true, ResyncIntervalSeconds: 0})
+	controller.numWorker = 0
+	controller.resyncInterval = 0
 
 	// Start() calls ForceSyncFromInformer for the pod informer, which should add a registration.
 	controller.Start()
@@ -1151,4 +1189,83 @@ func TestControllerStart(t *testing.T) {
 
 	podsOnReservation := controller.getPodsOnReservation("res-uid-start-test")
 	assert.Len(t, podsOnReservation, 1, "expected test pod to be indexed by reservation UID")
+}
+
+// TestProcessNextWorkItem covers the queue machinery directly. It used to be
+// exercised only as a side effect of worker goroutines that the tests above
+// started and never stopped, which is precisely the coupling those tests now
+// avoid, so it needs a test of its own.
+func TestProcessNextWorkItem(t *testing.T) {
+	fakeClientSet := kubefake.NewSimpleClientset()
+	fakeKoordClientSet := koordfake.NewSimpleClientset()
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+	koordSharedInformerFactory := koordinformers.NewSharedInformerFactory(fakeKoordClientSet, 0)
+
+	// Not assigned to a node yet, so sync() reaches syncAssignedReservation and
+	// returns without touching the status.
+	unassigned := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               uuid.NewUUID(),
+			Name:              "unassignedReservation",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			TTL:      &metav1.Duration{Duration: time.Hour},
+			Template: &corev1.PodTemplateSpec{},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationAvailable,
+		},
+	}
+	// Already terminated, so sync() returns without asking for a retry.
+	terminated := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               uuid.NewUUID(),
+			Name:              "terminatedReservation",
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationSucceeded,
+		},
+	}
+	for _, r := range []*schedulingv1alpha1.Reservation{unassigned, terminated} {
+		_, err := fakeKoordClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), r, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	controller := New(sharedInformerFactory, koordSharedInformerFactory, fakeClientSet, fakeKoordClientSet, &config.ReservationArgs{})
+	sharedInformerFactory.Start(nil)
+	koordSharedInformerFactory.Start(nil)
+	sharedInformerFactory.WaitForCacheSync(nil)
+	koordSharedInformerFactory.WaitForCacheSync(nil)
+
+	// Not assigned to a node, so sync() asks to be retried later and the key
+	// leaves the ready queue.
+	controller.queue.Add(getReservationKey(unassigned))
+	assert.True(t, controller.processNextWorkItem())
+	assert.Equal(t, 0, controller.queue.Len())
+
+	// Already terminated, so sync() wants no retry and the key is forgotten.
+	controller.queue.Add(getReservationKey(terminated))
+	assert.True(t, controller.processNextWorkItem())
+	assert.Equal(t, 0, controller.queue.Len())
+
+	// worker() has to return once the queue is shut down. Nothing shuts the
+	// queue down today, which is why the workers Start() launches outlive
+	// whatever started them, so assert at least that the loop itself is not
+	// what keeps them alive.
+	workerReturned := make(chan struct{})
+	go func() {
+		controller.worker()
+		close(workerReturned)
+	}()
+	controller.queue.ShutDown()
+	select {
+	case <-workerReturned:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("worker did not return after the queue was shut down")
+	}
+
+	// The same condition, seen from the loop's perspective.
+	assert.False(t, controller.processNextWorkItem())
 }


### PR DESCRIPTION
## Summary

`TestSyncStatus` fails intermittently in the `unit-tests(Run Go test)` job. It failed on main in [run 30001423786](https://github.com/koordinator-sh/koordinator/actions/runs/30001423786):

```
--- FAIL: TestSyncStatus (0.20s)
     scheduler_reservation_resource{name="normalReservation",resource="cpu",type="allocatable",unit="core"} 10
    -scheduler_reservation_resource{name="normalReservation",resource="cpu",type="allocated",unit="core"} 0
    -scheduler_reservation_resource{name="normalReservation",resource="cpu",type="utilization",unit="ratio"} 0
    +scheduler_reservation_resource{name="normalReservation",resource="cpu",type="allocated",unit="core"} 8
    +scheduler_reservation_resource{name="normalReservation",resource="cpu",type="utilization",unit="ratio"} 0.8
```

`allocatable` is correct while `allocated` and `utilization` are zeroed. Only one code path emits that combination: `RecordReservationResource` on a reservation whose `Status.Allocatable` is set and whose `Status.Allocated` is empty — the copy the reservation lister held before `syncStatus()` wrote the allocation. And only `resyncReservations()` calls `metrics.ResetReservationResource()`, which is what makes the previously recorded `8` disappear rather than merely be overwritten.

## Cause

The test drives `controller.sync()` itself and then asserts on `metrics.ReservationResource`, a process-wide gauge. It also calls `controller.Start()`, which launches a background writer of that same gauge: `resyncReservations()` resets it and re-records every reservation from the lister, and the lister is eventually consistent with the status update `sync()` writes through the client. A resync that runs after `sync()` but before the informer catches up therefore records `allocated=0` over the freshly recorded `8`.

`wait.Until` runs its function immediately, so on an unloaded machine the resync almost always happens during the `time.Sleep(100 * time.Millisecond)` that follows `Start()`, before the test's own `sync()`. That is why this passes locally. On a loaded CI runner the goroutine can be scheduled past that sleep and land in the assertion window.

## Fix

**Isolate the test.** The background loops are disabled instead of slept around: `Start()` already guards all three (`numWorker`, `isGCDisabled`, `resyncInterval`), and `Start()` itself is covered by `TestControllerStart`. Note that neither args field disables them on its own — `New()` falls back to `defaultResyncInterval` for any `ResyncIntervalSeconds` that is not positive, and to one worker when `ControllerWorkers` is not positive — so both are set on the controller directly. `TestControllerStart` gets the same treatment; its comment claimed resync was disabled through `ResyncIntervalSeconds: 0`, which never worked.

**Wait, do not sleep.** The 100 ms sleep is replaced by a wait on the condition it was standing in for. `Start()` registers the pod handlers through `ForceSyncFromInformer`, which only adds the handler — the waiting lives in `WaitForHandlersSync` — and the `WaitForCacheSync` inside `Start()` covers the listers rather than handler delivery. Since `sync()` derives the allocation from the index those handlers maintain (`getPodsOnReservation`), the test polls that index for the reservation's owner pods. It is a `t.Fatalf` precondition rather than an assertion, because continuing past it only produces confusing secondary failures.

**Keep the queue machinery covered.** Disabling the loops removes the incidental coverage `worker()` and `processNextWorkItem()` used to get from goroutines the tests started and never stopped. `TestProcessNextWorkItem` covers them deliberately instead, including that `worker()` returns once the queue is shut down — the lifecycle property this whole area depends on. The only statements this PR stops covering are the three bare `go f()` launches in `Start()`, which cannot be reached without starting the very loops the tests are isolating themselves from; two previously unreachable `else` branches become covered in exchange.

No production code changes.

## Scope

This PR isolates the unit tests. It does **not** fix the two production problems the investigation turned up:

- **#3151** — `Controller.Start()` launches its workers before the pod handler it depends on has delivered its initial list. `frameworkexthelper.WaitForHandlersSync` runs inside `startInformersAndWaitForSync()`, which completes before `extenderFactory.Run()` reaches `controllerMaps.Start()`, so nothing ever waits for the handler this controller registers. A worker that picks up a reservation in that window recomputes its owners and allocation from an empty index, overwrites the persisted values, and — since `AllocateOnce` defaults to true with no guard on having observed any owner — marks the reservation `Succeeded`, which is terminal and does not self-correct.
- **#3149** — resync cannot be disabled through args, the `if c.resyncInterval > 0` guard in `Start()` is therefore unreachable, and neither background loop can be stopped because `wait.Until` is given a nil stop channel.

Both need `Start()` to take a stop channel or context and to be able to fail, which is a lifecycle change rather than a mechanical one, so folding it in here would make this diff much harder to review.

## Test plan

- [x] `go test ./pkg/scheduler/plugins/reservation/controller -run TestSyncStatus -race -count=100` ok
- [x] `GOMAXPROCS=1 go test ./pkg/scheduler/plugins/reservation/controller -run TestSyncStatus -race -count=100` ok
- [x] `GOMAXPROCS=8 go test ./pkg/scheduler/plugins/reservation/controller -run TestSyncStatus -race -count=100` ok
- [x] `go test ./pkg/scheduler/plugins/reservation/controller -race -shuffle=on -count=20` ok — this matters because shuffling can order `TestControllerStart` before `TestSyncStatus`, which is exactly when a leaked worker could reach the gauge
- [x] `go test ./pkg/scheduler/plugins/reservation/controller -run TestProcessNextWorkItem -race -count=50` ok
- [x] `go vet` and gofmt clean

I could not reproduce the original failure locally: 60 runs at `GOMAXPROCS=1` were clean, and even calling `resyncReservations()` explicitly between `sync()` and the assertion passes, because by then the lister has caught up. The window is narrow — the resync goroutine has to be delayed past `sync()` yet reach the gauge before the informer propagates the status update — which is consistent with this only being seen on CI. The diagnosis therefore rests on the failure being numerically identical to what `RecordReservationResource` emits for a pre-sync lister copy, and on `resyncReservations()` being the only caller of `ResetReservationResource()`.

The flake fixed here is a different one from #2957, which is about `TestSyncedEventHandler` timing out in `pkg/scheduler/frameworkext/helper`. That test passes 20/20 locally for me and is not addressed by this change.
