### PR TITLE
scheduler: fix in-flight pod leak when error-handler filter suppresse…

### DIFF
--- a/pkg/scheduler/frameworkext/errorhandler_dispatcher.go
+++ b/pkg/scheduler/frameworkext/errorhandler_dispatcher.go
@@ -34,6 +34,9 @@ type errorHandlerDispatcher struct {
 	preHandlerFilters  []PreErrorHandlerFilter
 	postHandlerFilters []PostErrorHandlerFilter
 	defaultHandler     scheduler.FailureHandlerFn
+	// schedulingQueue is used to release the pod's in-flight bookkeeping when a
+	// pre-handler filter suppresses the default failure handler.
+	schedulingQueue SchedulingQueue
 }
 
 func newErrorHandlerDispatcher() *errorHandlerDispatcher {
@@ -42,6 +45,10 @@ func newErrorHandlerDispatcher() *errorHandlerDispatcher {
 
 func (d *errorHandlerDispatcher) setDefaultHandler(handler scheduler.FailureHandlerFn) {
 	d.defaultHandler = handler
+}
+
+func (d *errorHandlerDispatcher) setSchedulingQueue(queue SchedulingQueue) {
+	d.schedulingQueue = queue
 }
 
 func (d *errorHandlerDispatcher) RegisterErrorHandlerFilters(preFilter PreErrorHandlerFilter, postFilter PostErrorHandlerFilter) {
@@ -67,6 +74,17 @@ func (d *errorHandlerDispatcher) Error(ctx context.Context, fwk framework.Framew
 
 	for _, handlerFilter := range d.preHandlerFilters {
 		if handlerFilter(ctx, fwk, podInfo, status, nominatingInfo, start) {
+			// The filter suppresses the default failure handler, which is the only
+			// code path calling SchedulingQueue.Done() on the scheduling-cycle
+			// failure path. Release the pod's in-flight bookkeeping explicitly,
+			// otherwise the pod stays in inFlightPods forever, disables the
+			// pruning of inFlightEvents, and all subsequent cluster events
+			// accumulate unboundedly (memory leak). Done() is idempotent, so it
+			// is also safe on the binding-cycle path where Done() has already
+			// been called before Bind.
+			if d.schedulingQueue != nil {
+				d.schedulingQueue.Done(podInfo.Pod.UID)
+			}
 			return
 		}
 	}

--- a/pkg/scheduler/frameworkext/errorhandler_dispatcher_test.go
+++ b/pkg/scheduler/frameworkext/errorhandler_dispatcher_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -114,4 +115,91 @@ func TestErrorHandlerDispatcher(t *testing.T) {
 	assert.False(t, handler2Processed)
 	assert.False(t, afterHandler2Processed)
 	assert.False(t, enterDefaultHandler)
+}
+
+// TestErrorHandlerDispatcherReleasesInFlightPodOnSuppression verifies that when a
+// pre-handler filter suppresses the default failure handler, the dispatcher still
+// calls SchedulingQueue.Done() to release the pod's in-flight bookkeeping.
+// Otherwise the pod stays in inFlightPods forever, disables the pruning of
+// inFlightEvents, and all subsequent cluster events accumulate unboundedly,
+// leaking scheduler memory (see asi-release-v1.8.0 koord-scheduler OOM).
+func TestErrorHandlerDispatcherReleasesInFlightPodOnSuppression(t *testing.T) {
+	noOpHandler := func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) {
+	}
+
+	t.Run("suppressed failure releases the in-flight pod", func(t *testing.T) {
+		dispatcher := newErrorHandlerDispatcher()
+		defaultHandlerCalled := false
+		dispatcher.setDefaultHandler(func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) {
+			defaultHandlerCalled = true
+		})
+		queue := &FakeQueue{}
+		dispatcher.setSchedulingQueue(queue)
+		dispatcher.RegisterErrorHandlerFilters(func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) bool {
+			return true
+		}, nil)
+
+		podInfo := &framework.QueuedPodInfo{
+			PodInfo: &framework.PodInfo{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "suppressed",
+						UID:  types.UID("suppressed-uid"),
+					},
+				},
+			},
+		}
+		dispatcher.Error(context.TODO(), nil, podInfo, nil, nil, time.Now())
+		assert.False(t, defaultHandlerCalled)
+		assert.Equal(t, []types.UID{types.UID("suppressed-uid")}, queue.DonePods)
+	})
+
+	t.Run("unsuppressed failure leaves Done to the default handler", func(t *testing.T) {
+		dispatcher := newErrorHandlerDispatcher()
+		defaultHandlerCalled := false
+		dispatcher.setDefaultHandler(func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) {
+			defaultHandlerCalled = true
+		})
+		queue := &FakeQueue{}
+		dispatcher.setSchedulingQueue(queue)
+		dispatcher.RegisterErrorHandlerFilters(func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) bool {
+			return false
+		}, nil)
+
+		podInfo := &framework.QueuedPodInfo{
+			PodInfo: &framework.PodInfo{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "normal",
+						UID:  types.UID("normal-uid"),
+					},
+				},
+			},
+		}
+		dispatcher.Error(context.TODO(), nil, podInfo, nil, nil, time.Now())
+		assert.True(t, defaultHandlerCalled)
+		assert.Empty(t, queue.DonePods)
+	})
+
+	t.Run("suppression without a queue wired does not panic", func(t *testing.T) {
+		dispatcher := newErrorHandlerDispatcher()
+		dispatcher.setDefaultHandler(noOpHandler)
+		dispatcher.RegisterErrorHandlerFilters(func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) bool {
+			return true
+		}, nil)
+
+		podInfo := &framework.QueuedPodInfo{
+			PodInfo: &framework.PodInfo{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "suppressed-no-queue",
+						UID:  types.UID("suppressed-no-queue-uid"),
+					},
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			dispatcher.Error(context.TODO(), nil, podInfo, nil, nil, time.Now())
+		})
+	})
 }

--- a/pkg/scheduler/frameworkext/framework_extender_factory.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory.go
@@ -461,6 +461,7 @@ func (f *FrameworkExtenderFactory) CollectSchedulePodResult(sched *scheduler.Sch
 
 func (f *FrameworkExtenderFactory) InterceptSchedulerError(sched *scheduler.Scheduler) {
 	f.errorHandlerDispatcher.setDefaultHandler(sched.FailureHandler)
+	f.errorHandlerDispatcher.setSchedulingQueue(&queueAdapter{sched})
 	sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwktype.Status, nominatingInfo *fwktype.NominatingInfo, start time.Time) {
 		f.errorHandlerDispatcher.Error(ctx, fwk, podInfo, status, nominatingInfo, start)
 		f.monitor.Complete(podInfo.Pod, status)

--- a/pkg/scheduler/frameworkext/framework_extender_factory_test.go
+++ b/pkg/scheduler/frameworkext/framework_extender_factory_test.go
@@ -506,3 +506,17 @@ func TestFrameworkExtenderFactory_updatePlugins_NextPodPlugin(t *testing.T) {
 		})
 	}
 }
+
+func TestInterceptSchedulerErrorWiresSchedulingQueue(t *testing.T) {
+	f := &FrameworkExtenderFactory{
+		errorHandlerDispatcher: newErrorHandlerDispatcher(),
+	}
+	mockSched := &scheduler.Scheduler{}
+	f.InterceptSchedulerError(mockSched)
+	// the failure handler is replaced by the dispatcher wrapper
+	assert.NotNil(t, mockSched.FailureHandler)
+	// the dispatcher is wired with the scheduler queue so that it can release
+	// the pod's in-flight bookkeeping when a filter suppresses the default
+	// failure handler (see TestErrorHandlerDispatcherReleasesInFlightPodOnSuppression)
+	assert.NotNil(t, f.errorHandlerDispatcher.schedulingQueue)
+}

--- a/pkg/scheduler/frameworkext/scheduler_adapter.go
+++ b/pkg/scheduler/frameworkext/scheduler_adapter.go
@@ -240,6 +240,9 @@ type FakeQueue struct {
 	// MovedEvents records the arguments of every MoveAllToActiveOrBackoffQueue call so tests
 	// can assert the event and the carried objects (e.g. the oldObj must not be nil).
 	MovedEvents []MovedEvent
+	// DonePods records the UID of every Done call so tests can assert that the
+	// pod's in-flight bookkeeping is released.
+	DonePods []types.UID
 }
 
 // MovedEvent captures a single MoveAllToActiveOrBackoffQueue invocation for assertions in tests.
@@ -364,4 +367,6 @@ func (f *FakeQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwkt
 func (f *FakeQueue) Activate(logger klog.Logger, pods map[string]*corev1.Pod) {
 }
 
-func (f *FakeQueue) Done(pod types.UID) {}
+func (f *FakeQueue) Done(pod types.UID) {
+	f.DonePods = append(f.DonePods, pod)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`errorHandlerDispatcher.Error()` returns early as soon as a registered `PreErrorHandlerFilter` returns `true`, so the default failure handler (`handleSchedulingFailure`) is never invoked. That default handler is the only code path that calls `SchedulingQueue.Done()` on the scheduling-cycle failure path.

When `SchedulerQueueingHints` is enabled, `Done()` is what removes the pod from `activeQ.inFlightPods`. Skipping it leads to an unbounded memory leak:

1. the pod stays in `inFlightPods` forever;
2. a non-empty `inFlightPods` is exactly what gates the pruning of `inFlightEvents`, so that list can never be pruned;
3. every subsequent cluster event is appended to `inFlightEvents` together with its full `oldObj`/`newObj`.

There is no upper bound: the retained set grows with the cluster event rate for as long as the process lives, and the scheduler is eventually OOM-killed. Clusters running with `SchedulerQueueingHints` disabled are unaffected, because the in-flight bookkeeping does not exist there.

Fix: release the pod's in-flight bookkeeping in the dispatcher before honoring the suppression.

```go
for _, handlerFilter := range d.preHandlerFilters {
    if handlerFilter(ctx, fwk, podInfo, status, nominatingInfo, start) {
        if d.schedulingQueue != nil {
            d.schedulingQueue.Done(podInfo.Pod.UID)
        }
        return
    }
}
```

Fixing it in the dispatcher rather than in each filter keeps the invariant "whoever terminates the scheduling cycle must also terminate the in-flight bookkeeping" in one place, and covers every present and future suppressing filter — including out-of-tree ones, since `RegisterErrorHandlerFilters` is a public extension point.

Changes:

- `errorhandler_dispatcher.go`: hold a `SchedulingQueue` and call `Done()` on the suppression path.
- `framework_extender_factory.go`: wire the scheduler's queue adapter into the dispatcher in `InterceptSchedulerError`.
- `scheduler_adapter.go`: `FakeQueue` now records `Done()` calls in `DonePods` so tests can assert the release.
- `errorhandler_dispatcher_test.go`: add `TestErrorHandlerDispatcherReleasesInFlightPodOnSuppression`.
- `framework_extender_factory_test.go`: add `TestInterceptSchedulerErrorWiresSchedulingQueue`, so the new wiring statement is covered too.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Unit tests:

```bash
go test ./pkg/scheduler/frameworkext/ -run 'TestErrorHandlerDispatcher|TestInterceptSchedulerError' -count=1 -v
```

They cover:

- a `PreErrorHandlerFilter` returning `true` → the default handler is not called **and** `Done(pod.UID)` is called for the suppressed pod;
- filters returning `false` → `Done()` is left to the default handler, behaviour unchanged;
- suppression with no queue wired (`schedulingQueue == nil`) → no panic, previous behaviour preserved;
- `InterceptSchedulerError()` → the dispatcher really ends up holding a non-nil scheduling queue.

End-to-end: run with `SchedulerQueueingHints=true` plus a plugin whose `PreErrorHandlerFilter` suppresses the failure handler for some pods, and keep triggering scheduling failures for those pods. Before this change the scheduler's heap and the length of `inFlightEvents` grow monotonically and never recover; after it, both stay flat because the pod's in-flight record is released on every suppressed failure.

### Ⅳ. Special notes for reviews

- No interface change was required: `Done(types.UID)` is already part of the existing `SchedulingQueue` interface, so the dispatcher only depends on what the queue adapter already exposes.
- `Done()` is idempotent, so the added call is also safe on the binding-cycle path, where `Done()` has already been called before `Bind` — the second call for the same UID is a no-op rather than an error, which is why it is intentionally left unguarded.
- The `nil` check keeps `newErrorHandlerDispatcher()` usable in tests and in any code path that does not go through `InterceptSchedulerError`.

### V. Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
