### PR TITLE
koord-device-daemon: propagate printer initialization errors instead of silently returning nil

### DIFF
--- a/cmd/koord-device-daemon/main.go
+++ b/cmd/koord-device-daemon/main.go
@@ -191,7 +191,7 @@ func (rfd *resourceFeatureDiscovery) run(sigs chan os.Signal) (bool, error) {
 rerun:
 	loopPrinters, err := printmanager.NewPrinters(rfd.manager)
 	if err != nil {
-		return false, nil
+		return false, fmt.Errorf("error creating printers: %w", err)
 	}
 	prints, err := loopPrinters.Prints()
 	if err != nil {

--- a/cmd/koord-device-daemon/main_test.go
+++ b/cmd/koord-device-daemon/main_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resourceconifg "github.com/koordinator-sh/koordinator/cmd/koord-device-daemon/config/v1"
+	"github.com/koordinator-sh/koordinator/pkg/device-daemon/resource"
+)
+
+// fakeFailingManager is a resource.Manager whose GetDevices call always
+// fails, simulating a vendor tool (e.g. nvidia-smi, xpu-smi) erroring out
+// during device discovery.
+type fakeFailingManager struct {
+	vendor string
+	err    error
+}
+
+func (f *fakeFailingManager) GetDeviceVendor() string {
+	return f.vendor
+}
+
+func (f *fakeFailingManager) GetDevices() ([]resource.Device, error) {
+	return nil, f.err
+}
+
+func (f *fakeFailingManager) GetDriverVersion() (string, error) {
+	return "", nil
+}
+
+// TestRun_PropagatesPrinterInitError guards against a regression of the bug
+// where (*resourceFeatureDiscovery).run silently swallowed errors returned
+// by printmanager.NewPrinters and returned (false, nil), making a failed
+// discovery run look like a successful one.
+func TestRun_PropagatesPrinterInitError(t *testing.T) {
+	underlying := errors.New("nvidia-smi: device query failed")
+
+	oneshot := true
+	rfd := &resourceFeatureDiscovery{
+		manager: map[string]resource.Manager{
+			"nvidia": &fakeFailingManager{vendor: "nvidia", err: underlying},
+		},
+		config: &resourceconifg.Config{
+			Flags: resourceconifg.Flags{
+				CommandLineFlags: resourceconifg.CommandLineFlags{
+					KDD: &resourceconifg.KDDCommandLineFlags{
+						Oneshot:       &oneshot,
+						SleepInterval: &metav1.Duration{},
+					},
+				},
+			},
+		},
+	}
+
+	restart, err := rfd.run(make(chan os.Signal, 1))
+
+	require.Error(t, err, "run() must not swallow the printer initialization error")
+	assert.False(t, restart)
+	// printmanager.NewPrinters wraps the underlying error with fmt.Errorf's
+	// %v verb rather than %w, so the original error's message text is
+	// preserved but its identity is not chainable via errors.Is/errors.As.
+	assert.Contains(t, err.Error(), underlying.Error(), "the original error message must be preserved")
+	assert.Contains(t, err.Error(), "nvidia", "the error should retain vendor context")
+}


### PR DESCRIPTION
## Describe what this PR does

While reviewing the discovery loop in `koord-device-daemon`, I found that `(*resourceFeatureDiscovery).run` in `cmd/koord-device-daemon/main.go` was discarding errors returned by printer initialization:

```go
loopPrinters, err := printmanager.NewPrinters(rfd.manager)
if err != nil {
	return false, nil
}
```

When `NewPrinters` fails , for example, if `manager.GetDevices()` or `device.GetDeviceInfo()` returns an error due to a failing vendor tool such as `nvidia-smi` , the error is silently discarded and `run()` returns `false, nil`.

As a result, the failure is not propagated to the caller, making the discovery loop appear to terminate successfully even though device discovery did not complete.

This PR fixes the issue by propagating the initialization error with `%w`:

```go
if err != nil {
	return false, fmt.Errorf("error creating printers: %w", err)
}
```

This preserves the original error in the wrapping chain, allowing callers and tests to inspect it with `errors.Is` / `errors.As`. The existing vendor-specific context from `newPrinter()` is also preserved.

## Does this pull request fix one issue?

Fixes #3118

## Describe how to verify it

Added `TestRun_PropagatesPrinterInitError` in `cmd/koord-device-daemon/main_test.go`.

The test uses a fake `resource.Manager` whose `GetDevices()` returns a known error, then calls `run()` and verifies that:

* `run()` returns a non-nil error.
* `errors.Is()` can identify the original error, confirming that it is properly wrapped with `%w`.
* The returned error contains the vendor name, ensuring the existing diagnostic context is preserved.

The behavior can also be reproduced manually by configuring a `resource.Manager` to return an error from `GetDevices()` or a device to return an error from `GetDeviceInfo()`. The daemon should surface the initialization failure instead of silently treating the discovery run as successful.

## Special notes for reviewers

This PR intentionally keeps the scope limited to the swallowed printer initialization error.

I did not change the `%v` vs `%w` wrapping in `pkg/device-daemon/printer/printer.go`, although that could be considered a related cleanup. I believe that change is better handled separately to keep this PR focused on the issue described in #3118.
