### PR TITLE
scheduler: drop reserve pod nominations the informer store has invalidated

### DIFF
--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go
@@ -122,7 +122,14 @@ func MakeReservationErrorHandler(
 	}
 }
 
-func addNominatedReservation(f framework.Framework, podInfo *framework.QueuedPodInfo, nominatingInfo *fwktype.NominatingInfo) {
+// addNominatedReservation records the node the failed cycle nominated.
+//
+// cycleReservePod must be the reserve pod that cycle actually ran with, not the
+// one rebuilt from the current reservation before requeuing: the nominator
+// validates the node decision against the shape it was made for, and handing it
+// the current shape would make that check compare the current object with
+// itself and accept a node chosen for a shape the reservation no longer has.
+func addNominatedReservation(f framework.Framework, cycleReservePod *corev1.Pod, nominatingInfo *fwktype.NominatingInfo) {
 	frameworkExtender, ok := f.(frameworkext.FrameworkExtender)
 	if !ok {
 		return
@@ -136,9 +143,9 @@ func addNominatedReservation(f framework.Framework, podInfo *framework.QueuedPod
 	if nominatingInfo.Mode() == fwktype.ModeOverride {
 		nodeName = nominatingInfo.NominatedNodeName
 	} else if nominatingInfo.Mode() == fwktype.ModeNoop {
-		nodeName = podInfo.Pod.Status.NominatedNodeName
+		nodeName = cycleReservePod.Status.NominatedNodeName
 	}
-	reservationNominator.AddNominatedReservePod(podInfo.Pod, nodeName)
+	reservationNominator.AddNominatedReservePod(cycleReservePod, nodeName)
 }
 
 // input:
@@ -292,7 +299,16 @@ func handleReservationSchedulingFailure(sched *scheduler.Scheduler,
 				"pod", klog.KObj(pod), "reservation", rName, "node", nodeName)
 			// We need to call DonePod here because we don't call AddUnschedulableIfNotPresent in this case.
 		} else {
-			podInfo.PodInfo, _ = framework.NewPodInfo(reservationutil.NewReservePod(cachedR))
+			currentPodInfo, buildErr := framework.NewPodInfo(reservationutil.NewReservePod(cachedR))
+			if buildErr != nil {
+				// Requeued anyway: dropping it here would leave the reservation
+				// with nothing in the queue until some other event arrives,
+				// which is worse than one more attempt on a partially parsed
+				// pod. The nominator refuses such a pod separately.
+				klog.ErrorS(buildErr, "Reserve pod for the current reservation could not be fully parsed",
+					"pod", klog.KObj(pod), "reservation", rName)
+			}
+			podInfo.PodInfo = currentPodInfo
 			if e = schedAdapter.GetSchedulingQueue().AddUnschedulableIfNotPresent(logger, podInfo, schedAdapter.GetSchedulingQueue().SchedulingCycle()); e != nil {
 				klog.ErrorS(e, "Error occurred")
 			}
@@ -300,10 +316,15 @@ func handleReservationSchedulingFailure(sched *scheduler.Scheduler,
 		}
 
 		// nominate for the reserve pod if it is
+		// NOTE: pod, not podInfo.Pod. The branch above may have replaced
+		// podInfo.PodInfo with the current reservation, while the nominated node
+		// still comes from the cycle that failed, so the nominator has to be
+		// given the reserve pod that cycle ran with to be able to tell the two
+		// revisions apart.
 		// FIXME: We expect use the default nominator for a nominated reserve pod, since it makes no benefit to
 		//   maintain another nominator. However, the default nominator relies the podLister to fetch the real pod
 		//   from the informer cache.
-		addNominatedReservation(fwk, podInfo, nominatingInfo)
+		addNominatedReservation(fwk, pod, nominatingInfo)
 
 		errMsg := status.Message()
 		msg := truncateMessage(errMsg)

--- a/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
+++ b/pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -1914,4 +1915,153 @@ func Test_generatePodEventOnReservationLevel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMakeReservationErrorHandler_NominatesWithTheCycleShape pins down which
+// reserve pod the failure handler hands to the nominator.
+//
+// The handler replaces podInfo.PodInfo with a reserve pod rebuilt from the
+// current reservation before requeuing it, but the node it nominates was chosen
+// by the cycle that just failed. The nominator can only tell a stale node
+// decision from a current one by comparing the shape that decision was made
+// for, so it has to receive the cycle's reserve pod. Handing it the rebuilt one
+// makes that comparison current-against-current, which always agrees.
+func TestMakeReservationErrorHandler_NominatesWithTheCycleShape(t *testing.T) {
+	reservationWithCPU := func(cpu string) *schedulingv1alpha1.Reservation {
+		return &schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: "reserve-pod-shape", UID: "uid-shape"},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						SchedulerName: "default-scheduler",
+						Containers: []corev1.Container{{
+							Name: "c",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(cpu)},
+							},
+						}},
+					},
+				},
+				Owners: []schedulingv1alpha1.ReservationOwner{
+					{Object: &corev1.ObjectReference{Name: "test-pod-1"}},
+				},
+				TTL: &metav1.Duration{Duration: 30 * time.Minute},
+			},
+			Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+		}
+	}
+	// The cycle ran against a reservation asking for 8 CPUs; by the time it
+	// fails, the current object only asks for 2.
+	cycleReservation := reservationWithCPU("8")
+	currentReservation := reservationWithCPU("2")
+
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	clientSet := kubefake.NewSimpleClientset()
+	fh, err := schedulertesting.NewFramework(context.TODO(), registeredPlugins, "default-scheduler",
+		frameworkruntime.WithEventRecorder(record.NewEventRecorderAdapter(record.NewFakeRecorder(1024))),
+		frameworkruntime.WithClientSet(clientSet),
+		frameworkruntime.WithInformerFactory(informers.NewSharedInformerFactory(clientSet, 0)),
+	)
+	assert.Nil(t, err)
+
+	koordClientSet := koordfake.NewSimpleClientset(currentReservation)
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+	rNominator := frameworkext.NewFakeReservationNominator()
+	frameworkExtenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
+		frameworkext.WithKoordinatorClientSet(koordClientSet),
+		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+		frameworkext.WithReservationNominator(rNominator),
+	)
+	extendedHandle := frameworkext.NewFrameworkExtender(frameworkExtenderFactory, fh)
+	sched := &scheduler.Scheduler{Profiles: profile.Map{"default-scheduler": extendedHandle}}
+	handler := MakeReservationErrorHandler(sched, frameworkext.NewFakeScheduler(), koordClientSet, koordSharedInformerFactory)
+
+	koordSharedInformerFactory.Start(nil)
+	koordSharedInformerFactory.WaitForCacheSync(nil)
+
+	cyclePodInfo, err := framework.NewPodInfo(reservationutil.NewReservePod(cycleReservation))
+	assert.NoError(t, err)
+	handler(context.TODO(), extendedHandle, &framework.QueuedPodInfo{PodInfo: cyclePodInfo},
+		fwktype.NewStatus(fwktype.Unschedulable, "test error"),
+		&fwktype.NominatingInfo{NominatingMode: fwktype.ModeOverride, NominatedNodeName: "node-1"}, time.Now())
+
+	nominated := rNominator.NominatedReservePodForNode("node-1")
+	assert.Equal(t, 1, len(nominated))
+	gotCPU := nominated[0].Pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "8", gotCPU.String(),
+		"the nominator must receive the reserve pod the failed cycle ran with, not one rebuilt from the current reservation")
+}
+
+// TestMakeReservationErrorHandler_RequeuesUnparsableCurrentReservation covers
+// the reserve pod rebuilt from a current reservation whose affinity does not
+// parse. The pod is requeued regardless: dropping it would leave the
+// reservation with nothing in the scheduling queue until an unrelated event
+// arrives, which is worse than one more attempt on a partially parsed pod. The
+// nominator refuses such a pod separately.
+func TestMakeReservationErrorHandler_RequeuesUnparsableCurrentReservation(t *testing.T) {
+	unparsable := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "reserve-pod-unparsable", UID: "uid-unparsable"},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SchedulerName: "default-scheduler",
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{Key: "app", Operator: "NotAnOperator"},
+									},
+								},
+								TopologyKey: "kubernetes.io/hostname",
+							}},
+						},
+					},
+				},
+			},
+			Owners: []schedulingv1alpha1.ReservationOwner{
+				{Object: &corev1.ObjectReference{Name: "test-pod-1"}},
+			},
+			TTL: &metav1.Duration{Duration: 30 * time.Minute},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+	}
+
+	registeredPlugins := []schedulertesting.RegisterPluginFunc{
+		schedulertesting.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		schedulertesting.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+	}
+	clientSet := kubefake.NewSimpleClientset()
+	fh, err := schedulertesting.NewFramework(context.TODO(), registeredPlugins, "default-scheduler",
+		frameworkruntime.WithEventRecorder(record.NewEventRecorderAdapter(record.NewFakeRecorder(1024))),
+		frameworkruntime.WithClientSet(clientSet),
+		frameworkruntime.WithInformerFactory(informers.NewSharedInformerFactory(clientSet, 0)),
+	)
+	assert.Nil(t, err)
+
+	koordClientSet := koordfake.NewSimpleClientset(unparsable)
+	koordSharedInformerFactory := koordinatorinformers.NewSharedInformerFactory(koordClientSet, 0)
+	frameworkExtenderFactory, _ := frameworkext.NewFrameworkExtenderFactory(
+		frameworkext.WithKoordinatorClientSet(koordClientSet),
+		frameworkext.WithKoordinatorSharedInformerFactory(koordSharedInformerFactory),
+		frameworkext.WithReservationNominator(frameworkext.NewFakeReservationNominator()),
+	)
+	extendedHandle := frameworkext.NewFrameworkExtender(frameworkExtenderFactory, fh)
+	sched := &scheduler.Scheduler{Profiles: profile.Map{"default-scheduler": extendedHandle}}
+	internalHandler := frameworkext.NewFakeScheduler()
+	handler := MakeReservationErrorHandler(sched, internalHandler, koordClientSet, koordSharedInformerFactory)
+
+	koordSharedInformerFactory.Start(nil)
+	koordSharedInformerFactory.WaitForCacheSync(nil)
+
+	cyclePodInfo, _ := framework.NewPodInfo(reservationutil.NewReservePod(unparsable))
+	handler(context.TODO(), extendedHandle, &framework.QueuedPodInfo{PodInfo: cyclePodInfo},
+		fwktype.NewStatus(fwktype.Unschedulable, "test error"),
+		&fwktype.NominatingInfo{NominatingMode: fwktype.ModeNoop}, time.Now())
+
+	assert.NotNil(t, internalHandler.Queue.UnschedulablePods[string(unparsable.UID)],
+		"the reserve pod must still reach the scheduling queue")
 }

--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -19,6 +19,7 @@ package reservation
 import (
 	"context"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -65,6 +66,15 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
+	if oldR.UID != newR.UID {
+		// A delete followed by a same-named create can reach handlers as a
+		// single update. The nominator keys reserve pods by reservation UID,
+		// so the cleanups below - which all build the reserve pod from newR -
+		// would leave the replaced reservation's nomination occupying its old
+		// node forever.
+		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(oldR))
+	}
+
 	if reservationutil.IsReservationActive(newR) {
 		h.cache.updateReservation(newR)
 		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(newR))
@@ -79,6 +89,36 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		klog.V(4).InfoS("update reservation into terminated so only update cache if exists",
 			"reservation", klog.KObj(newR), "node", reservationutil.GetReservationNodeName(newR))
 		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(newR))
+	} else if !newR.DeletionTimestamp.IsZero() {
+		// A reservation that entered deletion will never have its reserve pod
+		// scheduled, even while a finalizer keeps the object around, so no
+		// revision of it may keep holding a node.
+		h.rrNominator.DeleteReservePod(reservationutil.NewReservePod(newR))
+		klog.V(4).InfoS("delete nominated reserve pod for terminating reservation",
+			"reservation", klog.KObj(newR), "uid", newR.UID)
+	} else if oldR.Generation != newR.Generation ||
+		!apiequality.Semantic.DeepEqual(oldR.Labels, newR.Labels) ||
+		!apiequality.Semantic.DeepEqual(oldR.Annotations, newR.Annotations) {
+		// A scheduling-relevant update of a still-unscheduled reservation can
+		// invalidate its nomination: placement constraints (nodeSelector,
+		// affinities, tolerations, ...) or even the schedulerName may have
+		// changed, and on a schedulerName handover the framework handler only
+		// removes the reserve pod from the scheduling queue, never from this
+		// nominator. Dropping it is the conservative choice - if the
+		// reservation still belongs to this scheduler, its reserve pod
+		// re-nominates on its next cycle.
+		//
+		// Only if it is actually stale, judged against the informer store rather
+		// than against this event. This handler and the scheduling cycle run on
+		// goroutines with no ordering between them, so by the time this runs a
+		// cycle may already have recorded a nomination for a revision newer than
+		// newR, and discarding that one would be worse than keeping a stale
+		// entry: the read path drops what no longer matches the store, but
+		// nothing recreates an entry that was deleted. This handler only makes
+		// the node available sooner - the read path is the guarantee.
+		h.rrNominator.DeleteReservePodIfStale(reservationutil.NewReservePod(newR))
+		klog.V(4).InfoS("reconciled the nominated reserve pod of an updated unscheduled reservation",
+			"reservation", klog.KObj(newR), "uid", newR.UID)
 	}
 }
 

--- a/pkg/scheduler/plugins/reservation/eventhandler.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler.go
@@ -97,6 +97,7 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		klog.V(4).InfoS("delete nominated reserve pod for terminating reservation",
 			"reservation", klog.KObj(newR), "uid", newR.UID)
 	} else if oldR.Generation != newR.Generation ||
+		oldR.Status.NodeName != newR.Status.NodeName ||
 		!apiequality.Semantic.DeepEqual(oldR.Labels, newR.Labels) ||
 		!apiequality.Semantic.DeepEqual(oldR.Annotations, newR.Annotations) {
 		// A scheduling-relevant update of a still-unscheduled reservation can
@@ -116,6 +117,9 @@ func (h *reservationEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		// entry: the read path drops what no longer matches the store, but
 		// nothing recreates an entry that was deleted. This handler only makes
 		// the node available sooner - the read path is the guarantee.
+		//
+		// status.nodeName is a trigger but not part of the identity: a Pending
+		// reservation acquiring a node reaches none of the branches above.
 		h.rrNominator.DeleteReservePodIfStale(reservationutil.NewReservePod(newR))
 		klog.V(4).InfoS("reconciled the nominated reserve pod of an updated unscheduled reservation",
 			"reservation", klog.KObj(newR), "uid", newR.UID)

--- a/pkg/scheduler/plugins/reservation/eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler_test.go
@@ -17,16 +17,22 @@ limitations under the License.
 package reservation
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	clientcache "k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	listerschedulingv1alpha1 "github.com/koordinator-sh/koordinator/pkg/client/listers/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/util/reservation"
 )
 
@@ -257,4 +263,773 @@ func TestEventHandlerDelete(t *testing.T) {
 	assert.NotNil(t, rInfo)
 	assert.False(t, rInfo.IsAvailable())
 	assert.Equal(t, []*framework.PodInfo{}, eh.rrNominator.NominatedReservePodForNode("test-node"))
+}
+
+func TestEventHandlerUpdatePendingDeletesNomination(t *testing.T) {
+	pendingReservation := &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:        uuid.NewUUID(),
+			Name:       "test-pending-reservation",
+			Generation: 1,
+		},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("8000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{
+			Phase: schedulingv1alpha1.ReservationPending,
+		},
+	}
+	eh := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: newNominator(nil, nil)}
+	reservePodInfo, _ := framework.NewPodInfo(reservation.NewReservePod(pendingReservation))
+	eh.rrNominator.AddNominatedReservePod(reservePodInfo, "test-node")
+
+	// A status-only write keeps the nomination untouched.
+	statusTouched := pendingReservation.DeepCopy()
+	eh.OnUpdate(pendingReservation, statusTouched)
+	assert.Equal(t, 1, len(eh.rrNominator.NominatedReservePodForNode("test-node")))
+
+	// A scheduling-relevant update (spec resize, placement constraints, or a
+	// schedulerName handover - the framework handler never cleans this
+	// nominator on a handover) must delete the nomination instead of
+	// refreshing it in place; the reserve pod re-nominates on its next cycle
+	// if the reservation still belongs to this scheduler.
+	updatedReservation := pendingReservation.DeepCopy()
+	updatedReservation.Generation = 2
+	updatedReservation.Spec.Template.Spec.SchedulerName = "other-scheduler"
+	eh.OnUpdate(pendingReservation, updatedReservation)
+	assert.Equal(t, 0, len(eh.rrNominator.NominatedReservePodForNode("test-node")),
+		"scheduling-relevant update must remove the nomination, or a schedulerName handover leaks a ghost nomination")
+}
+
+// newPendingReservationForNomination builds a still-unscheduled reservation
+// with an explicit resourceVersion, matching what an informer store holds.
+func newPendingReservationForNomination(name string, uid types.UID, rv string, cpu string) *schedulingv1alpha1.Reservation {
+	return &schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid, ResourceVersion: rv, Generation: 1},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(cpu)},
+						},
+					}},
+				},
+			},
+		},
+		Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+	}
+}
+
+func newNominatorWithReservations(t *testing.T, rs ...*schedulingv1alpha1.Reservation) (*nominator, clientcache.Indexer) {
+	indexer := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{})
+	for _, r := range rs {
+		assert.NoError(t, indexer.Add(r))
+	}
+	return newNominator(nil, listerschedulingv1alpha1.NewReservationLister(indexer)), indexer
+}
+
+// TestNominatedReservePodForNodeRevalidates verifies the ordering invariant the
+// QueueingHints rely on: the informer store (lister) is updated before any
+// event handler runs, so a read must already reflect what that store says even
+// when the listener maintaining this nominator has not processed the update.
+func TestNominatedReservePodForNodeRevalidates(t *testing.T) {
+	t.Run("a spec change drops the nomination", func(t *testing.T) {
+		stored := newPendingReservationForNomination("r-spec", "uid-spec", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, stored)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(stored))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+		assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+
+		// The CRD has the status subresource, so a spec edit bumps the
+		// generation. The reserve pod's placement constraints, requests,
+		// priority or even schedulerName may have moved, so the nominated node
+		// need not still be a valid choice for it - which is also why
+		// reservationEventHandler.OnUpdate deletes the nomination for this.
+		resized := newPendingReservationForNomination("r-spec", "uid-spec", "2", "2000m")
+		resized.Generation = 2
+		assert.NoError(t, indexer.Update(resized))
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"a reserve pod whose shape changed must not stay accounted for on the old node")
+	})
+
+	t.Run("a status-only write keeps the nomination", func(t *testing.T) {
+		stored := newPendingReservationForNomination("r-status", "uid-status", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, stored)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(stored))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+
+		// This scheduler records an unschedulable condition on the reservation
+		// after every failed attempt, so status-only bumps are the common case
+		// and must not cost the reserve pod its nominated node.
+		touched := stored.DeepCopy()
+		touched.ResourceVersion = "2"
+		touched.Status.Conditions = []schedulingv1alpha1.ReservationCondition{{
+			Type:   schedulingv1alpha1.ReservationConditionScheduled,
+			Status: schedulingv1alpha1.ConditionStatusFalse,
+			Reason: schedulingv1alpha1.ReasonReservationUnschedulable,
+		}}
+		assert.NoError(t, indexer.Update(touched))
+
+		nominated := nm.NominatedReservePodForNode("test-node")
+		assert.Equal(t, 1, len(nominated))
+		assert.Equal(t, pi.Pod.UID, nominated[0].Pod.UID)
+	})
+}
+
+// TestNominatedReservePodForNodeDropsInvalidated covers the nominations that
+// must disappear as soon as the store says so. Keeping them would let a
+// phantom reserve pod occupy the node during exactly the window in which a
+// requeued waiter re-evaluates, and no further event would wake that waiter.
+func TestNominatedReservePodForNodeDropsInvalidated(t *testing.T) {
+	t.Run("reservation deleted from the store", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-gone", "uid-gone", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, r)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+
+		assert.NoError(t, indexer.Delete(r))
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"a deleted reservation must not keep occupying its nominated node")
+	})
+
+	t.Run("reservation replaced by a same-named object", func(t *testing.T) {
+		old := newPendingReservationForNomination("r-replaced", "uid-old", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, old)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(old))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+
+		replaced := newPendingReservationForNomination("r-replaced", "uid-new", "2", "8000m")
+		assert.NoError(t, indexer.Update(replaced))
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"the replaced reservation's nomination must not survive as a phantom")
+	})
+
+	t.Run("reservation became active", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-active", "uid-active", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, r)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+
+		active := r.DeepCopy()
+		active.ResourceVersion = "2"
+		assert.NoError(t, reservation.SetReservationAvailable(active, "test-node"))
+		assert.NoError(t, indexer.Update(active))
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"an assumed reserve pod is already accounted for by the scheduler cache, so the nomination must not double count it")
+	})
+
+	t.Run("reservation terminated", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-failed", "uid-failed", "1", "8000m")
+		nm, indexer := newNominatorWithReservations(t, r)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+
+		failed := r.DeepCopy()
+		failed.ResourceVersion = "2"
+		failed.Status.Phase = schedulingv1alpha1.ReservationFailed
+		assert.NoError(t, indexer.Update(failed))
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"))
+	})
+
+	t.Run("nil lister keeps the stored snapshot", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-nolister", "uid-nolister", "1", "8000m")
+		nm := newNominator(nil, nil)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+		assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+	})
+}
+
+// TestAddNominatedReservePodRejectsReplaced covers the other half of a
+// same-name replacement: a scheduling cycle still holding the previous reserve
+// pod must not be able to resurrect its nomination after cleanup.
+func TestAddNominatedReservePodRejectsReplaced(t *testing.T) {
+	old := newPendingReservationForNomination("r-race", "uid-old", "1", "8000m")
+	replaced := newPendingReservationForNomination("r-race", "uid-new", "2", "8000m")
+	nm, _ := newNominatorWithReservations(t, replaced)
+
+	stalePodInfo, err := framework.NewPodInfo(reservation.NewReservePod(old))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(stalePodInfo, "test-node")
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a stale reserve pod must not be nominated once its reservation was replaced")
+}
+
+// TestEventHandlerUpdateReplacedUIDDeletesOldNomination covers the informer
+// coalescing a delete and a same-named create into a single update: the
+// nominator keys reserve pods by reservation UID, so cleaning up only the new
+// UID would leave the replaced reservation occupying its old node forever.
+func TestEventHandlerUpdateReplacedUIDDeletesOldNomination(t *testing.T) {
+	old := newPendingReservationForNomination("r-coalesced", "uid-old", "1", "8000m")
+	eh := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: newNominator(nil, nil)}
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(old))
+	assert.NoError(t, err)
+	eh.rrNominator.AddNominatedReservePod(pi, "test-node")
+	assert.Equal(t, 1, len(eh.rrNominator.NominatedReservePodForNode("test-node")))
+
+	replaced := newPendingReservationForNomination("r-coalesced", "uid-new", "2", "8000m")
+	eh.OnUpdate(old, replaced)
+	assert.Empty(t, eh.rrNominator.NominatedReservePodForNode("test-node"),
+		"the replaced reservation's nomination must be removed, not just the new UID's")
+}
+
+// BenchmarkNominatedReservePodForNode measures the per-pod-per-node read path
+// that BeforeFilter runs: one lister lookup and one PodInfo copy per
+// nomination. The status-bumped variant exists to show that a resourceVersion
+// change alone does not make the read more expensive, since revalidation
+// compares the reservation's scheduling identity rather than its revision.
+func BenchmarkNominatedReservePodForNode(b *testing.B) {
+	run := func(b *testing.B, count int, bumpVersion bool) {
+		indexer := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{})
+		nm := newNominator(nil, listerschedulingv1alpha1.NewReservationLister(indexer))
+		for i := 0; i < count; i++ {
+			r := &schedulingv1alpha1.Reservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "r-bench-" + strconv.Itoa(i), UID: types.UID("uid-bench-" + strconv.Itoa(i)),
+					ResourceVersion: "1", Generation: 1,
+				},
+				Spec: schedulingv1alpha1.ReservationSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+								},
+							}},
+							Affinity: &corev1.Affinity{
+								PodAntiAffinity: &corev1.PodAntiAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+										LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "bench"}},
+										TopologyKey:   "kubernetes.io/hostname",
+									}},
+								},
+							},
+						},
+					},
+				},
+				Status: schedulingv1alpha1.ReservationStatus{Phase: schedulingv1alpha1.ReservationPending},
+			}
+			if err := indexer.Add(r); err != nil {
+				b.Fatal(err)
+			}
+			pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+			if err != nil {
+				b.Fatal(err)
+			}
+			nm.AddNominatedReservePod(pi, "bench-node")
+			if bumpVersion {
+				bumped := r.DeepCopy()
+				bumped.ResourceVersion = "2"
+				if err := indexer.Update(bumped); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = nm.NominatedReservePodForNode("bench-node")
+		}
+	}
+
+	b.Run("1-nomination", func(b *testing.B) { run(b, 1, false) })
+	b.Run("10-nominations", func(b *testing.B) { run(b, 10, false) })
+	b.Run("10-nominations-status-bumped", func(b *testing.B) { run(b, 10, true) })
+}
+
+// badAffinityReservation carries a pod affinity term whose selector cannot be
+// parsed, which is what makes framework.NewPodInfo fail.
+func badAffinityReservation(name string, uid types.UID, rv string) *schedulingv1alpha1.Reservation {
+	r := newPendingReservationForNomination(name, uid, rv, "2")
+	r.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "app", Operator: "NotAnOperator"}},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			}},
+		},
+	}
+	return r
+}
+
+// TestAddNominatedReservePodSkipsUnbuildableCurrent covers the case where the
+// current object cannot be turned into a reserve pod at all. Storing a
+// partially parsed PodInfo would understate what the nomination occupies for
+// every pod that later reads it, so nothing is nominated.
+func TestAddNominatedReservePodSkipsUnbuildableCurrent(t *testing.T) {
+	unparsable := badAffinityReservation("r-badaffinity", "uid-bad", "1")
+	nm, _ := newNominatorWithReservations(t, unparsable)
+
+	// The caller carries the same unparsable shape, so the call gets past the
+	// shape comparison and fails where the reserve pod is actually built. A
+	// caller with a different shape would be turned away earlier and would
+	// leave this path untested.
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(unparsable))
+	assert.Error(t, err, "the fixture is only useful if NewPodInfo does reject it")
+	assert.NotNil(t, pi)
+	nm.AddNominatedReservePod(pi, "test-node")
+
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a reservation whose current shape cannot be parsed must not be nominated")
+}
+
+// TestPluginAddNominatedReservePodSkipsUnparsable ensures a reserve pod whose
+// PodInfo cannot be built is not nominated at all: a partially parsed PodInfo
+// would understate its constraints for every pod that later reads it.
+func TestPluginAddNominatedReservePodSkipsUnparsable(t *testing.T) {
+	pl := &Plugin{nominator: newNominator(nil, nil)}
+	bad := reservation.NewReservePod(badAffinityReservation("r-skip", "uid-skip", "1"))
+	pl.AddNominatedReservePod(bad, "test-node")
+	assert.Empty(t, pl.nominator.NominatedReservePodForNode("test-node"))
+
+	good := reservation.NewReservePod(newPendingReservationForNomination("r-ok", "uid-ok", "1", "2"))
+	pl.AddNominatedReservePod(good, "test-node")
+	assert.Equal(t, 1, len(pl.nominator.NominatedReservePodForNode("test-node")))
+}
+
+// TestBeforeFilterEarlyReturns covers the two guards at the top of
+// BeforeFilter: a NodeInfo without a Node must not be dereferenced, and a node
+// holding no nominations must be returned untouched.
+func TestBeforeFilterEarlyReturns(t *testing.T) {
+	pl := &Plugin{nominator: newNominator(nil, nil)}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "p"}}
+
+	nilNodeInfo := framework.NewNodeInfo()
+	gotPod, gotNodeInfo, transformed, status := pl.BeforeFilter(context.TODO(), framework.NewCycleState(), pod, nilNodeInfo)
+	assert.True(t, status == nil || status.IsSuccess())
+	assert.False(t, transformed)
+	assert.Equal(t, pod, gotPod)
+	assert.Equal(t, nilNodeInfo, gotNodeInfo)
+
+	emptyNodeInfo := framework.NewNodeInfo()
+	emptyNodeInfo.SetNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}})
+	gotPod, gotNodeInfo, transformed, status = pl.BeforeFilter(context.TODO(), framework.NewCycleState(), pod, emptyNodeInfo)
+	assert.True(t, status == nil || status.IsSuccess())
+	assert.False(t, transformed, "a node without nominations must not be snapshotted")
+	assert.Equal(t, pod, gotPod)
+	assert.Equal(t, emptyNodeInfo, gotNodeInfo)
+}
+
+// TestNominatedReservePodForNodeDropsTerminating covers the state a
+// finalizer creates: the object stays Pending with every field a nomination is
+// keyed on unchanged, but its reserve pod will never be scheduled, so the node
+// it was holding has to be released. ReservationInfo.IsUnschedulable already
+// treats terminating reservations this way.
+func TestNominatedReservePodForNodeDropsTerminating(t *testing.T) {
+	r := newPendingReservationForNomination("r-terminating", "uid-terminating", "1", "2")
+	r.Finalizers = []string{"example.com/cleanup"}
+	nm, indexer := newNominatorWithReservations(t, r)
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(pi, "test-node")
+	assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+
+	terminating := r.DeepCopy()
+	terminating.ResourceVersion = "2"
+	now := metav1.Now()
+	terminating.DeletionTimestamp = &now
+	assert.NoError(t, indexer.Update(terminating))
+
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a reservation waiting on a finalizer must not keep holding its nominated node")
+}
+
+// TestAddNominatedReservePodRejectsStaleNodeDecision covers a late scheduling
+// cycle: addNominatedReservation reuses the NominatedNodeName from the cycle
+// that failed, so a cycle that ran against an older revision would otherwise
+// pin the current reservation to a node chosen for a shape it no longer has.
+// This also subsumes what a caller's stale PodInfo could do on its own: once
+// the shapes have to match, the caller's copy and a rebuild from the current
+// object are byte-identical, since NewReservePod derives the reserve pod from
+// exactly the spec, labels and annotations being compared.
+func TestAddNominatedReservePodRejectsStaleNodeDecision(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*schedulingv1alpha1.Reservation)
+		rejects bool
+	}{
+		{
+			name: "requests changed",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("8000m")
+			},
+			rejects: true,
+		},
+		{
+			name: "required node affinity now points elsewhere",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Spec.Template.Spec.Affinity = &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+								MatchFields: []corev1.NodeSelectorRequirement{{
+									Key: "metadata.name", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-1"},
+								}},
+							}},
+						},
+					},
+				}
+			},
+			rejects: true,
+		},
+		{
+			name: "schedulerName handed to another scheduler",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Spec.Template.Spec.SchedulerName = "other-scheduler"
+			},
+			rejects: true,
+		},
+		{
+			name: "labels changed",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Labels = map[string]string{"tier": "gold"}
+			},
+			rejects: true,
+		},
+		{
+			// Same shape, older revision: the cycle still describes the current
+			// reservation, so its node choice stands.
+			name:    "nothing that affects scheduling changed",
+			mutate:  func(r *schedulingv1alpha1.Reservation) {},
+			rejects: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := newPendingReservationForNomination("r-stalenode", "uid-stalenode", "2", "2000m")
+			current.Generation = 2
+			nm, _ := newNominatorWithReservations(t, current)
+
+			// A newer cycle already nominated the node the current shape belongs on.
+			currentPodInfo, err := framework.NewPodInfo(reservation.NewReservePod(current))
+			assert.NoError(t, err)
+			nm.AddNominatedReservePod(currentPodInfo, "node-2")
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-2")))
+
+			// The older cycle finishes afterwards, carrying its own node choice.
+			stale := newPendingReservationForNomination("r-stalenode", "uid-stalenode", "1", "2000m")
+			tt.mutate(stale)
+			stalePodInfo, err := framework.NewPodInfo(reservation.NewReservePod(stale))
+			assert.NoError(t, err)
+			nm.AddNominatedReservePod(stalePodInfo, "node-1")
+
+			if tt.rejects {
+				assert.Empty(t, nm.NominatedReservePodForNode("node-1"),
+					"a node chosen for an older revision must not be nominated")
+				assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-2")),
+					"the rejected call must leave the newer cycle's nomination alone")
+				return
+			}
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-1")),
+				"an unchanged shape means the cycle still describes the current reservation")
+		})
+	}
+}
+
+// TestAddNominatedReservePodRejectsTerminating covers a cycle that finishes
+// after its reservation entered deletion: the reserve pod will never be
+// scheduled, so its node choice must not be recorded.
+func TestAddNominatedReservePodRejectsTerminating(t *testing.T) {
+	r := newPendingReservationForNomination("r-term-add", "uid-term-add", "1", "2")
+	r.Finalizers = []string{"example.com/cleanup"}
+	terminatingAt := metav1.Now()
+	r.DeletionTimestamp = &terminatingAt
+	nm, _ := newNominatorWithReservations(t, r)
+
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(pi, "test-node")
+
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a terminating reservation must not take a node, whatever a late cycle decided")
+}
+
+// TestAddNominatedReservePodRejectionPaths covers what happens to an existing
+// nomination when a call is refused. Anything that says the reservation is no
+// longer waiting on a node must clear it; a call that is merely unusable must
+// leave it alone.
+func TestAddNominatedReservePodRejectionPaths(t *testing.T) {
+	newNominatedAt := func(t *testing.T, r *schedulingv1alpha1.Reservation) (*nominator, clientcache.Indexer) {
+		nm, indexer := newNominatorWithReservations(t, r)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+		assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+		return nm, indexer
+	}
+
+	t.Run("an empty nominated node clears the nomination", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-nonode", "uid-nonode", "1", "2")
+		nm, _ := newNominatedAt(t, r)
+
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "")
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"losing the nominated node must release the one being held")
+	})
+
+	t.Run("a reservation that left the store clears the nomination", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-gonemid", "uid-gonemid", "1", "2")
+		nm, indexer := newNominatedAt(t, r)
+
+		assert.NoError(t, indexer.Delete(r))
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"))
+	})
+
+	t.Run("a reservation that got scheduled clears the nomination", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-scheduled", "uid-scheduled", "1", "2")
+		nm, indexer := newNominatedAt(t, r)
+
+		active := r.DeepCopy()
+		active.ResourceVersion = "2"
+		assert.NoError(t, reservation.SetReservationAvailable(active, "test-node"))
+		assert.NoError(t, indexer.Update(active))
+
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, "test-node")
+		assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+			"an assumed reserve pod is accounted for by the scheduler cache instead")
+	})
+
+	t.Run("a pod that is not a reserve pod is ignored", func(t *testing.T) {
+		r := newPendingReservationForNomination("r-notreserve", "uid-notreserve", "1", "2")
+		nm, _ := newNominatedAt(t, r)
+
+		plain, err := framework.NewPodInfo(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "plain", Namespace: "default", UID: "plain"},
+		})
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(plain, "test-node")
+		assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")),
+			"an unrelated pod must not disturb an existing nomination")
+	})
+}
+
+// TestNominatedReservePodForNodeDropsForeignNode covers the window where a
+// reservation has been given a node but has not become active yet.
+// isReservationWaitingForScheduling deliberately still accepts it, because
+// during that window the nomination is the only thing accounting for its
+// reserve pod - but only on the node it is actually going to.
+func TestNominatedReservePodForNodeDropsForeignNode(t *testing.T) {
+	r := newPendingReservationForNomination("r-foreign", "uid-foreign", "1", "2")
+	nm, indexer := newNominatorWithReservations(t, r)
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(r))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(pi, "test-node")
+	assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+
+	// A status-only write, so the scheduling identity is untouched and only the
+	// assigned node distinguishes this from the stored nomination.
+	assigned := r.DeepCopy()
+	assigned.ResourceVersion = "2"
+	assigned.Status.NodeName = "another-node"
+	assert.NoError(t, indexer.Update(assigned))
+
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a reservation on its way to another node must not keep holding this one")
+}
+
+// TestPluginAddNominatedReservePodEmptyNodeDeletes covers the exported entry
+// point's empty-node contract. An empty node means the reserve pod lost its
+// nomination, and that has to be honored even for a pod the framework cannot
+// parse - otherwise a reserve pod whose affinity just became invalid keeps
+// holding the node it was nominated to beforehand.
+func TestPluginAddNominatedReservePodEmptyNodeDeletes(t *testing.T) {
+	pl := &Plugin{nominator: newNominator(nil, nil)}
+	r := newPendingReservationForNomination("r-empty-node", "uid-empty-node", "1", "2")
+	pl.AddNominatedReservePod(reservation.NewReservePod(r), "test-node")
+	assert.Equal(t, 1, len(pl.nominator.NominatedReservePodForNode("test-node")))
+
+	// The reservation's affinity is edited to something unparsable, and the
+	// cycle that follows finds no node for it.
+	unparsable := reservation.NewReservePod(badAffinityReservation("r-empty-node", "uid-empty-node", "2"))
+	pl.AddNominatedReservePod(unparsable, "")
+
+	assert.Empty(t, pl.nominator.NominatedReservePodForNode("test-node"),
+		"losing the nominated node must release it even when the reserve pod no longer parses")
+}
+
+// TestEventHandlerUpdateKeepsNominationMadeAfterTheUpdate covers the ordering
+// this handler cannot control: the informer store is already at the new
+// revision, a scheduling cycle sees it and records a nomination for it, and only
+// then does this handler get the same update. Deleting by UID would discard a
+// nomination that describes the current object, and the read path never
+// recreates one.
+func TestEventHandlerUpdateKeepsNominationMadeAfterTheUpdate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*schedulingv1alpha1.Reservation)
+	}{
+		{
+			name:   "spec change",
+			mutate: func(r *schedulingv1alpha1.Reservation) { r.Generation = 2 },
+		},
+		{
+			name:   "label change",
+			mutate: func(r *schedulingv1alpha1.Reservation) { r.Labels = map[string]string{"tier": "gold"} },
+		},
+		{
+			name: "annotation change",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Annotations = map[string]string{"example.com/key": "value"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldR := newPendingReservationForNomination("r-late-handler", "uid-late-handler", "1", "2")
+			newR := oldR.DeepCopy()
+			newR.ResourceVersion = "2"
+			tt.mutate(newR)
+
+			// The store is already at newR, and a cycle that saw it nominated a node.
+			nm, _ := newNominatorWithReservations(t, newR)
+			h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+			pi, err := framework.NewPodInfo(reservation.NewReservePod(newR))
+			assert.NoError(t, err)
+			nm.AddNominatedReservePod(pi, "node-new")
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-new")))
+
+			// The handler only now catches up with that same update.
+			h.OnUpdate(oldR, newR)
+
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-new")),
+				"a nomination recorded for the new revision must survive the late handler")
+		})
+	}
+}
+
+// TestEventHandlerUpdateTerminatingDeletesUnconditionally is the counterpart to
+// the late-handler case above. A shape change only removes the nomination that
+// predates it, but a reservation entering deletion will never have its reserve
+// pod scheduled at all, so no revision of it may keep holding a node - not even
+// one recorded after the update was already visible.
+func TestEventHandlerUpdateTerminatingDeletesUnconditionally(t *testing.T) {
+	oldR := newPendingReservationForNomination("r-term-handler", "uid-term-handler", "1", "2")
+	oldR.Finalizers = []string{"example.com/cleanup"}
+	newR := oldR.DeepCopy()
+	newR.ResourceVersion = "2"
+	terminatingAt := metav1.Now()
+	newR.DeletionTimestamp = &terminatingAt
+
+	// The store is already terminating, so the recorded identity is the new
+	// revision's - the case the shape-change branch deliberately keeps.
+	nm, indexer := newNominatorWithReservations(t, oldR)
+	h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(oldR))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(pi, "test-node")
+	assert.Equal(t, 1, len(nm.NominatedReservePodForNode("test-node")))
+	assert.NoError(t, indexer.Update(newR))
+
+	h.OnUpdate(oldR, newR)
+
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"),
+		"a terminating reservation must not keep a nomination whatever recorded it")
+}
+
+// TestEventHandlerUpdateKeepsNominationAfterMetadataRoundTrip covers labels and
+// annotations returning to an earlier value. A CRD with the status subresource
+// does not advance metadata.generation for metadata-only writes, so the two
+// visits to A produce identical scheduling identities. A cleanup that compared
+// the stored identity with the event's old object would see a match on the
+// delayed A -> B event and delete the nomination a cycle had just recorded for
+// the second A.
+func TestEventHandlerUpdateKeepsNominationAfterMetadataRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		setA func(*schedulingv1alpha1.Reservation)
+		setB func(*schedulingv1alpha1.Reservation)
+	}{
+		{
+			name: "labels",
+			setA: func(r *schedulingv1alpha1.Reservation) { r.Labels = map[string]string{"tier": "a"} },
+			setB: func(r *schedulingv1alpha1.Reservation) { r.Labels = map[string]string{"tier": "b"} },
+		},
+		{
+			name: "annotations",
+			setA: func(r *schedulingv1alpha1.Reservation) { r.Annotations = map[string]string{"example.com/k": "a"} },
+			setB: func(r *schedulingv1alpha1.Reservation) { r.Annotations = map[string]string{"example.com/k": "b"} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := newPendingReservationForNomination("r-aba", "uid-aba", "1", "2")
+			tt.setA(first)
+			second := first.DeepCopy()
+			second.ResourceVersion = "2"
+			tt.setB(second)
+			third := first.DeepCopy() // back to A, generation never moved
+			third.ResourceVersion = "3"
+
+			// The store is already at the second A and a cycle nominated for it.
+			nm, _ := newNominatorWithReservations(t, third)
+			h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+			pi, err := framework.NewPodInfo(reservation.NewReservePod(third))
+			assert.NoError(t, err)
+			nm.AddNominatedReservePod(pi, "node-current")
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-current")))
+
+			// The handler only now catches up with the earlier A -> B event.
+			h.OnUpdate(first, second)
+
+			assert.Equal(t, 1, len(nm.NominatedReservePodForNode("node-current")),
+				"a nomination matching the current store must survive an older update")
+		})
+	}
+}
+
+// TestEventHandlerUpdateKeepsPreAllocationOfCurrentCycle covers the other state
+// this cleanup could reach. Pre-allocation candidates are recorded without any
+// identity, so a cleanup that treated "no identity" as "no provenance" would
+// clear the candidates a cycle in progress had just recorded.
+func TestEventHandlerUpdateKeepsPreAllocationOfCurrentCycle(t *testing.T) {
+	oldR := newPendingReservationForNomination("r-prealloc", "uid-prealloc", "1", "2")
+	newR := oldR.DeepCopy()
+	newR.ResourceVersion = "2"
+	newR.Generation = 2
+
+	nm, _ := newNominatorWithReservations(t, newR)
+	h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+	rInfo := frameworkext.NewReservationInfo(newR)
+	candidate := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "candidate", Namespace: "default", UID: "candidate"},
+		Spec:       corev1.PodSpec{NodeName: "test-node"},
+	}
+	nm.AddNominatedPreAllocation(rInfo, "test-node", candidate)
+	assert.NotNil(t, nm.GetNominatedPreAllocation(rInfo, "test-node"))
+
+	h.OnUpdate(oldR, newR)
+
+	assert.NotNil(t, nm.GetNominatedPreAllocation(rInfo, "test-node"),
+		"a reserve pod cleanup must not take the pre-allocation state of a cycle in progress")
 }

--- a/pkg/scheduler/plugins/reservation/eventhandler_test.go
+++ b/pkg/scheduler/plugins/reservation/eventhandler_test.go
@@ -751,6 +751,27 @@ func TestAddNominatedReservePodRejectsStaleNodeDecision(t *testing.T) {
 // TestAddNominatedReservePodRejectsTerminating covers a cycle that finishes
 // after its reservation entered deletion: the reserve pod will never be
 // scheduled, so its node choice must not be recorded.
+// TestAddNominatedReservePodAcceptsAssignedNode covers the window
+// nominationStillValid is written for: a Pending reservation that has acquired
+// status.nodeName but whose reserve pod is not in the scheduler cache yet, so
+// the nomination is the only accounting for that node. NewReservePod copies
+// status.nodeName into Spec.NodeName, so a cycle that began before the
+// assignment must still be accepted for the node it is going to.
+func TestAddNominatedReservePodAcceptsAssignedNode(t *testing.T) {
+	r := newPendingReservationForNomination("r-assigned", "uid-assigned", "1", "1000m")
+	nm, indexer := newNominatorWithReservations(t, r)
+	stale, err := framework.NewPodInfo(reservation.NewReservePod(r))
+	assert.NoError(t, err)
+
+	assigned := r.DeepCopy()
+	assigned.Status.NodeName = "test-node"
+	assert.NoError(t, indexer.Update(assigned))
+
+	nm.AddNominatedReservePod(stale, "test-node")
+	assert.Len(t, nm.NominatedReservePodForNode("test-node"), 1,
+		"a cycle that started before status.nodeName was written still accounts for that node")
+}
+
 func TestAddNominatedReservePodRejectsTerminating(t *testing.T) {
 	r := newPendingReservationForNomination("r-term-add", "uid-term-add", "1", "2")
 	r.Finalizers = []string{"example.com/cleanup"}
@@ -1032,4 +1053,156 @@ func TestEventHandlerUpdateKeepsPreAllocationOfCurrentCycle(t *testing.T) {
 
 	assert.NotNil(t, nm.GetNominatedPreAllocation(rInfo, "test-node"),
 		"a reserve pod cleanup must not take the pre-allocation state of a cycle in progress")
+}
+
+// TestEventHandlerUpdateAssignedNodeReconcilesNomination covers the update no
+// lifecycle branch sees: a still Pending reservation acquiring status.nodeName
+// is neither active nor terminal nor terminating, and the write bumps neither
+// generation nor labels. The read path already filtered such an entry out (see
+// TestNominatedReservePodForNodeDropsForeignNode); asserting on the map itself
+// separates that from the event path actually retracting it.
+//
+// The store advances only after the nomination is recorded, which is the real
+// ordering: NewReservePod copies status.nodeName into the reserve pod, so a
+// cycle nominating against the pre-assignment revision is what
+// AddNominatedReservePod accepts.
+func TestEventHandlerUpdateAssignedNodeReconcilesNomination(t *testing.T) {
+	const nominatedNode = "test-node"
+
+	tests := []struct {
+		name        string
+		assignNode  string
+		mutate      func(*schedulingv1alpha1.Reservation)
+		wantRetains bool
+		reason      string
+	}{
+		{
+			name:        "assigned to another node retracts the nomination",
+			assignNode:  "another-node",
+			wantRetains: false,
+			reason:      "a reservation on its way to another node must stop holding this one",
+		},
+		{
+			name:        "assigned to the nominated node keeps it",
+			assignNode:  nominatedNode,
+			wantRetains: true,
+			reason:      "the nomination is the only accounting for the reserve pod until it is assumed",
+		},
+		{
+			name:       "status heartbeat keeps the nomination",
+			assignNode: "",
+			mutate: func(r *schedulingv1alpha1.Reservation) {
+				r.Status.Conditions = []schedulingv1alpha1.ReservationCondition{{
+					Reason:        schedulingv1alpha1.ReasonReservationUnschedulable,
+					LastProbeTime: metav1.Now(),
+				}}
+			},
+			wantRetains: true,
+			reason:      "the unschedulable condition this scheduler writes after every failed attempt must not drop a valid nomination",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldR := newPendingReservationForNomination("r-assigned", "uid-assigned", "1", "2")
+			nm, indexer := newNominatorWithReservations(t, oldR)
+			h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+
+			// A cycle nominates a node while the reservation is still unassigned.
+			pi, err := framework.NewPodInfo(reservation.NewReservePod(oldR))
+			assert.NoError(t, err)
+			nm.AddNominatedReservePod(pi, nominatedNode)
+			assert.Equal(t, nominatedNode, nm.nominatedReservePodToNode[oldR.UID])
+
+			// The status write lands in the store, then the handler sees it.
+			newR := oldR.DeepCopy()
+			newR.ResourceVersion = "2"
+			newR.Status.NodeName = tt.assignNode
+			if tt.mutate != nil {
+				tt.mutate(newR)
+			}
+			assert.NoError(t, indexer.Update(newR))
+
+			h.OnUpdate(oldR, newR)
+
+			if tt.wantRetains {
+				assert.Equal(t, nominatedNode, nm.nominatedReservePodToNode[oldR.UID], tt.reason)
+				assert.Len(t, nm.NominatedReservePodForNode(nominatedNode), 1, tt.reason)
+				return
+			}
+			assert.NotContains(t, nm.nominatedReservePodToNode, oldR.UID, tt.reason)
+			assert.Empty(t, nm.NominatedReservePodForNode(nominatedNode), tt.reason)
+		})
+	}
+}
+
+// TestDeleteReservePodIfStaleKeepsNominationForCurrentNode is the unit-level
+// counterpart: the helper must not treat an assignment to the node it is
+// already holding as staleness, and must not delete a nomination the store
+// still agrees with when a delayed event arrives for an older revision.
+func TestDeleteReservePodIfStaleKeepsNominationForCurrentNode(t *testing.T) {
+	const nominatedNode = "test-node"
+
+	t.Run("assignment to the nominated node is not stale", func(t *testing.T) {
+		stored := newPendingReservationForNomination("r-same", "uid-same", "1", "2")
+		nm, indexer := newNominatorWithReservations(t, stored)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(stored))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, nominatedNode)
+
+		assigned := stored.DeepCopy()
+		assigned.ResourceVersion = "2"
+		assigned.Status.NodeName = nominatedNode
+		assert.NoError(t, indexer.Update(assigned))
+
+		nm.DeleteReservePodIfStale(reservation.NewReservePod(assigned))
+		assert.Equal(t, nominatedNode, nm.nominatedReservePodToNode[stored.UID])
+	})
+
+	t.Run("a delayed event does not retract a nomination the store agrees with", func(t *testing.T) {
+		// The store is at the current revision and a cycle nominated against
+		// it; the handler is only now catching up with an older event whose
+		// reserve pod happens to rebuild to the same shape.
+		current := newPendingReservationForNomination("r-delayed", "uid-delayed", "2", "2")
+		nm, _ := newNominatorWithReservations(t, current)
+		pi, err := framework.NewPodInfo(reservation.NewReservePod(current))
+		assert.NoError(t, err)
+		nm.AddNominatedReservePod(pi, nominatedNode)
+
+		stale := current.DeepCopy()
+		stale.ResourceVersion = "1"
+		nm.DeleteReservePodIfStale(reservation.NewReservePod(stale))
+
+		assert.Equal(t, nominatedNode, nm.nominatedReservePodToNode[current.UID],
+			"the newer nomination must survive a delayed event")
+	})
+}
+
+// TestEventHandlerUpdateSchedulerNameHandoverRetractsNomination pins down that
+// a schedulerName handover needs no cleanup path of its own. schedulerName
+// lives in the reservation's pod template, so changing it bumps
+// metadata.generation, which is part of the nomination identity, and the
+// existing scheduling-relevant branch retracts the hold.
+func TestEventHandlerUpdateSchedulerNameHandoverRetractsNomination(t *testing.T) {
+	oldR := newPendingReservationForNomination("r-handover", "uid-handover", "1", "2")
+	oldR.Spec.Template.Spec.SchedulerName = "koord-scheduler"
+
+	nm, indexer := newNominatorWithReservations(t, oldR)
+	h := &reservationEventHandler{cache: newReservationCache(nil), rrNominator: nm}
+	pi, err := framework.NewPodInfo(reservation.NewReservePod(oldR))
+	assert.NoError(t, err)
+	nm.AddNominatedReservePod(pi, "test-node")
+	assert.Equal(t, "test-node", nm.nominatedReservePodToNode[oldR.UID])
+
+	newR := oldR.DeepCopy()
+	newR.ResourceVersion = "2"
+	newR.Generation = 2
+	newR.Spec.Template.Spec.SchedulerName = "another-scheduler"
+	assert.NoError(t, indexer.Update(newR))
+
+	h.OnUpdate(oldR, newR)
+
+	assert.NotContains(t, nm.nominatedReservePodToNode, oldR.UID,
+		"a reservation handed to another scheduler must not keep holding a node here")
+	assert.Empty(t, nm.NominatedReservePodForNode("test-node"))
 }

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
@@ -46,7 +47,91 @@ type nominator struct {
 	// nominatedReservePod is map keyed by nodeName to the nominated reservation's PodInfo for preemption.
 	nominatedReservePod       map[string][]*framework.PodInfo
 	nominatedReservePodToNode map[types.UID]string
-	lock                      sync.RWMutex
+	// nominatedReserveIdentity records what the stored PodInfo was built from,
+	// so a read can tell whether it still describes the current reservation.
+	nominatedReserveIdentity map[types.UID]reserveIdentity
+	lock                     sync.RWMutex
+}
+
+// reserveIdentity captures everything NewReservePod derives from a Reservation:
+// the spec through metadata.generation (the CRD has the status subresource, so
+// the generation bumps exactly on spec updates) plus the labels and annotations
+// it copies onto the reserve pod. An unchanged identity therefore means a
+// rebuilt reserve pod would be identical to the stored one, and a changed one
+// means the nomination describes a reservation that no longer exists in that
+// shape - which is also when reservationEventHandler.OnUpdate deletes it.
+//
+// resourceVersion is deliberately not part of this: it advances on every write,
+// including the Unschedulable status this scheduler records after each failed
+// attempt, so it would report a change on updates that cannot invalidate a
+// nomination.
+type reserveIdentity struct {
+	generation  int64
+	labels      map[string]string
+	annotations map[string]string
+}
+
+func identityOf(r *schedulingv1alpha1.Reservation) reserveIdentity {
+	return reserveIdentity{
+		generation:  r.Generation,
+		labels:      r.Labels,
+		annotations: r.Annotations,
+	}
+}
+
+func (id reserveIdentity) matches(other reserveIdentity) bool {
+	return id.generation == other.generation &&
+		apiequality.Semantic.DeepEqual(id.labels, other.labels) &&
+		apiequality.Semantic.DeepEqual(id.annotations, other.annotations)
+}
+
+// isReservationWaitingForScheduling reports whether a reservation is still
+// waiting for a node, which is the only state a reserve pod nomination is
+// meaningful in.
+//
+// The phase is checked as an allowlist rather than by excluding the terminal
+// ones, so an unknown or partially written phase fails closed. Excluding via
+// IsReservationActive would also let Available or Waiting through whenever
+// status.nodeName happened to be empty, since that predicate requires both.
+//
+// A reservation that already carries status.nodeName while still Pending does
+// count as waiting, deliberately: between the node being chosen and the reserve
+// pod being assumed into the scheduler cache, this nomination is the only thing
+// accounting for it. The read path narrows that to the node it is going to.
+//
+// A terminating reservation is excluded even while it lingers behind a
+// finalizer: ReservationInfo.IsUnschedulable already treats it that way, and its
+// reserve pod will never be scheduled.
+func isReservationWaitingForScheduling(r *schedulingv1alpha1.Reservation) bool {
+	if r == nil || !r.DeletionTimestamp.IsZero() {
+		return false
+	}
+	phase := r.Status.Phase
+	return phase == "" || phase == schedulingv1alpha1.ReservationPending
+}
+
+// sameSchedulingShape reports whether two reserve pods would be scheduled
+// identically. It compares what NewReservePod derives from a Reservation, and
+// deliberately ignores status, which the framework mutates on the copy it
+// carries through a scheduling cycle.
+// sameSchedulingShape reports whether two reserve pods describe the same
+// scheduling problem.
+//
+// It can only compare what NewReservePod puts into the synthetic pod: the
+// template spec, and the reservation's labels and annotations. A reserve pod
+// cycle also reads fields straight off the Reservation that never reach the
+// pod - Spec.Owners and PreAllocationPolicy select the pre-allocatable
+// candidates, whose nodes narrow the feasible set. A cycle spanning an update
+// that touched only those fields is therefore indistinguishable here and its
+// node is accepted. That gap predates this nominator - the previous code
+// accepted every late node decision unconditionally - and closing it needs the
+// generation the cycle actually used to travel with it, which is tracked in
+// #3158.
+func sameSchedulingShape(a, b *corev1.Pod) bool {
+	return a.Namespace == b.Namespace &&
+		apiequality.Semantic.DeepEqual(a.Spec, b.Spec) &&
+		apiequality.Semantic.DeepEqual(a.Labels, b.Labels) &&
+		apiequality.Semantic.DeepEqual(a.Annotations, b.Annotations)
 }
 
 func newNominator(podLister corelisters.PodLister, rLister listerschedulingv1alpha1.ReservationLister) *nominator {
@@ -57,6 +142,7 @@ func newNominator(podLister corelisters.PodLister, rLister listerschedulingv1alp
 		nominatedPreAllocatable:   map[types.UID]map[string][]*corev1.Pod{},
 		nominatedReservePod:       map[string][]*framework.PodInfo{},
 		nominatedReservePodToNode: map[types.UID]string{},
+		nominatedReserveIdentity:  map[types.UID]reserveIdentity{},
 	}
 }
 
@@ -108,10 +194,6 @@ func (nm *nominator) AddNominatedReservePod(pi *framework.PodInfo, nodeName stri
 	nm.lock.Lock()
 	defer nm.lock.Unlock()
 
-	// Always delete the reservation if it already exists, to ensure we never store more than
-	// one instance of the reservation.
-	nm.deleteReservePod(pi.Pod)
-
 	rName := reservationutil.GetReservationNameFromReservePod(pi.Pod)
 	if len(rName) <= 0 { // not a reserve pod
 		klog.V(4).InfoS("reservation nominator aborts nominating pod which is not a reserve pod",
@@ -121,32 +203,68 @@ func (nm *nominator) AddNominatedReservePod(pi *framework.PodInfo, nodeName stri
 	if nodeName == "" {
 		klog.V(4).InfoS("reservation nominated node is removed",
 			"pod", klog.KObj(pi.Pod), "reservation", rName, "nominatedNodeName", nodeName)
+		nm.deleteReservePod(pi.Pod)
 		return
 	}
 
+	// Nothing is removed until the nomination has been accepted. The caller can
+	// be an older scheduling cycle finishing late - addNominatedReservation
+	// reuses the NominatedNodeName from the cycle that failed - so a rejected
+	// call must leave a newer cycle's nomination alone.
+	stored, identity := pi, reserveIdentity{}
 	if nm.rLister != nil {
-		// If a reservation is just deleted or scheduled, don't nominate it.
 		r, err := nm.rLister.Get(rName)
 		if err != nil {
 			klog.V(4).InfoS("reservation doesn't exist in rLister, aborted adding it to the nominator",
 				"pod", klog.KObj(pi.Pod), "reservation", rName)
+			nm.deleteReservePod(pi.Pod)
 			return
 		}
-		if reservationutil.IsReservationActive(r) {
-			klog.V(4).InfoS("reservation is already scheduled to a node and become active, aborted to adding it to the nominator",
+		if r.UID != pi.Pod.UID {
+			// The reservation was replaced by a same-named one. Drop what the
+			// replaced one held; the new one nominates on its own cycle.
+			klog.V(4).InfoS("reservation was replaced, aborted adding the stale reserve pod to the nominator",
+				"pod", klog.KObj(pi.Pod), "reservation", rName, "currentUID", r.UID)
+			nm.deleteReservePod(pi.Pod)
+			return
+		}
+		if !isReservationWaitingForScheduling(r) {
+			klog.V(4).InfoS("reservation is no longer waiting to be scheduled, aborted adding it to the nominator",
+				"pod", klog.KObj(pi.Pod), "reservation", rName, "phase", r.Status.Phase)
+			nm.deleteReservePod(pi.Pod)
+			return
+		}
+		currentReservePod := reservationutil.NewReservePod(r)
+		if !sameSchedulingShape(pi.Pod, currentReservePod) {
+			// The node was chosen for a shape the reservation no longer has, so
+			// it says nothing about where the current one belongs. Keep whatever
+			// is stored: it may come from a cycle that ran on the current shape.
+			klog.V(4).InfoS("reserve pod was scheduled against an older revision, aborted nominating its node",
+				"pod", klog.KObj(pi.Pod), "reservation", rName, "nominatedNodeName", nodeName)
+			return
+		}
+		// Store the reserve pod built from the object the identity is taken
+		// from, so the two can never describe different revisions.
+		fresh, err := framework.NewPodInfo(currentReservePod)
+		if err != nil {
+			klog.ErrorS(err, "failed to build the reserve pod info, aborted nominating it",
 				"pod", klog.KObj(pi.Pod), "reservation", rName)
 			return
 		}
+		stored, identity = fresh, identityOf(r)
 	}
 
+	// Accepted: replace any entry this reservation already had. deleteReservePod
+	// is keyed by reservation UID, so this only ever touches its own.
+	nm.deleteReservePod(pi.Pod)
 	nm.nominatedReservePodToNode[pi.Pod.UID] = nodeName
-	for _, npi := range nm.nominatedReservePod[nodeName] {
-		if npi.Pod.UID == pi.Pod.UID {
-			klog.V(4).InfoS("reservation already exists in the nominator", "pod", klog.KObj(npi.Pod), "reservation", rName)
-			return
-		}
+	if nm.rLister != nil {
+		// Recorded only when a lister established which revision this is. With
+		// no lister there is no provenance to compare against later, and the
+		// read path cannot validate either, so the entry is left unlabelled.
+		nm.nominatedReserveIdentity[pi.Pod.UID] = identity
 	}
-	nm.nominatedReservePod[nodeName] = append(nm.nominatedReservePod[nodeName], pi)
+	nm.nominatedReservePod[nodeName] = append(nm.nominatedReservePod[nodeName], stored)
 }
 
 func (nm *nominator) AddNominatedPreAllocation(rInfo *frameworkext.ReservationInfo, nodeName string, pod *corev1.Pod) {
@@ -199,14 +317,130 @@ func (nm *nominator) AddNominatedPreAllocation(rInfo *frameworkext.ReservationIn
 }
 
 func (nm *nominator) NominatedReservePodForNode(nodeName string) []*framework.PodInfo {
-	nm.lock.RLock()
-	defer nm.lock.RUnlock()
-	// Make a copy of the nominated Pods so the caller can mutate safely.
-	reservePods := make([]*framework.PodInfo, len(nm.nominatedReservePod[nodeName]))
-	for i := 0; i < len(reservePods); i++ {
-		reservePods[i] = nm.nominatedReservePod[nodeName][i].DeepCopy()
+	type nomination struct {
+		podInfo  *framework.PodInfo
+		identity reserveIdentity
+	}
+	stored := func() []nomination {
+		nm.lock.RLock()
+		defer nm.lock.RUnlock()
+		nominations := make([]nomination, 0, len(nm.nominatedReservePod[nodeName]))
+		for _, pi := range nm.nominatedReservePod[nodeName] {
+			nominations = append(nominations, nomination{
+				podInfo:  pi,
+				identity: nm.nominatedReserveIdentity[pi.Pod.UID],
+			})
+		}
+		return nominations
+	}()
+	// The critical section above is only a slice clone: revalidating a
+	// nomination reads the lister, and BeforeFilter calls this once per pod per
+	// node, so holding the read lock across that work would stall concurrent
+	// nominator writes (and a blocked writer also blocks later readers).
+	//
+	// Entries are revalidated against the reservation's current state instead of
+	// returned blindly from the snapshot. The informer store is updated before
+	// any event handler runs, so this read-through keeps a waiter requeued by a
+	// Reservation event from being blocked by a nomination the store already
+	// invalidated, even when the listener that maintains this nominator has not
+	// processed the same event yet. The caller may mutate the results.
+	reservePods := make([]*framework.PodInfo, 0, len(stored))
+	for _, n := range stored {
+		if podInfo, ok := nm.revalidateNominatedPodInfo(n.podInfo, n.identity, nodeName); ok {
+			reservePods = append(reservePods, podInfo)
+		}
 	}
 	return reservePods
+}
+
+// revalidateNominatedPodInfo reports whether a stored nomination still stands.
+// It is dropped once the lister shows that the reservation is gone, was
+// replaced by a same-named object, is no longer waiting to be scheduled
+// (assigned, terminated, or terminating behind a finalizer), or no longer has
+// the shape the nomination was built from. Keeping any of those would let a phantom reserve pod occupy the node
+// until this nominator's own listener catches up, which is exactly the window
+// in which a requeued waiter re-evaluates.
+//
+// The last case is why the identity is compared field by field. A spec, label or
+// annotation change can move the reserve pod's placement constraints, its
+// requests, its priority or even its schedulerName, so the nominated node need
+// not be a valid choice for it any more - reservationEventHandler.OnUpdate
+// deletes the nomination for exactly these changes, and this read converges on
+// the same answer rather than re-applying the new shape to the old node. When
+// the identity does hold, the stored PodInfo is by construction what a rebuild
+// would produce, so nothing is rebuilt on this per-pod-per-node path.
+//
+// rLister is immutable after construction, so no lock is needed here.
+func (nm *nominator) revalidateNominatedPodInfo(pi *framework.PodInfo, identity reserveIdentity, nodeName string) (*framework.PodInfo, bool) {
+	if nm.rLister == nil {
+		return pi.DeepCopy(), true
+	}
+	r, err := nm.rLister.Get(reservationutil.GetReservationNameFromReservePod(pi.Pod))
+	if err != nil || r.UID != pi.Pod.UID ||
+		!isReservationWaitingForScheduling(r) ||
+		!identityOf(r).matches(identity) {
+		return nil, false
+	}
+	// A nomination holds a candidate node. isReservationWaitingForScheduling
+	// deliberately still accepts a reservation that already carries
+	// status.nodeName but has not become active yet, because the nomination is
+	// the only accounting for it during that window - but only on the node it
+	// is actually going to. Any other node it was holding is stale.
+	if assigned := reservationutil.GetReservationNodeName(r); assigned != "" && assigned != nodeName {
+		return nil, false
+	}
+	return pi.DeepCopy(), true
+}
+
+// DeleteReservePodIfStale applies the read path's validity test now instead of
+// waiting for the next read, so a node stops being held as soon as the update
+// that invalidated it is processed.
+//
+// It reconciles against the informer store rather than against the old object
+// of the event that triggered it. Those differ: this handler and the scheduling
+// cycle run on goroutines with no ordering between them, so by the time an
+// update is handled here the store may be further ahead, and a cycle may
+// already have recorded a nomination for what the store holds now. Comparing
+// with the event's old identity would delete that nomination whenever the two
+// happen to be equal - and they can be, because a CRD with the status
+// subresource does not advance metadata.generation for metadata-only writes, so
+// labels or annotations going A -> B -> A produce two identical identities.
+//
+// Deleting too much is the failure that matters here: NominatedReservePodForNode
+// validates the entries it finds, it never recreates a missing one.
+//
+// Pre-allocation nominations are deliberately left alone. They carry no
+// identity to judge them by (AddNominatedPreAllocation records only the
+// candidate), and a cycle in progress writes them before reading them back, so
+// clearing them here would take state from a cycle this update says nothing
+// about. Their staleness is tracked in #3158.
+func (nm *nominator) DeleteReservePodIfStale(pod *corev1.Pod) {
+	// The lister read below is deliberately inside the lock, unlike the one in
+	// NominatedReservePodForNode. What matters here is that no concurrent Add
+	// can record a newer nomination between reading the stored identity and
+	// deleting it - reading the store first and locking afterwards would bring
+	// back exactly the race this function exists to avoid. The store itself can
+	// move either way; that is what makes the read path the backstop. A lister
+	// Get is an indexer map lookup, and this is not the per-pod-per-node path.
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	if _, nominated := nm.nominatedReservePodToNode[pod.UID]; !nominated {
+		return
+	}
+	if nm.rLister == nil {
+		// Nothing can establish what the entry was built from, and the read path
+		// cannot validate it either, so this is its only cleanup.
+		nm.deleteNominatedReservePodOnly(pod)
+		return
+	}
+	stored, ok := nm.nominatedReserveIdentity[pod.UID]
+	r, err := nm.rLister.Get(reservationutil.GetReservationNameFromReservePod(pod))
+	if !ok || err != nil || r.UID != pod.UID ||
+		!isReservationWaitingForScheduling(r) ||
+		!identityOf(r).matches(stored) {
+		nm.deleteNominatedReservePodOnly(pod)
+	}
 }
 
 func (nm *nominator) DeleteReservePod(pod *corev1.Pod) {
@@ -219,6 +453,14 @@ func (nm *nominator) DeleteReservePod(pod *corev1.Pod) {
 func (nm *nominator) deleteReservePod(pod *corev1.Pod) {
 	// delete pre-allocation for the reservation if exists
 	delete(nm.nominatedPreAllocatable, pod.UID)
+	nm.deleteNominatedReservePodOnly(pod)
+}
+
+// deleteNominatedReservePodOnly drops the reserve pod's own nomination and
+// leaves the reservation's pre-allocation candidates in place, for callers that
+// have judged the former stale and have no basis to judge the latter.
+func (nm *nominator) deleteNominatedReservePodOnly(pod *corev1.Pod) {
+	delete(nm.nominatedReserveIdentity, pod.UID)
 
 	nnn, ok := nm.nominatedReservePodToNode[pod.UID]
 	if !ok {
@@ -429,7 +671,23 @@ func (pl *Plugin) RemoveNominatedReservations(pod *corev1.Pod) {
 }
 
 func (pl *Plugin) AddNominatedReservePod(pod *corev1.Pod, nodeName string) {
-	podInfo, _ := framework.NewPodInfo(pod)
+	if nodeName == "" {
+		// An empty node means the reserve pod lost its nomination, which has to
+		// be honored even when the pod cannot be parsed - otherwise a reserve
+		// pod whose affinity became invalid keeps holding the node it was
+		// nominated to before that change.
+		pl.nominator.DeleteReservePod(pod)
+		return
+	}
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		// A partially parsed PodInfo would understate the reserve pod's
+		// constraints for every pod that later reads this nomination, so skip
+		// it rather than nominate something incomplete.
+		klog.ErrorS(err, "Failed to build the reserve pod info, skipped nominating it",
+			"pod", klog.KObj(pod), "node", nodeName)
+		return
+	}
 	pl.nominator.AddNominatedReservePod(podInfo, nodeName)
 }
 

--- a/pkg/scheduler/plugins/reservation/nominator.go
+++ b/pkg/scheduler/plugins/reservation/nominator.go
@@ -38,7 +38,10 @@ import (
 
 type nominator struct {
 	podLister corelisters.PodLister
-	rLister   listerschedulingv1alpha1.ReservationLister
+	// rLister is always set in production: New builds it from the informer
+	// factory, which is the only call site of newNominator. The nil paths below
+	// exist for tests that construct a nominator without a store.
+	rLister listerschedulingv1alpha1.ReservationLister
 	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is nominated to reserve.
 	nominatedPodToNode map[types.UID]map[string]types.UID
 	// nominatedPreAllocatable is map keyed by a Reservation UID to the node name where there are
@@ -110,12 +113,32 @@ func isReservationWaitingForScheduling(r *schedulingv1alpha1.Reservation) bool {
 	return phase == "" || phase == schedulingv1alpha1.ReservationPending
 }
 
-// sameSchedulingShape reports whether two reserve pods would be scheduled
-// identically. It compares what NewReservePod derives from a Reservation, and
-// deliberately ignores status, which the framework mutates on the copy it
-// carries through a scheduling cycle.
+// nominationStillValid reports whether a nomination recorded for nodeName is
+// still what the store describes: the same object, still waiting for a node,
+// still in the shape it was nominated from, and not already on its way
+// elsewhere. The read path and the event cleanup both go through it so the two
+// cannot drift apart.
+func nominationStillValid(r *schedulingv1alpha1.Reservation, uid types.UID, identity reserveIdentity, nodeName string) bool {
+	if r == nil || r.UID != uid || !isReservationWaitingForScheduling(r) ||
+		!identityOf(r).matches(identity) {
+		return false
+	}
+	// A Pending reservation may already carry status.nodeName. The nomination
+	// is still the only accounting for it, but only on the node it is going to.
+	assigned := reservationutil.GetReservationNodeName(r)
+	return assigned == "" || assigned == nodeName
+}
+
 // sameSchedulingShape reports whether two reserve pods describe the same
 // scheduling problem.
+//
+// Spec.NodeName is excluded. NewReservePod moves a node pinned by the template
+// into AnnotationReservationNode, compared below, and then fills Spec.NodeName
+// from status.nodeName, so what is left there records the assignment rather
+// than the shape. Comparing it would make a cycle that began before the
+// reservation acquired a node look like a different revision, and drop the
+// nomination that is the only accounting for that node until the reserve pod
+// is assumed into the scheduler cache.
 //
 // It can only compare what NewReservePod puts into the synthetic pod: the
 // template spec, and the reservation's labels and annotations. A reserve pod
@@ -128,8 +151,10 @@ func isReservationWaitingForScheduling(r *schedulingv1alpha1.Reservation) bool {
 // generation the cycle actually used to travel with it, which is tracked in
 // #3158.
 func sameSchedulingShape(a, b *corev1.Pod) bool {
+	aSpec, bSpec := a.Spec, b.Spec
+	aSpec.NodeName, bSpec.NodeName = "", ""
 	return a.Namespace == b.Namespace &&
-		apiequality.Semantic.DeepEqual(a.Spec, b.Spec) &&
+		apiequality.Semantic.DeepEqual(aSpec, bSpec) &&
 		apiequality.Semantic.DeepEqual(a.Labels, b.Labels) &&
 		apiequality.Semantic.DeepEqual(a.Annotations, b.Annotations)
 }
@@ -376,17 +401,7 @@ func (nm *nominator) revalidateNominatedPodInfo(pi *framework.PodInfo, identity 
 		return pi.DeepCopy(), true
 	}
 	r, err := nm.rLister.Get(reservationutil.GetReservationNameFromReservePod(pi.Pod))
-	if err != nil || r.UID != pi.Pod.UID ||
-		!isReservationWaitingForScheduling(r) ||
-		!identityOf(r).matches(identity) {
-		return nil, false
-	}
-	// A nomination holds a candidate node. isReservationWaitingForScheduling
-	// deliberately still accepts a reservation that already carries
-	// status.nodeName but has not become active yet, because the nomination is
-	// the only accounting for it during that window - but only on the node it
-	// is actually going to. Any other node it was holding is stale.
-	if assigned := reservationutil.GetReservationNodeName(r); assigned != "" && assigned != nodeName {
+	if err != nil || !nominationStillValid(r, pi.Pod.UID, identity, nodeName) {
 		return nil, false
 	}
 	return pi.DeepCopy(), true
@@ -425,7 +440,8 @@ func (nm *nominator) DeleteReservePodIfStale(pod *corev1.Pod) {
 	nm.lock.Lock()
 	defer nm.lock.Unlock()
 
-	if _, nominated := nm.nominatedReservePodToNode[pod.UID]; !nominated {
+	nodeName, nominated := nm.nominatedReservePodToNode[pod.UID]
+	if !nominated {
 		return
 	}
 	if nm.rLister == nil {
@@ -436,9 +452,7 @@ func (nm *nominator) DeleteReservePodIfStale(pod *corev1.Pod) {
 	}
 	stored, ok := nm.nominatedReserveIdentity[pod.UID]
 	r, err := nm.rLister.Get(reservationutil.GetReservationNameFromReservePod(pod))
-	if !ok || err != nil || r.UID != pod.UID ||
-		!isReservationWaitingForScheduling(r) ||
-		!identityOf(r).matches(stored) {
+	if !ok || err != nil || !nominationStillValid(r, pod.UID, stored, nodeName) {
 		nm.deleteNominatedReservePodOnly(pod)
 	}
 }

--- a/pkg/scheduler/plugins/reservation/transformer.go
+++ b/pkg/scheduler/plugins/reservation/transformer.go
@@ -980,14 +980,15 @@ func getDiagnosisTaintKey(taint *corev1.Taint) string {
 }
 
 func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodeInfo fwktype.NodeInfo) (*corev1.Pod, fwktype.NodeInfo, bool, *fwktype.Status) {
-	// Both the reserve pod or the normal pod should consider the nominated reserve pods.
-	nominatedReservationInfos := pl.nominator.NominatedReservePodForNode(nodeInfo.Node().Name)
-	if len(nominatedReservationInfos) == 0 {
+	node := nodeInfo.Node()
+	if node == nil {
+		// This may happen only in tests.
 		return pod, nodeInfo, false, nil
 	}
 
-	if nodeInfo.Node() == nil {
-		// This may happen only in tests.
+	// Both the reserve pod or the normal pod should consider the nominated reserve pods.
+	nominatedReservationInfos := pl.nominator.NominatedReservePodForNode(node.Name)
+	if len(nominatedReservationInfos) == 0 {
 		return pod, nodeInfo, false, nil
 	}
 
@@ -998,14 +999,16 @@ func (pl *Plugin) BeforeFilter(ctx context.Context, cycleState fwktype.CycleStat
 	for _, rInfo := range nominatedReservationInfos {
 		if schedulingcorev1.PodPriority(rInfo.Pod) >= schedulingcorev1.PodPriority(pod) && rInfo.Pod.UID != pod.UID &&
 			(podsOfSameJob == nil || !podsOfSameJob.Has(string(rInfo.Pod.UID))) {
-			pInfo, _ := framework.NewPodInfo(rInfo.Pod)
-			nodeInfoOut.AddPodInfo(pInfo)
-			status := pl.handle.RunPreFilterExtensionAddPod(ctx, cycleState, pod, pInfo, nodeInfoOut)
+			// The nominator already returns a caller-owned PodInfo built from
+			// the reservation's current state; rebuilding it here would parse
+			// the affinity terms a second time on this per-pod-per-node path.
+			nodeInfoOut.AddPodInfo(rInfo)
+			status := pl.handle.RunPreFilterExtensionAddPod(ctx, cycleState, pod, rInfo, nodeInfoOut)
 			if !status.IsSuccess() {
 				return pod, nodeInfo, false, status
 			}
 			klog.V(4).Infof("nodeName %s, to schedule pod %s (reserve pod %s) with nominated reservation %s",
-				nodeInfo.Node().Name, klog.KObj(pod),
+				node.Name, klog.KObj(pod),
 				reservationutil.GetReservationNameFromReservePod(pod),
 				reservationutil.GetReservationNameFromReservePod(rInfo.Pod))
 		}


### PR DESCRIPTION
## Summary

The reservation nominator holds a reserve pod against a candidate node so that other pods evaluated for that node account for it (`BeforeFilter` → `NominatedReservePodForNode` → the transformer adds it to the node snapshot). Nothing removed that hold when the reservation it stands for stopped being able to use the node, so a phantom reserve pod could keep occupying capacity for every pod filtered against that node.

This PR is behaviour-affecting on its own and is **not** behind any feature gate. It was split out of #2927 for that reason: #2927 adds a default-off feature (`ReservationArgs.EnableQueueHint`), whereas everything here takes effect on merge, and the two deserve to be judged separately. #2927 now contains only the queueing-hint wiring. The two do not depend on each other and can merge in either order.

## What was wrong

A nomination survived all of these:

- **A UID replacement.** A delete followed by a same-named create reaches handlers as a single update. The nominator keys reserve pods by reservation UID, so the old entry stayed on its node forever.
- **A move to a terminal phase**, and **a reservation entering deletion behind a finalizer.** The object stays `Pending` with its generation, labels and annotations unchanged, so nothing about it looked different, while its reserve pod would never be scheduled. `ReservationInfo.IsUnschedulable()` already counts a terminating reservation as unschedulable; the nominator did not.
- **Any spec, label or annotation change** — even though `reservationEventHandler.OnUpdate` deletes the nomination for exactly these. Such an edit can move the reserve pod's placement constraints, its requests, its priority or even its `schedulerName`, so the nominated node need not still be a valid choice for it.
- **A node decision from an older scheduling cycle.** `handleReservationSchedulingFailure` replaces `podInfo.PodInfo` with a reserve pod rebuilt from the current reservation before requeuing it, while the node it nominates still comes from the cycle that just failed. A cycle that ran against an older revision could therefore pin the current reservation to a node chosen for a shape it no longer has, and overwrite a newer cycle's nomination on the way.
- **An unparsable reserve pod losing its node.** The exported entry point built the `PodInfo` first and returned on error, so the empty-node signal that means "this nomination is gone" never reached the cleanup.

## What changed

| File | Change |
| --- | --- |
| ``pkg/scheduler/plugins/reservation/nominator.go`` | Nominations carry the scheduling identity they were built from (generation, labels, annotations — exactly what ``NewReservePod`` derives a reserve pod from) and are revalidated against the informer store on read: dropped unless the reservation is still present, still the same object, still waiting for a node, still in that shape, and not holding a different node of its own. ``AddNominatedReservePod`` validates before it removes anything and refuses a node whose cycle ran against a different shape. The empty-node deletion now precedes parsing the reserve pod |
| ``pkg/scheduler/frameworkext/eventhandlers/reservation_handler.go`` | Hand the nominator the reserve pod the failed cycle ran with, so the shape check has two different revisions to compare instead of the current object against itself |
| ``pkg/scheduler/plugins/reservation/eventhandler.go`` | Delete the nomination on a same-named UID replacement and on a reservation entering deletion, unconditionally; on a scheduling-relevant update of an unscheduled reservation (covers `schedulerName` handovers, which the framework handler does not clean up) only when the stored nomination predates that update |
| ``pkg/scheduler/plugins/reservation/transformer.go`` | ``BeforeFilter`` checks for a nil ``Node`` before dereferencing it, and stops rebuilding the ``PodInfo`` the nominator just handed it |
| ``pkg/scheduler/plugins/reservation/eventhandler_test.go`` | Nomination dropped on UID replacement, terminal and terminating phases, spec/label/annotation changes, an assigned node that is not the one being read, and an unparsable current object; kept on status-only writes. A late cycle can neither pin its own stale node choice (requests / node affinity / `schedulerName` / labels) nor disturb a newer nomination, and an unchanged shape is still accepted. A nomination recorded for the new revision survives a handler that processes the same update afterwards, while a terminating one is removed whatever recorded it. Plus the four rejection paths of ``AddNominatedReservePod`` and a benchmark for the read path |
| ``pkg/scheduler/frameworkext/eventhandlers/reservation_handler_test.go`` | The failure handler hands over the cycle's reserve pod, not one rebuilt from the current reservation (verified to fail without the fix) |

## One rule, applied twice

The event handler and the scheduling cycle run on goroutines with no ordering between them. By the time the handler sees an update, the informer store may be further ahead still, and a cycle may already have recorded a nomination for what the store holds now.

So the handler does not reason about the event it received. It asks the same question the read path asks — *does this entry still match the store?* — and deletes only if the answer is no. The handler is an optimization that frees the node sooner; the read path is the guarantee. Deleting too little is safe, because the next read drops whatever no longer matches; deleting too much is not, because nothing recreates a deleted entry.

Comparing against the event's old object instead would be wrong in a way that is easy to miss: a CRD with the status subresource does not advance `metadata.generation` for metadata-only writes, so labels or annotations going `A -> B -> A` produce two identical identities, and a delayed `A -> B` event would delete the nomination recorded for the second `A`.

Deletion, a terminal phase and a UID replacement stay unconditional — no revision of those may keep holding a node, and a replacement's nomination lives under a different UID key, so the old one's cleanup cannot reach it.

Pre-allocation candidates are left alone by the reserve pod's cleanup. They are recorded with no identity to judge them by, and a cycle in progress writes them before reading them back, so clearing them on a reservation update would take state from a cycle the update says nothing about. Their staleness is #3158.

## A limit of the shape comparison

`sameSchedulingShape` can only compare what `NewReservePod` puts into the synthetic pod: its namespace, the template spec, and the reservation's labels and annotations. A reserve pod cycle also reads fields straight off the Reservation — `Spec.Owners` and `PreAllocationPolicy` select the pre-allocatable candidates whose nodes narrow the feasible set. A cycle spanning an update that touched only those fields is indistinguishable here, and its node is accepted.

That gap predates this PR: the previous code accepted every late node decision unconditionally and stored the caller's own stale pod. Closing it needs the generation the cycle actually used to travel with it, which changes `NewReservePod` — whose output also feeds the scheduler cache, the queue, `PreFilter` and `Bind` — so it is tracked separately in #3158 rather than folded in here.

## On the read path's cost

`NominatedReservePodForNode` now does a lister `Get` and two small-map `DeepEqual`s per nomination, where it previously only copied the stored `PodInfo`. `BeforeFilter` calls it once per waiting pod per candidate node.

The cost scales with the number of *nominated* reserve pods on the node — the number of unscheduled reservations that failed a cycle there, normally zero, in which case a map lookup is the whole cost. In exchange, the path no longer rebuilds a reserve pod at all (an earlier revision of this work rebuilt one per read), and `BeforeFilter` no longer re-parses affinity for a `PodInfo` the nominator already built.

An earlier revision short-circuited the comparison on `resourceVersion`. That is deliberately gone: this scheduler writes an Unschedulable status after every failed attempt, so the stored `resourceVersion` stops matching almost immediately and the shortcut would never fire again in the steady state, while implying a cheaper cost than the code actually pays. Comparing the fields directly is behaviour-identical, since an equal `resourceVersion` implies equal generation, labels and annotations.

I have not run a `benchstat` matrix against the base, so I am not claiming the net effect is zero. `BenchmarkNominatedReservePodForNode` covers the shape of the path; ask if you want the numbers across nomination counts and annotation sizes.

## Out of scope

- **#3154** — a terminating or UID-replaced reservation can still be scheduled and have `Available` written onto it: the framework handler's `isReservationActive` ignores `deletionTimestamp`, and neither `PreFilter` nor `Bind` checks `deletionTimestamp` or the UID. This PR stops the *nominator* from holding a node for such a reservation; the queue, `PreFilter` and `Bind` paths are untouched here.
- **#3148** — the plugin's `reservationCache` and the scheduling queue are driven by different informer listeners with no happens-before between them. The nominator no longer contributes to that window, since it revalidates against the store on read, but `reservationCache` cannot be fixed the same way: a `ReservationInfo` accumulates assigned pods and allocated amounts from **Pod** events, which the Reservation object does not carry.
- **#3155** — widening a Restricted reservation's tracked resource set re-masks an already-masked `Allocated`, so the recovered dimensions stay at zero.

## Test plan

- [x] ``go test ./pkg/scheduler/plugins/reservation/ ./pkg/scheduler/frameworkext/eventhandlers/ -race -count=1`` ok
- [x] gofmt clean; golangci-lint v2.5.0 clean against main (0 issues)
- [x] The failure-handler regression test verified to fail without the fix
- [x] Verified standalone on a branch cut from main, independent of #2927

Ref #2852
