### PR TITLE
scheduler: align the deviceshare NUMA hints with the nominated reservation

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/plugin.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin.go
@@ -594,6 +594,29 @@ func (p *Plugin) allocate(ctx context.Context, cycleState fwktype.CycleState, po
 		affinity, _ = store.GetAffinity(node.Name)
 	}
 
+	result, status := p.allocateWithNUMAAffinity(cycleState, state, nodeDeviceInfo, pod, node, affinity, reuseNominatedOnly)
+	if !status.IsSuccess() {
+		return status
+	}
+	state.allocationResult = result
+	return nil
+}
+
+// allocateWithNUMAAffinity allocates the devices constrained in the given NUMA affinity. It is shared by the Reserve
+// phase and the NUMA hint provider, so that the allocation admitted while the NUMA affinity is being chosen has the
+// same scope and constraints as the allocation the Reserve phase makes. The concrete devices are not guaranteed to be
+// the same ones: both allocate against the live node device cache and the equally scored candidates are not tie-broken
+// deterministically. probeMatchedWithoutNomination is documented in allocateWithReservationScope and must be disabled
+// for an allocation that is going to be assumed.
+func (p *Plugin) allocateWithNUMAAffinity(
+	cycleState fwktype.CycleState,
+	state *preFilterState,
+	nodeDeviceInfo *nodeDevice,
+	pod *corev1.Pod,
+	node *corev1.Node,
+	affinity topologymanager.NUMATopologyHint,
+	probeMatchedWithoutNomination bool,
+) (apiext.DeviceAllocations, *fwktype.Status) {
 	allocator := &AutopilotAllocator{
 		state:              state,
 		nodeDevice:         nodeDeviceInfo,
@@ -612,9 +635,64 @@ func (p *Plugin) allocate(ctx context.Context, cycleState fwktype.CycleState, po
 	nodeDeviceInfo.lock.RLock()
 	defer nodeDeviceInfo.lock.RUnlock()
 
-	result, nominated, status := p.allocateWithNominated(allocator, state, restoreState, node, pod, preemptible)
+	return p.allocateWithReservationScope(cycleState, allocator, state, restoreState, nodeDeviceInfo, pod, node, preemptible, probeMatchedWithoutNomination, logResolvedScope)
+}
+
+const (
+	// reuseNominatedOnly is the named false value of the probeMatchedWithoutNomination parameter of
+	// allocateWithNUMAAffinity and allocateWithReservationScope.
+	reuseNominatedOnly = false
+
+	// logResolvedScope is the named true value of the logAllocationScope parameter of allocateWithReservationScope.
+	logResolvedScope = true
+)
+
+// beforeReservationNominated reports whether the allocation being made is unable to see a nominated reservation yet,
+// because a reservation is nominated no earlier than the PreScore phase.
+// It relies on frameworkext.frameworkExtenderImpl.RunReservePluginsReserve recording the Reserve phase before running
+// the Reserve plugins, which is what makes the BestEffort NUMA hints, calculated inside nodenumaresource.Reserve,
+// observe the Reserve phase. A path running the Reserve plugins without the framework extender, or a NUMA admission
+// moved to another extension point, would silently widen the reservation scope back without failing any test.
+func beforeReservationNominated(cycleState fwktype.CycleState) bool {
+	return schedulingphase.GetExtensionPointBeingExecuted(cycleState) != schedulingphase.Reserve
+}
+
+// allocateWithReservationScope allocates the devices in the reservation scope shared by the Reserve phase and the
+// NUMA hint calculation: once the pod is nominated to a reservation reserving tracked device resources, its devices
+// MUST come from that reservation. Sharing the scope prevents a NUMA affinity from being admitted with the devices
+// that the Reserve phase is not allowed to allocate, e.g. a NUMA node holding no device reserved by the nominated
+// reservation.
+// The caller must hold the read lock of the nodeDeviceInfo, and the allocator must carry the NUMA nodes to allocate
+// from. logAllocationScope should be disabled when probing the NUMA node masks one by one, otherwise the resolved
+// scope is logged once per mask.
+// A reservation is nominated no earlier than the PreScore phase, so an allocation made before it, e.g. the hints of
+// the Restricted and the SingleNUMANode policies which are calculated during the Filter phase, has no nomination to
+// resolve the scope with. probeMatchedWithoutNomination lets such an allocation keep probing all the matched
+// reservations, which is what the hint calculation did before the scope was shared, so that the scope is only
+// narrowed where a nomination actually exists. It must be disabled for an allocation that is going to be assumed,
+// because occupying the devices reserved by a reservation the pod is not nominated to breaks the reservation
+// contract.
+func (p *Plugin) allocateWithReservationScope(
+	cycleState fwktype.CycleState,
+	allocator *AutopilotAllocator,
+	state *preFilterState,
+	restoreState *nodeReservationRestoreStateData,
+	nodeDeviceInfo *nodeDevice,
+	pod *corev1.Pod,
+	node *corev1.Node,
+	basicPreemptible map[schedulingv1alpha1.DeviceType]deviceResources,
+	probeMatchedWithoutNomination bool,
+	logAllocationScope bool,
+) (apiext.DeviceAllocations, *fwktype.Status) {
+	result, nominated, status := p.allocateWithNominated(allocator, state, restoreState, node, pod, basicPreemptible)
 	if !status.IsSuccess() {
-		return status
+		return nil, status
+	}
+	if len(result) == 0 && !nominated && probeMatchedWithoutNomination {
+		result, status = p.tryAllocateFromReusable(allocator, state, restoreState, restoreState.matched, pod, node, basicPreemptible, state.isReservationRequired)
+		if !status.IsSuccess() {
+			return nil, status
+		}
 	}
 	if len(result) == 0 {
 		// If the pod is nominated to a reservation reserving tracked device resources, its devices MUST come from
@@ -623,22 +701,30 @@ func (p *Plugin) allocate(ctx context.Context, cycleState fwktype.CycleState, po
 		// A nomination whose target reserves no tracked device resource reports nominated=false and falls back to
 		// the node unallocated resources below.
 		if nominated {
-			klog.V(4).InfoS("failed to allocate devices from the nominated reservation",
+			if logAllocationScope {
+				klog.V(4).InfoS("failed to allocate devices from the nominated reservation",
+					"pod", klog.KObj(pod), "node", node.Name,
+					"phase", schedulingphase.GetExtensionPointBeingExecuted(cycleState),
+					"numaNodes", allocator.numaNodes,
+					"matched", dumpReusableAllocs(restoreState.matched))
+			}
+			return nil, fwktype.NewStatus(fwktype.Unschedulable, ErrInsufficientDevicesInNominatedReservation)
+		}
+		if logAllocationScope {
+			klog.V(5).InfoS("allocating devices without reusing any reservation",
 				"pod", klog.KObj(pod), "node", node.Name,
 				"phase", schedulingphase.GetExtensionPointBeingExecuted(cycleState),
 				"matched", dumpReusableAllocs(restoreState.matched))
-			return fwktype.NewStatus(fwktype.Unschedulable, ErrInsufficientDevicesInNominatedReservation)
 		}
-		klog.V(5).InfoS("allocating devices without reusing any reservation",
-			"pod", klog.KObj(pod), "node", node.Name,
-			"phase", schedulingphase.GetExtensionPointBeingExecuted(cycleState),
-			"matched", dumpReusableAllocs(restoreState.matched))
-		preemptible = appendAllocated(preemptible, restoreState.mergedMatchedAllocatable)
+		// the reserved but unallocated resources of the matched reservations are counted in the node used ones, so
+		// they have to be added back to allocate from the node unallocated resources. Build a new preemptible map
+		// to keep the caller's one untouched, which is reused when the NUMA node masks are probed one by one.
+		preemptible := appendAllocated(nil, basicPreemptible, restoreState.mergedMatchedAllocatable)
 		var requiredDeviceResource map[schedulingv1alpha1.DeviceType]deviceResources
 		if len(state.designatedAllocation) > 0 {
 			err := fillGPUTotalMem(state.designatedAllocation, nodeDeviceInfo)
 			if err != nil {
-				return fwktype.NewStatus(fwktype.Error, fmt.Sprintf("fillGPUTotalMem failed: %v, node: %v", err, node.Name))
+				return nil, fwktype.NewStatus(fwktype.Error, fmt.Sprintf("fillGPUTotalMem failed: %v, node: %v", err, node.Name))
 			}
 			requiredDeviceResource = make(map[schedulingv1alpha1.DeviceType]deviceResources, len(state.designatedAllocation))
 			for deviceType, minorResources := range state.designatedAllocation {
@@ -650,15 +736,14 @@ func (p *Plugin) allocate(ctx context.Context, cycleState fwktype.CycleState, po
 		}
 		result, status = allocator.Allocate(nil, nil, requiredDeviceResource, preemptible)
 		if !status.IsSuccess() {
-			return status
+			return nil, status
 		}
 	}
 	err := fillGPUTotalMem(result, nodeDeviceInfo)
 	if err != nil {
-		return fwktype.NewStatus(fwktype.Error, fmt.Sprintf("fillGPUTotalMem failed: %v, node: %v", err, node.Name))
+		return nil, fwktype.NewStatus(fwktype.Error, fmt.Sprintf("fillGPUTotalMem failed: %v, node: %v", err, node.Name))
 	}
-	state.allocationResult = result
-	return nil
+	return result, nil
 }
 
 func (p *Plugin) Unreserve(ctx context.Context, cycleState fwktype.CycleState, pod *corev1.Pod, nodeName string) {

--- a/pkg/scheduler/plugins/deviceshare/plugin_test.go
+++ b/pkg/scheduler/plugins/deviceshare/plugin_test.go
@@ -5545,6 +5545,56 @@ func Test_Plugin_Unreserve(t *testing.T) {
 	}
 }
 
+func Test_Plugin_UnreserveNeverAssumed(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "123456789",
+			Namespace: "default",
+			Name:      "test",
+		},
+	}
+	nodeDeviceInfo := newNodeDevice()
+	nodeDeviceInfo.resetDeviceTotal(map[schedulingv1alpha1.DeviceType]deviceResources{
+		schedulingv1alpha1.GPU: {
+			0: corev1.ResourceList{
+				apiext.ResourceGPUCore:        resource.MustParse("100"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+				apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+			},
+		},
+	})
+	wantFree := copyDeviceResources(nodeDeviceInfo.deviceFree)
+
+	p := &Plugin{nodeDeviceCache: &nodeDeviceCache{
+		nodeDeviceInfos: map[string]*nodeDevice{"test-node": nodeDeviceInfo},
+	}}
+	// an allocation result that has never been accounted in the cache by the Reserve phase. Rolling it back must be a
+	// no-op: updateCacheUsed(add=false) admits a release only for a pod recorded in the allocateSet, which is keyed by
+	// the pod namespace/name.
+	state := &preFilterState{
+		allocationResult: apiext.DeviceAllocations{
+			schedulingv1alpha1.GPU: {
+				{
+					Minor: 0,
+					Resources: corev1.ResourceList{
+						apiext.ResourceGPUCore:        resource.MustParse("100"),
+						apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+						apiext.ResourceGPUMemory:      resource.MustParse("16Gi"),
+					},
+				},
+			},
+		},
+	}
+	cycleState := framework.NewCycleState()
+	cycleState.Write(stateKey, state)
+
+	p.Unreserve(context.TODO(), cycleState, pod, "test-node")
+
+	assert.Empty(t, state.allocationResult)
+	assert.Equal(t, wantFree, nodeDeviceInfo.deviceFree)
+	assert.Empty(t, nodeDeviceInfo.allocateSet[schedulingv1alpha1.GPU])
+}
+
 func Test_Plugin_PreBind(t *testing.T) {
 	now := time.Now()
 	dpAdapterClock = fakeclock.NewFakeClock(now)

--- a/pkg/scheduler/plugins/deviceshare/topology_hint.go
+++ b/pkg/scheduler/plugins/deviceshare/topology_hint.go
@@ -126,34 +126,19 @@ func (p *Plugin) Allocate(ctx context.Context, cycleState fwktype.CycleState, af
 		return nil
 	}
 
-	reservationRestoreState := getReservationRestoreState(cycleState)
-	restoreState := reservationRestoreState.getNodeState(node.Name)
-	preemptible := appendAllocated(nil, restoreState.mergedUnmatchedUsed, state.preemptibleDevices[node.Name])
-
-	allocator := &AutopilotAllocator{
-		state:      state,
-		nodeDevice: nodeDeviceInfo,
-		node:       node,
-		pod:        pod,
-		numaNodes:  affinity.NUMANodeAffinity,
-	}
-
-	nodeDeviceInfo.lock.RLock()
-	defer nodeDeviceInfo.lock.RUnlock()
-	allocateResult, status := p.tryAllocateFromReusable(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.isReservationRequired)
+	// The affinity here is the one finally chosen for the pod, so this allocation has to be as strict as the one the
+	// Reserve phase will redo with the same constraints, otherwise the pod would be admitted here and then rejected
+	// during Reserve. The allocations of the other phases, e.g. the preemption simulation during PostFilter, are only
+	// probing the feasibility and keep the scope they had before the nominated reservation was taken into account.
+	// The result is deliberately dropped instead of being handed over to Reserve: one more allocation per scheduling
+	// cycle buys not carrying an allocation across extension points, which would require a flag telling Reserve and
+	// Unreserve whether the result has already been accounted in the node device cache.
+	_, status = p.allocateWithNUMAAffinity(cycleState, state, nodeDeviceInfo, pod, node, affinity,
+		beforeReservationNominated(cycleState))
 	if !status.IsSuccess() {
 		return status
 	}
-	if len(allocateResult) > 0 {
-		return nil
-	}
-
-	preemptible = appendAllocated(preemptible, restoreState.mergedMatchedAllocatable)
-	_, status = allocator.Allocate(nil, nil, nil, preemptible)
-	if status.IsSuccess() {
-		return nil
-	}
-	return status
+	return nil
 }
 
 func (p *Plugin) generateTopologyHints(cycleState fwktype.CycleState, state *preFilterState, nodeDevice *nodeDevice, node *corev1.Node, pod *corev1.Pod) (map[string][]topologymanager.NUMATopologyHint, *fwktype.Status) {
@@ -181,6 +166,11 @@ func (p *Plugin) generateTopologyHints(cycleState fwktype.CycleState, state *pre
 	var statusUnsatisfied *fwktype.Status
 	var bestAllocationResult apiext.DeviceAllocations
 	var feasibleAllocationResults []*numaScopedAllocation
+
+	// The hints of the Restricted and the SingleNUMANode policies are calculated during the Filter phase, where no
+	// reservation has been nominated yet. Only the hints calculated during the Reserve phase, i.e. the BestEffort
+	// ones, are able to resolve the scope with the nomination.
+	probeMatchedWithoutNomination := beforeReservationNominated(cycleState)
 
 	bitmask.IterateBitMasks(numaNodes, func(mask bitmask.BitMask) {
 		nodeDevice.lock.RLock()
@@ -215,16 +205,9 @@ func (p *Plugin) generateTopologyHints(cycleState fwktype.CycleState, state *pre
 			}
 		}
 
-		allocateResult, status = p.tryAllocateFromReusable(allocator, state, restoreState, restoreState.matched, pod, node, preemptible, state.isReservationRequired)
-		if !status.IsSuccess() {
+		allocateResult, status = p.allocateWithReservationScope(cycleState, allocator, state, restoreState, nodeDevice, pod, node, preemptible, probeMatchedWithoutNomination, mask.Count() == len(numaNodes))
+		if !status.IsSuccess() || len(allocateResult) == 0 {
 			return
-		}
-		if len(allocateResult) == 0 {
-			preemptible := appendAllocated(preemptible, restoreState.mergedMatchedAllocatable)
-			allocateResult, status = allocator.Allocate(nil, nil, nil, preemptible)
-			if !status.IsSuccess() || len(allocateResult) == 0 {
-				return
-			}
 		}
 
 		nodeCount := mask.Count()

--- a/pkg/scheduler/plugins/deviceshare/topology_hint_test.go
+++ b/pkg/scheduler/plugins/deviceshare/topology_hint_test.go
@@ -24,11 +24,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	fwktype "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiext "github.com/koordinator-sh/koordinator/apis/extension"
 	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext"
+	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/schedulingphase"
 	"github.com/koordinator-sh/koordinator/pkg/scheduler/frameworkext/topologymanager"
 	"github.com/koordinator-sh/koordinator/pkg/util/bitmask"
 )
@@ -267,6 +271,308 @@ func TestPlugin_GetPodTopologyHints(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPlugin_TopologyHintsWithNominatedReservation reproduces the production incident where the NUMA hints were
+// generated without knowing the reservation nominated for the pod: the feasibility of a NUMA node mask was probed
+// against every matched reservation and even against the node unallocated resources, while the Reserve phase is
+// only allowed to allocate the devices reserved by the nominated reservation. A NUMA node holding no reserved
+// device was therefore admitted and the pod got rejected with ErrInsufficientDevicesInNominatedReservation.
+func TestPlugin_TopologyHintsWithNominatedReservation(t *testing.T) {
+	f := newReservedGPUHintFixture(t)
+	// the pod is scheduled with the best-effort NUMA policy, so the hints are calculated during the Reserve phase,
+	// where the reservation has already been nominated for the pod
+	schedulingphase.RecordPhase(f.cycleState, schedulingphase.Reserve)
+	f.pl.handle.GetReservationNominator().AddNominatedReservation(f.pod, f.node.Name, f.rInfo)
+
+	got, status := f.pl.GetPodTopologyHints(context.TODO(), f.cycleState, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	// NUMA node 0 holds no device reserved by the nominated reservation, so it must not be hinted at all
+	assert.Equal(t, reservedGPUHints(), got)
+
+	// the hint provider only admits the chosen affinity, the Reserve phase redoes the allocation with the same
+	// constraints and it has to stay within the nominated reservation
+	status = f.pl.Allocate(context.TODO(), f.cycleState, topologymanager.NUMATopologyHint{NUMANodeAffinity: newBitMask(1)}, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	assert.Nil(t, f.state.allocationResult)
+
+	status = f.pl.Reserve(context.TODO(), f.cycleState, f.pod, f.node.Name)
+	assert.True(t, status.IsSuccess())
+	f.assertReservedGPUAllocated(t, f.state.allocationResult[schedulingv1alpha1.GPU])
+}
+
+// TestPlugin_TopologyHintsWithoutNominatedReservation covers the Restricted and the SingleNUMANode policies, whose
+// NUMA affinity is admitted during the Filter phase. A reservation is nominated no earlier than the PreScore phase,
+// so the scope has to be resolved with the matched reservations there: the pod is required to allocate from one of
+// them, hence the NUMA nodes holding none of the reserved devices must not be hinted.
+func TestPlugin_TopologyHintsWithoutNominatedReservation(t *testing.T) {
+	f := newReservedGPUHintFixture(t)
+	// no phase is recorded during the Filter phase, and no reservation has been nominated for the pod yet
+	f.state.isReservationRequired = true
+
+	got, status := f.pl.GetPodTopologyHints(context.TODO(), f.cycleState, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	assert.Equal(t, reservedGPUHints(), got)
+
+	// the hint provider never keeps its allocation, the Reserve phase is the only one filling the result
+	status = f.pl.Allocate(context.TODO(), f.cycleState, topologymanager.NUMATopologyHint{NUMANodeAffinity: newBitMask(1)}, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	assert.Nil(t, f.state.allocationResult)
+}
+
+// reservedGPUHintFixture holds a pod requesting one whole GPU on a node whose GPU 0~3 belong to NUMA node 0 and GPU
+// 4~7 belong to NUMA node 1, with one Restricted reservation matched for the pod reserving reservedGPUMinor. Only
+// the NUMA node masks including NUMA node 1 are able to allocate the reserved GPU.
+type reservedGPUHintFixture struct {
+	pl         *Plugin
+	node       *corev1.Node
+	pod        *corev1.Pod
+	rInfo      *frameworkext.ReservationInfo
+	state      *preFilterState
+	cycleState *framework.CycleState
+}
+
+const reservedGPUMinor = 6
+
+func wholeGPUResources() corev1.ResourceList {
+	return corev1.ResourceList{
+		apiext.ResourceGPUCore:        resource.MustParse("100"),
+		apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+		apiext.ResourceGPUMemory:      resource.MustParse("83201216Ki"),
+	}
+}
+
+// reservedGPUHints are the hints allocating the reserved GPU: NUMA node 0 holds none of the reserved devices, so it
+// is not hinted alone, and the mask of all the NUMA nodes allocates the same GPU as the preferred one.
+func reservedGPUHints() map[string][]topologymanager.NUMATopologyHint {
+	return map[string][]topologymanager.NUMATopologyHint{
+		string(schedulingv1alpha1.GPU): {
+			{NUMANodeAffinity: newBitMask(1), Preferred: true, Score: defaultNUMAScore},
+			{NUMANodeAffinity: newBitMask(0, 1), Preferred: false, Score: defaultNUMAScore},
+		},
+	}
+}
+
+func newReservedGPUHintFixture(t *testing.T) *reservedGPUHintFixture {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	reservedGPU := func() map[schedulingv1alpha1.DeviceType]deviceResources {
+		return map[schedulingv1alpha1.DeviceType]deviceResources{
+			schedulingv1alpha1.GPU: {reservedGPUMinor: wholeGPUResources()},
+		}
+	}
+	rInfo := frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-0", UID: "gen-0-uid"},
+		Spec: schedulingv1alpha1.ReservationSpec{
+			Template:       &corev1.PodTemplateSpec{},
+			AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+		},
+		Status: schedulingv1alpha1.ReservationStatus{NodeName: node.Name},
+	})
+
+	suit := newPluginTestSuit(t, []*corev1.Node{node})
+	deviceCR := fakeDeviceCR.DeepCopy()
+	deviceCR.Name = node.Name
+	deviceCR.ResourceVersion = "1"
+	_, err := suit.koordClientSet.SchedulingV1alpha1().Devices().Create(context.TODO(), deviceCR, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+
+	suit.koordinatorSharedInformerFactory.Start(nil)
+	suit.SharedInformerFactory().Start(nil)
+	suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)
+	suit.SharedInformerFactory().WaitForCacheSync(nil)
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default", Name: "gpu-pod", UID: "gpu-pod-uid",
+	}}
+	state := &preFilterState{
+		podRequests: map[schedulingv1alpha1.DeviceType]corev1.ResourceList{
+			schedulingv1alpha1.GPU: {
+				apiext.ResourceGPUCore:        resource.MustParse("100"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("100"),
+			},
+		},
+	}
+	state.gpuRequirements, err = parseGPURequirements(pod, state.podRequests, nil, nil, nil)
+	assert.NoError(t, err)
+
+	cycleState := framework.NewCycleState()
+	cycleState.Write(stateKey, state)
+	cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+		nodeToState: frameworkext.NodeReservationRestoreStates{
+			node.Name: &nodeReservationRestoreStateData{
+				matched:                  []reusableAlloc{{rInfo: rInfo, allocatable: reservedGPU(), remained: reservedGPU()}},
+				mergedMatchedAllocatable: reservedGPU(),
+			},
+		},
+	})
+
+	return &reservedGPUHintFixture{
+		pl:         p.(*Plugin),
+		node:       node,
+		pod:        pod,
+		rInfo:      rInfo,
+		state:      state,
+		cycleState: cycleState,
+	}
+}
+
+func (f *reservedGPUHintFixture) assertReservedGPUAllocated(t *testing.T, allocations []*apiext.DeviceAllocation) {
+	t.Helper()
+	if !assert.Len(t, allocations, 1) {
+		return
+	}
+	assert.Equal(t, int32(reservedGPUMinor), allocations[0].Minor)
+	wholeGPU := wholeGPUResources()
+	assert.True(t, quotav1.Equals(wholeGPU, allocations[0].Resources),
+		"expected the whole reserved GPU %v, but got %v", wholeGPU, allocations[0].Resources)
+}
+
+// TestPlugin_TopologyHintsWithReservationOnAnotherNUMANode is the case a single matched reservation cannot cover: the
+// NUMA node masks the nominated reservation cannot satisfy have to be dropped even when another reservation matched for
+// the pod does satisfy them. It also runs the hints through the topology manager merge, which is where dropping them
+// matters: a narrower preferred hint wins over a wider non preferred one whatever the scores are, so a leaked hint for
+// the NUMA node of the other reservation would be the admitted affinity and the Reserve phase would then reject the pod
+// with ErrInsufficientDevicesInNominatedReservation, over and over.
+func TestPlugin_TopologyHintsWithReservationOnAnotherNUMANode(t *testing.T) {
+	f := newCrossNUMAReservationHintFixture(t)
+	// the pod is scheduled with the best-effort NUMA policy, so the hints are calculated during the Reserve phase,
+	// where the reservation has already been nominated for the pod
+	schedulingphase.RecordPhase(f.cycleState, schedulingphase.Reserve)
+	f.pl.handle.GetReservationNominator().AddNominatedReservation(f.pod, f.node.Name, f.rInfo)
+
+	hints, status := f.pl.GetPodTopologyHints(context.TODO(), f.cycleState, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	// The nominated reservation holds a single GPU on each NUMA node, so neither NUMA node alone can host the two
+	// GPUs of the pod and only the mask of both of them is hinted. NUMA node 0 does host the two GPUs of the other
+	// matched reservation, which is exactly the hint that must not be produced.
+	assert.Equal(t, map[string][]topologymanager.NUMATopologyHint{
+		string(schedulingv1alpha1.GPU): {
+			{NUMANodeAffinity: newBitMask(0, 1), Preferred: true, Score: defaultNUMAScore},
+		},
+	}, hints)
+
+	affinity, admit, _ := topologymanager.NewBestEffortPolicy(crossNUMANodes).Merge(
+		[]map[string][]topologymanager.NUMATopologyHint{hints},
+		apiext.NumaTopologyExclusivePreferred,
+		[]apiext.NumaNodeStatus{apiext.NumaNodeStatusIdle, apiext.NumaNodeStatusIdle},
+	)
+	assert.True(t, admit)
+	assert.Equal(t, newBitMask(0, 1), affinity.NUMANodeAffinity)
+
+	topologymanager.InitStore(f.cycleState)
+	topologymanager.GetStore(f.cycleState).SetAffinity(f.node.Name, affinity)
+	status = f.pl.Allocate(context.TODO(), f.cycleState, affinity, f.pod, f.node)
+	assert.True(t, status.IsSuccess())
+	assert.Nil(t, f.state.allocationResult)
+
+	status = f.pl.Reserve(context.TODO(), f.cycleState, f.pod, f.node.Name)
+	assert.True(t, status.IsSuccess())
+	assertGPUMinorsAllocated(t, f.state.allocationResult[schedulingv1alpha1.GPU], crossNUMAReservedGPUMinors)
+}
+
+var (
+	// crossNUMANodes are the NUMA nodes of the node built by newCrossNUMAReservationHintFixture.
+	crossNUMANodes = []int{0, 1}
+
+	// crossNUMAReservedGPUMinors are the GPUs of the nominated reservation, one on each NUMA node, and
+	// singleNUMAReservedGPUMinors are the ones of the other matched reservation, both on NUMA node 0.
+	crossNUMAReservedGPUMinors  = []int{2, 4}
+	singleNUMAReservedGPUMinors = []int{0, 1}
+)
+
+// newCrossNUMAReservationHintFixture holds a pod requesting two whole GPUs on a node whose GPU 0~3 belong to NUMA node
+// 0 and GPU 4~7 belong to NUMA node 1, with two Restricted reservations matched for the pod: the nominated one reserves
+// crossNUMAReservedGPUMinors and the other one reserves singleNUMAReservedGPUMinors.
+func newCrossNUMAReservationHintFixture(t *testing.T) *reservedGPUHintFixture {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	reserved := func(minors []int) map[schedulingv1alpha1.DeviceType]deviceResources {
+		gpus := deviceResources{}
+		for _, minor := range minors {
+			gpus[minor] = wholeGPUResources()
+		}
+		return map[schedulingv1alpha1.DeviceType]deviceResources{schedulingv1alpha1.GPU: gpus}
+	}
+	newRInfo := func(name string) *frameworkext.ReservationInfo {
+		return frameworkext.NewReservationInfo(&schedulingv1alpha1.Reservation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")},
+			Spec: schedulingv1alpha1.ReservationSpec{
+				Template:       &corev1.PodTemplateSpec{},
+				AllocatePolicy: schedulingv1alpha1.ReservationAllocatePolicyRestricted,
+			},
+			Status: schedulingv1alpha1.ReservationStatus{NodeName: node.Name},
+		})
+	}
+	crossNUMARInfo, singleNUMARInfo := newRInfo("cross-numa"), newRInfo("single-numa")
+
+	suit := newPluginTestSuit(t, []*corev1.Node{node})
+	deviceCR := fakeDeviceCR.DeepCopy()
+	deviceCR.Name = node.Name
+	deviceCR.ResourceVersion = "1"
+	_, err := suit.koordClientSet.SchedulingV1alpha1().Devices().Create(context.TODO(), deviceCR, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	p, err := suit.proxyNew(context.TODO(), getDefaultArgs(), suit.Framework)
+	assert.NoError(t, err)
+
+	suit.koordinatorSharedInformerFactory.Start(nil)
+	suit.SharedInformerFactory().Start(nil)
+	suit.koordinatorSharedInformerFactory.WaitForCacheSync(nil)
+	suit.SharedInformerFactory().WaitForCacheSync(nil)
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default", Name: "gpu-pod", UID: "gpu-pod-uid",
+	}}
+	state := &preFilterState{
+		podRequests: map[schedulingv1alpha1.DeviceType]corev1.ResourceList{
+			schedulingv1alpha1.GPU: {
+				apiext.ResourceGPUCore:        resource.MustParse("200"),
+				apiext.ResourceGPUMemoryRatio: resource.MustParse("200"),
+			},
+		},
+	}
+	state.gpuRequirements, err = parseGPURequirements(pod, state.podRequests, nil, nil, nil)
+	assert.NoError(t, err)
+
+	cycleState := framework.NewCycleState()
+	cycleState.Write(stateKey, state)
+	cycleState.Write(reservationRestoreStateKey, &reservationRestoreStateData{
+		nodeToState: frameworkext.NodeReservationRestoreStates{
+			node.Name: &nodeReservationRestoreStateData{
+				matched: []reusableAlloc{
+					{rInfo: singleNUMARInfo, allocatable: reserved(singleNUMAReservedGPUMinors), remained: reserved(singleNUMAReservedGPUMinors)},
+					{rInfo: crossNUMARInfo, allocatable: reserved(crossNUMAReservedGPUMinors), remained: reserved(crossNUMAReservedGPUMinors)},
+				},
+				mergedMatchedAllocatable: reserved(append(append([]int{}, singleNUMAReservedGPUMinors...), crossNUMAReservedGPUMinors...)),
+			},
+		},
+	})
+
+	return &reservedGPUHintFixture{
+		pl:         p.(*Plugin),
+		node:       node,
+		pod:        pod,
+		rInfo:      crossNUMARInfo,
+		state:      state,
+		cycleState: cycleState,
+	}
+}
+
+func assertGPUMinorsAllocated(t *testing.T, allocations []*apiext.DeviceAllocation, minors []int) {
+	t.Helper()
+	if !assert.Len(t, allocations, len(minors)) {
+		return
+	}
+	var gotMinors []int
+	for _, allocation := range allocations {
+		gotMinors = append(gotMinors, int(allocation.Minor))
+		wholeGPU := wholeGPUResources()
+		assert.True(t, quotav1.Equals(wholeGPU, allocation.Resources),
+			"expected the whole GPU %v, but got %v", wholeGPU, allocation.Resources)
+	}
+	assert.ElementsMatch(t, minors, gotMinors)
 }
 
 func TestPlugin_Allocate(t *testing.T) {

--- a/test/e2e/scheduling/numahintreservation.go
+++ b/test/e2e/scheduling/numahintreservation.go
@@ -1,0 +1,464 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8spodutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/utils/ptr"
+
+	apiext "github.com/koordinator-sh/koordinator/apis/extension"
+	schedulingv1alpha1 "github.com/koordinator-sh/koordinator/apis/scheduling/v1alpha1"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework"
+	"github.com/koordinator-sh/koordinator/test/e2e/framework/manifest"
+	e2epod "github.com/koordinator-sh/koordinator/test/e2e/framework/pod"
+)
+
+const (
+	// numaHintTargetNodeLabel pins the case to a dedicated node when the environment provides one. The case counts
+	// the GPUs of the node to decide how many background pods are needed, so an unrelated GPU workload landing on
+	// the same node would silently invalidate the setup.
+	numaHintTargetNodeLabel = "e2e-numa-hint-target"
+
+	numaHintOwnerLabel  = "e2e-numa-hint-owner"
+	numaHintFillerLabel = "e2e-numa-hint-filler"
+
+	// wholeGPU is the koordinator.sh/gpu request of an entire GPU card.
+	wholeGPU = "100"
+
+	// gpusPerReservation is how many cards each reservation of the case holds. Two cards are the minimum letting a
+	// reservation span two NUMA nodes, which is what the case needs to tell the hint scopes apart.
+	gpusPerReservation = 2
+)
+
+var _ = SIGDescribe("NUMAHintReservation", func() {
+	f := framework.NewDefaultFramework("numahint-reservation")
+	var koordSchedulerName string
+
+	ginkgo.BeforeEach(func() {
+		koordSchedulerName = framework.TestContext.KoordSchedulerName
+		framework.AllNodesReady(f.ClientSet, time.Minute)
+	})
+
+	ginkgo.AfterEach(func() {
+		ls := metav1.SetAsLabelSelector(map[string]string{
+			"e2e-test-reservation": "true",
+		})
+		reservationList, err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(ls),
+		})
+		framework.ExpectNoError(err)
+		for _, v := range reservationList.Items {
+			err := f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+		}
+	})
+
+	framework.KoordinatorDescribe("BestEffort NUMA hint scoped by the nominated reservation", func() {
+		// The invariant under test is that the NUMA affinity the topology manager admits must be one the reservation
+		// nominated for the pod can actually satisfy. The hint is instead resolved over every reservation the pod
+		// could match, so an affinity backed by a reservation the pod was not nominated to can win the admission and
+		// is then rejected while reserving the devices, leaving the pod unschedulable for good.
+		//
+		// Telling the two scopes apart takes two reservations. A hint scoped to the nomination only ever proposes
+		// affinities the nominated reservation can satisfy, so the unnominated reservation has to be the one making a
+		// second affinity look feasible. It also has to be the more attractive one, otherwise the wider hint would win
+		// anyway and the case would pass on both a correct and a broken scope: the nominated reservation therefore
+		// spans two NUMA nodes, so the only affinity satisfying it is the wider, non preferred one, while the
+		// unnominated one sits on a single NUMA node and contributes a narrower, preferred affinity. A preferred hint
+		// beats a non preferred one whatever the scores are, which is what makes the outcome deterministic instead of
+		// depending on how the hint scores happen to be computed.
+		framework.ConformanceIt("admits a NUMA affinity the nominated reservation can satisfy", func() {
+			node, topology := skipUnlessIdleGPUNodeWithMultiNUMA(f, 2)
+			singleNUMA, crossNUMA := skipUnlessGPULayoutFitsCrossNUMAReservation(topology)
+			// Every pod below has to reach the node through the scheduler, otherwise no device would be allocated and
+			// the GPUs would stay allocatable from the scheduler point of view. So the node is pinned by its hostname
+			// label rather than by spec.nodeName, and its taints are tolerated.
+			nodeSelector := map[string]string{corev1.LabelHostname: node.Labels[corev1.LabelHostname]}
+			tolerations := tolerationsForNode(node)
+
+			ginkgo.By(fmt.Sprintf("Occupy every GPU of node %s with a filler pod", node.Name))
+			fillers := occupyEveryGPU(f, koordSchedulerName, topology, nodeSelector, tolerations)
+
+			// Releasing exactly the cards a reservation has to hold is what makes its placement deterministic: no
+			// other card of the node is allocatable when it gets scheduled, so the case does not rely on how the
+			// device plugin ranks the NUMA nodes and the cards within them.
+			ginkgo.By(fmt.Sprintf("Reserve GPUs %v, which sit on the single NUMA node %d", singleNUMA, topology.minorToNUMA[singleNUMA[0]]))
+			fillers.release(f, singleNUMA)
+			singleNUMAReservation := createGPUReservation(f, koordSchedulerName, "numa-hint-reservation-single-numa", 0, nodeSelector, tolerations)
+			gomega.Expect(gpuMinorsOfAllocations(singleNUMAReservation.Annotations)).Should(gomega.ConsistOf(singleNUMA),
+				"the single NUMA node reservation did not take the only allocatable GPUs")
+
+			// The reservation order label pins which reservation gets nominated: the nominator picks the matching
+			// reservation with the lowest non zero order before it scores the others, so the nomination no longer
+			// depends on the reservation scores.
+			ginkgo.By(fmt.Sprintf("Reserve GPUs %v, which span two NUMA nodes, and make it the nominated reservation", crossNUMA))
+			fillers.release(f, crossNUMA)
+			crossNUMAReservation := createGPUReservation(f, koordSchedulerName, "numa-hint-reservation-cross-numa", 1, nodeSelector, tolerations)
+			gomega.Expect(gpuMinorsOfAllocations(crossNUMAReservation.Annotations)).Should(gomega.ConsistOf(crossNUMA),
+				"the cross NUMA node reservation did not take the only allocatable GPUs")
+			gomega.Expect(topology.numaNodesOfGPUAllocations(crossNUMAReservation.Annotations).Len()).Should(gomega.Equal(2),
+				"the cross NUMA node reservation is expected to span two NUMA nodes")
+
+			ginkgo.By("Create the target pod matching both reservations with the BestEffort NUMA topology policy")
+			pod := createPausePod(f, pausePodConfig{
+				Name:      "numa-hint-target",
+				Namespace: f.Namespace.Name,
+				Labels: map[string]string{
+					numaHintOwnerLabel: "true",
+				},
+				Annotations: map[string]string{
+					// BestEffort hints are the ones resolved during Reserve, i.e. once a reservation has been
+					// nominated, which is the only phase where the two scopes can differ. The pod deliberately
+					// carries no reservation affinity: restricting it to the nominated reservation would narrow the
+					// hint scope as a side effect and hide the very behaviour under test.
+					apiext.AnnotationNUMATopologySpec: `{"numaTopologyPolicy":"BestEffort"}`,
+				},
+				Resources:     &corev1.ResourceRequirements{Requests: reservedRequests(), Limits: reservedRequests()},
+				SchedulerName: koordSchedulerName,
+				NodeSelector:  nodeSelector,
+				Tolerations:   tolerations,
+			})
+
+			ginkgo.By("Wait for the target pod scheduled")
+			framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, pod.Namespace, pod.Name,
+				"scheduled on the NUMA nodes of the nominated reservation", 2*time.Minute, func(p *corev1.Pod) (bool, error) {
+					_, scheduledCondition := k8spodutil.GetPodCondition(&p.Status, corev1.PodScheduled)
+					if scheduledCondition == nil {
+						return false, nil
+					}
+					// The rejection happens while reserving the devices of the nominated reservation, after the
+					// NUMA affinity has been admitted, so it is reported as a plain unschedulable pod and is
+					// indistinguishable from a pod still waiting for room. Hence the wait for the timeout rather
+					// than a fail fast, with the message logged to tell the two apart when it expires.
+					if scheduledCondition.Status != corev1.ConditionTrue {
+						framework.Logf("The target pod is not scheduled yet: %s: %s", scheduledCondition.Reason, scheduledCondition.Message)
+						return false, nil
+					}
+					return true, nil
+				}))
+
+			ginkgo.By("Check the target pod took the GPUs of the nominated reservation")
+			expectPodBoundReservation(f.ClientSet, f.KoordinatorClientSet, pod.Namespace, pod.Name, crossNUMAReservation.Name)
+			pod, err := f.PodClient().Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "unable to get the target pod")
+			gomega.Expect(gpuMinorsOfAllocations(pod.Annotations)).Should(gomega.ConsistOf(crossNUMA),
+				"the pod did not take the GPUs reserved by the nominated reservation")
+		})
+	})
+})
+
+// reservedRequests is what both the reservations and the target pod ask for, so that the pod fits either reservation as
+// far as the resources are concerned and only the NUMA topology decides.
+func reservedRequests() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("4Gi"),
+		apiext.ResourceGPU:    resource.MustParse(strconv.Itoa(gpusPerReservation * 100)),
+	}
+}
+
+func fillerRequests() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1"),
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+		apiext.ResourceGPU:    resource.MustParse(wholeGPU),
+	}
+}
+
+// createGPUReservation creates a Restricted reservation holding gpusPerReservation whole GPUs on the given node and
+// waits for it to become available. A non zero order is published as the reservation order label, which the nominator
+// honors before scoring.
+func createGPUReservation(f *framework.Framework, koordSchedulerName, name string, order int, nodeSelector map[string]string, tolerations []corev1.Toleration) *schedulingv1alpha1.Reservation {
+	reservation, err := manifest.ReservationFromManifest("scheduling/simple-reservation.yaml")
+	framework.ExpectNoError(err, "unable to load reservation")
+	reservation.Name = name
+	if order != 0 {
+		reservation.Labels[apiext.LabelReservationOrder] = strconv.Itoa(order)
+	}
+	reservation.Spec.AllocateOnce = ptr.To[bool](false)
+	reservation.Spec.AllocatePolicy = schedulingv1alpha1.ReservationAllocatePolicyRestricted
+	reservation.Spec.Owners = []schedulingv1alpha1.ReservationOwner{
+		{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					numaHintOwnerLabel: "true",
+				},
+			},
+		},
+	}
+	reservation.Spec.Template.Spec.NodeSelector = nodeSelector
+	reservation.Spec.Template.Spec.Tolerations = tolerations
+	// The manifest hardcodes koord-scheduler, while the scheduler under test may be deployed under another name.
+	reservation.Spec.Template.Spec.SchedulerName = koordSchedulerName
+	reservation.Spec.Template.Spec.Containers = []corev1.Container{
+		{
+			Name:      "main",
+			Resources: corev1.ResourceRequirements{Requests: reservedRequests(), Limits: reservedRequests()},
+		},
+	}
+	reservation, err = f.KoordinatorClientSet.SchedulingV1alpha1().Reservations().Create(context.TODO(), reservation, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "unable to create reservation %s", name)
+	return waitingForReservationScheduled(f.KoordinatorClientSet, reservation)
+}
+
+// gpuFillers tracks which filler pod holds which GPU minor, so that a given card can be freed on demand.
+type gpuFillers struct {
+	podNameOfMinor map[int32]string
+}
+
+// release deletes the filler pods holding the given minors and waits for them to be gone, which is what hands the cards
+// back to the scheduler.
+func (o *gpuFillers) release(f *framework.Framework, minors []int32) {
+	var podNames []string
+	for _, minor := range minors {
+		podName, ok := o.podNameOfMinor[minor]
+		gomega.Expect(ok).Should(gomega.BeTrue(), "GPU minor %d is held by no filler pod", minor)
+		err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, *metav1.NewDeleteOptions(0))
+		framework.ExpectNoError(err, "unable to delete the filler pod %s holding GPU minor %d", podName, minor)
+		delete(o.podNameOfMinor, minor)
+		podNames = append(podNames, podName)
+	}
+	// A card is handed back to the scheduler only once the pod holding it is gone, so the reservation created next
+	// would otherwise race with the deletion and find nothing allocatable.
+	for _, podName := range podNames {
+		framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(f.ClientSet, podName, f.Namespace.Name, framework.PollShortTimeout),
+			"the filler pod %s is expected to be deleted", podName)
+	}
+}
+
+// occupyEveryGPU runs one filler pod per GPU of the node, so that from there on the allocatable cards are exactly the
+// ones the case deliberately frees.
+func occupyEveryGPU(f *framework.Framework, koordSchedulerName string, topology *gpuNUMATopology, nodeSelector map[string]string, tolerations []corev1.Toleration) *gpuFillers {
+	var podNames []string
+	for i := 0; i < len(topology.minorToNUMA); i++ {
+		pod := createPausePod(f, pausePodConfig{
+			Name:      fmt.Sprintf("numa-hint-filler-%d", i),
+			Namespace: f.Namespace.Name,
+			Labels: map[string]string{
+				numaHintFillerLabel: "true",
+			},
+			Resources:     &corev1.ResourceRequirements{Requests: fillerRequests(), Limits: fillerRequests()},
+			SchedulerName: koordSchedulerName,
+			NodeSelector:  nodeSelector,
+			Tolerations:   tolerations,
+		})
+		podNames = append(podNames, pod.Name)
+	}
+
+	fillers := &gpuFillers{podNameOfMinor: map[int32]string{}}
+	for _, podName := range podNames {
+		framework.ExpectNoError(e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, podName,
+			"scheduled", framework.PollShortTimeout, func(p *corev1.Pod) (bool, error) {
+				return p.Spec.NodeName != "", nil
+			}), "the filler pods are expected to fit the GPUs of node %s", topology.nodeName)
+		pod, err := f.PodClient().Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "unable to get the filler pod %s", podName)
+		minors := gpuMinorsOfAllocations(pod.Annotations)
+		gomega.Expect(minors).Should(gomega.HaveLen(1), "the filler pod %s is expected to hold a single GPU", podName)
+		gomega.Expect(fillers.podNameOfMinor).ShouldNot(gomega.HaveKey(minors[0]), "GPU minor %d is held by two filler pods", minors[0])
+		fillers.podNameOfMinor[minors[0]] = podName
+	}
+	gomega.Expect(fillers.podNameOfMinor).Should(gomega.HaveLen(len(topology.minorToNUMA)), "the filler pods did not take every GPU of node %s", topology.nodeName)
+	return fillers
+}
+
+// gpuNUMATopology is the GPU layout of a single node, read from its Device object.
+type gpuNUMATopology struct {
+	nodeName     string
+	minorToNUMA  map[int32]int32
+	numaToMinors map[int32][]int32
+}
+
+// gpuMinorsOfAllocations returns the GPU minors the device allocations of the annotations hold.
+func gpuMinorsOfAllocations(annotations map[string]string) []int32 {
+	allocations, err := apiext.GetDeviceAllocations(annotations)
+	framework.ExpectNoError(err, "unable to get device allocations")
+	var minors []int32
+	for _, allocation := range allocations[schedulingv1alpha1.GPU] {
+		minors = append(minors, allocation.Minor)
+	}
+	return minors
+}
+
+func (t *gpuNUMATopology) numaNodesOfGPUAllocations(annotations map[string]string) sets.Set[int32] {
+	allocations, err := apiext.GetDeviceAllocations(annotations)
+	framework.ExpectNoError(err, "unable to get device allocations")
+	numaNodes := sets.New[int32]()
+	for _, allocation := range allocations[schedulingv1alpha1.GPU] {
+		numaNode, ok := t.minorToNUMA[allocation.Minor]
+		gomega.Expect(ok).Should(gomega.BeTrue(), "GPU minor %d is missing from the device topology of node %s", allocation.Minor, t.nodeName)
+		numaNodes.Insert(numaNode)
+	}
+	gomega.Expect(numaNodes.Len()).ShouldNot(gomega.BeZero(), "no GPU allocation found in annotations of node %s", t.nodeName)
+	return numaNodes
+}
+
+func newGPUNUMATopology(device *schedulingv1alpha1.Device) *gpuNUMATopology {
+	topology := &gpuNUMATopology{
+		nodeName:     device.Name,
+		minorToNUMA:  map[int32]int32{},
+		numaToMinors: map[int32][]int32{},
+	}
+	for i := range device.Spec.Devices {
+		info := &device.Spec.Devices[i]
+		if info.Type != schedulingv1alpha1.GPU || !info.Health || info.Minor == nil || info.Topology == nil {
+			continue
+		}
+		topology.minorToNUMA[*info.Minor] = info.Topology.NodeID
+		topology.numaToMinors[info.Topology.NodeID] = append(topology.numaToMinors[info.Topology.NodeID], *info.Minor)
+	}
+	// The Device object lists the GPUs in an unspecified order, while the cases pick the cards to free by index and
+	// report them, both of which are easier to follow when the minors are sorted.
+	for _, minors := range topology.numaToMinors {
+		sort.Slice(minors, func(i, j int) bool { return minors[i] < minors[j] })
+	}
+	return topology
+}
+
+// skipUnlessGPULayoutFitsCrossNUMAReservation picks the GPUs of the two reservations the case needs: gpusPerReservation
+// cards on a single NUMA node, plus gpusPerReservation cards spread over that NUMA node and another one. It returns the
+// two sets of minors and skips the case when the GPU layout of the node cannot host them.
+func skipUnlessGPULayoutFitsCrossNUMAReservation(topology *gpuNUMATopology) (singleNUMA, crossNUMA []int32) {
+	// The NUMA node hosting the single NUMA node reservation also contributes all but one of the cards of the cross
+	// NUMA node one, so that a second NUMA node with a single card is enough.
+	needed := gpusPerReservation + gpusPerReservation - 1
+	numaNodes := make([]int32, 0, len(topology.numaToMinors))
+	for numaNode := range topology.numaToMinors {
+		numaNodes = append(numaNodes, numaNode)
+	}
+	sort.Slice(numaNodes, func(i, j int) bool { return numaNodes[i] < numaNodes[j] })
+
+	for _, crowded := range numaNodes {
+		if len(topology.numaToMinors[crowded]) < needed {
+			continue
+		}
+		for _, other := range numaNodes {
+			if other == crowded || len(topology.numaToMinors[other]) < 1 {
+				continue
+			}
+			singleNUMA = topology.numaToMinors[crowded][:gpusPerReservation]
+			crossNUMA = append(crossNUMA, topology.numaToMinors[crowded][gpusPerReservation:needed]...)
+			crossNUMA = append(crossNUMA, topology.numaToMinors[other][0])
+			return singleNUMA, crossNUMA
+		}
+	}
+	ginkgo.Skip(fmt.Sprintf("node %s exposes no NUMA node with %d healthy GPUs next to a NUMA node with one", topology.nodeName, needed))
+	return nil, nil
+}
+
+// skipUnlessIdleGPUNodeWithMultiNUMA looks for a schedulable node exposing healthy GPUs on at least minNUMANodes NUMA
+// nodes and currently running no other GPU pod. Nodes labelled with numaHintTargetNodeLabel are considered first so
+// that an environment can pin the case to a node it has drained. The case is skipped rather than failed when nothing
+// matches, because the CI clusters carry no GPU at all.
+func skipUnlessIdleGPUNodeWithMultiNUMA(f *framework.Framework, minNUMANodes int) (*corev1.Node, *gpuNUMATopology) {
+	deviceList, err := f.KoordinatorClientSet.SchedulingV1alpha1().Devices().List(context.TODO(), metav1.ListOptions{})
+	framework.ExpectNoError(err, "unable to list Device")
+
+	var fallbackNode *corev1.Node
+	var fallbackTopology *gpuNUMATopology
+	for i := range deviceList.Items {
+		topology := newGPUNUMATopology(&deviceList.Items[i])
+		if len(topology.numaToMinors) < minNUMANodes {
+			continue
+		}
+		node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), topology.nodeName, metav1.GetOptions{})
+		if err != nil || node.Spec.Unschedulable {
+			continue
+		}
+		// The hostname label is not necessarily the node name, and it is the only handle the pods have to land here.
+		if node.Labels[corev1.LabelHostname] == "" {
+			framework.Logf("Skipping node %s for the NUMA hint case, it carries no %s label", node.Name, corev1.LabelHostname)
+			continue
+		}
+		if occupied := gpuPodsOnNode(f, node.Name); occupied > 0 {
+			framework.Logf("Skipping node %s for the NUMA hint case, %d GPU pods are still running on it", node.Name, occupied)
+			continue
+		}
+		if node.Labels[numaHintTargetNodeLabel] == "true" {
+			return node, topology
+		}
+		if fallbackNode == nil {
+			fallbackNode, fallbackTopology = node, topology
+		}
+	}
+	if fallbackNode != nil {
+		return fallbackNode, fallbackTopology
+	}
+	ginkgo.Skip(fmt.Sprintf("no idle schedulable node exposes healthy GPUs on at least %d NUMA nodes", minNUMANodes))
+	return nil, nil
+}
+
+func gpuPodsOnNode(f *framework.Framework, nodeName string) int {
+	podList, err := f.ClientSet.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	framework.ExpectNoError(err, "unable to list pods of node %s", nodeName)
+	count := 0
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		if requestsGPU(pod) {
+			count++
+		}
+	}
+	return count
+}
+
+// requestsGPU reports whether any container asks for a GPU flavored resource. The device plugins expose several names,
+// e.g. koordinator.sh/gpu, koordinator.sh/gpu-core and nvidia.com/gpu, and matching only one of them would let a GPU
+// workload pass unnoticed.
+func requestsGPU(pod *corev1.Pod) bool {
+	containers := append([]corev1.Container{}, pod.Spec.Containers...)
+	containers = append(containers, pod.Spec.InitContainers...)
+	for i := range containers {
+		for name := range containers[i].Resources.Requests {
+			if strings.Contains(strings.ToLower(string(name)), "gpu") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tolerationsForNode tolerates every taint of the node, so that a GPU node carrying resource pool taints can host the
+// case without the taints being hardcoded here.
+func tolerationsForNode(node *corev1.Node) []corev1.Toleration {
+	var tolerations []corev1.Toleration
+	for _, taint := range node.Spec.Taints {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      taint.Key,
+			Operator: corev1.TolerationOpExists,
+			Effect:   taint.Effect,
+		})
+	}
+	return tolerations
+}


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

The DeviceShare NUMA hints were generated without knowing which reservation had been nominated for the pod. The feasibility of every NUMA node mask was probed against **all** the matched reservations and, when none of them fit, against the node unallocated resources as well. The Reserve phase, in contrast, is only allowed to allocate the devices reserved by the **nominated** reservation.

As a result, a NUMA node holding no reserved device could be admitted as a Preferred hint, and the pod was then rejected during Reserve with `Reservation(s) Insufficient GPU Devices`. Which NUMA node won depended on the map iteration order of the matched reservations, so the replicas of one workload behaved inconsistently and the failure looked random.

This PR:

1. Converges the hint provider `Allocate` and the Reserve allocation into `allocateWithNUMAAffinity`, and lets both the per-mask probing and the Reserve phase resolve the reservation scope in `allocateWithReservationScope`. Once the pod is nominated to a reservation reserving tracked device resources, its devices must come from that reservation and the node unallocated resources are no longer a fallback, so only the masks covering the reserved devices are hinted.
2. Keeps the phase distinction. A reservation is nominated no earlier than the PreScore phase, so the NUMA affinity admitted during the Filter phase (Restricted / SingleNUMANode) keeps probing the matched reservations as before; the scope is only narrowed where a nomination actually exists. `beforeReservationNominated` encapsulates that predicate.
3. The hint provider only probes feasibility with the same scope and constraints as Reserve and drops its allocation result; Reserve redoes the allocation from the topology manager store and the nominated reservation on the cycle state (both already fixed by then), yielding an equally valid result within the same NUMA and reservation scope.
4. Fixes a latent issue where `appendAllocated` mutated the map it was given, so the preemptible resources accumulated across the probed masks; the shared helper now builds a new map and leaves the caller's one untouched.

### Scope

This change covers the **BestEffort** policy only. The Restricted and SingleNUMANode hints are computed during the Filter phase, before a nomination exists, so they are not tightened here and those pods may still be rejected during Reserve; that is tracked separately.

## Ⅱ. Does this pull request fix one issue?

Fixes the random `Reservation(s) Insufficient GPU Devices` rejection for BestEffort GPU pods nominated to a reservation.

## Ⅲ. Describe how to verify it

- `TestPlugin_TopologyHintsWithReservationOnAnotherNUMANode`: a pod nominated to a reservation whose devices sit on one NUMA node must not advertise the other NUMA node as a Preferred affinity.
- A new `test/e2e` NUMA hint reservation scope case: reserves the devices of one NUMA node, nominates a BestEffort pod to that reservation and asserts the pod is admitted on the reserved node.
- `go test ./pkg/scheduler/plugins/deviceshare/...`, `nodenumaresource` and `frameworkext/topologymanager` all pass; `gofmt` / `go vet` clean; the e2e suite compiles.

## Ⅳ. Special notes for reviews

The hint provider deliberately discards its allocation result rather than handing it to Reserve — keeping it would make a filled-but-unaccounted allocation a normal state and let Reserve account it without re-validating against the node device cache.