### PR TITLE
descheduler: optimize FragmentationAware imbalance score calculation to O(1) per pod

### DIFF
--- a/pkg/descheduler/framework/plugins/fragmentationaware/fragmentation_aware.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/fragmentation_aware.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 
 	deschedulerconfig "github.com/koordinator-sh/koordinator/pkg/descheduler/apis/config"
@@ -186,6 +187,15 @@ type evictionCandidate struct {
 func (pl *FragmentationAware) chooseBestEvictionCandidate(node *corev1.Node, allPods []*corev1.Pod, evictablePods []*corev1.Pod, candidateNodes []*corev1.Node, stdBefore float64) *evictionCandidate {
 	var bestCandidate *evictionCandidate
 
+	// Pre-calculate base node utilization to achieve O(1) time complexity w.r.t pods when simulating removal
+	utilization := nodeutil.NodeUtilization(allPods, pl.args.Resources)
+	baseRequests := make(corev1.ResourceList, len(utilization))
+	for res, qty := range utilization {
+		if qty != nil {
+			baseRequests[res] = *qty
+		}
+	}
+
 	for _, pod := range evictablePods {
 		if pl.args.NodeFit {
 			if !nodeutil.PodFitsAnyOtherNode(pl.handle.GetPodsAssignedToNodeFunc(), pod, candidateNodes) {
@@ -193,14 +203,19 @@ func (pl *FragmentationAware) chooseBestEvictionCandidate(node *corev1.Node, all
 			}
 		}
 
-		var podsAfter []*corev1.Pod
-		for _, p := range allPods {
-			if p.UID != pod.UID {
-				podsAfter = append(podsAfter, p)
+		// Calculate what the node requests would be if this pod were removed in O(1) time
+		requestsAfter := baseRequests.DeepCopy()
+		podRequests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+
+		for _, res := range pl.args.Resources {
+			if podReq, ok := podRequests[res]; ok {
+				qty := requestsAfter[res]
+				qty.Sub(podReq)
+				requestsAfter[res] = qty
 			}
 		}
 
-		stdAfter := scoreNodeImbalance(node, podsAfter, pl.args.Resources)
+		stdAfter := scoreNodeImbalanceWithRequests(node, requestsAfter, pl.args.Resources)
 		gain := stdBefore - stdAfter
 
 		if gain <= pl.args.MinImprovementThreshold {

--- a/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/scoring.go
@@ -74,3 +74,12 @@ func scoreNodeImbalance(node *corev1.Node, pods []*corev1.Pod, resources []corev
 	fractions := allocationFractions(requests, node.Status.Allocatable, resources)
 	return stdDev(fractions)
 }
+
+// scoreNodeImbalanceWithRequests computes the standard deviation of allocation fractions across resources using precalculated requests.
+func scoreNodeImbalanceWithRequests(node *corev1.Node, requests corev1.ResourceList, resources []corev1.ResourceName) float64 {
+	if node == nil {
+		return 0
+	}
+	fractions := allocationFractions(requests, node.Status.Allocatable, resources)
+	return stdDev(fractions)
+}

--- a/pkg/descheduler/framework/plugins/fragmentationaware/scoring_test.go
+++ b/pkg/descheduler/framework/plugins/fragmentationaware/scoring_test.go
@@ -130,3 +130,38 @@ func TestScoreNodeImbalance(t *testing.T) {
 		assert.Equal(t, 0.25, stdDev)
 	})
 }
+
+func TestScoreNodeImbalanceWithRequests(t *testing.T) {
+	resources := []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+
+	t.Run("nil node returns zero", func(t *testing.T) {
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(512, resource.BinarySI),
+		}
+		stdDev := scoreNodeImbalanceWithRequests(nil, requests, resources)
+		assert.Equal(t, 0.0, stdDev)
+	})
+
+	t.Run("balanced CPU/memory node gives low stddev", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(512, resource.BinarySI),
+		}
+
+		stdDev := scoreNodeImbalanceWithRequests(node, requests, resources)
+		assert.True(t, stdDev < 0.01)
+	})
+
+	t.Run("CPU-heavy node gives high stddev", func(t *testing.T) {
+		node := makeNode(1000, 1024)
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(900, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(100, resource.BinarySI),
+		}
+
+		stdDev := scoreNodeImbalanceWithRequests(node, requests, resources)
+		assert.True(t, stdDev > 0.1)
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR optimizes the standard deviation recalculation in the `FragmentationAware` descheduler plugin, addressing the known `O(pods²)` per-node cost limitation.

Previously, when simulating the removal of an eviction candidate, `scoreNodeImbalance` iterated over all the remaining pods on the node to recalculate the total node utilization from scratch. On nodes packed with hundreds of pods, this became very expensive since it was done for every evictable pod candidate.

We achieve an `O(1)` time complexity per pod by:
1. Pre-calculating the node's base resource requests upfront (`O(P)`).
2. Deep copying the base requests and directly subtracting the eviction candidate's requests (`O(1)`).
3. Computing the standard deviation of allocation fractions across the requested resources using a new helper `scoreNodeImbalanceWithRequests`.


### Ⅱ. Does this pull request fix one issue?

Part of #2332 

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
