### PR TITLE
webhook: return error instead of panicking on CA cert/watcher init failure

### DIFF
--- a/pkg/webhook/util/health/checker.go
+++ b/pkg/webhook/util/health/checker.go
@@ -34,9 +34,13 @@ import (
 var (
 	caCertFilePath = path.Join(webhookutil.GetCertDir(), "ca-cert.pem")
 
-	onceWatch sync.Once
-	lock      sync.Mutex
-	client    *http.Client
+	initMu        sync.Mutex
+	initialized   bool
+	caCertWatcher *fsnotify.Watcher
+	watchDone     chan struct{}
+
+	lock   sync.Mutex
+	client *http.Client
 )
 
 func loadHTTPClientWithCACert() error {
@@ -107,20 +111,42 @@ func isRemove(event fsnotify.Event) bool {
 	return event.Op&fsnotify.Remove == fsnotify.Remove
 }
 
+// ensureCACertWatcherStarted lazily loads the CA cert and starts the file watcher that
+// keeps it up to date. Unlike sync.Once, a failed attempt does not permanently give up:
+// the next call will retry, since the underlying error (e.g. a missing file) may be
+// transient and there is no HTTP client to serve requests with until this succeeds.
+func ensureCACertWatcherStarted() error {
+	initMu.Lock()
+	defer initMu.Unlock()
+	if initialized {
+		return nil
+	}
+
+	if err := loadHTTPClientWithCACert(); err != nil {
+		return fmt.Errorf("failed to load ca-cert for the first time: %v", err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to new ca-cert watcher: %v", err)
+	}
+	if err = watcher.Add(caCertFilePath); err != nil {
+		_ = watcher.Close()
+		return fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err)
+	}
+	caCertWatcher = watcher
+	watchDone = make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		watchCACert(watcher)
+	}()
+	initialized = true
+	return nil
+}
+
 func Checker(_ *http.Request) error {
-	onceWatch.Do(func() {
-		if err := loadHTTPClientWithCACert(); err != nil {
-			panic(fmt.Errorf("failed to load ca-cert for the first time: %v", err))
-		}
-		watcher, err := fsnotify.NewWatcher()
-		if err != nil {
-			panic(fmt.Errorf("failed to new ca-cert watcher: %v", err))
-		}
-		if err = watcher.Add(caCertFilePath); err != nil {
-			panic(fmt.Errorf("failed to add %v into watcher: %v", caCertFilePath, err))
-		}
-		go watchCACert(watcher)
-	})
+	if err := ensureCACertWatcherStarted(); err != nil {
+		return err
+	}
 
 	url := fmt.Sprintf("https://localhost:%d/healthz", webhookutil.GetPort())
 	req, err := http.NewRequest("GET", url, nil)

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// resetState swaps in a test-local caCertFilePath/initialized state and restores the
+// package globals afterwards, since they are shared across tests in this package. Any
+// watcher goroutine started during the test is stopped and awaited before the globals
+// are restored, so it never observes a path mutated by a later test.
+func resetState(t *testing.T, caCertPath string) {
+	origPath := caCertFilePath
+	origInitialized := initialized
+	t.Cleanup(func() {
+		if caCertWatcher != nil {
+			_ = caCertWatcher.Close()
+			<-watchDone
+			caCertWatcher = nil
+			watchDone = nil
+		}
+		caCertFilePath = origPath
+		initialized = origInitialized
+	})
+	caCertFilePath = caCertPath
+	initialized = false
+}
+
+func TestEnsureCACertWatcherStartedMissingCACert(t *testing.T) {
+	dir := t.TempDir()
+	resetState(t, filepath.Join(dir, "missing-ca-cert.pem"))
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = ensureCACertWatcherStarted()
+	})
+	assert.Error(t, err)
+	assert.False(t, initialized)
+}
+
+func TestEnsureCACertWatcherStartedSuccess(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	assert.NoError(t, os.WriteFile(caCertPath, []byte("dummy-cert-content"), 0644))
+	resetState(t, caCertPath)
+
+	err := ensureCACertWatcherStarted()
+	assert.NoError(t, err)
+	assert.True(t, initialized)
+	assert.NotNil(t, client)
+
+	// A second call should be a no-op, since the watcher is already running.
+	err = ensureCACertWatcherStarted()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`pkg/webhook/util/health/checker.go`'s `Checker()` panics inside a `sync.Once.Do(...)` when it fails to load the CA cert or set up the fsnotify watcher for it. `webhook.Checker` (a thin wrapper) is called directly, not over HTTP, inside `webhook.WaitReady()`, which runs in a bare `go func(){}()` in `cmd/koord-manager/main.go` with no `recover()`. A panic on that path crashes the whole `koord-manager` process. Separately, `sync.Once.Do` marks itself "done" even if `f` panics, so after one transient failure (e.g. the CA file briefly missing at startup) the package-level client stays nil forever and every later call falls through to `client.Do(req)`, a permanent nil-pointer panic with no way to recover even once the CA file reappears.

This PR replaces the `sync.Once` with a `sync.Mutex` + bool `initialized` guard in a new `ensureCACertWatcherStarted()` function. A failed attempt now returns an error instead of panicking, and does not set `initialized`, so the next call retries the whole load/watch setup instead of being stuck forever. `Checker()` propagates that error to its caller instead of panicking.

Note that the `/healthz` HTTP endpoint (`health.Handler.ServeHTTP`) never called `Checker()` at all — it unconditionally returns 200. The only real callers are the "webhook-ready" readyz check registered via `mgr.AddReadyzCheck` and the `WaitReady()` polling loop, both in `cmd/koord-manager/main.go`.

### Ⅱ. Does this pull request fix one issue?

fixes #2902

### Ⅲ. Describe how to verify it

Added `pkg/webhook/util/health/checker_test.go` with:
- `TestEnsureCACertWatcherStartedMissingCACert`: missing CA file returns an error without panicking, and `initialized` stays false so a later retry is still possible.
- `TestEnsureCACertWatcherStartedSuccess`: valid file succeeds, client gets set, a second call is a no-op.

Manually confirmed against the pre-fix code that `Checker(nil)` panics with `"failed to load ca-cert for the first time: ..."` on a missing CA file, i.e. the new test targets the exact defect described in the report.

Ran:
```
go build ./...
go test ./pkg/webhook/util/health/... -race -count=15 -v
```
Both pass; the `-race -count=15` run shows no data races and no stray error logs from leftover goroutines across repeated runs.

### Ⅳ. Special notes for reviews

- Behavior change: `Checker()` now returns an error on init failure instead of panicking, so callers (the readyz check and `WaitReady()`) get a chance to retry instead of crashing the process.
- Fixes the permanent-nil-client bug caused by `sync.Once` treating a panicking initializer as "done."

### V. Checklist

- [ ] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`

---
AI assistance: this change was drafted with Claude Code.