### PR TITLE
coscheduling: report collected children count in gang basic check

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/core.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core.go
@@ -272,7 +272,8 @@ func (pgMgr *PodGroupManager) basicGangRequirementsCheck(gang *Gang, pod *corev1
 			continue
 		}
 		if memberGang.getChildrenNum() < memberGang.getGangMinNum() {
-			gangsOfMinNumUnSatisfied = append(gangsOfMinNumUnSatisfied, gangID)
+			gangsOfMinNumUnSatisfied = append(gangsOfMinNumUnSatisfied,
+				fmt.Sprintf("%s(collected %d/%d children)", gangID, memberGang.getChildrenNum(), memberGang.getGangMinNum()))
 			continue
 		}
 	}
@@ -284,7 +285,7 @@ func (pgMgr *PodGroupManager) basicGangRequirementsCheck(gang *Gang, pod *corev1
 		failedMsg = append(failedMsg, fmt.Sprintf("memberGangs %+v has not init", gangsOfGangNotInit))
 	}
 	if len(gangsOfMinNumUnSatisfied) > 0 {
-		failedMsg = append(failedMsg, fmt.Sprintf("memberGangs %+v child pod not collect enough", gangGroup))
+		failedMsg = append(failedMsg, fmt.Sprintf("memberGangs %+v child pod not collect enough", gangsOfMinNumUnSatisfied))
 	}
 	if len(failedMsg) > 0 {
 		return fmt.Errorf("gangGroup %v basic check: %s, current gang: %s, podName: %v",

--- a/pkg/scheduler/plugins/coscheduling/core/core_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/core_test.go
@@ -160,7 +160,7 @@ func TestPlugin_PreEnqueue(t *testing.T) {
 				st.MakePod().Name("pod3-1").UID("pod3-1").Namespace("ganga_ns").Label(v1alpha1.PodGroupLabel, "ganga").Obj(),
 			},
 			pgs:                        makePg("ganga", "ganga_ns", 4, &gangACreatedTime, nil),
-			expectedErrorMessage:       "gangGroup [ganga_ns/ganga] basic check: memberGangs [ganga_ns/ganga] child pod not collect enough, current gang: ganga_ns/ganga, podName: ganga_ns/pod3",
+			expectedErrorMessage:       "gangGroup [ganga_ns/ganga] basic check: memberGangs [ganga_ns/ganga(collected 2/4 children)] child pod not collect enough, current gang: ganga_ns/ganga, podName: ganga_ns/pod3",
 			expectedScheduleCycle:      1,
 			expectedChildCycleMap:      map[string]int{},
 			expectedScheduleCycleValid: true,


### PR DESCRIPTION
When a gang fails PreEnqueue because minMember is not satisfied, the error only named the gang, leaving no clue how many member pods had been collected. Include collected/min counts per unsatisfied gang so the gap is visible directly from the event message.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
