### PR TITLE
scheduler: don't spill devices of other reservations when allocation …

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -475,7 +475,8 @@ func (p *Plugin) FilterNominateReservation(ctx context.Context, cycleState fwkty
 	// if pre-allocation, we filter the reserve pod with the pre-allocatable pod
 	if restoreState.preAllocationRInfo != nil {
 		for i, v := range restoreState.matched {
-			if v.preAllocatable.GetUID() == pod.GetUID() {
+			// the allocations restored for the matched reservations carry no pre-allocatable pod
+			if v.preAllocatable != nil && v.preAllocatable.GetUID() == pod.GetUID() {
 				allocIndex = i
 				break
 			}

--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -53,6 +53,11 @@ const (
 
 	// stateKey is the key in CycleState to pre-computed data.
 	stateKey = Name
+
+	// ErrInsufficientDevicesInNominatedReservation is reported when a pod nominated to a reservation cannot
+	// allocate its devices from that reservation's reserved devices. In this case the pod must not fall back
+	// to the devices reserved by other reservations.
+	ErrInsufficientDevicesInNominatedReservation = "Insufficient devices in the nominated reservation"
 )
 
 var (
@@ -606,11 +611,25 @@ func (p *Plugin) allocate(ctx context.Context, cycleState fwktype.CycleState, po
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
 
-	result, status := p.allocateWithNominated(allocator, state, restoreState, node, pod, preemptible)
+	result, nominated, status := p.allocateWithNominated(allocator, state, restoreState, node, pod, preemptible)
 	if !status.IsSuccess() {
 		return status
 	}
 	if len(result) == 0 {
+		// If a reservation has been nominated to the pod, its devices MUST come from that reservation.
+		// Silently spilling into other matched reservations' reserved devices would violate the reservation
+		// contract (e.g. Restricted) and let the pod occupy devices reserved for another owner.
+		if nominated {
+			klog.V(4).InfoS("failed to allocate devices from the nominated reservation",
+				"pod", klog.KObj(pod), "node", node.Name,
+				"phase", schedulingphase.GetExtensionPointBeingExecuted(cycleState),
+				"matched", dumpReusableAllocs(restoreState.matched))
+			return fwktype.NewStatus(fwktype.Unschedulable, ErrInsufficientDevicesInNominatedReservation)
+		}
+		klog.V(5).InfoS("allocating devices without reusing any reservation",
+			"pod", klog.KObj(pod), "node", node.Name,
+			"phase", schedulingphase.GetExtensionPointBeingExecuted(cycleState),
+			"matched", dumpReusableAllocs(restoreState.matched))
 		preemptible = appendAllocated(preemptible, restoreState.mergedMatchedAllocatable)
 		var requiredDeviceResource map[schedulingv1alpha1.DeviceType]deviceResources
 		if len(state.designatedAllocation) > 0 {

--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -18,9 +18,12 @@ package deviceshare
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 
@@ -445,7 +448,7 @@ func calcRequiredDeviceResources(alloc *reusableAlloc, preemptibleInRR map[sched
 		}
 		for deviceType, minors := range minorHints {
 			resources := deviceResources{}
-			for minor := range minors.UnsortedList() {
+			for _, minor := range minors.UnsortedList() {
 				resources[minor] = corev1.ResourceList{}
 			}
 			required[deviceType] = resources
@@ -454,6 +457,11 @@ func calcRequiredDeviceResources(alloc *reusableAlloc, preemptibleInRR map[sched
 	return required
 }
 
+// allocateWithNominated tries to allocate the devices reserved by the reservation, or by the pre-allocatable pod,
+// nominated for the pod.
+// The second return value reports whether the pod has been nominated to a reservation. Once nominated, the caller
+// MUST NOT fall back to allocating the devices reserved by the other reservations. Otherwise the pod would be
+// accounted as an owner of the nominated reservation while occupying the devices reserved by a different one.
 func (p *Plugin) allocateWithNominated(
 	allocator *AutopilotAllocator,
 	state *preFilterState,
@@ -461,22 +469,25 @@ func (p *Plugin) allocateWithNominated(
 	node *corev1.Node,
 	pod *corev1.Pod,
 	basicPreemptible map[schedulingv1alpha1.DeviceType]deviceResources,
-) (apiext.DeviceAllocations, *fwktype.Status) {
+) (apiext.DeviceAllocations, bool, *fwktype.Status) {
 	if reservationutil.IsReservePod(pod) && !reservationutil.IsReservePodPreAllocation(pod) {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// if the pod is reservation-ignored, it should allocate the node unallocated resources and all the reserved
 	// unallocated resources.
 	if apiext.IsReservationIgnored(pod) {
-		return p.tryAllocateIgnoreReservation(allocator, state, restoreState, restoreState.matched, node, basicPreemptible)
+		result, status := p.tryAllocateIgnoreReservation(allocator, state, restoreState, restoreState.matched, node, basicPreemptible)
+		return result, false, status
 	}
 
-	nominatedReusableAlloc, status := p.getNominatedReusableAlloc(restoreState, pod, node)
+	nominatedReusableAlloc, nominated, status := p.getNominatedReusableAlloc(restoreState, pod, node)
 	if !status.IsSuccess() {
-		return nil, status
+		return nil, nominated, status
 	}
 
+	// The pod is going to be bound to the nominated reservation, so its devices have to be allocated from the
+	// reserved ones. Reject the allocation instead of falling back if the reserved devices are unsatisfied.
 	result, status := p.tryAllocateFromReusable(
 		allocator,
 		state,
@@ -485,9 +496,9 @@ func (p *Plugin) allocateWithNominated(
 		pod,
 		node,
 		basicPreemptible,
-		false,
+		len(nominatedReusableAlloc) > 0,
 	)
-	return result, status
+	return result, nominated, status
 }
 
 func (p *Plugin) scoreWithNominatedReservation(
@@ -525,42 +536,92 @@ func (p *Plugin) scoreWithNominatedReservation(
 	return score, status
 }
 
-func (p *Plugin) getNominatedReusableAlloc(restoreState *nodeReservationRestoreStateData, pod *corev1.Pod, node *corev1.Node) ([]reusableAlloc, *fwktype.Status) {
+// getNominatedReusableAlloc returns the reusable allocation of the reservation, or of the pre-allocatable pod,
+// nominated for the pod.
+// The second return value reports whether a reservation or a pre-allocatable pod has been nominated, no matter
+// whether it reserves any device resource.
+func (p *Plugin) getNominatedReusableAlloc(restoreState *nodeReservationRestoreStateData, pod *corev1.Pod, node *corev1.Node) ([]reusableAlloc, bool, *fwktype.Status) {
 	if !reservationutil.IsReservePod(pod) {
 		reservation := p.handle.GetReservationNominator().GetNominatedReservation(pod, node.Name)
 		if reservation == nil {
-			return nil, nil
+			return nil, false, nil
 		}
 
 		for i, v := range restoreState.matched {
 			if v.rInfo.UID() == reservation.UID() {
-				return restoreState.matched[i : i+1], nil
+				return restoreState.matched[i : i+1], true, nil
 			}
 		}
-		klog.V(5).Infof("nominated reservation %v doesn't reserve any device resource, pod %s, node %s", klog.KObj(reservation), klog.KObj(pod), node.Name)
-		return nil, nil
+		klog.V(4).InfoS("nominated reservation doesn't reserve any device resource",
+			"reservation", reservation.GetName(), "reservationUID", reservation.UID(),
+			"pod", klog.KObj(pod), "node", node.Name, "matched", dumpReusableAllocs(restoreState.matched))
+		return nil, true, nil
 	}
 
 	if !reservationutil.IsReservePodPreAllocation(pod) {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	if restoreState.preAllocationRInfo == nil {
 		klog.V(5).Infof("node has no pre-allocatable device resource, pod %s, node %s", klog.KObj(pod), node.Name)
-		return nil, nil
+		return nil, false, nil
 	}
 
 	preAllocatable := p.handle.GetReservationNominator().GetNominatedPreAllocation(restoreState.preAllocationRInfo, node.Name)
 	if preAllocatable == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	for i, v := range restoreState.matched {
 		if v.preAllocatable.GetUID() == preAllocatable.GetUID() {
-			return restoreState.matched[i : i+1], nil
+			return restoreState.matched[i : i+1], true, nil
 		}
 	}
-	klog.V(5).Infof("nominated pre-allocatable %v doesn't reserve any device resource, pod %s, node %s", klog.KObj(preAllocatable), klog.KObj(pod), node.Name)
-	return nil, nil
+	klog.V(4).InfoS("nominated pre-allocatable pod doesn't reserve any device resource",
+		"preAllocatable", klog.KObj(preAllocatable), "preAllocatableUID", preAllocatable.GetUID(),
+		"pod", klog.KObj(pod), "node", node.Name, "matched", dumpReusableAllocs(restoreState.matched))
+	return nil, true, nil
+}
+
+// dumpReusableAllocs summarizes the reserved and the still remained device minors of the reusable allocations,
+// which helps to diagnose why a pod fails to reuse the devices reserved by its nominated reservation.
+func dumpReusableAllocs(allocs []reusableAlloc) []string {
+	if len(allocs) == 0 {
+		return nil
+	}
+	dumps := make([]string, 0, len(allocs))
+	for i := range allocs {
+		alloc := &allocs[i]
+		var name, uid, policy string
+		if alloc.rInfo != nil {
+			name, uid, policy = alloc.rInfo.GetName(), string(alloc.rInfo.UID()), string(alloc.rInfo.GetAllocatePolicy())
+		}
+		if alloc.preAllocatable != nil {
+			name = name + "/" + alloc.preAllocatable.Name
+		}
+		dumps = append(dumps, fmt.Sprintf("%s(uid=%s, policy=%s, allocatable=%v, remained=%v)",
+			name, uid, policy, dumpDeviceMinors(alloc.allocatable), dumpDeviceMinors(alloc.remained)))
+	}
+	return dumps
+}
+
+// dumpDeviceMinors lists the sorted minors which still hold non-zero resources per device type.
+func dumpDeviceMinors(resources map[schedulingv1alpha1.DeviceType]deviceResources) map[schedulingv1alpha1.DeviceType][]int {
+	if len(resources) == 0 {
+		return nil
+	}
+	r := make(map[schedulingv1alpha1.DeviceType][]int, len(resources))
+	for deviceType, minorResources := range resources {
+		minors := make([]int, 0, len(minorResources))
+		for minor, resource := range minorResources {
+			if quotav1.IsZero(resource) {
+				continue
+			}
+			minors = append(minors, minor)
+		}
+		sort.Ints(minors)
+		r[deviceType] = minors
+	}
+	return r
 }
 
 // isDeviceAllocationsInclude checks if allocations include all devices from required

--- a/pkg/scheduler/plugins/deviceshare/reservation.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation.go
@@ -572,7 +572,8 @@ func (p *Plugin) getNominatedReusableAlloc(restoreState *nodeReservationRestoreS
 		return nil, false, nil
 	}
 	for i, v := range restoreState.matched {
-		if v.preAllocatable.GetUID() == preAllocatable.GetUID() {
+		// the allocations restored for the matched reservations carry no pre-allocatable pod
+		if v.preAllocatable != nil && v.preAllocatable.GetUID() == preAllocatable.GetUID() {
 			return restoreState.matched[i : i+1], true, nil
 		}
 	}

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -1511,3 +1511,500 @@ func Test_isDeviceAllocationsInclude(t *testing.T) {
 		})
 	}
 }
+
+func Test_dumpDeviceMinors(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources map[schedulingv1alpha1.DeviceType]deviceResources
+		want      map[schedulingv1alpha1.DeviceType][]int
+	}{
+		{
+			name:      "nil resources",
+			resources: nil,
+			want:      nil,
+		},
+		{
+			name:      "empty resources",
+			resources: map[schedulingv1alpha1.DeviceType]deviceResources{},
+			want:      nil,
+		},
+		{
+			name: "minors are sorted",
+			resources: map[schedulingv1alpha1.DeviceType]deviceResources{
+				schedulingv1alpha1.GPU: {
+					7: {apiext.ResourceGPUCore: resource.MustParse("100")},
+					2: {apiext.ResourceGPUCore: resource.MustParse("100")},
+					5: {apiext.ResourceGPUCore: resource.MustParse("100")},
+				},
+			},
+			want: map[schedulingv1alpha1.DeviceType][]int{
+				schedulingv1alpha1.GPU: {2, 5, 7},
+			},
+		},
+		{
+			// an exhausted reservation holds zero-valued resources, which must not be reported
+			// as a minor still having remaining capacity
+			name: "zero and empty resources are skipped",
+			resources: map[schedulingv1alpha1.DeviceType]deviceResources{
+				schedulingv1alpha1.GPU: {
+					0: {apiext.ResourceGPUCore: resource.MustParse("0")},
+					1: {},
+					2: {apiext.ResourceGPUCore: resource.MustParse("100")},
+				},
+			},
+			want: map[schedulingv1alpha1.DeviceType][]int{
+				schedulingv1alpha1.GPU: {2},
+			},
+		},
+		{
+			name: "multiple device types",
+			resources: map[schedulingv1alpha1.DeviceType]deviceResources{
+				schedulingv1alpha1.GPU: {
+					1: {apiext.ResourceGPUCore: resource.MustParse("100")},
+				},
+				schedulingv1alpha1.RDMA: {
+					3: {apiext.ResourceRDMA: resource.MustParse("100")},
+					0: {apiext.ResourceRDMA: resource.MustParse("0")},
+				},
+			},
+			want: map[schedulingv1alpha1.DeviceType][]int{
+				schedulingv1alpha1.GPU:  {1},
+				schedulingv1alpha1.RDMA: {3},
+			},
+		},
+		{
+			// a device type whose every minor is exhausted still reports an entry, so the log
+			// distinguishes "reserved but exhausted" from "never reserved"
+			name: "device type with all minors exhausted",
+			resources: map[schedulingv1alpha1.DeviceType]deviceResources{
+				schedulingv1alpha1.GPU: {
+					0: {apiext.ResourceGPUCore: resource.MustParse("0")},
+				},
+			},
+			want: map[schedulingv1alpha1.DeviceType][]int{
+				schedulingv1alpha1.GPU: {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dumpDeviceMinors(tt.resources))
+		})
+	}
+}
+
+func Test_dumpReusableAllocs(t *testing.T) {
+	newRInfo := func(name string, uid types.UID, policy schedulingv1alpha1.ReservationAllocatePolicy) *frameworkext.ReservationInfo {
+		return frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template:       &corev1.PodTemplateSpec{},
+				AllocatePolicy: policy,
+			},
+		})
+	}
+
+	tests := []struct {
+		name   string
+		allocs []reusableAlloc
+		want   []string
+	}{
+		{
+			name:   "nil allocs",
+			allocs: nil,
+			want:   nil,
+		},
+		{
+			name:   "empty allocs",
+			allocs: []reusableAlloc{},
+			want:   nil,
+		},
+		{
+			// the reservation still holds its whole reserved device, so remained equals allocatable
+			name: "restricted reservation with remaining capacity",
+			allocs: []reusableAlloc{
+				{
+					rInfo: newRInfo("reservation-a", "uid-a", schedulingv1alpha1.ReservationAllocatePolicyRestricted),
+					allocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {7: {apiext.ResourceGPUCore: resource.MustParse("100")}},
+					},
+					remained: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {7: {apiext.ResourceGPUCore: resource.MustParse("100")}},
+					},
+				},
+			},
+			want: []string{
+				"reservation-a(uid=uid-a, policy=Restricted, allocatable=map[gpu:[7]], remained=map[gpu:[7]])",
+			},
+		},
+		{
+			// an exhausted reservation reports an empty remained, which is the signal that the
+			// nominated reservation cannot serve the pod
+			name: "exhausted reservation reports empty remained",
+			allocs: []reusableAlloc{
+				{
+					rInfo: newRInfo("reservation-b", "uid-b", schedulingv1alpha1.ReservationAllocatePolicyRestricted),
+					allocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {2: {apiext.ResourceGPUCore: resource.MustParse("100")}},
+					},
+					remained: nil,
+				},
+			},
+			want: []string{
+				"reservation-b(uid=uid-b, policy=Restricted, allocatable=map[gpu:[2]], remained=map[])",
+			},
+		},
+		{
+			name: "pre-allocatable pod is appended to the reservation name",
+			allocs: []reusableAlloc{
+				{
+					rInfo:          newRInfo("reservation-c", "uid-c", schedulingv1alpha1.ReservationAllocatePolicyAligned),
+					preAllocatable: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pre-allocatable-pod"}},
+					allocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {1: {apiext.ResourceGPUCore: resource.MustParse("100")}},
+					},
+				},
+			},
+			want: []string{
+				"reservation-c/pre-allocatable-pod(uid=uid-c, policy=Aligned, allocatable=map[gpu:[1]], remained=map[])",
+			},
+		},
+		{
+			// dumping is only used for logging, so a malformed alloc must not panic
+			name:   "nil rInfo does not panic",
+			allocs: []reusableAlloc{{}},
+			want:   []string{"(uid=, policy=, allocatable=map[], remained=map[])"},
+		},
+		{
+			name: "multiple allocs keep their order",
+			allocs: []reusableAlloc{
+				{rInfo: newRInfo("reservation-d", "uid-d", schedulingv1alpha1.ReservationAllocatePolicyRestricted)},
+				{rInfo: newRInfo("reservation-e", "uid-e", schedulingv1alpha1.ReservationAllocatePolicyDefault)},
+			},
+			want: []string{
+				"reservation-d(uid=uid-d, policy=Restricted, allocatable=map[], remained=map[])",
+				"reservation-e(uid=uid-e, policy=, allocatable=map[], remained=map[])",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dumpReusableAllocs(tt.allocs))
+		})
+	}
+}
+
+func Test_getNominatedReusableAlloc(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+
+	newRInfo := func(uid types.UID, preAllocation bool) *frameworkext.ReservationInfo {
+		return frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: "reservation-" + string(uid), UID: uid},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template:       &corev1.PodTemplateSpec{},
+				PreAllocation:  preAllocation,
+				AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			},
+			Status: schedulingv1alpha1.ReservationStatus{NodeName: node.Name},
+		})
+	}
+	reservedGPU := func(minor int) map[schedulingv1alpha1.DeviceType]deviceResources {
+		return map[schedulingv1alpha1.DeviceType]deviceResources{
+			schedulingv1alpha1.GPU: {minor: {apiext.ResourceGPUCore: resource.MustParse("100")}},
+		}
+	}
+
+	normalPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "normal-pod", UID: "normal-pod-uid"}}
+	reservePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "reserve-pod", UID: "reserve-pod-uid",
+		Annotations: map[string]string{reservationutil.AnnotationReservePod: "true"},
+	}}
+	preAllocReservePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "pre-alloc-reserve-pod", UID: "pre-alloc-reserve-pod-uid",
+		Annotations: map[string]string{
+			reservationutil.AnnotationReservePod:      "true",
+			reservationutil.AnnotationIsPreAllocation: "true",
+		},
+	}}
+	preAllocatablePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pre-allocatable-pod", UID: "pre-allocatable-pod-uid"}}
+	otherPreAllocatablePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-pre-allocatable-pod", UID: "other-pre-allocatable-pod-uid"}}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		// setup builds the restore state and registers the nomination on the plugin's nominator.
+		setup func(pl *Plugin) *nodeReservationRestoreStateData
+		// wantMatchedIndex is the index in restoreState.matched expected to be returned,
+		// or -1 when no reusable allocation is expected.
+		wantMatchedIndex int
+		wantNominated    bool
+	}{
+		{
+			name: "normal pod without nominated reservation",
+			pod:  normalPod,
+			setup: func(_ *Plugin) *nodeReservationRestoreStateData {
+				return &nodeReservationRestoreStateData{}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    false,
+		},
+		{
+			name: "normal pod nominated to a reservation reserving devices",
+			pod:  normalPod,
+			setup: func(pl *Plugin) *nodeReservationRestoreStateData {
+				rInfo := newRInfo("reserving-devices", false)
+				pl.handle.GetReservationNominator().AddNominatedReservation(normalPod, node.Name, rInfo)
+				return &nodeReservationRestoreStateData{
+					matched: []reusableAlloc{
+						{rInfo: newRInfo("other", false), allocatable: reservedGPU(2), remained: reservedGPU(2)},
+						{rInfo: rInfo, allocatable: reservedGPU(7), remained: reservedGPU(7)},
+					},
+				}
+			},
+			wantMatchedIndex: 1,
+			wantNominated:    true,
+		},
+		{
+			// The reservation is nominated but reserves no device resource, so it is absent from
+			// the restored matched list. It must still be reported as nominated, otherwise the
+			// caller would fall back and take the devices reserved by the other reservations.
+			name: "normal pod nominated to a reservation reserving no device",
+			pod:  normalPod,
+			setup: func(pl *Plugin) *nodeReservationRestoreStateData {
+				pl.handle.GetReservationNominator().AddNominatedReservation(normalPod, node.Name, newRInfo("reserving-nothing", false))
+				return &nodeReservationRestoreStateData{
+					matched: []reusableAlloc{
+						{rInfo: newRInfo("other", false), allocatable: reservedGPU(2), remained: reservedGPU(2)},
+					},
+				}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    true,
+		},
+		{
+			name: "reserve pod without pre-allocation",
+			pod:  reservePod,
+			setup: func(_ *Plugin) *nodeReservationRestoreStateData {
+				return &nodeReservationRestoreStateData{}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    false,
+		},
+		{
+			name: "pre-allocating reserve pod without restored pre-allocation info",
+			pod:  preAllocReservePod,
+			setup: func(_ *Plugin) *nodeReservationRestoreStateData {
+				return &nodeReservationRestoreStateData{}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    false,
+		},
+		{
+			name: "pre-allocating reserve pod without nominated pre-allocatable pod",
+			pod:  preAllocReservePod,
+			setup: func(_ *Plugin) *nodeReservationRestoreStateData {
+				return &nodeReservationRestoreStateData{
+					preAllocationRInfo: newRInfo("pre-allocating", true),
+					matched: []reusableAlloc{
+						{rInfo: newRInfo("pre-allocating", true), preAllocatable: preAllocatablePod, allocatable: reservedGPU(7)},
+					},
+				}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    false,
+		},
+		{
+			name: "pre-allocating reserve pod nominated to a pre-allocatable pod reserving devices",
+			pod:  preAllocReservePod,
+			setup: func(pl *Plugin) *nodeReservationRestoreStateData {
+				rInfo := newRInfo("pre-allocating", true)
+				pl.handle.GetReservationNominator().AddNominatedPreAllocation(rInfo, node.Name, preAllocatablePod)
+				return &nodeReservationRestoreStateData{
+					preAllocationRInfo: rInfo,
+					matched: []reusableAlloc{
+						{rInfo: rInfo, preAllocatable: otherPreAllocatablePod, allocatable: reservedGPU(2)},
+						{rInfo: rInfo, preAllocatable: preAllocatablePod, allocatable: reservedGPU(7)},
+					},
+				}
+			},
+			wantMatchedIndex: 1,
+			wantNominated:    true,
+		},
+		{
+			// The nominated pre-allocatable pod holds no device, so it is absent from the matched
+			// list while the nomination itself still stands.
+			name: "pre-allocating reserve pod nominated to a pre-allocatable pod reserving no device",
+			pod:  preAllocReservePod,
+			setup: func(pl *Plugin) *nodeReservationRestoreStateData {
+				rInfo := newRInfo("pre-allocating", true)
+				pl.handle.GetReservationNominator().AddNominatedPreAllocation(rInfo, node.Name, preAllocatablePod)
+				return &nodeReservationRestoreStateData{
+					preAllocationRInfo: rInfo,
+					matched: []reusableAlloc{
+						{rInfo: rInfo, preAllocatable: otherPreAllocatablePod, allocatable: reservedGPU(2)},
+					},
+				}
+			},
+			wantMatchedIndex: -1,
+			wantNominated:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, []*corev1.Node{node})
+			p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+
+			restoreState := tt.setup(pl)
+
+			got, nominated, status := pl.getNominatedReusableAlloc(restoreState, tt.pod, node)
+
+			assert.True(t, status.IsSuccess())
+			assert.Equal(t, tt.wantNominated, nominated)
+			if tt.wantMatchedIndex < 0 {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, restoreState.matched[tt.wantMatchedIndex:tt.wantMatchedIndex+1], got)
+		})
+	}
+}
+
+// Test_Plugin_Reserve_NominatedReservationMustNotSpill reproduces the production incident where a pod
+// nominated to a Restricted reservation holding one GPU was allocated the GPU reserved by a *different*
+// reservation: every device of the node was reserved, the nominated reservation could not serve the pod,
+// and the allocation silently fell back to the devices released by mergedMatchedAllocatable, picking the
+// smallest minor. Such a pod would be accounted as an owner of its nominated reservation while occupying
+// another reservation's device, so it must be rejected instead.
+func Test_Plugin_Reserve_NominatedReservationMustNotSpill(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+
+	wholeGPU := corev1.ResourceList{
+		apiext.ResourceGPUCore:        resource.MustParse("100"),
+		apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+		apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+	}
+	reservedGPU := func(minor int) map[schedulingv1alpha1.DeviceType]deviceResources {
+		return map[schedulingv1alpha1.DeviceType]deviceResources{
+			schedulingv1alpha1.GPU: {minor: wholeGPU.DeepCopy()},
+		}
+	}
+	newRInfo := func(name string, uid types.UID) *frameworkext.ReservationInfo {
+		return frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template:       &corev1.PodTemplateSpec{},
+				AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			},
+			Status: schedulingv1alpha1.ReservationStatus{NodeName: node.Name},
+		})
+	}
+
+	// Both GPUs of the node are entirely held by the two reserve pods, so nothing is free outside
+	// of the reservations, exactly like the node observed in the incident.
+	newNodeDeviceCache := func() *nodeDeviceCache {
+		return &nodeDeviceCache{
+			nodeDeviceInfos: map[string]*nodeDevice{
+				node.Name: {
+					deviceTotal: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {0: wholeGPU.DeepCopy(), 1: wholeGPU.DeepCopy()},
+					},
+					deviceUsed: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {0: wholeGPU.DeepCopy(), 1: wholeGPU.DeepCopy()},
+					},
+					deviceFree: map[schedulingv1alpha1.DeviceType]deviceResources{
+						schedulingv1alpha1.GPU: {},
+					},
+					allocateSet:   map[schedulingv1alpha1.DeviceType]map[types.NamespacedName]deviceResources{},
+					vfAllocations: map[schedulingv1alpha1.DeviceType]*VFAllocation{},
+					numaTopology:  &NUMATopology{},
+					deviceInfos: map[schedulingv1alpha1.DeviceType][]*schedulingv1alpha1.DeviceInfo{
+						schedulingv1alpha1.GPU: {
+							{Type: schedulingv1alpha1.GPU, Health: true, UUID: "gpu-0", Minor: ptr.To[int32](0), Resources: wholeGPU.DeepCopy()},
+							{Type: schedulingv1alpha1.GPU, Health: true, UUID: "gpu-1", Minor: ptr.To[int32](1), Resources: wholeGPU.DeepCopy()},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	rInfoA := newRInfo("reservation-a", "reservation-a-uid")
+	rInfoB := newRInfo("reservation-b", "reservation-b-uid")
+
+	tests := []struct {
+		name         string
+		restoreState *nodeReservationRestoreStateData
+	}{
+		{
+			// reservation-b reserves GPU 1 but has already handed it to its own owner pods,
+			// so the Restricted policy leaves the pod nothing to reuse.
+			name: "nominated reservation is exhausted",
+			restoreState: &nodeReservationRestoreStateData{
+				matched: []reusableAlloc{
+					{rInfo: rInfoA, allocatable: reservedGPU(0), remained: reservedGPU(0)},
+					{rInfo: rInfoB, allocatable: reservedGPU(1), remained: nil},
+				},
+				mergedMatchedAllocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+					schedulingv1alpha1.GPU: {0: wholeGPU.DeepCopy(), 1: wholeGPU.DeepCopy()},
+				},
+			},
+		},
+		{
+			// reservation-b is nominated but reserves no device at all, so it is absent from the
+			// restored matched list. The pod must not take GPU 0 reserved by reservation-a.
+			name: "nominated reservation reserves no device",
+			restoreState: &nodeReservationRestoreStateData{
+				matched: []reusableAlloc{
+					{rInfo: rInfoA, allocatable: reservedGPU(0), remained: reservedGPU(0)},
+				},
+				mergedMatchedAllocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+					schedulingv1alpha1.GPU: {0: wholeGPU.DeepCopy()},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			suit := newPluginTestSuit(t, []*corev1.Node{node})
+			p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+			assert.NoError(t, err)
+			pl := p.(*Plugin)
+			pl.nodeDeviceCache = newNodeDeviceCache()
+
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default", Name: "gpu-pod", UID: "gpu-pod-uid",
+			}}
+			state := &preFilterState{
+				skip: false,
+				podRequests: map[schedulingv1alpha1.DeviceType]corev1.ResourceList{
+					schedulingv1alpha1.GPU: wholeGPU.DeepCopy(),
+				},
+			}
+			state.gpuRequirements, err = parseGPURequirements(pod, state.podRequests, nil,
+				testGPUSharedResourceTemplatesCache, testGPUSharedResourceTemplatesMatchedResources)
+			assert.NoError(t, err)
+
+			cycleState := framework.NewCycleState()
+			cycleState.Write(stateKey, state)
+			cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+				nodeToState: frameworkext.NodeReservationRestoreStates{node.Name: tt.restoreState},
+			})
+			// the reservation plugin has already nominated reservation-b for this pod
+			pl.handle.GetReservationNominator().AddNominatedReservation(pod, node.Name, rInfoB)
+
+			status := pl.Reserve(context.TODO(), cycleState, pod, node.Name)
+
+			assert.Equal(t, fwktype.Unschedulable, status.Code(), "the pod must be rejected, got status %v", status)
+			// most importantly, it must not have been given GPU 0 reserved by reservation-a
+			assert.Nil(t, state.allocationResult)
+		})
+	}
+}

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -1850,6 +1850,26 @@ func Test_getNominatedReusableAlloc(t *testing.T) {
 			wantMatchedIndex: -1,
 			wantNominated:    true,
 		},
+		{
+			// RestoreReservationPreAllocation appends the pre-allocatable allocations to the ones
+			// already restored by RestoreReservation, and the latter carry no pre-allocatable pod.
+			// Such entries must be skipped rather than dereferenced.
+			name: "pre-allocating reserve pod with a plain matched reservation in the restore state",
+			pod:  preAllocReservePod,
+			setup: func(pl *Plugin) *nodeReservationRestoreStateData {
+				rInfo := newRInfo("pre-allocating", true)
+				pl.handle.GetReservationNominator().AddNominatedPreAllocation(rInfo, node.Name, preAllocatablePod)
+				return &nodeReservationRestoreStateData{
+					preAllocationRInfo: rInfo,
+					matched: []reusableAlloc{
+						{rInfo: newRInfo("plain", false), allocatable: reservedGPU(2), remained: reservedGPU(2)},
+						{rInfo: rInfo, preAllocatable: preAllocatablePod, allocatable: reservedGPU(7)},
+					},
+				}
+			},
+			wantMatchedIndex: 1,
+			wantNominated:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2007,4 +2027,82 @@ func Test_Plugin_Reserve_NominatedReservationMustNotSpill(t *testing.T) {
 			assert.Nil(t, state.allocationResult)
 		})
 	}
+}
+
+// Test_Plugin_FilterNominateReservation_PreAllocation checks that the pre-allocation branch skips the
+// allocations restored for the matched reservations, which carry no pre-allocatable pod, instead of
+// dereferencing them. RestoreReservationPreAllocation appends the pre-allocatable allocations to the
+// ones already restored by RestoreReservation, so both kinds can coexist in the matched list.
+func Test_Plugin_FilterNominateReservation_PreAllocation(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	suit := newPluginTestSuit(t, []*corev1.Node{node})
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+	pl := p.(*Plugin)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	suit.Framework.SharedInformerFactory().Start(stopCh)
+	suit.Framework.SharedInformerFactory().WaitForCacheSync(stopCh)
+
+	wholeGPU := corev1.ResourceList{
+		apiext.ResourceGPUCore:        resource.MustParse("100"),
+		apiext.ResourceGPUMemory:      resource.MustParse("8Gi"),
+		apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+	}
+	pl.nodeDeviceCache.updateNodeDevice(node.Name, &schedulingv1alpha1.Device{
+		Spec: schedulingv1alpha1.DeviceSpec{
+			Devices: []schedulingv1alpha1.DeviceInfo{
+				{Type: schedulingv1alpha1.GPU, Minor: ptr.To[int32](1), Health: true, Resources: wholeGPU.DeepCopy()},
+			},
+		},
+	})
+
+	preAllocatablePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pre-allocatable-pod", UID: uuid.NewUUID()},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				apiext.ResourceGPU: resource.MustParse("100"),
+			}},
+		}}},
+	}
+
+	cycleState := framework.NewCycleState()
+	_, status := pl.PreFilter(context.TODO(), cycleState, preAllocatablePod, nil)
+	assert.True(t, status.IsSuccess())
+
+	newRInfo := func(name string, preAllocation bool) *frameworkext.ReservationInfo {
+		return frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uuid.NewUUID()},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template:       &corev1.PodTemplateSpec{},
+				PreAllocation:  preAllocation,
+				AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			},
+			Status: schedulingv1alpha1.ReservationStatus{NodeName: node.Name},
+		})
+	}
+	reservedGPU := func() map[schedulingv1alpha1.DeviceType]deviceResources {
+		return map[schedulingv1alpha1.DeviceType]deviceResources{
+			schedulingv1alpha1.GPU: {1: wholeGPU.DeepCopy()},
+		}
+	}
+
+	preAllocRInfo := newRInfo("pre-allocating-reservation", true)
+	cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+		nodeToState: frameworkext.NodeReservationRestoreStates{
+			node.Name: &nodeReservationRestoreStateData{
+				preAllocationRInfo: preAllocRInfo,
+				matched: []reusableAlloc{
+					// restored by RestoreReservation, so it has no pre-allocatable pod
+					{rInfo: newRInfo("plain-reservation", false), allocatable: reservedGPU(), remained: reservedGPU()},
+					// restored by RestoreReservationPreAllocation
+					{rInfo: preAllocRInfo, preAllocatable: preAllocatablePod, allocatable: reservedGPU(), remained: reservedGPU()},
+				},
+			},
+		},
+	})
+
+	status = pl.FilterNominateReservation(context.TODO(), cycleState, preAllocatablePod, preAllocRInfo, node.Name)
+	assert.True(t, status.IsSuccess(), "status: %v", status)
 }

--- a/pkg/scheduler/plugins/deviceshare/reservation_test.go
+++ b/pkg/scheduler/plugins/deviceshare/reservation_test.go
@@ -1189,8 +1189,11 @@ func Test_allocateWithNominated(t *testing.T) {
 		name              string
 		pod               *corev1.Pod
 		buildRestoreState func(rInfo *frameworkext.ReservationInfo) *nodeReservationRestoreStateData
+		nominate          bool
+		allocatePolicy    schedulingv1alpha1.ReservationAllocatePolicy
 		wantNil           bool
 		wantSuccess       bool
+		wantNominated     bool
 	}{
 		{
 			name: "reserve pod without pre-allocation",
@@ -1264,6 +1267,43 @@ func Test_allocateWithNominated(t *testing.T) {
 			wantNil:     true,
 			wantSuccess: true,
 		},
+		{
+			// The pod is nominated to a Restricted reservation whose reserved device is exhausted.
+			// It must be rejected instead of silently spilling over to the devices reserved by
+			// the other reservations or to the remaining devices of the node.
+			name: "normal pod nominated to an exhausted restricted reservation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "normal-pod",
+					UID:  normalPodUID,
+				},
+			},
+			nominate:       true,
+			allocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			buildRestoreState: func(rInfo *frameworkext.ReservationInfo) *nodeReservationRestoreStateData {
+				return &nodeReservationRestoreStateData{
+					matched: []reusableAlloc{
+						{
+							rInfo: rInfo,
+							allocatable: map[schedulingv1alpha1.DeviceType]deviceResources{
+								schedulingv1alpha1.GPU: {
+									0: {
+										apiext.ResourceGPUCore:        resource.MustParse("50"),
+										apiext.ResourceGPUMemory:      resource.MustParse("4Gi"),
+										apiext.ResourceGPUMemoryRatio: resource.MustParse("50"),
+									},
+								},
+							},
+							// fully consumed by the other owner pods, so nothing is reusable
+							remained: nil,
+						},
+					},
+				}
+			},
+			wantNil:       true,
+			wantSuccess:   false,
+			wantNominated: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1289,7 +1329,13 @@ func Test_allocateWithNominated(t *testing.T) {
 			pl.nodeDeviceCache.updateNodeDevice("test-node", newDevice())
 
 			rInfo := newReservationInfo()
+			if tt.allocatePolicy != "" {
+				rInfo.Reservation.Spec.AllocatePolicy = tt.allocatePolicy
+			}
 			restoreState := tt.buildRestoreState(rInfo)
+			if tt.nominate {
+				pl.handle.GetReservationNominator().AddNominatedReservation(tt.pod, node.Name, rInfo)
+			}
 
 			state := &preFilterState{
 				podRequests: map[schedulingv1alpha1.DeviceType]corev1.ResourceList{
@@ -1312,7 +1358,7 @@ func Test_allocateWithNominated(t *testing.T) {
 				pod:        tt.pod,
 			}
 
-			result, status := pl.allocateWithNominated(
+			result, nominated, status := pl.allocateWithNominated(
 				allocator,
 				state,
 				restoreState,
@@ -1332,6 +1378,7 @@ func Test_allocateWithNominated(t *testing.T) {
 			} else {
 				assert.False(t, status.IsSuccess())
 			}
+			assert.Equal(t, tt.wantNominated, nominated)
 		})
 	}
 }


### PR DESCRIPTION
…from the nominated reservation fails

When a pod is nominated to a reservation, the reservation plugin records the pod as an owner of that reservation. The DeviceShare plugin, however, invoked tryAllocateFromReusable with requiredFromReservation=false, so a failed allocation from the nominated reservation was swallowed and returned as an empty result. The caller then treated the empty result as "the pod does not reuse any reservation" and fell back to allocating with mergedMatchedAllocatable added to the preemptible resources, which releases the devices reserved by *all* matched reservations.

As a result a pod could be accounted as an owner of reservation A while actually occupying a device reserved by reservation B. This bypasses the Restricted allocate policy entirely: with no required/preferred minors left, the fallback simply picks the candidate with the best score and the smallest minor. It was observed on a node whose devices were all reserved, where a pod nominated to a reservation holding GPU minor 7 was allocated GPU minor 2, i.e. the device reserved by a different reservation.

Reject the allocation instead of falling back once a reservation has been nominated to the pod:

- allocateWithNominated requires the allocation to come from the nominated reusable allocation, so an unsatisfied reservation surfaces as Unschedulable rather than an empty result.
- allocate() no longer releases mergedMatchedAllocatable when a reservation has been nominated, so the pod can never take the devices reserved for another owner.

Also fix calcRequiredDeviceResources iterating over the indexes instead of the values of the reserved minors, which named the wrong minors when marking an exhausted reservation as having no remaining capacity. This currently yields the same "no capacity" outcome because the marker resource lists are empty, so it is a latent bug rather than an observable one.

Log the nominated reservation and the reserved/remaining minors of the matched reservations to make this class of mismatch diagnosable from the scheduler log.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
