### PR TITLE
scheduler: confine late members of satisfied topology-aware gangs in …

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/gang.go
+++ b/pkg/scheduler/plugins/coscheduling/core/gang.go
@@ -476,6 +476,16 @@ func (gang *Gang) getWaitingChildrenFromGang() (children []*v1.Pod) {
 	return children
 }
 
+func (gang *Gang) getBoundChildrenFromGang() (children []*v1.Pod) {
+	gang.lock.RLock()
+	defer gang.lock.RUnlock()
+	children = make([]*v1.Pod, 0, len(gang.BoundChildren))
+	for _, pod := range gang.BoundChildren {
+		children = append(children, pod)
+	}
+	return children
+}
+
 func (gang *Gang) isGangFromAnnotation() bool {
 	gang.lock.RLock()
 	defer gang.lock.RUnlock()

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_late_member_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_late_member_test.go
@@ -1,0 +1,316 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	fwktype "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/apis/thirdparty/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/networktopology"
+)
+
+func newLateMemberTestNodes() []*corev1.Node {
+	newNode := func(name, spine, block string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					networktopology.FakeSpineLabel: spine,
+					networktopology.FakeBlockLabel: block,
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("16"),
+					corev1.ResourcePods: resource.MustParse("110"),
+				},
+			},
+		}
+	}
+	return []*corev1.Node{
+		newNode("node-1", "s1", "b1"),
+		newNode("node-2", "s1", "b1"),
+		newNode("node-3", "s1", "b2"),
+		newNode("node-5", "s2", "b3"),
+	}
+}
+
+func newMustGatherBlockTopologySpec() *extension.NetworkTopologySpec {
+	return &extension.NetworkTopologySpec{
+		GatherStrategy: []extension.NetworkTopologyGatherRule{
+			{
+				Layer:    "BlockLayer",
+				Strategy: extension.NetworkTopologyGatherStrategyMustGather,
+			},
+		},
+	}
+}
+
+func newLateMemberPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+			UID:       types.UID(name),
+			Labels: map[string]string{
+				v1alpha1.PodGroupLabel: "gangA",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("16"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
+	gangID := "default/gangA"
+	boundPodOnNode := func(name, nodeName string) *corev1.Pod {
+		pod := newLateMemberPod(name)
+		pod.Spec.NodeName = nodeName
+		return pod
+	}
+	tests := []struct {
+		name                   string
+		triggerPod             *corev1.Pod
+		withClusterTopology    bool
+		networkTopologySpec    *extension.NetworkTopologySpec
+		boundPods              []*corev1.Pod
+		manuallySetSatisfied   bool
+		wantResult             *fwktype.PreFilterResult
+		wantStatusCode         fwktype.Code
+		wantStatusMsgSubstring string
+	}{
+		{
+			name:                "not a gang pod",
+			triggerPod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "late-pod"}},
+			withClusterTopology: true,
+			networkTopologySpec: newMustGatherBlockTopologySpec(),
+			wantStatusCode:      fwktype.Success,
+		},
+		{
+			name:                "gang without network topology spec",
+			triggerPod:          newLateMemberPod("late-pod"),
+			withClusterTopology: true,
+			networkTopologySpec: nil,
+			wantStatusCode:      fwktype.Success,
+		},
+		{
+			name:                "gang not satisfied yet",
+			triggerPod:          newLateMemberPod("late-pod"),
+			withClusterTopology: true,
+			networkTopologySpec: newMustGatherBlockTopologySpec(),
+			wantStatusCode:      fwktype.Success,
+		},
+		{
+			name:                   "no cluster network topology",
+			triggerPod:             newLateMemberPod("late-pod"),
+			withClusterTopology:    false,
+			networkTopologySpec:    newMustGatherBlockTopologySpec(),
+			boundPods:              []*corev1.Pod{boundPodOnNode("bound-pod-1", "node-1")},
+			wantStatusCode:         fwktype.UnschedulableAndUnresolvable,
+			wantStatusMsgSubstring: ErrNoClusterNetworkTopology,
+		},
+		{
+			name:                "no must-gather requirement",
+			triggerPod:          newLateMemberPod("late-pod"),
+			withClusterTopology: true,
+			networkTopologySpec: &extension.NetworkTopologySpec{
+				GatherStrategy: []extension.NetworkTopologyGatherRule{
+					{
+						Layer:    "BlockLayer",
+						Strategy: extension.NetworkTopologyGatherStrategyPreferGather,
+					},
+				},
+			},
+			boundPods:      []*corev1.Pod{boundPodOnNode("bound-pod-1", "node-1")},
+			wantStatusCode: fwktype.Success,
+		},
+		{
+			name:                   "satisfied but no bound member",
+			triggerPod:             newLateMemberPod("late-pod"),
+			withClusterTopology:    true,
+			networkTopologySpec:    newMustGatherBlockTopologySpec(),
+			manuallySetSatisfied:   true,
+			wantStatusCode:         fwktype.UnschedulableAndUnresolvable,
+			wantStatusMsgSubstring: "no bound member is found",
+		},
+		{
+			name:                   "bound member node not in cluster network topology",
+			triggerPod:             newLateMemberPod("late-pod"),
+			withClusterTopology:    true,
+			networkTopologySpec:    newMustGatherBlockTopologySpec(),
+			boundPods:              []*corev1.Pod{boundPodOnNode("bound-pod-1", "node-unknown")},
+			wantStatusCode:         fwktype.UnschedulableAndUnresolvable,
+			wantStatusMsgSubstring: `bound member "default/bound-pod-1" is on node "node-unknown" which is not in the cluster network topology`,
+		},
+		{
+			name:                "bound members span multiple blocks",
+			triggerPod:          newLateMemberPod("late-pod"),
+			withClusterTopology: true,
+			networkTopologySpec: newMustGatherBlockTopologySpec(),
+			boundPods: []*corev1.Pod{
+				boundPodOnNode("bound-pod-1", "node-1"),
+				boundPodOnNode("bound-pod-2", "node-3"),
+			},
+			wantStatusCode:         fwktype.UnschedulableAndUnresolvable,
+			wantStatusMsgSubstring: "the bound members span multiple must-gather topology domains",
+		},
+		{
+			name:                "confined to the bound members' block",
+			triggerPod:          newLateMemberPod("late-pod"),
+			withClusterTopology: true,
+			networkTopologySpec: newMustGatherBlockTopologySpec(),
+			boundPods: []*corev1.Pod{
+				boundPodOnNode("bound-pod-1", "node-1"),
+				boundPodOnNode("bound-pod-2", "node-2"),
+			},
+			wantResult: &fwktype.PreFilterResult{NodeNames: sets.New("node-1", "node-2")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterNetworkTopology := networktopology.FakeClusterNetworkTopology
+			if !tt.withClusterTopology {
+				clusterNetworkTopology = nil
+			}
+			extendedFramework := NewFakeExtendedFramework(t, newLateMemberTestNodes(), nil, nil, nil, clusterNetworkTopology)
+			pgMgr := &PodGroupManager{handle: extendedFramework}
+			pgMgr.cache = NewGangCache(nil, nil, nil, nil, nil)
+
+			gang := NewGang(gangID)
+			gang.HasGangInit = true
+			gang.NetworkTopologySpec = tt.networkTopologySpec
+			for _, boundPod := range tt.boundPods {
+				gang.addBoundPod(boundPod)
+			}
+			if tt.manuallySetSatisfied {
+				gang.setResourceSatisfied()
+			}
+			pgMgr.cache.gangItems[gangID] = gang
+
+			result, status := pgMgr.PreFilter(context.TODO(), framework.NewCycleState(), tt.triggerPod, nil)
+			if tt.wantResult != nil {
+				assert.True(t, status.IsSuccess())
+				assert.NotNil(t, result)
+				assert.True(t, tt.wantResult.NodeNames.Equal(result.NodeNames))
+			} else if tt.wantStatusCode == fwktype.Success {
+				assert.Nil(t, status)
+				assert.Nil(t, result)
+			} else {
+				assert.Nil(t, result)
+				assert.Equal(t, tt.wantStatusCode, status.Code())
+				if tt.wantStatusMsgSubstring != "" {
+					assert.Contains(t, status.Message(), tt.wantStatusMsgSubstring)
+				}
+			}
+		})
+	}
+}
+
+func TestGroupPlacementByMustGatherDomain(t *testing.T) {
+	extendedFramework := NewFakeExtendedFramework(t, newLateMemberTestNodes(), nil, nil, nil, networktopology.FakeClusterNetworkTopology)
+	snapshot := extendedFramework.(frameworkext.ExtendedHandle).GetNetworkTopologyTreeManager().GetSnapshot()
+	mustGatherSpec := newMustGatherBlockTopologySpec()
+	preferGatherSpec := &extension.NetworkTopologySpec{
+		GatherStrategy: []extension.NetworkTopologyGatherRule{
+			{
+				Layer:    "BlockLayer",
+				Strategy: extension.NetworkTopologyGatherStrategyPreferGather,
+			},
+		},
+	}
+	blockB1 := networktopology.TreeNodeMeta{Layer: "BlockLayer", Name: "b1"}
+	blockB2 := networktopology.TreeNodeMeta{Layer: "BlockLayer", Name: "b2"}
+	blockUnknown := networktopology.TreeNodeMeta{Layer: "BlockLayer", Name: "unknown"}
+
+	tests := []struct {
+		name        string
+		spec        *extension.NetworkTopologySpec
+		snapshot    *networktopology.TreeSnapshot
+		podToNode   map[string]string
+		wantLayer   schedulingv1alpha1.TopologyLayer
+		wantDomains map[networktopology.TreeNodeMeta][]string
+	}{
+		{
+			name:      "no topology snapshot",
+			spec:      mustGatherSpec,
+			snapshot:  nil,
+			podToNode: map[string]string{"default/pod-1": "node-1", "default/pod-2": "node-2"},
+			wantLayer: "",
+			wantDomains: map[networktopology.TreeNodeMeta][]string{
+				{}: {"default/pod-1 -> node-1", "default/pod-2 -> node-2"},
+			},
+		},
+		{
+			name:      "no must-gather requirement",
+			spec:      preferGatherSpec,
+			snapshot:  snapshot,
+			podToNode: map[string]string{"default/pod-1": "node-1"},
+			wantLayer: "",
+			wantDomains: map[networktopology.TreeNodeMeta][]string{
+				{}: {"default/pod-1 -> node-1"},
+			},
+		},
+		{
+			name:      "gathered in one block",
+			spec:      mustGatherSpec,
+			snapshot:  snapshot,
+			podToNode: map[string]string{"default/pod-1": "node-1", "default/pod-2": "node-2"},
+			wantLayer: "BlockLayer",
+			wantDomains: map[networktopology.TreeNodeMeta][]string{
+				blockB1: {"default/pod-1 -> node-1", "default/pod-2 -> node-2"},
+			},
+		},
+		{
+			name:      "scattered across blocks",
+			spec:      mustGatherSpec,
+			snapshot:  snapshot,
+			podToNode: map[string]string{"default/pod-1": "node-1", "default/pod-2": "node-3"},
+			wantLayer: "BlockLayer",
+			wantDomains: map[networktopology.TreeNodeMeta][]string{
+				blockB1: {"default/pod-1 -> node-1"},
+				blockB2: {"default/pod-2 -> node-3"},
+			},
+		},
+		{
+			name:      "placement on node missing in topology",
+			spec:      mustGatherSpec,
+			snapshot:  snapshot,
+			podToNode: map[string]string{"default/pod-1": "node-unknown"},
+			wantLayer: "BlockLayer",
+			wantDomains: map[networktopology.TreeNodeMeta][]string{
+				blockUnknown: {"default/pod-1 -> node-unknown"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLayer, gotDomains := groupPlacementByMustGatherDomain(tt.spec, tt.snapshot, tt.podToNode)
+			assert.Equal(t, tt.wantLayer, gotLayer)
+			assert.Equal(t, len(tt.wantDomains), len(gotDomains))
+			for domainMeta, wantPlacements := range tt.wantDomains {
+				gotPlacements := gotDomains[domainMeta]
+				assert.ElementsMatch(t, wantPlacements, gotPlacements)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_late_member_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_late_member_test.go
@@ -81,7 +81,7 @@ func newLateMemberPod(name string) *corev1.Pod {
 	}
 }
 
-func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
+func TestPodGroupManager_FindOneNode_LateMembersOfSatisfiedGang(t *testing.T) {
 	gangID := "default/gangA"
 	boundPodOnNode := func(name, nodeName string) *corev1.Pod {
 		pod := newLateMemberPod(name)
@@ -91,34 +91,35 @@ func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
 	tests := []struct {
 		name                   string
 		triggerPod             *corev1.Pod
+		pendingPods            []*corev1.Pod
 		withClusterTopology    bool
 		networkTopologySpec    *extension.NetworkTopologySpec
 		boundPods              []*corev1.Pod
 		manuallySetSatisfied   bool
-		wantResult             *fwktype.PreFilterResult
 		wantStatusCode         fwktype.Code
 		wantStatusMsgSubstring string
+		wantPlannedNodes       sets.Set[string]
 	}{
 		{
 			name:                "not a gang pod",
 			triggerPod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "late-pod"}},
 			withClusterTopology: true,
 			networkTopologySpec: newMustGatherBlockTopologySpec(),
-			wantStatusCode:      fwktype.Success,
+			wantStatusCode:      fwktype.Skip,
 		},
 		{
 			name:                "gang without network topology spec",
 			triggerPod:          newLateMemberPod("late-pod"),
 			withClusterTopology: true,
 			networkTopologySpec: nil,
-			wantStatusCode:      fwktype.Success,
+			wantStatusCode:      fwktype.Skip,
 		},
 		{
 			name:                "gang not satisfied yet",
 			triggerPod:          newLateMemberPod("late-pod"),
 			withClusterTopology: true,
 			networkTopologySpec: newMustGatherBlockTopologySpec(),
-			wantStatusCode:      fwktype.Success,
+			wantStatusCode:      fwktype.Skip,
 		},
 		{
 			name:                   "no cluster network topology",
@@ -142,7 +143,7 @@ func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
 				},
 			},
 			boundPods:      []*corev1.Pod{boundPodOnNode("bound-pod-1", "node-1")},
-			wantStatusCode: fwktype.Success,
+			wantStatusCode: fwktype.Skip,
 		},
 		{
 			name:                   "satisfied but no bound member",
@@ -175,15 +176,32 @@ func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
 			wantStatusMsgSubstring: "the bound members span multiple must-gather topology domains",
 		},
 		{
-			name:                "confined to the bound members' block",
+			name:                "batch scheduled within the bound members' block",
 			triggerPod:          newLateMemberPod("late-pod"),
+			pendingPods:         []*corev1.Pod{newLateMemberPod("late-pod-2")},
 			withClusterTopology: true,
 			networkTopologySpec: newMustGatherBlockTopologySpec(),
 			boundPods: []*corev1.Pod{
 				boundPodOnNode("bound-pod-1", "node-1"),
 				boundPodOnNode("bound-pod-2", "node-2"),
 			},
-			wantResult: &fwktype.PreFilterResult{NodeNames: sets.New("node-1", "node-2")},
+			wantStatusCode:   fwktype.Success,
+			wantPlannedNodes: sets.New("node-1", "node-2"),
+		},
+		{
+			name:       "insufficient offer slot in the bound members' block",
+			triggerPod: newLateMemberPod("late-pod"),
+			pendingPods: []*corev1.Pod{
+				newLateMemberPod("late-pod-2"),
+				newLateMemberPod("late-pod-3"),
+			},
+			withClusterTopology: true,
+			networkTopologySpec: newMustGatherBlockTopologySpec(),
+			boundPods: []*corev1.Pod{
+				boundPodOnNode("bound-pod-1", "node-1"),
+				boundPodOnNode("bound-pod-2", "node-2"),
+			},
+			wantStatusCode: fwktype.Unschedulable,
 		},
 	}
 	for _, tt := range tests {
@@ -193,11 +211,12 @@ func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
 				clusterNetworkTopology = nil
 			}
 			extendedFramework := NewFakeExtendedFramework(t, newLateMemberTestNodes(), nil, nil, nil, clusterNetworkTopology)
-			pgMgr := &PodGroupManager{handle: extendedFramework}
+			pgMgr := &PodGroupManager{handle: extendedFramework, networkTopologySolver: NewNetworkTopologySolver(extendedFramework)}
 			pgMgr.cache = NewGangCache(nil, nil, nil, nil, nil)
 
 			gang := NewGang(gangID)
 			gang.HasGangInit = true
+			gang.GangGroup = []string{gangID}
 			gang.NetworkTopologySpec = tt.networkTopologySpec
 			for _, boundPod := range tt.boundPods {
 				gang.addBoundPod(boundPod)
@@ -205,18 +224,27 @@ func TestPodGroupManager_PreFilter_LateMemberOfSatisfiedGang(t *testing.T) {
 			if tt.manuallySetSatisfied {
 				gang.setResourceSatisfied()
 			}
+			gang.setChild(tt.triggerPod)
+			for _, pendingPod := range tt.pendingPods {
+				gang.setChild(pendingPod)
+			}
 			pgMgr.cache.gangItems[gangID] = gang
 
-			result, status := pgMgr.PreFilter(context.TODO(), framework.NewCycleState(), tt.triggerPod, nil)
-			if tt.wantResult != nil {
+			cycleState := framework.NewCycleState()
+			frameworkext.InitDiagnosis(cycleState, tt.triggerPod)
+			plan, status := pgMgr.FindOneNode(context.TODO(), cycleState, tt.triggerPod, nil)
+			if tt.wantStatusCode == fwktype.Success {
 				assert.True(t, status.IsSuccess())
-				assert.NotNil(t, result)
-				assert.True(t, tt.wantResult.NodeNames.Equal(result.NodeNames))
-			} else if tt.wantStatusCode == fwktype.Success {
-				assert.Nil(t, status)
-				assert.Nil(t, result)
+				assert.NotNil(t, plan)
+				assert.Len(t, plan.Pods, len(tt.pendingPods)+1)
+				plannedNodeNames := sets.New[string]()
+				for podKey, nodeName := range plan.PodToNodeName {
+					assert.Contains(t, tt.wantPlannedNodes, nodeName, "pod %s planned to unexpected node", podKey)
+					plannedNodeNames.Insert(nodeName)
+				}
+				assert.True(t, tt.wantPlannedNodes.Equal(plannedNodeNames))
 			} else {
-				assert.Nil(t, result)
+				assert.Nil(t, plan)
 				assert.Equal(t, tt.wantStatusCode, status.Code())
 				if tt.wantStatusMsgSubstring != "" {
 					assert.Contains(t, status.Message(), tt.wantStatusMsgSubstring)

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_solver.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_solver.go
@@ -147,7 +147,10 @@ func (solver *networkTopologySolverImpl) calculateNodeOfferSlot(
 			offerSlot += 1
 		}
 		statusLock.Lock()
-		topologyState.NodeOfferSlot[nodeInfo.Node().Name] = offerSlot
+		// skip nodes with no offer slot to keep the diagnosis compact
+		if offerSlot > 0 {
+			topologyState.NodeOfferSlot[nodeInfo.Node().Name] = offerSlot
+		}
 		if !status.IsSuccess() {
 			topologyState.NodeToStatusMap[nodeInfo.Node().Name] = status
 		}

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow.go
@@ -50,11 +50,7 @@ const (
 func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
 	gangSchedulingContext := pgMgr.holder.getCurrentGangSchedulingContext()
 	if gangSchedulingContext == nil {
-		// no gang scheduling cycle is ongoing. the pod may be a late member of an
-		// already-satisfied topology-aware gang (e.g. recreated after the batch
-		// was scheduled), which bypassed BeforePreFilter. confine it to the
-		// topology domain of the existing members, or reject it.
-		return pgMgr.preFilterLateMemberOfSatisfiedGang(ctx, pod)
+		return nil, nil
 	}
 	if gangSchedulingContext.networkTopologySpec == nil {
 		return nil, nil
@@ -78,8 +74,14 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, state fwktype.Cycle
 
 func (pgMgr *PodGroupManager) FindOneNode(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, preRes *fwktype.PreFilterResult) (*frameworkext.BatchScheduleResult, *fwktype.Status) {
 	gangSchedulingContext := pgMgr.holder.getCurrentGangSchedulingContext()
-	if gangSchedulingContext == nil ||
-		gangSchedulingContext.failedMessage != "" ||
+	if gangSchedulingContext == nil {
+		// no gang scheduling cycle is ongoing. the pod may be a late member of an
+		// already-satisfied topology-aware gang (e.g. recreated after the batch was
+		// scheduled), which bypassed BeforePreFilter. batch-schedule the remaining
+		// delta members together, confined to the topology domain of the bound members.
+		return pgMgr.findOneNodeForDeltaMembers(ctx, cycleState, pod, preRes)
+	}
+	if gangSchedulingContext.failedMessage != "" ||
 		gangSchedulingContext.networkTopologySpec == nil {
 		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
@@ -337,27 +339,30 @@ func (pgMgr *PodGroupManager) Score(ctx context.Context, state fwktype.CycleStat
 	return int64(preScoreState.(*PreScoreState).nodesIndex[nodeInfo.Node().Name]), nil
 }
 
-// preFilterLateMemberOfSatisfiedGang handles late members (typically recreated
-// pods/reservations) of an already-satisfied topology-aware gang. Such pods bypassed
-// BeforePreFilter because the gang is once-satisfied, so no gang scheduling context was
-// created for them. It confines the candidate nodes to the must-gather topology domain
-// where the bound members are placed. If the domain cannot be determined, the pod is
-// rejected instead of being placed arbitrarily.
-func (pgMgr *PodGroupManager) preFilterLateMemberOfSatisfiedGang(ctx context.Context, pod *corev1.Pod) (*fwktype.PreFilterResult, *fwktype.Status) {
+// findOneNodeForDeltaMembers batch-schedules the pending late members of an already-satisfied
+// topology-aware gang. Such pods bypassed BeforePreFilter because the gang is once-satisfied,
+// so no gang scheduling context was created for them. Instead of letting every late member
+// walk the topology tree on its own, the whole remaining delta is planned in one PlacePods
+// round, confined to the must-gather topology domain where the bound members are placed. The
+// returned plan cooperates with the inline batch scheduler (EnableInlineBatchSchedule): when
+// the gate is on, all delta members are batch-scheduled together; otherwise the framework
+// extender falls back to placing the trigger pod on its planned node. If the domain cannot be
+// determined, the pod is rejected instead of being placed arbitrarily.
+func (pgMgr *PodGroupManager) findOneNodeForDeltaMembers(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, preRes *fwktype.PreFilterResult) (*frameworkext.BatchScheduleResult, *fwktype.Status) {
 	if !util.IsPodNeedGang(pod) {
-		return nil, nil
+		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
 	gang := pgMgr.GetGangByPod(pod)
 	if gang == nil || gang.NetworkTopologySpec == nil {
-		return nil, nil
+		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
 	if gang.getGangMatchPolicy() != extension.GangMatchPolicyOnceSatisfied || !gang.isGangOnceResourceSatisfied() {
-		return nil, nil
+		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
 	podKey := util.GetId(pod.Namespace, pod.Name)
 	extendedHandle, ok := pgMgr.handle.(frameworkext.ExtendedHandle)
 	if !ok {
-		return nil, nil
+		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
 	treeManager := extendedHandle.GetNetworkTopologyTreeManager()
 	var snapshot *networktopology.TreeSnapshot
@@ -371,8 +376,8 @@ func (pgMgr *PodGroupManager) preFilterLateMemberOfSatisfiedGang(ctx context.Con
 	}
 	mustGatherLayer := GetMustGatherLayer(gang.NetworkTopologySpec, snapshot.IsAncestor)
 	if mustGatherLayer == "" {
-		// no must-gather requirement, the topology is only a soft preference, don't confine
-		return nil, nil
+		// no must-gather requirement, the topology is only a soft preference, don't constrain
+		return nil, fwktype.NewStatus(fwktype.Skip)
 	}
 	domain, status := pgMgr.getMustGatherDomainOfBoundMembers(gang, pod, snapshot, mustGatherLayer)
 	if !status.IsSuccess() {
@@ -380,15 +385,94 @@ func (pgMgr *PodGroupManager) preFilterLateMemberOfSatisfiedGang(ctx context.Con
 	}
 	domainNodeNames := sets.New[string]()
 	collectLeafNodeNames(domain, domainNodeNames)
+	if preRes != nil && !preRes.AllNodes() {
+		domainNodeNames = domainNodeNames.Intersection(preRes.NodeNames)
+	}
 	if len(domainNodeNames) == 0 {
 		return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
 			fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but the must-gather topology domain %s/%s has no node",
 				podKey, gang.GangGroupId, domain.Layer, domain.Name))
 	}
 
-	klog.Infof("confine late member %q of satisfied gang group %q to the must-gather topology domain %s/%s",
-		podKey, gang.GangGroupId, domain.Layer, domain.Name)
-	return &fwktype.PreFilterResult{NodeNames: domainNodeNames}, nil
+	allPendingPods := pgMgr.cache.getPendingPods(gang.getGangGroup())
+	// the trigger pod must be covered by the plan; the framework extender rejects a success
+	// plan which carries no node for the trigger pod
+	triggerPlanned := false
+	for _, pendingPod := range allPendingPods {
+		if pendingPod.Namespace == pod.Namespace && pendingPod.Name == pod.Name {
+			triggerPlanned = true
+			break
+		}
+	}
+	if !triggerPlanned {
+		allPendingPods = append(allPendingPods, pod)
+	}
+	extension.SortPodsByIndex(allPendingPods)
+	allPendingPodUIDs := sets.New[string]()
+	for _, pendingPod := range allPendingPods {
+		allPendingPodUIDs.Insert(string(pendingPod.UID))
+	}
+	frameworkext.MakeNominatedPodsOfTheSameJob(cycleState, allPendingPodUIDs)
+
+	nodes := make([]fwktype.NodeInfo, 0, len(domainNodeNames))
+	for n := range domainNodeNames {
+		nInfo, err := pgMgr.handle.SnapshotSharedLister().NodeInfos().Get(n)
+		if err != nil {
+			return nil, fwktype.AsStatus(err)
+		}
+		nodes = append(nodes, nInfo.Snapshot())
+	}
+	nodeLevelCycleState := make(map[string]fwktype.CycleState, len(nodes))
+	for _, node := range nodes {
+		nodeLevelCycleState[node.Node().Name] = cycleState.Clone()
+	}
+
+	addPod := func(state fwktype.CycleState, toSchedulePod *corev1.Pod, api fwktype.PodInfo, nodeInfo fwktype.NodeInfo) error {
+		nodeInfo.AddPodInfo(api)
+		status := pgMgr.handle.RunPreFilterExtensionAddPod(ctx, state, toSchedulePod, api, nodeInfo)
+		if !status.IsSuccess() {
+			return status.AsError()
+		}
+		return nil
+	}
+
+	topologyState := &TopologyState{
+		JobTopologyRequirements: &JobTopologyRequirements{
+			TopologyLayerMustGather: mustGatherLayer,
+			DesiredOfferSlot:        len(allPendingPods),
+		},
+	}
+	defer func() {
+		diagnosis := frameworkext.GetDiagnosis(cycleState)
+		diagnosis.TopologyKeyToExplain = string(topologyState.JobTopologyRequirements.TopologyLayerMustGather)
+		if diagnosis.ScheduleDiagnosis == nil {
+			diagnosis.ScheduleDiagnosis = &frameworkext.ScheduleDiagnosis{}
+		}
+		diagnosis.ScheduleDiagnosis.SchedulingMode = frameworkext.JobSchedulingMode
+		diagnosis.ScheduleDiagnosis.NodeOfferSlot = topologyState.NodeOfferSlot
+		diagnosis.ScheduleDiagnosis.NodeToStatusMap = topologyState.NodeToStatusMap
+	}()
+	ctx = ContextWithTopologyState(ctx, topologyState)
+	plannedNodes, status := pgMgr.networkTopologySolver.PlacePods(
+		ctx,
+		nodeLevelCycleState,
+		allPendingPods,
+		nodes,
+		addPod,
+		topologyState.JobTopologyRequirements,
+		networktopology.DeepCopyTreeNode(snapshot.TreeNode, nil),
+		nil,
+	)
+	if !status.IsSuccess() {
+		return nil, status
+	}
+	klog.Infof("delta mode: plan %d late members of satisfied gang group %q within the must-gather topology domain %s/%s",
+		len(allPendingPods), gang.GangGroupId, domain.Layer, domain.Name)
+	recordBatchPlacement(gang.GangGroupId, gang.NetworkTopologySpec, snapshot, plannedNodes)
+	return &frameworkext.BatchScheduleResult{
+		Pods:          allPendingPods,
+		PodToNodeName: plannedNodes,
+	}, nil
 }
 
 // getMustGatherDomainOfBoundMembers returns the single must-gather topology domain that all

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow.go
@@ -23,13 +23,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 
 	"github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/networktopology"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/plugins/coscheduling/util"
 )
 
 const (
@@ -46,8 +49,14 @@ const (
 
 func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, state fwktype.CycleState, pod *corev1.Pod, nodes []fwktype.NodeInfo) (*fwktype.PreFilterResult, *fwktype.Status) {
 	gangSchedulingContext := pgMgr.holder.getCurrentGangSchedulingContext()
-	if gangSchedulingContext == nil ||
-		gangSchedulingContext.networkTopologySpec == nil {
+	if gangSchedulingContext == nil {
+		// no gang scheduling cycle is ongoing. the pod may be a late member of an
+		// already-satisfied topology-aware gang (e.g. recreated after the batch
+		// was scheduled), which bypassed BeforePreFilter. confine it to the
+		// topology domain of the existing members, or reject it.
+		return pgMgr.preFilterLateMemberOfSatisfiedGang(ctx, pod)
+	}
+	if gangSchedulingContext.networkTopologySpec == nil {
 		return nil, nil
 	}
 	if gangSchedulingContext.failedMessage != "" {
@@ -161,6 +170,8 @@ func (pgMgr *PodGroupManager) FindOneNode(ctx context.Context, cycleState fwktyp
 		return nil, status
 	}
 	gangSchedulingContext.networkTopologyPlannedNodes = plannedNodes
+	recordBatchPlacement(gangSchedulingContext.gangGroupID,
+		gangSchedulingContext.networkTopologySpec, gangSchedulingContext.networkTopologySnapshot, plannedNodes)
 	return &frameworkext.BatchScheduleResult{
 		Pods:          allPendingPods,
 		PodToNodeName: plannedNodes,
@@ -224,6 +235,8 @@ func (ev *preemptionEvaluatorImpl) PlanNodes(
 		preemptionState.NodeToOfferSlot = topologyState.NodeOfferSlot
 		return nil, nil, topologyState.NodeToStatusMap, status
 	}
+	recordBatchPlacement(preemptionState.gangSchedulingContext.gangGroupID,
+		networkTopologySpec, preemptionState.gangSchedulingContext.networkTopologySnapshot, plannedNodes)
 	successPods = make(map[string]*Placements, len(plannedNodes))
 
 	for i := range allPendingPods {
@@ -322,4 +335,221 @@ func (pgMgr *PodGroupManager) Score(ctx context.Context, state fwktype.CycleStat
 		return 0, fwktype.NewStatus(fwktype.Error, fmt.Sprintf("failed to read pre score state: %v", err))
 	}
 	return int64(preScoreState.(*PreScoreState).nodesIndex[nodeInfo.Node().Name]), nil
+}
+
+// preFilterLateMemberOfSatisfiedGang handles late members (typically recreated
+// pods/reservations) of an already-satisfied topology-aware gang. Such pods bypassed
+// BeforePreFilter because the gang is once-satisfied, so no gang scheduling context was
+// created for them. It confines the candidate nodes to the must-gather topology domain
+// where the bound members are placed. If the domain cannot be determined, the pod is
+// rejected instead of being placed arbitrarily.
+func (pgMgr *PodGroupManager) preFilterLateMemberOfSatisfiedGang(ctx context.Context, pod *corev1.Pod) (*fwktype.PreFilterResult, *fwktype.Status) {
+	if !util.IsPodNeedGang(pod) {
+		return nil, nil
+	}
+	gang := pgMgr.GetGangByPod(pod)
+	if gang == nil || gang.NetworkTopologySpec == nil {
+		return nil, nil
+	}
+	if gang.getGangMatchPolicy() != extension.GangMatchPolicyOnceSatisfied || !gang.isGangOnceResourceSatisfied() {
+		return nil, nil
+	}
+	podKey := util.GetId(pod.Namespace, pod.Name)
+	extendedHandle, ok := pgMgr.handle.(frameworkext.ExtendedHandle)
+	if !ok {
+		return nil, nil
+	}
+	treeManager := extendedHandle.GetNetworkTopologyTreeManager()
+	var snapshot *networktopology.TreeSnapshot
+	if treeManager != nil {
+		snapshot = treeManager.GetSnapshot()
+	}
+	if snapshot == nil || snapshot.TreeNode == nil {
+		return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+			fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but %s",
+				podKey, gang.GangGroupId, ErrNoClusterNetworkTopology))
+	}
+	mustGatherLayer := GetMustGatherLayer(gang.NetworkTopologySpec, snapshot.IsAncestor)
+	if mustGatherLayer == "" {
+		// no must-gather requirement, the topology is only a soft preference, don't confine
+		return nil, nil
+	}
+	domain, status := pgMgr.getMustGatherDomainOfBoundMembers(gang, pod, snapshot, mustGatherLayer)
+	if !status.IsSuccess() {
+		return nil, status
+	}
+	domainNodeNames := sets.New[string]()
+	collectLeafNodeNames(domain, domainNodeNames)
+	if len(domainNodeNames) == 0 {
+		return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+			fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but the must-gather topology domain %s/%s has no node",
+				podKey, gang.GangGroupId, domain.Layer, domain.Name))
+	}
+
+	klog.Infof("confine late member %q of satisfied gang group %q to the must-gather topology domain %s/%s",
+		podKey, gang.GangGroupId, domain.Layer, domain.Name)
+	return &fwktype.PreFilterResult{NodeNames: domainNodeNames}, nil
+}
+
+// getMustGatherDomainOfBoundMembers returns the single must-gather topology domain that all
+// bound members of the gang group are placed in. It returns a rejection status when the domain
+// cannot be determined or the bound members span multiple domains.
+func (pgMgr *PodGroupManager) getMustGatherDomainOfBoundMembers(gang *Gang, pod *corev1.Pod, snapshot *networktopology.TreeSnapshot, mustGatherLayer schedulingv1alpha1.TopologyLayer) (*networktopology.TreeNode, *fwktype.Status) {
+	podKey := util.GetId(pod.Namespace, pod.Name)
+	boundPods := make([]*corev1.Pod, 0)
+	for _, gangID := range gang.getGangGroup() {
+		memberGang := pgMgr.cache.getGangFromCacheByGangId(gangID, false)
+		if memberGang == nil {
+			continue
+		}
+		boundPods = append(boundPods, memberGang.getBoundChildrenFromGang()...)
+	}
+
+	nodeToTreeNode := enumerateNodeTopologyNode(snapshot.TreeNode, len(boundPods))
+	domains := map[networktopology.TreeNodeMeta]*networktopology.TreeNode{}
+	for _, boundPod := range boundPods {
+		if boundPod.UID == pod.UID || boundPod.Spec.NodeName == "" {
+			continue
+		}
+		leafNode := nodeToTreeNode[boundPod.Spec.NodeName]
+		if leafNode == nil {
+			return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+				fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but bound member %q is on node %q which is not in the cluster network topology",
+					podKey, gang.GangGroupId, util.GetId(boundPod.Namespace, boundPod.Name), boundPod.Spec.NodeName))
+		}
+		domain := findAncestorAtLayer(leafNode, mustGatherLayer)
+		if domain == nil {
+			return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+				fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but cannot find the must-gather layer %q for node %q",
+					podKey, gang.GangGroupId, mustGatherLayer, boundPod.Spec.NodeName))
+		}
+		domains[domain.TreeNodeMeta] = domain
+	}
+	if len(domains) == 0 {
+		return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+			fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but no bound member is found to determine the must-gather topology domain",
+				podKey, gang.GangGroupId))
+	}
+	if len(domains) > 1 {
+		domainNames := make([]string, 0, len(domains))
+		for domainMeta := range domains {
+			domainNames = append(domainNames, fmt.Sprintf("%s/%s", domainMeta.Layer, domainMeta.Name))
+		}
+		sort.Strings(domainNames)
+		return nil, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable,
+			fmt.Sprintf("pod %q belongs to the satisfied topology-aware gang group %q, but the bound members span multiple must-gather topology domains %v",
+				podKey, gang.GangGroupId, domainNames))
+	}
+	for _, domain := range domains {
+		return domain, nil
+	}
+	return nil, nil
+}
+
+// findAncestorAtLayer walks up from the given tree node and returns the ancestor (or itself) at the target layer.
+func findAncestorAtLayer(treeNode *networktopology.TreeNode, layer schedulingv1alpha1.TopologyLayer) *networktopology.TreeNode {
+	for cur := treeNode; cur != nil; cur = cur.Parent {
+		if cur.Layer == layer {
+			return cur
+		}
+	}
+	return nil
+}
+
+// collectLeafNodeNames collects the names of all node-layer descendants of the given tree node.
+func collectLeafNodeNames(treeNode *networktopology.TreeNode, names sets.Set[string]) {
+	if treeNode.Layer == schedulingv1alpha1.NodeTopologyLayer {
+		names.Insert(treeNode.Name)
+		return
+	}
+	for _, child := range treeNode.Children {
+		collectLeafNodeNames(child, names)
+	}
+}
+
+// recordBatchPlacement logs a structured summary of where each pod of the gang group is placed,
+// grouped by the must-gather topology domain, so that unexpected placements (e.g. a batch expected
+// to land in the same rack being scattered across racks) can be diagnosed.
+func recordBatchPlacement(gangGroupID string, spec *extension.NetworkTopologySpec, snapshot *networktopology.TreeSnapshot, podToNode map[string]string) {
+	if len(podToNode) == 0 {
+		return
+	}
+	mustGatherLayer, domainToPlacements := groupPlacementByMustGatherDomain(spec, snapshot, podToNode)
+	if mustGatherLayer == "" {
+		placements := flattenPlacements(domainToPlacements)
+		klog.InfoS("Network topology batch placement",
+			"gangGroup", gangGroupID, "podCount", len(placements), "placements", placements)
+		return
+	}
+	domains := make([]networktopology.TreeNodeMeta, 0, len(domainToPlacements))
+	for domainMeta := range domainToPlacements {
+		domains = append(domains, domainMeta)
+	}
+	sort.Slice(domains, func(i, j int) bool { return domains[i].Name < domains[j].Name })
+	for _, domainMeta := range domains {
+		domainPlacements := domainToPlacements[domainMeta]
+		sort.Strings(domainPlacements)
+		klog.InfoS("Network topology batch placement",
+			"gangGroup", gangGroupID,
+			"mustGatherLayer", string(mustGatherLayer),
+			"topologyDomain", fmt.Sprintf("%s/%s", domainMeta.Layer, domainMeta.Name),
+			"podCount", len(domainPlacements),
+			"placements", domainPlacements,
+		)
+	}
+	if len(domainToPlacements) > 1 {
+		domainNames := make([]string, 0, len(domains))
+		for _, domainMeta := range domains {
+			domainNames = append(domainNames, fmt.Sprintf("%s/%s", domainMeta.Layer, domainMeta.Name))
+		}
+		klog.Warningf("gang group %s with must-gather layer %q landed in %d topology domains %v, placements: %v",
+			gangGroupID, mustGatherLayer, len(domainToPlacements), domainNames, flattenPlacements(domainToPlacements))
+	}
+}
+
+// groupPlacementByMustGatherDomain groups the pod-to-node placements by the must-gather topology
+// domain of each node. It returns an empty layer when there is no must-gather requirement or the
+// topology tree is unavailable; in that case all placements are grouped under an empty domain.
+func groupPlacementByMustGatherDomain(
+	spec *extension.NetworkTopologySpec,
+	snapshot *networktopology.TreeSnapshot,
+	podToNode map[string]string,
+) (schedulingv1alpha1.TopologyLayer, map[networktopology.TreeNodeMeta][]string) {
+	domainToPlacements := map[networktopology.TreeNodeMeta][]string{}
+	var mustGatherLayer schedulingv1alpha1.TopologyLayer
+	if spec != nil && snapshot != nil && snapshot.TreeNode != nil {
+		mustGatherLayer = GetMustGatherLayer(spec, snapshot.IsAncestor)
+	}
+	if mustGatherLayer == "" || snapshot == nil || snapshot.TreeNode == nil {
+		for podKey, nodeName := range podToNode {
+			domainToPlacements[networktopology.TreeNodeMeta{}] = append(domainToPlacements[networktopology.TreeNodeMeta{}], podKey+" -> "+nodeName)
+		}
+		return "", domainToPlacements
+	}
+	nodeToTreeNode := enumerateNodeTopologyNode(snapshot.TreeNode, len(podToNode))
+	for podKey, nodeName := range podToNode {
+		placement := podKey + " -> " + nodeName
+		var domainMeta networktopology.TreeNodeMeta
+		found := false
+		if leafNode := nodeToTreeNode[nodeName]; leafNode != nil {
+			if domain := findAncestorAtLayer(leafNode, mustGatherLayer); domain != nil {
+				domainMeta = domain.TreeNodeMeta
+				found = true
+			}
+		}
+		if !found {
+			domainMeta = networktopology.TreeNodeMeta{Layer: mustGatherLayer, Name: "unknown"}
+		}
+		domainToPlacements[domainMeta] = append(domainToPlacements[domainMeta], placement)
+	}
+	return mustGatherLayer, domainToPlacements
+}
+
+func flattenPlacements(domainToPlacements map[networktopology.TreeNodeMeta][]string) []string {
+	placements := make([]string, 0)
+	for _, domainPlacements := range domainToPlacements {
+		placements = append(placements, domainPlacements...)
+	}
+	sort.Strings(placements)
+	return placements
 }

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow_test.go
@@ -1261,10 +1261,8 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 					SchedulingMode:      frameworkext.JobSchedulingMode,
 					AlreadyWaitForBound: 0,
 					NodeOfferSlot: map[string]int{
-						"node-1": 0,
 						"node-2": 1,
 						"node-3": 1,
-						"node-4": 0,
 						"node-5": 1,
 						"node-6": 1,
 						"node-7": 1,
@@ -1738,10 +1736,7 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 					SchedulingMode:      frameworkext.JobSchedulingMode,
 					AlreadyWaitForBound: 0,
 					NodeOfferSlot: map[string]int{
-						"node-1": 0,
-						"node-2": 0,
 						"node-3": 1,
-						"node-4": 0,
 						"node-5": 1,
 						"node-6": 1,
 						"node-7": 1,
@@ -1777,10 +1772,8 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 					"node-8": fwktype.NewStatus(fwktype.Unschedulable, "Insufficient cpu").WithPlugin("FakeFitPlugin"),
 				},
 				NodeToOfferSlot: map[string]int{
-					"node-1": 0,
 					"node-2": 1,
 					"node-3": 1,
-					"node-4": 0,
 					"node-5": 1,
 					"node-6": 1,
 					"node-7": 1,


### PR DESCRIPTION
…PreFilter and log batch placement

After a topology-aware gang batch is scheduled, recreated pods/reservations bypass gang and network-topology scheduling because the gang is once-satisfied, so they may land outside the expected topology domain. In PreFilter, when no gang scheduling cycle is ongoing, confine such late members to the must-gather topology domain of the bound members via PreFilterResult, or reject them when the domain cannot be uniquely determined.

Also record a structured per-domain placement summary after each successful batch placement to diagnose batches scattering across topology domains, and skip nodes with zero offer slot in the diagnosis.

### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
