### PR TITLE
test(e2e): fix nil-map panic when preparing slo-controller-config

### DIFF
--- a/test/e2e/slocontroller/batchresource.go
+++ b/test/e2e/slocontroller/batchresource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -79,65 +78,11 @@ var _ = SIGDescribe("BatchResource", func() {
 
 	framework.KoordinatorDescribe("BatchResource AllocatableUpdate", func() {
 		framework.ConformanceIt("update batch resources in the node allocatable", func() {
-			ginkgo.By("Loading slo-controller-config in the cluster")
-			isConfigCreated := false
-			configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
-			if err == nil {
-				isConfigCreated = true
-				framework.Logf("successfully get slo-controller-config %s/%s", koordNamespace, sloConfigName)
-			} else if errors.IsNotFound(err) {
-				framework.Logf("cannot get slo-controller-config %s/%s, try to create a new one",
-					koordNamespace, sloConfigName)
-			} else {
-				framework.Failf("failed to get slo-controller-config %s/%s, got unexpected error: %v",
-					koordNamespace, sloConfigName, err)
-			}
-
-			// If configmap is created, try to patch it with colocation enabled.
-			// If not exist, create the slo-controller-config.
 			// NOTE: slo-controller-config should not be modified by the others during the e2e test.
 			ginkgo.By("Prepare slo-controller-config to enable colocation")
-			if isConfigCreated {
-				needUpdate := false
-				rollbackData := map[string]string{}
-				if configMap.Data == nil {
-					needUpdate = true
-				} else if configMap.Data[configuration.ColocationConfigKey] != colocationEnabledConfigData {
-					rollbackData[configuration.ColocationConfigKey] = configMap.Data[configuration.ColocationConfigKey]
-					needUpdate = true
-				}
-
-				if _, ok := rollbackData[configuration.ColocationConfigKey]; ok && needUpdate {
-					defer rollbackSLOConfigData(f, koordNamespace, sloConfigName, rollbackData)
-				}
-
-				if needUpdate {
-					framework.Logf("colocation is not enabled in slo-controller-config, need update")
-					newConfigMap := configMap.DeepCopy()
-					newConfigMap.Data[configuration.ColocationConfigKey] = colocationEnabledConfigData
-					newConfigMapUpdated, err := c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
-					framework.ExpectNoError(err)
-					framework.Logf("update slo-controller-config successfully, data: %+v", newConfigMapUpdated.Data)
-					configMap = newConfigMapUpdated
-				} else {
-					framework.Logf("colocation is already enabled in slo-controller-config, keep the same")
-				}
-			} else {
-				framework.Logf("slo-controller-config does not exist, need create")
-				newConfigMap, err := manifest.ConfigMapFromManifest("slocontroller/slo-controller-config.yaml")
-				framework.ExpectNoError(err)
-
-				newConfigMap.SetNamespace(koordNamespace)
-				newConfigMap.SetName(sloConfigName)
-				newConfigMap.Data[configuration.ColocationConfigKey] = colocationEnabledConfigData
-
-				newConfigMapCreated, err := c.CoreV1().ConfigMaps(koordNamespace).Create(context.TODO(), newConfigMap, metav1.CreateOptions{})
-				framework.ExpectNoError(err)
-				framework.Logf("create slo-controller-config successfully, data: %+v", newConfigMapCreated.Data)
-				configMap = newConfigMapCreated
-
-				defer rollbackSLOConfigObject(f, koordNamespace, sloConfigName)
-			}
+			defer ensureSLOConfigData(f, koordNamespace, sloConfigName, map[string]string{
+				configuration.ColocationConfigKey: colocationEnabledConfigData,
+			})()
 
 			ginkgo.By("Check node allocatable for batch resources")
 			totalCount, allocatableCount := len(nodeList.Items), 0 // assert totalCount > 0
@@ -265,19 +210,6 @@ func isNodeBatchResourcesValid(node *corev1.Node, nodeMetric *slov1alpha1.NodeMe
 	}
 
 	return true, ""
-}
-
-// restore the slo-controller-config by updating with the initial data
-func rollbackSLOConfigData(f *framework.Framework, sloConfigNamespace, sloConfigName string, rollbackData map[string]string) {
-	configMap, err := f.ClientSet.CoreV1().ConfigMaps(sloConfigNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
-	newConfigMap := configMap.DeepCopy()
-	for k, v := range rollbackData {
-		newConfigMap.Data[k] = v
-	}
-	newConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(sloConfigNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
-	framework.ExpectNoError(err)
-	framework.Logf("finish rollback updating slo-controller-config, final data: %v", newConfigMap.Data)
 }
 
 // delete slo-controller-config configmap if it does not exist initially

--- a/test/e2e/slocontroller/cpunormalization.go
+++ b/test/e2e/slocontroller/cpunormalization.go
@@ -27,7 +27,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -36,7 +35,6 @@ import (
 	"github.com/koordinator-sh/koordinator/apis/extension"
 	koordinatorclientset "github.com/koordinator-sh/koordinator/pkg/client/clientset/versioned"
 	"github.com/koordinator-sh/koordinator/test/e2e/framework"
-	"github.com/koordinator-sh/koordinator/test/e2e/framework/manifest"
 	e2enode "github.com/koordinator-sh/koordinator/test/e2e/framework/node"
 )
 
@@ -155,67 +153,12 @@ var _ = SIGDescribe("CPUNormalization", func() {
 			framework.ExpectNoError(err)
 			cpuNormalizationData := string(cpuNormalizationConfigBytes)
 
-			ginkgo.By("Loading slo-controller-config in the cluster")
-			isConfigCreated := false
-			configMap, err := c.CoreV1().ConfigMaps(koordNamespace).Get(context.TODO(), sloConfigName, metav1.GetOptions{})
-			if err == nil {
-				isConfigCreated = true
-				framework.Logf("successfully get slo-controller-config %s/%s", koordNamespace, sloConfigName)
-			} else if errors.IsNotFound(err) {
-				framework.Logf("cannot get slo-controller-config %s/%s, try to create a new one",
-					koordNamespace, sloConfigName)
-			} else {
-				framework.Failf("failed to get slo-controller-config %s/%s, got unexpected error: %v",
-					koordNamespace, sloConfigName, err)
-			}
-
-			// If configmap is created, try to patch it with colocation enabled.
-			// If not exist, create the slo-controller-config.
 			// NOTE: slo-controller-config should not be modified by the others during the e2e test.
 			ginkgo.By("Prepare slo-controller-config to enable cpu normalization")
-			if isConfigCreated {
-				needUpdate := false
-				rollbackData := map[string]string{}
-				if configMap.Data == nil {
-					needUpdate = true
-				} else if configMap.Data[configuration.ColocationConfigKey] != colocationEnabledConfigData ||
-					configMap.Data[configuration.CPUNormalizationConfigKey] != cpuNormalizationData {
-					rollbackData[configuration.ColocationConfigKey] = configMap.Data[configuration.ColocationConfigKey]
-					rollbackData[configuration.CPUNormalizationConfigKey] = configMap.Data[configuration.CPUNormalizationConfigKey]
-					needUpdate = true
-				}
-
-				if needUpdate {
-					framework.Logf("cpu normalization is not enabled in slo-controller-config, need update")
-					defer rollbackSLOConfigData(f, koordNamespace, sloConfigName, rollbackData)
-
-					newConfigMap := configMap.DeepCopy()
-					newConfigMap.Data[configuration.ColocationConfigKey] = colocationEnabledConfigData
-					newConfigMap.Data[configuration.CPUNormalizationConfigKey] = cpuNormalizationData
-					newConfigMapUpdated, err := c.CoreV1().ConfigMaps(koordNamespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
-					framework.ExpectNoError(err)
-					framework.Logf("update slo-controller-config successfully, data: %+v", newConfigMapUpdated.Data)
-					configMap = newConfigMapUpdated
-				} else {
-					framework.Logf("cpu normalization is already enabled in slo-controller-config, keep the same")
-				}
-			} else {
-				framework.Logf("slo-controller-config does not exist, need create")
-				newConfigMap, err := manifest.ConfigMapFromManifest("slocontroller/slo-controller-config.yaml")
-				framework.ExpectNoError(err)
-
-				newConfigMap.SetNamespace(koordNamespace)
-				newConfigMap.SetName(sloConfigName)
-				newConfigMap.Data[configuration.ColocationConfigKey] = colocationEnabledConfigData
-				newConfigMap.Data[configuration.CPUNormalizationConfigKey] = cpuNormalizationData
-
-				newConfigMapCreated, err := c.CoreV1().ConfigMaps(koordNamespace).Create(context.TODO(), newConfigMap, metav1.CreateOptions{})
-				framework.ExpectNoError(err)
-				framework.Logf("create slo-controller-config successfully, data: %+v", newConfigMapCreated.Data)
-				configMap = newConfigMapCreated
-
-				defer rollbackSLOConfigObject(f, koordNamespace, sloConfigName)
-			}
+			defer ensureSLOConfigData(f, koordNamespace, sloConfigName, map[string]string{
+				configuration.ColocationConfigKey:       colocationEnabledConfigData,
+				configuration.CPUNormalizationConfigKey: cpuNormalizationData,
+			})()
 
 			ginkgo.By("Check node cpu normalization ratios")
 			totalCount, validNodeCount, skippedCount = len(nodeList.Items), 0, 0

--- a/test/e2e/slocontroller/sloconfig.go
+++ b/test/e2e/slocontroller/sloconfig.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slocontroller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework/manifest"
+)
+
+// sloConfigAction describes how to reach a wanted slo-controller-config value
+// and how to put back what was there before.
+//
+// Kept separate from the API calls so the branch it decides can be tested
+// without a cluster: the case this exists for -- a ConfigMap whose Data is nil
+// -- is the one a kind environment does not reach, because the chart always
+// creates the object with data.
+type sloConfigAction struct {
+	// needUpdate is false when the key already holds the wanted value.
+	needUpdate bool
+	// newData is what to write. Never nil when needUpdate is true.
+	newData map[string]string
+	// restoreData is what to write back on cleanup.
+	restoreData map[string]string
+	// removeKeys are keys the ConfigMap did not have, so cleanup drops them
+	// rather than leaving a key the cluster never carried.
+	removeKeys []string
+	// restoreNil says the ConfigMap had no Data at all, so cleanup puts it
+	// back to nil rather than writing an empty key over it.
+	restoreNil bool
+}
+
+// planSLOConfigData decides how to set wanted on an existing ConfigMap.
+//
+// The nil case is the one that used to be handled and then crashed: the caller
+// noticed Data == nil, recorded nothing to roll back, and wrote into the nil
+// map anyway.
+func planSLOConfigData(data map[string]string, wanted map[string]string) sloConfigAction {
+	if data == nil {
+		newData := make(map[string]string, len(wanted))
+		for k, v := range wanted {
+			newData[k] = v
+		}
+		return sloConfigAction{
+			needUpdate: true,
+			newData:    newData,
+			restoreNil: true,
+		}
+	}
+
+	needUpdate := false
+	for k, v := range wanted {
+		if current, ok := data[k]; !ok || current != v {
+			needUpdate = true
+			break
+		}
+	}
+	if !needUpdate {
+		// Already what we want; nothing to change and nothing to restore.
+		return sloConfigAction{}
+	}
+
+	newData := make(map[string]string, len(data)+len(wanted))
+	for k, v := range data {
+		newData[k] = v
+	}
+	restoreData := map[string]string{}
+	var removeKeys []string
+	for k, v := range wanted {
+		if current, ok := data[k]; ok {
+			// The key existed with another value, so put that value back.
+			restoreData[k] = current
+		} else {
+			// The key was not there at all. Restoring it to "" would leave a
+			// key the cluster never had, so cleanup removes it instead.
+			removeKeys = append(removeKeys, k)
+		}
+		newData[k] = v
+	}
+
+	return sloConfigAction{
+		needUpdate:  true,
+		newData:     newData,
+		restoreData: restoreData,
+		removeKeys:  removeKeys,
+	}
+}
+
+// ensureSLOConfigData makes the slo-controller-config ConfigMap hold key=data
+// and returns a cleanup that restores the state it found.
+//
+// It handles the three shapes a spec can meet, so a spec does not carry the
+// boilerplate itself:
+//
+//   - the ConfigMap does not exist: it is created from the manifest, and
+//     cleanup deletes it again;
+//   - the ConfigMap exists with no Data: the map is initialised, and cleanup
+//     puts Data back to nil;
+//   - the ConfigMap exists with a different value: it is overwritten, and
+//     cleanup writes the old value back (or drops the key if it was absent).
+//
+// The returned cleanup is always non-nil and is safe to defer even when
+// nothing needed changing.
+func ensureSLOConfigData(f *framework.Framework, namespace, name string, wanted map[string]string) func() {
+	c := f.ClientSet
+	configMap, err := c.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		framework.Failf("failed to get slo-controller-config %s/%s, got unexpected error: %v",
+			namespace, name, err)
+	}
+
+	if errors.IsNotFound(err) {
+		framework.Logf("slo-controller-config %s/%s does not exist, need create", namespace, name)
+		newConfigMap, err := manifest.ConfigMapFromManifest("slocontroller/slo-controller-config.yaml")
+		framework.ExpectNoError(err)
+
+		newConfigMap.SetNamespace(namespace)
+		newConfigMap.SetName(name)
+		if newConfigMap.Data == nil {
+			newConfigMap.Data = map[string]string{}
+		}
+		for k, v := range wanted {
+			newConfigMap.Data[k] = v
+		}
+
+		created, err := c.CoreV1().ConfigMaps(namespace).Create(context.TODO(), newConfigMap, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		framework.Logf("create slo-controller-config successfully, data: %+v", created.Data)
+
+		return func() { rollbackSLOConfigObject(f, namespace, name) }
+	}
+
+	action := planSLOConfigData(configMap.Data, wanted)
+	if !action.needUpdate {
+		framework.Logf("slo-controller-config %s/%s already has the wanted data, keep the same",
+			namespace, name)
+		return func() {}
+	}
+
+	newConfigMap := configMap.DeepCopy()
+	newConfigMap.Data = action.newData
+	updated, err := c.CoreV1().ConfigMaps(namespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err)
+	framework.Logf("update slo-controller-config successfully, data: %+v", updated.Data)
+
+	return func() { restoreSLOConfigData(f, namespace, name, action) }
+}
+
+// restoreSLOConfigData puts back the Data that ensureSLOConfigData replaced.
+func restoreSLOConfigData(f *framework.Framework, namespace, name string, action sloConfigAction) {
+	configMap, err := f.ClientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Something else removed it; there is nothing left to restore.
+		framework.Logf("slo-controller-config %s/%s is gone, skip rollback", namespace, name)
+		return
+	}
+	framework.ExpectNoError(err)
+
+	newConfigMap := configMap.DeepCopy()
+	if action.restoreNil {
+		newConfigMap.Data = nil
+	} else {
+		if newConfigMap.Data == nil {
+			// Something replaced Data while the spec ran; restoring into a nil
+			// map is what panicked before this helper existed.
+			newConfigMap.Data = map[string]string{}
+		}
+		for k, v := range action.restoreData {
+			newConfigMap.Data[k] = v
+		}
+		for _, k := range action.removeKeys {
+			delete(newConfigMap.Data, k)
+		}
+	}
+
+	restored, err := f.ClientSet.CoreV1().ConfigMaps(namespace).Update(context.TODO(), newConfigMap, metav1.UpdateOptions{})
+	framework.ExpectNoError(err)
+	framework.Logf("finish rollback updating slo-controller-config, final data: %v", restored.Data)
+}

--- a/test/e2e/slocontroller/sloconfig_test.go
+++ b/test/e2e/slocontroller/sloconfig_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slocontroller
+
+import (
+	"reflect"
+	"testing"
+)
+
+const testKey = "colocation-config"
+
+func TestPlanSLOConfigData(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]string
+		want sloConfigAction
+	}{
+		{
+			// The branch this whole helper exists for. The old code noticed
+			// Data == nil, set needUpdate, recorded nothing to roll back, and
+			// then wrote into the nil map: "assignment to entry in nil map".
+			name: "nil data is initialised and restored to nil",
+			data: nil,
+			want: sloConfigAction{
+				needUpdate: true,
+				newData:    map[string]string{testKey: "wanted"},
+				restoreNil: true,
+			},
+		},
+		{
+			// An empty map is not the same as no map: writing into it is fine,
+			// so cleanup must drop the key rather than blank out Data.
+			name: "empty data gets the key and cleanup removes it",
+			data: map[string]string{},
+			want: sloConfigAction{
+				needUpdate:  true,
+				newData:     map[string]string{testKey: "wanted"},
+				restoreData: map[string]string{},
+				removeKeys:  []string{testKey},
+			},
+		},
+		{
+			name: "different value is overwritten and the old one restored",
+			data: map[string]string{testKey: "old"},
+			want: sloConfigAction{
+				needUpdate:  true,
+				newData:     map[string]string{testKey: "wanted"},
+				restoreData: map[string]string{testKey: "old"},
+			},
+		},
+		{
+			name: "matching value needs no update and no rollback",
+			data: map[string]string{testKey: "wanted"},
+			want: sloConfigAction{},
+		},
+		{
+			// Keys the spec does not own must survive both the write and the
+			// rollback, so they are copied rather than replaced.
+			name: "unrelated keys are preserved",
+			data: map[string]string{testKey: "old", "other-config": "keep"},
+			want: sloConfigAction{
+				needUpdate:  true,
+				newData:     map[string]string{testKey: "wanted", "other-config": "keep"},
+				restoreData: map[string]string{testKey: "old"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planSLOConfigData(tt.data, map[string]string{testKey: "wanted"})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("planSLOConfigData() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPlanSLOConfigDataMultipleKeys covers the cpunormalization shape, which
+// sets two keys at once. One key already matching must not stop the other from
+// being written, and only the keys that existed get restored.
+func TestPlanSLOConfigDataMultipleKeys(t *testing.T) {
+	const otherKey = "cpu-normalization-config"
+
+	t.Run("nil data with two keys", func(t *testing.T) {
+		got := planSLOConfigData(nil, map[string]string{testKey: "a", otherKey: "b"})
+
+		if !got.needUpdate || !got.restoreNil {
+			t.Fatalf("nil data should need an update and restore to nil, got %+v", got)
+		}
+		if got.newData[testKey] != "a" || got.newData[otherKey] != "b" {
+			t.Errorf("newData = %v, want both keys set", got.newData)
+		}
+	})
+
+	t.Run("one key matches, the other does not", func(t *testing.T) {
+		data := map[string]string{testKey: "a"}
+
+		got := planSLOConfigData(data, map[string]string{testKey: "a", otherKey: "b"})
+
+		if !got.needUpdate {
+			t.Fatal("a differing second key should still need an update")
+		}
+		if got.newData[otherKey] != "b" {
+			t.Errorf("second key was not written: %v", got.newData)
+		}
+		// testKey existed and is restored; otherKey did not and is removed.
+		if got.restoreData[testKey] != "a" {
+			t.Errorf("restoreData = %v, want the existing value kept", got.restoreData)
+		}
+		if len(got.removeKeys) != 1 || got.removeKeys[0] != otherKey {
+			t.Errorf("removeKeys = %v, want only the key that was absent", got.removeKeys)
+		}
+	})
+
+	t.Run("both keys already match", func(t *testing.T) {
+		data := map[string]string{testKey: "a", otherKey: "b"}
+
+		got := planSLOConfigData(data, map[string]string{testKey: "a", otherKey: "b"})
+
+		if got.needUpdate {
+			t.Errorf("no update should be needed, got %+v", got)
+		}
+	})
+}
+
+// TestPlanSLOConfigDataDoesNotMutateInput pins that the caller's ConfigMap data
+// is left alone. The plan is built before the Update call, and a spec that had
+// its own copy changed underneath it would roll back to the wrong value.
+func TestPlanSLOConfigDataDoesNotMutateInput(t *testing.T) {
+	data := map[string]string{testKey: "old", "other-config": "keep"}
+
+	action := planSLOConfigData(data, map[string]string{testKey: "wanted"})
+
+	if data[testKey] != "old" {
+		t.Errorf("input was mutated: %s = %q, want %q", testKey, data[testKey], "old")
+	}
+	if action.newData[testKey] != "wanted" {
+		t.Errorf("newData did not take the wanted value, got %q", action.newData[testKey])
+	}
+	// Writing through the returned map must not reach the caller's map either.
+	action.newData["other-config"] = "changed"
+	if data["other-config"] != "keep" {
+		t.Errorf("newData aliases the input map: other-config = %q", data["other-config"])
+	}
+}
+
+// TestPlanSLOConfigDataNilNeverWritesNilMap is the regression guard for the
+// panic itself: whatever else changes, the plan for a nil Data must hand back a
+// map that can be written to.
+func TestPlanSLOConfigDataNilNeverWritesNilMap(t *testing.T) {
+	action := planSLOConfigData(nil, map[string]string{testKey: "wanted"})
+
+	if !action.needUpdate {
+		t.Fatal("nil data should need an update")
+	}
+	if action.newData == nil {
+		t.Fatal("newData is nil; assigning into it would panic, which is the bug this guards")
+	}
+	// The assignment that used to panic.
+	action.newData["another"] = "value"
+}


### PR DESCRIPTION
Refs #3196.

## The bug

The slo-controller specs prepare `slo-controller-config` with an inline block that has a branch which crashes:

```go
if configMap.Data == nil {
    needUpdate = true            // rollbackData stays empty
} else if ... {
    rollbackData[key] = configMap.Data[key]
    needUpdate = true
}

if _, ok := rollbackData[key]; ok && needUpdate {
    defer rollbackSLOConfigData(...)   // not registered when Data was nil
}

newConfigMap := configMap.DeepCopy()
newConfigMap.Data[key] = data          // panic: assignment to entry in nil map
```

Two failures in one branch: the write panics, and even with the panic fixed the rollback is never registered, so the spec would leave its config behind for whatever runs next.

As the issue says, CI does not reach this — the chart creates the ConfigMap with `data`, so the nil branch is only met on a cluster where the object exists without it. It is a hole in an explicitly handled case rather than a red build.

## The change

`ensureSLOConfigData(f, namespace, name, wanted)` takes the keys a spec wants and returns the cleanup that restores what it found. It covers the three shapes:

| found | written | cleanup |
| --- | --- | --- |
| ConfigMap absent | created from the manifest | deletes the object |
| present, `Data == nil` | map initialised, keys set | puts `Data` back to `nil` |
| present, values differ | keys overwritten | restores previous values; drops keys that were absent |

Keys the spec does not own are copied through and left alone, on the write and on the rollback.

## Two things beyond the issue

**`cpunormalization.go` has the same defect.** The issue lists `batchresource.go` and `nodeprediction.go` (#3100). `cpunormalization.go` is already on `main` and carries an identical nil-map branch — it sets *two* keys rather than one, which is why the helper takes a map instead of the single `key, data` pair the issue sketches. Both existing call sites move onto it.

**`rollbackSLOConfigData` had the bug on the rollback path.** It did `newConfigMap.Data[k] = v` on a DeepCopy with no nil check, so a ConfigMap whose `Data` was nil at rollback time would panic there too. It is removed along with its last caller; the new `restoreSLOConfigData` guards the map and tolerates the object having been deleted underneath it.

**On #3100:** it adds a third copy of this block. If this lands first, that PR can call `ensureSLOConfigData` instead — which is the outcome the issue asks for ("这段样板会有第三份").

## Tests

The package had no unit tests, and the failing branch is the one a kind environment does not exercise. So the decision is made by a pure function and tested directly — `planSLOConfigData`, 11 cases across 4 groups:

- nil data → map initialised, restores to nil
- empty data → key added, cleanup removes it
- differing value → overwritten, old value restored
- matching value → no update, no rollback
- unrelated keys preserved
- input map not mutated, and the returned map does not alias it
- the two-key `cpunormalization` shape, including one key matching and the other not
- an explicit guard that a nil plan never hands back a nil map

They bite: reintroducing the original branch (flag the update, record no rollback, return the nil map) fails 3 of the 4 groups, including `newData is nil; assigning into it would panic, which is the bug this guards`.

```
go build ./test/...                     ok
go vet ./test/e2e/slocontroller/...      ok
go test ./test/e2e/slocontroller/...     ok   (4 groups, 11 cases)
gofmt                                    clean
```

## What I could not verify

**I did not run the e2e specs.** They need a kind cluster and this machine has no Docker, so `[slo-controller] BatchResource AllocatableUpdate` and the CPUNormalization spec are unverified by me — I am not going to present a compile-and-unit-test pass as more than it is.

The manual check from the issue, for whoever has a cluster:

```bash
kubectl -n koordinator-system patch configmap slo-controller-config --type=merge -p '{"data":null}'
./bin/ginkgo -v --focus='slo-controller' test/e2e -- <EXTRA_ARGS>
```

Before this change that panics with `assignment to entry in nil map`; after it the spec should run to completion and leave the ConfigMap back at `data: null`. Per the issue's note, worth confirming in the ginkgo output that the two specs actually appear and count toward `Ran N of M Specs` rather than only that CI is green.
