### PR TITLE
ci: disable build attestations to unblock multi-arch pushes to Aliyun ACR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,12 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         pull: true
+        # Aliyun ACR rejects the OCI 1.1 attestation manifests that newer
+        # BuildKit versions attach by default (denied: unknown manifest
+        # class for application/vnd.oci.empty.v1+json), which has failed
+        # every build-and-push on main since 2026-08-25.
+        provenance: false
+        sbom: false
         file: docker/${{ matrix.target }}.dockerfile
         labels: |
           org.opencontainers.image.title=${{ matrix.target }}


### PR DESCRIPTION
### What

Since **2026-08-25**, every `build-and-push` job on `main` has failed with:

```
failed to push registry.cn-beijing.aliyuncs.com/koordinator-sh/koord-<target>:latest:
denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

(e.g. [latest failing run](https://github.com/koordinator-sh/koordinator/actions/runs/33738890069) — all 5 targets red on the last 8 consecutive runs, while the same workflow last passed on 2026-07-31.)

### Root cause

Newer BuildKit/buildx versions on GitHub runners attach OCI 1.1 attestation manifests (provenance/SBOM, using the `application/vnd.oci.empty.v1+json` empty descriptor) to multi-arch pushes **by default**. Aliyun ACR does not accept this manifest class and denies the push. GHCR accepts it fine, but buildx pushes all 6 tags in one go, so the Aliyun denial fails the whole job.

Impact: the `:latest` images on GHCR, Aliyun Beijing and Aliyun Hangzhou registries have not been updated for ~5 weeks.

### Fix

Disable `provenance` and `sbom` for the multi-arch push step, restoring the manifest format all three registries accept. The push step only runs on `main`, so PR builds are unaffected.

### How to verify

After merge, the next push to `main` should turn all 5 `build-and-push` jobs green and refresh `:latest` on all three registries.

### Checklist

- [x] I have written necessary docs and comments