### PR TITLE
ci: let stale bot cover milestone items to prevent zombie backlog

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -36,5 +36,8 @@ closeComment: |
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
 
-# Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: true
+# Milestone items are NOT exempted: 'someday' previously accumulated
+# dormant proposals for years because exemptMilestones kept the stale
+# bot away. Items worth keeping long-term should use the `pinned` or
+# `security` labels, or be refreshed with `/remove-lifecycle stale`.
+exemptMilestones: false


### PR DESCRIPTION
### What

`exemptMilestones: true` in `.github/stale.yml` exempted every milestone item from the stale bot. That made the `someday` milestone a place where dormant proposals survived indefinitely — during this week's backlog triage we found several untouched for 2–4 years (e.g. proposals filed in 2023–2024 with zero comments, no assignee). Milestones should track scheduled work, not preserve stale items.

### Change

Remove the milestone exemption so milestone items follow the same lifecycle as everything else:

| | before | after |
|---|---|---|
| milestone items, 90d inactive | exempt | marked `lifecycle/stale` |
| milestone items, stale + 30d | exempt | auto-closed |

`pinned` / `security` labels remain as escape hatches for items that must never go stale, and `/remove-lifecycle stale` still resets the clock on items that are simply waiting.

### Impact on current milestones

- `someday` (33 open): long-dormant items will now age out naturally — the intended effect.
- `maintenance` (13 open): all items have open PRs or recent activity, unaffected for now.
- `v1.8.1` / `v1.9` / `aspirational-26`: planned mainline items that sit inactive for 90d will get a stale nudge — that is a feature: it forces periodic roadmap review instead of silent decay.

### Note for reviewers

This is a repo-wide policy change, so calling it out explicitly: @saintube PTAL if you have concerns about version milestones becoming stale-able.