### PR TITLE
descheduler: Fix ScaleDownBinPack pod listing panic

### DIFF
--- a/pkg/descheduler/framework/plugins/scaledownbinpack/scale_down_binpack.go
+++ b/pkg/descheduler/framework/plugins/scaledownbinpack/scale_down_binpack.go
@@ -122,7 +122,7 @@ func (pl *ScaleDownBinPack) Balance(ctx context.Context, nodes []*corev1.Node) *
 	)
 
 	for _, node := range selectedNodes {
-		allPods, err := getPodsFunc(node.Name, nil)
+		allPods, err := getPodsFunc(node.Name, func(*corev1.Pod) bool { return true })
 		if err != nil {
 			klog.ErrorS(err, "Failed to get pods for node", "node", node.Name)
 			continue


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes a panic in the `ScaleDownBinPack` descheduler plugin when it lists pods assigned to a node.

The plugin needs the full pod list for each candidate node, but it was calling `GetPodsAssignedToNodeFunc` with a nil filter. The framework adaptor expects a non-nil filter and calls it for each pod, causing a nil pointer panic during a live descheduler run.

This PR passes an explicit include-all filter instead.

### Ⅱ. Does this pull request fix one issue?

Part of #2790 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
