### PR TITLE
scheduler: bound the network topology failure message

### DIFF
--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_solver.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_solver.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
@@ -20,6 +21,10 @@ import (
 
 const (
 	MessageNoCandidateTopologyNodes = "no candidate topology nodes can accommodate job, desiredOfferSlot: %d, %s, %s"
+	// maxDiagnosticTopologyNodeReasons bounds the per-topology-node breakdown emitted by the
+	// diagnostic log. A gang that cannot be placed is retried, so an unbounded breakdown
+	// (thousands of topology nodes in a large cluster) would be re-emitted on every attempt.
+	maxDiagnosticTopologyNodeReasons = 100
 )
 
 const (
@@ -79,16 +84,19 @@ func (solver *networkTopologySolverImpl) PlacePods(
 			orderedNodes, actualSlot := distributeOfferSlot(jobNetworkRequirements.DesiredOfferSlot, candidate, distribution, jobNetworkRequirements.LayerPodCountMultiple)
 			if actualSlot >= jobNetworkRequirements.DesiredOfferSlot {
 				podToNode := distributePods(toSchedulePods, orderedNodes, distribution)
+				placements := make([]string, 0, len(toSchedulePods))
+				for _, pod := range toSchedulePods {
+					podKey := framework.GetNamespacedName(pod.Namespace, pod.Name)
+					placements = append(placements, fmt.Sprintf("%s->%s", podKey, podToNode[podKey]))
+				}
+				klog.Infof("[NetworkTopology] %s/%s placed by must-gather topology on %s/%s: %s",
+					toSchedulePods[0].Namespace, toSchedulePods[0].Name, candidate.Layer, candidate.Name, strings.Join(placements, ", "))
 				return podToNode, nil
 			}
 		}
 	}
 
-	var reasons []string
-	for _, node := range topologyState.MustGatheredTopologyNode {
-		reasons = append(reasons, fmt.Sprintf("topology topologyNode %s/%s: %d", node.Layer, node.Name, node.OfferSlot))
-	}
-	sort.Strings(reasons)
+	topologyNodeSummary := buildTopologyNodeSummary(topologyState.MustGatheredTopologyNode)
 
 	// Append PodCountMultiple constraint information if present
 	var podCountMultipleInfo string
@@ -107,7 +115,66 @@ func (solver *networkTopologySolverImpl) PlacePods(
 			NodeToStatus: framework.NewNodeToStatus(topologyState.NodeToStatusMap, fwktype.NewStatus(fwktype.UnschedulableAndUnresolvable)),
 		},
 	}
-	return nil, fwktype.NewStatus(fwktype.Unschedulable, fmt.Sprintf(MessageNoCandidateTopologyNodes, jobNetworkRequirements.DesiredOfferSlot, strings.Join(reasons, ";"), fitError.Error())+podCountMultipleInfo)
+	failureMessage := fmt.Sprintf(MessageNoCandidateTopologyNodes, jobNetworkRequirements.DesiredOfferSlot, topologyNodeSummary, fitError.Error()) + podCountMultipleInfo
+	// The failure message itself already reaches the Pod status/event and, once the diagnosis
+	// dump is turned on, the diagnosis as its preFilterMessage, so only the per-topology-node
+	// breakdown is logged here since no other channel carries it. It is emitted at a higher
+	// verbosity and bounded because a gang that cannot be placed is retried, which would
+	// otherwise re-emit the whole must-gather layer on every scheduling attempt.
+	if klog.V(4).Enabled() {
+		klog.V(4).Infof("[NetworkTopology] %s/%s cannot be placed by must-gather topology, must-gather topology nodes: %s",
+			toSchedulePods[0].Namespace, toSchedulePods[0].Name,
+			strings.Join(buildDiagnosticTopologyNodeReasons(topologyState.MustGatheredTopologyNode), ";"))
+	}
+	return nil, fwktype.NewStatus(fwktype.Unschedulable, failureMessage)
+}
+
+// buildTopologyNodeSummary reports how many topology nodes the must-gather layer holds and
+// the largest offer slot any of them can provide, which is all the job-level information
+// needed to tell how far the must-gather layer is from the desired offer slot. Enumerating
+// the topology nodes one by one is deliberately avoided: a large cluster may hold thousands
+// of them, which makes the status/event message huge. The per-topology-node breakdown is
+// emitted by the diagnostic log instead, and the underlying per-node filter failures are
+// already summarized by the FitError part.
+func buildTopologyNodeSummary(mustGatheredNodes []*networktopology.TreeNode) string {
+	maxOfferSlot := 0
+	for _, node := range mustGatheredNodes {
+		if node.OfferSlot > maxOfferSlot {
+			maxOfferSlot = node.OfferSlot
+		}
+	}
+	return fmt.Sprintf("max offer slot among %d must-gather topology nodes: %d", len(mustGatheredNodes), maxOfferSlot)
+}
+
+// buildDiagnosticTopologyNodeReasons enumerates the must-gathered topology nodes with their
+// offer slots for the diagnostic log, largest offer slot first so that the topology nodes
+// closest to satisfying the job are never truncated away, and caps the list to keep the log
+// bounded in large clusters.
+func buildDiagnosticTopologyNodeReasons(mustGatheredNodes []*networktopology.TreeNode) []string {
+	sortedTopologyNodes := make([]*networktopology.TreeNode, len(mustGatheredNodes))
+	copy(sortedTopologyNodes, mustGatheredNodes)
+	sort.Slice(sortedTopologyNodes, func(i, j int) bool {
+		a, b := sortedTopologyNodes[i], sortedTopologyNodes[j]
+		if a.OfferSlot != b.OfferSlot {
+			return a.OfferSlot > b.OfferSlot
+		}
+		if a.Layer != b.Layer {
+			return a.Layer < b.Layer
+		}
+		return a.Name < b.Name
+	})
+	listedNodes := len(sortedTopologyNodes)
+	if listedNodes > maxDiagnosticTopologyNodeReasons {
+		listedNodes = maxDiagnosticTopologyNodeReasons
+	}
+	reasons := make([]string, 0, listedNodes+1)
+	for _, node := range sortedTopologyNodes[:listedNodes] {
+		reasons = append(reasons, fmt.Sprintf("topology topologyNode %s/%s: %d", node.Layer, node.Name, node.OfferSlot))
+	}
+	if len(sortedTopologyNodes) > listedNodes {
+		reasons = append(reasons, fmt.Sprintf("and %d more topology nodes", len(sortedTopologyNodes)-listedNodes))
+	}
+	return reasons
 }
 
 func (solver *networkTopologySolverImpl) calculateNodeOfferSlot(

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_solver_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_solver_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -773,4 +774,115 @@ func Test_calculateNodeExistingPodsNum(t *testing.T) {
 			assert.Equal(t, tt.want, calculateNodeExistingPodsNum(context.TODO(), parallelize.NewParallelizer(16), tt.args.selectorKey, nodeInfos))
 		})
 	}
+}
+
+func TestBuildTopologyNodeSummary(t *testing.T) {
+	makeNodes := func(names []string, offerSlots []int) []*networktopology.TreeNode {
+		nodes := make([]*networktopology.TreeNode, 0, len(names))
+		for i := range names {
+			nodes = append(nodes, &networktopology.TreeNode{
+				TreeNodeMeta: networktopology.TreeNodeMeta{
+					Layer: schedulingv1alpha1.TopologyLayer("SpineLayer"),
+					Name:  names[i],
+				},
+				OfferSlot: offerSlots[i],
+			})
+		}
+		return nodes
+	}
+
+	t.Run("summary reports the largest offer slot", func(t *testing.T) {
+		nodes := makeNodes([]string{"s1", "s2", "s3"}, []int{2, 3, 1})
+		assert.Equal(t, "max offer slot among 3 must-gather topology nodes: 3", buildTopologyNodeSummary(nodes))
+		// the input slice must not be mutated
+		assert.Equal(t, "s1", nodes[0].Name)
+	})
+
+	// The production pattern: thousands of topology nodes whose member nodes all fail the
+	// filters, so none of them offers any slot. The summary stays a single bounded phrase
+	// instead of enumerating every topology node.
+	t.Run("large all-zero topology stays bounded", func(t *testing.T) {
+		names := make([]string, 0, 1836)
+		offerSlots := make([]int, 0, 1836)
+		for i := 0; i < 1836; i++ {
+			names = append(names, fmt.Sprintf("e01-cn-%d", i))
+			offerSlots = append(offerSlots, 0)
+		}
+		assert.Equal(t, "max offer slot among 1836 must-gather topology nodes: 0", buildTopologyNodeSummary(makeNodes(names, offerSlots)))
+	})
+
+	// Scenario: job needs desiredOfferSlot 8 within one hypernode, but the best hypernode
+	// holds 5 pods and the second best holds 3, while the remaining hypernodes have no
+	// member node passing the filters. Only the best offer slot is surfaced, telling how
+	// far the must-gather layer is from the desired offer slot.
+	t.Run("near-miss hypernodes are summarized by the best offer slot", func(t *testing.T) {
+		makeHyperNode := func(name string, offerSlot int) *networktopology.TreeNode {
+			return &networktopology.TreeNode{
+				TreeNodeMeta: networktopology.TreeNodeMeta{
+					Layer: schedulingv1alpha1.TopologyLayer("HyperNodeTopologyLayer"),
+					Name:  name,
+				},
+				OfferSlot: offerSlot,
+			}
+		}
+		nodes := []*networktopology.TreeNode{
+			makeHyperNode("hypernode-A", 5),
+			makeHyperNode("hypernode-B", 3),
+			makeHyperNode("hypernode-C", 0),
+			makeHyperNode("hypernode-D", 0),
+			makeHyperNode("hypernode-E", 0),
+			makeHyperNode("hypernode-F", 0),
+		}
+		assert.Equal(t, "max offer slot among 6 must-gather topology nodes: 5", buildTopologyNodeSummary(nodes))
+	})
+
+	t.Run("empty must-gather layer", func(t *testing.T) {
+		assert.Equal(t, "max offer slot among 0 must-gather topology nodes: 0", buildTopologyNodeSummary(nil))
+	})
+}
+
+func TestBuildDiagnosticTopologyNodeReasons(t *testing.T) {
+	makeHyperNode := func(name string, offerSlot int) *networktopology.TreeNode {
+		return &networktopology.TreeNode{
+			TreeNodeMeta: networktopology.TreeNodeMeta{
+				Layer: schedulingv1alpha1.TopologyLayer("HyperNodeTopologyLayer"),
+				Name:  name,
+			},
+			OfferSlot: offerSlot,
+		}
+	}
+
+	// The diagnostic log keeps the per-topology-node breakdown that the bounded status
+	// message reduces to a single max-offer-slot summary, largest offer slot first.
+	t.Run("breakdown is listed by offer slot desc", func(t *testing.T) {
+		nodes := []*networktopology.TreeNode{
+			makeHyperNode("hypernode-B", 3),
+			makeHyperNode("hypernode-A", 0),
+			makeHyperNode("hypernode-C", 0),
+		}
+		got := buildDiagnosticTopologyNodeReasons(nodes)
+		assert.Equal(t, []string{
+			"topology topologyNode HyperNodeTopologyLayer/hypernode-B: 3",
+			"topology topologyNode HyperNodeTopologyLayer/hypernode-A: 0",
+			"topology topologyNode HyperNodeTopologyLayer/hypernode-C: 0",
+		}, got)
+		// the input slice must not be mutated
+		assert.Equal(t, "hypernode-B", nodes[0].Name)
+	})
+
+	// The production pattern: thousands of topology nodes whose member nodes all fail the
+	// filters. The breakdown is capped, and the near-miss topology nodes keep their place
+	// at the head of the list so truncation never hides them.
+	t.Run("breakdown beyond the cap is truncated", func(t *testing.T) {
+		nodes := []*networktopology.TreeNode{}
+		for i := 0; i < 1836; i++ {
+			nodes = append(nodes, makeHyperNode(fmt.Sprintf("e01-cn-%d", i), 0))
+		}
+		nodes = append(nodes, makeHyperNode("hypernode-A", 5), makeHyperNode("hypernode-B", 3))
+		got := buildDiagnosticTopologyNodeReasons(nodes)
+		assert.Len(t, got, maxDiagnosticTopologyNodeReasons+1)
+		assert.Equal(t, "topology topologyNode HyperNodeTopologyLayer/hypernode-A: 5", got[0])
+		assert.Equal(t, "topology topologyNode HyperNodeTopologyLayer/hypernode-B: 3", got[1])
+		assert.Equal(t, fmt.Sprintf("and %d more topology nodes", 1838-maxDiagnosticTopologyNodeReasons), got[maxDiagnosticTopologyNodeReasons])
+	})
 }

--- a/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow_test.go
+++ b/pkg/scheduler/plugins/coscheduling/core/network_topology_workflow_test.go
@@ -1252,7 +1252,7 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 					},
 				},
 			},
-			wantScheduleStatus: fwktype.NewStatus(fwktype.Unschedulable, "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 3;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu."),
+			wantScheduleStatus: fwktype.NewStatus(fwktype.Unschedulable, "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu."),
 			wantDiagnosis: &frameworkext.Diagnosis{
 				TopologyKeyToExplain: "SpineLayer",
 				QuestionedKey:        "default/pending-pod-1",
@@ -1729,7 +1729,7 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 					},
 				},
 			},
-			wantScheduleStatus: fwktype.NewStatus(fwktype.Unschedulable, "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 2;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu."),
+			wantScheduleStatus: fwktype.NewStatus(fwktype.Unschedulable, "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu."),
 			wantDiagnosis: &frameworkext.Diagnosis{
 				QuestionedKey:        "default/pending-pod-1",
 				IsRootCausePod:       true,
@@ -1763,7 +1763,7 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 				TriggerPodKey:                 "default/pending-pod-1",
 				PreemptorKey:                  "default/gangA",
 				Reason:                        ReasonPreemptionNotHelpful,
-				Message:                       "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 3;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu.",
+				Message:                       "no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu.",
 				ClearNominatedNodeFailedMsg:   map[string]string{},
 				TerminatingPodOnNominatedNode: map[string]string{},
 				statusMap: map[string]*fwktype.Status{
@@ -1788,9 +1788,9 @@ func TestPodGroupManager_NetworkTopology(t *testing.T) {
 				},
 				SchedulingMode: frameworkext.JobSchedulingMode,
 			},
-			wantPreemptMessage: "preemption already attempted by default/pending-pod-1 with message no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 3;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu.",
+			wantPreemptMessage: "preemption already attempted by default/pending-pod-1 with message no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu.",
 			wantPreempt:        framework.NewPostFilterResultWithNominatedNode(""),
-			wantPreemptStatus:  fwktype.NewStatus(fwktype.Unschedulable, `no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 3;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu.`),
+			wantPreemptStatus:  fwktype.NewStatus(fwktype.Unschedulable, `no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu.`),
 			wantPossibleVictims: []schedulingv1alpha1.PossibleVictim{
 				{NamespacedName: schedulingv1alpha1.NamespacedName{Name: "existing-pod-3", Namespace: "default"}},
 			},


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When a network-topology gang cannot be placed, `MessageNoCandidateTopologyNodes` enumerated **every** must-gather topology node together with its offer slot. On a cluster holding thousands of hypernodes this produced a ~120KB message, which is written in full to the Pod's `PodScheduled=False` condition and truncated at `NoteLengthLimit` (1024 bytes) in the event, so neither channel ends up readable.

This PR bounds that message and moves the detail to a diagnostic log:

1. **The status/event message is now bounded.** Instead of enumerating topology nodes, it reports how many topology nodes the must-gather layer holds and the largest offer slot any of them provides (`buildTopologyNodeSummary`). That is the whole job-level answer to "how far is the must-gather layer from the desired offer slot", and the underlying per-node filter failures are already summarized by the `FitError` part of the message.

   Before:
   ```
   no candidate topology nodes can accommodate job, desiredOfferSlot: 4, topology topologyNode SpineLayer/s1: 3;topology topologyNode SpineLayer/s2: 3, 0/8 nodes are available: 8 Insufficient cpu.
   ```
   After:
   ```
   no candidate topology nodes can accommodate job, desiredOfferSlot: 4, max offer slot among 2 must-gather topology nodes: 3, 0/8 nodes are available: 8 Insufficient cpu.
   ```

2. **The per-topology-node breakdown moves to a `klog.V(4)` diagnostic log** (`buildDiagnosticTopologyNodeReasons`). It is ordered by offer slot descending so the near-miss topology nodes — the only ones that carry signal — are never truncated away, and it is capped so that a gang which cannot be placed does not re-emit the whole must-gather layer on every retry.

   The failure message itself is deliberately not logged again: it already reaches the Pod status/event, and the diagnosis dump carries it as `preFilterMessage`. The per-topology-node breakdown is the only piece no other channel carries.

3. **Successful placements now log** the chosen candidate topology node and every pod's assigned node, so a placement decision can be reviewed after the fact.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

The cap only affects the diagnostic log, never scheduling behavior. Because the breakdown is sorted by offer slot descending, truncation can only ever drop topology nodes that offer fewer slots than the ones kept, so the diagnostically interesting entries always survive.

## Does this PR introduce a user-facing change?

```release-note
The network topology "no candidate topology nodes" scheduling failure message no longer enumerates every must-gather topology node; it now reports the topology node count and the largest available offer slot, and the per-topology-node breakdown is emitted at klog verbosity 4 instead.
```
