### PR TITLE
ci: don't fail unit-tests on codecov upload errors for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,9 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         file: cover.out
-        fail_ci_if_error: true
+        # Dependabot PRs cannot access actions secrets, so the Codecov upload
+        # always fails on them and needlessly fails the unit-tests job.
+        fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
 
   build-and-push:
     needs: [ golangci-lint, unit-tests ]


### PR DESCRIPTION
### What

Dependabot PRs cannot access actions secrets, so the Codecov upload step always fails on them (`Token required because branch is protected`) and marks the `unit-tests(Run Go test)` job red even though all Go tests pass. Example: #3108, #3170, #3171.

This has effectively deadlocked every dependabot PR: the job is required, it can never go green on dependabot branches, and history shows all 6 previously closed dependabot PRs were closed unmerged (e.g. #2866, #2868, #2869, #2870, #2871, #3013).

This PR makes `fail_ci_if_error` conditional: false only when the actor is `dependabot[bot]`, strict (true) for everyone else, so coverage enforcement for regular PRs is unchanged.

Note: `codecov/patch` / `codecov/project` required statuses still won't be reported on dependabot branches since the upload itself fails — that half needs either a Dependabot-side secret (Settings → Secrets → Dependabot: `CODECOV_TOKEN`) or dropping those two contexts from required status checks.

### How to verify

- Regular PR: unit-tests still fails if codecov upload fails (behavior unchanged).
- Dependabot PR after rebase: unit-tests job goes green when tests pass.

### Checklist

- [x] I have written necessary docs and comments